### PR TITLE
Add an embedded wasm runner to clud

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +153,7 @@ dependencies = [
  "serde",
  "serde_json",
  "terminal_size",
+ "wasmi",
  "which",
 ]
 
@@ -229,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,10 +263,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -280,6 +324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +353,12 @@ version = "2.0.0"
 dependencies = [
  "serde_json",
 ]
+
+[[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
 
 [[package]]
 name = "nix"
@@ -520,6 +576,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "string-interner"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3275464d7a9f2d4cac57c89c2ef96a8524dba2864c8d6f82e3980baf136f9b"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +690,60 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasmi"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
+dependencies = [
+ "arrayvec",
+ "multi-stash",
+ "smallvec",
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80d6b275b1c922021939d561574bf376613493ae2b61c6963b15db0e8813562"
+dependencies = [
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8c51482cc32d31c2c7ff211cd2bedd73c5bd057ba16a2ed0110e7a96097c33"
+dependencies = [
+ "downcast-rs",
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e431a14c186db59212a88516788bd68ed51f87aa1e08d1df742522867b5289a"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.221.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
+dependencies = [
+ "bitflags 2.11.0",
+ "indexmap",
+]
 
 [[package]]
 name = "which"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ clud --safe -p "drop the table"   # Disable YOLO mode (keeps permission prompts)
 clud --dry-run -p "hello"         # Print what would run without executing
 echo "explain this error" | clud  # Pipe mode: read prompt from stdin
 clud -- --verbose --debug         # Pass extra flags through to the backend
+clud wasm guest.wasm              # Run a local wasm module with clud's embedded runtime
 ```
 
 ### Flags
@@ -92,6 +93,15 @@ Runs lint, test, cleanup, then commits.
 
 ```bash
 clud up
+```
+
+## `clud wasm` â€” Embedded Runtime
+
+Loads a local `.wasm` module, wires up a host logging import, and invokes an exported function.
+
+```bash
+clud wasm hello.wasm
+clud wasm hello.wasm --invoke _start
 ```
 
 ## Development

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -15,6 +15,7 @@ running-process-core = "3.0.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 terminal_size = "0.4"
+wasmi = "0.40.0"
 which = "7"
 
 [[bin]]

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -49,7 +49,7 @@ pub struct Args {
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
-    /// Subcommands: loop, up, rebase, fix.
+    /// Subcommands: loop, up, rebase, fix, wasm.
     #[command(subcommand)]
     pub command: Option<Command>,
 
@@ -88,6 +88,16 @@ pub enum Command {
     Fix {
         /// Optional GitHub URL to fetch logs from (e.g., actions run or PR URL).
         url: Option<String>,
+    },
+
+    /// Execute a local wasm module using clud's embedded runtime.
+    Wasm {
+        /// Path to the `.wasm` module.
+        module: String,
+
+        /// Exported function to invoke (default: run).
+        #[arg(long = "invoke", default_value = "run")]
+        invoke: String,
     },
 }
 
@@ -138,7 +148,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V"];
     // Known subcommands
-    let subcommands: &[&str] = &["loop", "up", "rebase", "fix"];
+    let subcommands: &[&str] = &["loop", "up", "rebase", "fix", "wasm"];
 
     // Once we hit a subcommand, everything after is known (clap handles it)
     let mut in_subcommand = false;
@@ -369,6 +379,36 @@ mod tests {
                 );
             }
             _ => panic!("expected Fix subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_wasm_subcommand() {
+        let args = parse(&["clud", "wasm", "guest.wasm"]);
+        match args.command {
+            Some(Command::Wasm {
+                ref module,
+                ref invoke,
+            }) => {
+                assert_eq!(module, "guest.wasm");
+                assert_eq!(invoke, "run");
+            }
+            _ => panic!("expected Wasm subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_wasm_subcommand_custom_entrypoint() {
+        let args = parse(&["clud", "wasm", "guest.wasm", "--invoke", "_start"]);
+        match args.command {
+            Some(Command::Wasm {
+                ref module,
+                ref invoke,
+            }) => {
+                assert_eq!(module, "guest.wasm");
+                assert_eq!(invoke, "_start");
+            }
+            _ => panic!("expected Wasm subcommand"),
         }
     }
 

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -129,6 +129,9 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
             cmd.push("-p".to_string());
             cmd.push(prompt);
         }
+        Some(Command::Wasm { .. }) => {
+            unreachable!("wasm execution is handled directly in main")
+        }
         None => {
             // Direct flags
             if let Some(ref prompt) = args.prompt {

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -159,7 +159,15 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
         loop {
             match process.poll() {
                 Ok(Some(code)) => {
+                    if interrupted.load(Ordering::SeqCst) {
+                        eprintln!("[clud] interrupted via Ctrl+C");
+                        return 130;
+                    }
                     last_exit = code;
+                    if interrupted.load(Ordering::SeqCst) {
+                        eprintln!("[clud] interrupted via Ctrl+C (pty)");
+                        return 130;
+                    }
                     if last_exit != 0 && plan.iterations > 1 {
                         eprintln!(
                             "[clud] iteration {} failed with exit code {}",
@@ -260,6 +268,10 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
             if let Ok(Some(code)) =
                 running_process_core::pty::poll_pty_process(&process.handles, &process.returncode)
             {
+                if interrupted.load(Ordering::SeqCst) {
+                    eprintln!("[clud] interrupted via Ctrl+C (pty)");
+                    return 130;
+                }
                 last_exit = code;
                 if last_exit != 0 && plan.iterations > 1 {
                     eprintln!(

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -2,6 +2,7 @@ mod args;
 mod backend;
 mod command;
 mod trampoline;
+mod wasm;
 
 use std::io::{self, Read};
 use std::sync::{
@@ -24,6 +25,26 @@ fn main() {
         let mut input = String::new();
         if io::stdin().read_to_string(&mut input).is_ok() && !input.trim().is_empty() {
             args.prompt = Some(input.trim().to_string());
+        }
+    }
+
+    if let Some(args::Command::Wasm { module, invoke }) = &args.command {
+        if args.dry_run {
+            let json = serde_json::json!({
+                "mode": "wasm",
+                "module": module,
+                "invoke": invoke,
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+            std::process::exit(0);
+        }
+
+        match wasm::run_file(module, invoke) {
+            Ok(code) => std::process::exit(code),
+            Err(error) => {
+                eprintln!("error: {error}");
+                std::process::exit(1);
+            }
         }
     }
 

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -122,6 +122,15 @@ fn get_terminal_size() -> (u16, u16) {
     }
 }
 
+fn normalize_exit_code(code: i32) -> i32 {
+    match code {
+        -2 => 130,
+        -9 => 137,
+        -15 => 143,
+        _ => code,
+    }
+}
+
 fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicBool) -> i32 {
     use running_process_core::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
 
@@ -164,10 +173,6 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
                         return 130;
                     }
                     last_exit = code;
-                    if interrupted.load(Ordering::SeqCst) {
-                        eprintln!("[clud] interrupted via Ctrl+C (pty)");
-                        return 130;
-                    }
                     if last_exit != 0 && plan.iterations > 1 {
                         eprintln!(
                             "[clud] iteration {} failed with exit code {}",
@@ -248,7 +253,7 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
                 Err(_) => {
                     // PTY stream closed — child exited.  Reap exit code.
                     match process.wait_impl(Some(1.0)) {
-                        Ok(code) => last_exit = code,
+                        Ok(code) => last_exit = normalize_exit_code(code),
                         Err(_) => last_exit = 1,
                     }
                     if last_exit != 0 && plan.iterations > 1 {
@@ -272,7 +277,7 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
                     eprintln!("[clud] interrupted via Ctrl+C (pty)");
                     return 130;
                 }
-                last_exit = code;
+                last_exit = normalize_exit_code(code);
                 if last_exit != 0 && plan.iterations > 1 {
                     eprintln!(
                         "[clud] iteration {} failed with exit code {}",
@@ -287,7 +292,7 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
             if interrupted.load(Ordering::SeqCst) {
                 let _ = process.send_interrupt_impl();
                 match process.wait_impl(Some(2.0)) {
-                    Ok(code) => last_exit = code,
+                    Ok(code) => last_exit = normalize_exit_code(code),
                     Err(_) => {
                         let _ = process.close_impl();
                         last_exit = 130;

--- a/crates/clud-bin/src/wasm.rs
+++ b/crates/clud-bin/src/wasm.rs
@@ -1,0 +1,102 @@
+use std::fmt;
+use std::path::Path;
+
+use wasmi::{Caller, Engine, Extern, Linker, Module, Store};
+
+#[derive(Default)]
+struct HostState {
+    stdout: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct WasmRuntimeError(String);
+
+impl fmt::Display for WasmRuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for WasmRuntimeError {}
+
+impl From<std::io::Error> for WasmRuntimeError {
+    fn from(value: std::io::Error) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<wasmi::Error> for WasmRuntimeError {
+    fn from(value: wasmi::Error) -> Self {
+        Self(value.to_string())
+    }
+}
+
+pub fn run_file(module_path: &str, invoke: &str) -> Result<i32, WasmRuntimeError> {
+    let wasm = std::fs::read(module_path)?;
+    run_bytes(module_path, &wasm, invoke)
+}
+
+fn run_bytes(module_path: &str, wasm: &[u8], invoke: &str) -> Result<i32, WasmRuntimeError> {
+    let engine = Engine::default();
+    let module = Module::new(&engine, wasm)
+        .map_err(|error| WasmRuntimeError(format!("failed to load '{module_path}': {error}")))?;
+    let mut store = Store::new(&engine, HostState::default());
+    let mut linker = Linker::new(&engine);
+
+    linker
+        .func_wrap(
+            "host",
+            "log",
+            |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> Result<(), wasmi::Error> {
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(Extern::into_memory)
+                    .ok_or_else(|| wasmi::Error::new("guest did not export memory"))?;
+                let start = usize::try_from(ptr)
+                    .map_err(|_| wasmi::Error::new("host.log received a negative pointer"))?;
+                let byte_len = usize::try_from(len)
+                    .map_err(|_| wasmi::Error::new("host.log received a negative length"))?;
+                let end = start
+                    .checked_add(byte_len)
+                    .ok_or_else(|| wasmi::Error::new("host.log pointer overflow"))?;
+                let bytes = {
+                    let data = memory.data(&caller);
+                    let range = data
+                        .get(start..end)
+                        .ok_or_else(|| wasmi::Error::new("host.log pointer was out of bounds"))?;
+                    range.to_vec()
+                };
+                caller.data_mut().stdout.extend_from_slice(&bytes);
+                Ok(())
+            },
+        )
+        .map_err(|error| WasmRuntimeError(format!("failed to register host imports: {error}")))?;
+
+    let pre = linker
+        .instantiate(&mut store, &module)
+        .map_err(|error| WasmRuntimeError(format!("failed to instantiate guest: {error}")))?;
+    let instance = pre
+        .start(&mut store)
+        .map_err(|error| WasmRuntimeError(format!("failed to start guest: {error}")))?;
+    let exit_code = if let Ok(function) = instance.get_typed_func::<(), i32>(&store, invoke) {
+        function.call(&mut store, ()).map_err(|error| {
+            WasmRuntimeError(format!("wasm function '{invoke}' failed: {error}"))
+        })?
+    } else if let Ok(function) = instance.get_typed_func::<(), ()>(&store, invoke) {
+        function.call(&mut store, ()).map_err(|error| {
+            WasmRuntimeError(format!("wasm function '{invoke}' failed: {error}"))
+        })?;
+        0
+    } else {
+        return Err(WasmRuntimeError(format!(
+            "failed to resolve exported zero-argument function '{invoke}' in '{}'",
+            Path::new(module_path).display()
+        )));
+    };
+    let output = String::from_utf8_lossy(&store.data().stdout);
+    if !output.is_empty() {
+        print!("{output}");
+    }
+
+    Ok(exit_code)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,13 @@ Repository = "https://github.com/zackees/clud"
 Issues = "https://github.com/zackees/clud/issues"
 
 [dependency-groups]
-dev = ["maturin[zig]>=1.7,<2", "pytest>=8.0.0", "pytest-cov>=6.0.0", "ruff>=0.8.0"]
+dev = [
+    "maturin[zig]>=1.7,<2",
+    "pytest>=8.0.0",
+    "pytest-cov>=6.0.0",
+    "ruff>=0.8.0",
+    "ziglang>=0.15.2,<0.16",
+]
 
 [tool.maturin]
 manifest-path = "crates/clud-bin/Cargo.toml"

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -1,0 +1,81 @@
+"""End-to-end unit test for the embedded wasm runtime."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _clud_binary() -> str:
+    """Find the clud binary in the venv."""
+    venv = Path(sys.executable).parent
+    if sys.platform == "win32":
+        candidate = venv / "clud.exe"
+    else:
+        candidate = venv / "clud"
+    if candidate.is_file():
+        return str(candidate)
+    return "clud"
+
+
+CLUD = _clud_binary()
+
+
+def _compile_cpp_to_wasm(source: Path, output: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ziglang",
+            "c++",
+            "-target",
+            "wasm32-freestanding",
+            "-O2",
+            "-nostdlib",
+            "-fno-exceptions",
+            "-fno-rtti",
+            "-Wl,--no-entry",
+            "-Wl,--export=run",
+            "-Wl,--export-memory",
+            "-Wl,--initial-memory=2097152",
+            "-o",
+            str(output),
+            str(source),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_wasm_cpp_hello_world(tmp_path: Path) -> None:
+    source = tmp_path / "hello.cpp"
+    output = tmp_path / "hello.wasm"
+    source.write_text(
+        """
+extern "C" __attribute__((import_module("host"), import_name("log")))
+void host_log(const char* ptr, int len);
+
+extern "C" __attribute__((export_name("run")))
+int run() {
+    static const char msg[] = "hello from wasm";
+    host_log(msg, 15);
+    return 0;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    compile_result = _compile_cpp_to_wasm(source, output)
+    assert compile_result.returncode == 0, compile_result.stderr or compile_result.stdout
+
+    result = subprocess.run(
+        [CLUD, "wasm", str(output)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "hello from wasm" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ziglang" },
 ]
 
 [package.metadata]
@@ -23,6 +24,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "ziglang", specifier = ">=0.15.2,<0.16" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a local `clud wasm <module>` execution path backed by an embedded `wasmi` runtime
- expose a simple `host.log` import and invoke exported zero-argument guest functions with `i32` or `()` return types
- add a red-to-green end-to-end unit test that writes a C++ hello-world guest, compiles it to wasm with Zig, and runs it through `clud`

Closes #15.

## Testing
- `uv run --no-editable -m ci.lint`
- `uv run --no-editable -m ci.test`