### PR TITLE
Check for uv installation before commands

### DIFF
--- a/install
+++ b/install
@@ -16,6 +16,13 @@ export LC_ALL=C.UTF-8
 export PYTHONUTF8=1
 export PYTHONIOENCODING=UTF-8
 
+# Check if uv is installed
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv is not installed. Please install uv first." >&2
+    echo "Visit https://docs.astral.sh/uv/getting-started/installation/ for installation instructions." >&2
+    exit 1
+fi
+
 set -ex
 if [ ! -d ".venv" ]; then
     echo "Creating Python 3.13 virtual environment..."

--- a/lint
+++ b/lint
@@ -2,6 +2,13 @@
 
 set -e
 
+# Check if uv is installed
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv is not installed. Please install uv first." >&2
+    echo "Visit https://docs.astral.sh/uv/getting-started/installation/ for installation instructions." >&2
+    exit 1
+fi
+
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in

--- a/test
+++ b/test
@@ -3,6 +3,13 @@ set -e
 
 cd "$(dirname "$0")"
 
+# Check if uv is installed
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv is not installed. Please install uv first." >&2
+    echo "Visit https://docs.astral.sh/uv/getting-started/installation/ for installation instructions." >&2
+    exit 1
+fi
+
 # Check if running integration tests specifically
 if [[ "$*" == *"tests/integration"* ]] || [[ "$PWD" == *"/tests/integration" ]]; then
     echo "Running integration tests sequentially (no parallel execution)"

--- a/upload_package.sh
+++ b/upload_package.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
+
+# Check if uv is installed
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv is not installed. Please install uv first." >&2
+    echo "Visit https://docs.astral.sh/uv/getting-started/installation/ for installation instructions." >&2
+    exit 1
+fi
+
 rm -rf build dist
 uv pip install wheel twine
 uv build --wheel


### PR DESCRIPTION
Add `uv` installation checks to `test`, `lint`, `install`, and `upload_package.sh` scripts to immediately error and exit if `uv` is not found.

---
<a href="https://cursor.com/background-agent?bcId=bc-603586fd-f352-4514-9a7e-794269e3f890">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-603586fd-f352-4514-9a7e-794269e3f890">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

