### PR TITLE
Release 2.0.1 and fix Claude PTY cwd propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "clap",
  "ctrlc",
@@ -299,7 +299,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mock-agent"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "serde_json",
 ]
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.0.15"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5742e1311612581d0e1a5e720d2bdc2dd24ed56c67f4293f60e3016e1bd21d44"
+checksum = "981f9b790e0737a122aea2d0a9f5735163995223c8dcad1ec2e846d3685aefce"
 dependencies = [
  "libc",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -11,7 +11,7 @@ description = "Fast CLI for running Claude Code and Codex in YOLO mode"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
-running-process-core = "3.0.15"
+running-process-core = "3.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 terminal_size = "0.4"

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -84,6 +84,7 @@ pub struct LaunchPlan {
     pub command: Vec<String>,
     pub iterations: u32,
     pub backend: Backend,
+    pub cwd: Option<String>,
 }
 
 /// Build the command to execute for the given args and backend.
@@ -158,6 +159,9 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         command: cmd,
         iterations,
         backend,
+        cwd: std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.to_string_lossy().to_string()),
     }
 }
 

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -102,6 +102,8 @@ fn get_terminal_size() -> (u16, u16) {
 }
 
 fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicBool) -> i32 {
+    use std::path::PathBuf;
+
     use running_process_core::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
 
     let env = child_env();
@@ -118,7 +120,7 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
 
         let config = ProcessConfig {
             command: CommandSpec::Argv(plan.command.clone()),
-            cwd: None,
+            cwd: plan.cwd.as_ref().map(PathBuf::from),
             env: Some(env.clone()),
             capture: false,
             stderr_mode: StderrMode::Stdout,
@@ -187,7 +189,7 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
 
         let process = match NativePtyProcess::new(
             plan.command.clone(),
-            None,
+            plan.cwd.clone(),
             Some(env.clone()),
             rows,
             cols,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "clud"
-version = "2.0.0"
+version = "2.0.1"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clud/__init__.py
+++ b/src/clud/__init__.py
@@ -1,3 +1,3 @@
 """clud — Fast Rust CLI for running Claude Code and Codex in YOLO mode."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/testbins/mock-agent/src/main.rs
+++ b/testbins/mock-agent/src/main.rs
@@ -57,6 +57,9 @@ fn main() {
     // Capture env vars relevant for testing
     let in_clud = std::env::var("IN_CLUD").ok();
     let originator = std::env::var("RUNNING_PROCESS_ORIGINATOR").ok();
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|path| path.to_string_lossy().to_string());
 
     if sleep_ms > 0 {
         std::thread::sleep(Duration::from_millis(sleep_ms));
@@ -69,6 +72,7 @@ fn main() {
         "stdin": stdin_content,
         "exit_code": exit_code,
         "sleep_ms": sleep_ms,
+        "cwd": cwd,
         "env": {
             "IN_CLUD": in_clud,
             "RUNNING_PROCESS_ORIGINATOR": originator,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,13 +15,32 @@ ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 def _find_clud() -> Path:
-    """Find the clud binary in the venv."""
-    venv = Path(sys.executable).parent
-    name = "clud.exe" if sys.platform == "win32" else "clud"
-    candidate = venv / name
-    if candidate.is_file():
-        return candidate
-    raise FileNotFoundError(f"clud binary not found at {candidate}")
+    """Build the current repo's clud binary and return its path."""
+    result = subprocess.run(
+        ["cargo", "build", "-p", "clud", "--message-format=json"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to build clud:\n{result.stderr}")
+
+    import json
+
+    for line in result.stdout.splitlines():
+        msg = json.loads(line)
+        if (
+            msg.get("reason") == "compiler-artifact"
+            and msg.get("target", {}).get("name") == "clud"
+            and msg.get("executable")
+        ):
+            return Path(msg["executable"])
+
+    ext = ".exe" if sys.platform == "win32" else ""
+    fallback = ROOT / "target" / "debug" / f"clud{ext}"
+    if fallback.is_file():
+        return fallback
+    raise RuntimeError("clud binary not found after build")
 
 
 def _build_mock_agent() -> Path:
@@ -94,7 +113,7 @@ def mock_env(mock_agent_binary: Path, tmp_path: Path) -> dict[str, str]:
 
 @pytest.fixture
 def clud_binary() -> Path:
-    """Return the path to the installed clud binary."""
+    """Return the path to the current repo's clud binary."""
     return _find_clud()
 
 

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -31,15 +33,20 @@ def _run(
     *args: str,
     env: dict[str, str],
     input_data: str | None = None,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [str(clud), *args],
-        capture_output=True,
-        text=True,
-        timeout=_TIMEOUT,
-        env=env,
-        input=input_data,
-    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        launch = Path(temp_dir) / clud.name
+        shutil.copy2(clud, launch)
+        return subprocess.run(
+            [str(launch), *args],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT,
+            env=env,
+            input=input_data,
+            cwd=cwd,
+        )
 
 
 def _parse_agent_report(result: subprocess.CompletedProcess[str]) -> dict:
@@ -78,6 +85,26 @@ class TestBackendSelection:
         assert result.returncode == 0
         report = _parse_agent_report(result)
         assert "claude" in report["program"].lower()
+
+    def test_codex_preserves_cwd(self, clud_binary: Path, mock_env: dict[str, str]) -> None:
+        result = _run(clud_binary, "--codex", "-p", "hello", env=mock_env)
+        assert result.returncode == 0
+        report = _parse_agent_report(result)
+        assert report["cwd"] == str(Path.cwd())
+
+    def test_claude_preserves_cwd(self, clud_binary: Path, mock_env: dict[str, str]) -> None:
+        result = _run(clud_binary, "--claude", "-p", "hello", env=mock_env)
+        assert result.returncode == 0
+        report = _parse_agent_report(result)
+        assert report["cwd"] == str(Path.cwd())
+
+    def test_claude_preserves_explicit_launch_cwd(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        result = _run(clud_binary, "--claude", "-p", "hello", env=mock_env, cwd=tmp_path)
+        assert result.returncode == 0
+        report = _parse_agent_report(result)
+        assert report["cwd"] == str(tmp_path)
 
 
 class TestYoloMode:

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -3,34 +3,57 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
 def _clud_binary() -> str:
-    """Find the clud binary in the venv."""
-    venv = Path(sys.executable).parent
-    if sys.platform == "win32":
-        candidate = venv / "clud.exe"
-    else:
-        candidate = venv / "clud"
-    if candidate.is_file():
-        return str(candidate)
-    return "clud"
+    """Build the current repo's clud binary and return its path."""
+    root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        ["cargo", "build", "-p", "clud", "--message-format=json"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to build clud:\n{result.stderr}")
+
+    for line in result.stdout.splitlines():
+        msg = json.loads(line)
+        if (
+            msg.get("reason") == "compiler-artifact"
+            and msg.get("target", {}).get("name") == "clud"
+            and msg.get("executable")
+        ):
+            return msg["executable"]
+
+    ext = ".exe" if sys.platform == "win32" else ""
+    fallback = root / "target" / "debug" / f"clud{ext}"
+    if fallback.is_file():
+        return str(fallback)
+    raise RuntimeError("clud binary not found after build")
 
 
 CLUD = _clud_binary()
 
 
 def _run(*args: str, input_data: str | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [CLUD, *args],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        input=input_data,
-    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source = Path(CLUD)
+        launch = Path(temp_dir) / source.name
+        shutil.copy2(source, launch)
+        return subprocess.run(
+            [str(launch), *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            input=input_data,
+        )
 
 
 def test_help() -> None:
@@ -46,7 +69,7 @@ def test_version() -> None:
     result = _run("--version")
     assert result.returncode == 0
     assert "clud" in result.stdout
-    assert "2.0.0" in result.stdout
+    assert "2.0.1" in result.stdout
 
 
 def test_dry_run_prompt() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- bump clud from 2.0.0 to 2.0.1 and update `running-process-core` to 3.1.0
- preserve the caller cwd for both subprocess and PTY launches so Claude starts in the requested working directory
- make the Python test harness build and execute the current repo binary from disposable copies, and extend the mock agent to report cwd

## Verification
- `uvx soldr cargo test --workspace`
- `python -m pytest tests/test_hello.py`
- `python -m pytest -m integration tests/integration/test_mock_agents.py`