### PR TITLE
Add detachable daemon session workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ clud --codex                      # Use Codex as the backend
 clud --claude                     # Use Claude as the backend (default)
 clud --pty                        # Force PTY launch mode
 clud --subprocess                 # Force subprocess launch mode
+clud --detach -p "review this PR" # Start a daemon-managed session without attaching
+clud --detachable -p "fix CI"     # Ctrl+C detaches; reattach later with clud attach
 clud -c                           # Continue the most recent conversation
 clud --resume                     # Resume a session
 clud --resume abc123              # Resume a specific session by ID or search term
@@ -39,6 +41,9 @@ clud --safe -p "drop the table"   # Disable YOLO mode (keeps permission prompts)
 clud --dry-run -p "hello"         # Print what would run without executing
 echo "explain this error" | clud  # Pipe mode: read prompt from stdin
 clud -- --verbose --debug         # Pass extra flags through to the backend
+clud attach                       # List attachable daemon-managed sessions
+clud attach sess-123              # Attach to a specific session
+clud list                         # Show attachable session IDs, PIDs, and cwd
 clud wasm guest.wasm              # Run a local wasm module with clud's embedded runtime
 ```
 
@@ -54,6 +59,8 @@ clud wasm guest.wasm              # Run a local wasm module with clud's embedded
 | `--codex` | Use Codex as the backend |
 | `--subprocess` | Force subprocess launch mode |
 | `--pty` | Force PTY launch mode |
+| `--detach` | Start a daemon-managed session and exit after printing the session ID |
+| `--detachable` | Run attached under the daemon; `Ctrl+C` detaches instead of interrupting |
 | `--model <NAME>` | Set model preference (e.g., haiku, sonnet, opus) |
 | `--safe` | Disable YOLO mode (don't inject `--dangerously-skip-permissions`) |
 | `--dry-run` | Print what would be executed, then exit |
@@ -65,6 +72,22 @@ Unknown flags are forwarded directly to the backend agent.
 
 `clud` now defaults to subprocess launch mode for Claude and Codex. Use `--pty`
 to opt back into PTY while Claude PTY issues are being investigated.
+
+## Detached Sessions
+
+Use daemon-managed sessions when you want to disconnect and reattach later.
+
+```bash
+clud --detachable --codex -p "refactor the parser"
+# press Ctrl+C to detach
+
+clud attach
+clud attach sess-123
+clud list
+```
+
+`clud attach` without a session ID lists live attachable sessions. `clud list`
+shows the same sessions with their root PID and current working directory.
 
 ## Voice Mode
 

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -43,6 +43,12 @@ pub struct Args {
     #[arg(long = "dry-run")]
     pub dry_run: bool,
 
+    #[arg(long = "detach", conflicts_with = "dry_run")]
+    pub detach: bool,
+
+    #[arg(long = "detachable", conflicts_with = "dry_run")]
+    pub detachable: bool,
+
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
@@ -81,10 +87,10 @@ pub enum Command {
         #[arg(long = "invoke", default_value = "run")]
         invoke: String,
     },
-    #[command(hide = true)]
     Attach {
-        session_id: String,
+        session_id: Option<String>,
     },
+    List,
     #[command(name = "__daemon", hide = true)]
     InternalDaemon {
         #[arg(long = "state-dir")]
@@ -139,6 +145,8 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--pty",
         "--safe",
         "--dry-run",
+        "--detach",
+        "--detachable",
         "--verbose",
         "--experimental-daemon-centralized",
         "--help",
@@ -146,7 +154,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V"];
     let subcommands: &[&str] = &[
-        "loop", "up", "rebase", "fix", "wasm", "attach", "__daemon", "__worker",
+        "loop", "up", "rebase", "fix", "wasm", "attach", "list", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;
@@ -278,6 +286,20 @@ mod tests {
     fn test_dry_run() {
         let args = parse(&["clud", "--dry-run", "-p", "hello"]);
         assert!(args.dry_run);
+    }
+
+    #[test]
+    fn test_detach_flag() {
+        let args = parse(&["clud", "--detach", "-p", "hello"]);
+        assert!(args.detach);
+        assert!(!args.detachable);
+    }
+
+    #[test]
+    fn test_detachable_flag() {
+        let args = parse(&["clud", "--detachable", "-p", "hello"]);
+        assert!(args.detachable);
+        assert!(!args.detach);
     }
 
     #[test]
@@ -422,6 +444,34 @@ mod tests {
     }
 
     #[test]
+    fn test_attach_without_session_id() {
+        let args = parse(&["clud", "attach"]);
+        match args.command {
+            Some(Command::Attach { session_id }) => {
+                assert!(session_id.is_none());
+            }
+            _ => panic!("expected Attach subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_attach_with_session_id() {
+        let args = parse(&["clud", "attach", "sess-123"]);
+        match args.command {
+            Some(Command::Attach { session_id }) => {
+                assert_eq!(session_id.as_deref(), Some("sess-123"));
+            }
+            _ => panic!("expected Attach subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_list_subcommand() {
+        let args = parse(&["clud", "list"]);
+        assert!(matches!(args.command, Some(Command::List)));
+    }
+
+    #[test]
     fn test_unknown_flags_passthrough() {
         let args = parse(&["clud", "--some-unknown-flag", "-p", "hello"]);
         assert_eq!(args.prompt.as_deref(), Some("hello"));
@@ -453,6 +503,8 @@ mod tests {
         assert!(!args.pty);
         assert!(!args.safe);
         assert!(!args.dry_run);
+        assert!(!args.detach);
+        assert!(!args.detachable);
         assert!(args.command.is_none());
         assert!(args.passthrough.is_empty());
     }

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -127,6 +127,7 @@ pub fn build_launch_plan(
             unreachable!("wasm execution is handled directly in main")
         }
         Some(Command::Attach { .. })
+        | Some(Command::List)
         | Some(Command::InternalDaemon { .. })
         | Some(Command::InternalWorker { .. }) => {}
         None => {

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -44,6 +44,10 @@ struct DaemonInfo {
 struct SessionSnapshot {
     id: String,
     kind: SessionKind,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    detachable: bool,
     daemon_pid: u32,
     worker_pid: u32,
     worker_port: u16,
@@ -55,6 +59,8 @@ struct SessionSnapshot {
 struct WorkerLaunchSpec {
     plan: LaunchPlan,
     kind: SessionKind,
+    #[serde(default)]
+    detachable: bool,
     rows: u16,
     cols: u16,
 }
@@ -313,7 +319,9 @@ impl Drop for RawTerminalGuard {
 }
 
 pub fn experimental_enabled(args: &Args) -> bool {
-    args.experimental_daemon_centralized
+    args.detach
+        || args.detachable
+        || args.experimental_daemon_centralized
         || std::env::var(ENV_FEATURE_FLAG)
             .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
             .unwrap_or(false)
@@ -321,9 +329,15 @@ pub fn experimental_enabled(args: &Args) -> bool {
 
 pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i32> {
     match &args.command {
-        Some(Command::Attach { session_id }) => {
+        Some(Command::Attach {
+            session_id: Some(session_id),
+        }) => {
             let state_dir = state_dir(args);
             Some(run_attach(session_id, &state_dir, interrupted))
+        }
+        Some(Command::Attach { session_id: None }) | Some(Command::List) => {
+            let state_dir = state_dir(args);
+            Some(run_list(&state_dir))
         }
         Some(Command::InternalDaemon { state_dir }) => Some(run_daemon(state_dir)),
         Some(Command::InternalWorker {
@@ -352,6 +366,7 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         spec: WorkerLaunchSpec {
             plan: plan.clone(),
             kind,
+            detachable: args.detach || args.detachable,
             rows,
             cols,
         },
@@ -367,7 +382,11 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
     match response {
         DaemonResponse::Created { session } => {
             eprintln!("[clud] daemon session {}", session.id);
-            attach_to_session(&session, interrupted)
+            if args.detach {
+                0
+            } else {
+                attach_to_session(&session, interrupted)
+            }
         }
         DaemonResponse::Error { message } => {
             eprintln!("[clud] daemon error: {}", message);
@@ -526,7 +545,7 @@ fn attach_to_session(session: &SessionSnapshot, interrupted: &AtomicBool) -> i32
         && io::stdin().is_terminal()
         && io::stdout().is_terminal()
     {
-        run_remote_interactive(Arc::clone(&writer), interrupted)
+        run_remote_interactive(Arc::clone(&writer), interrupted, session.detachable)
     } else {
         while !interrupted.load(Ordering::SeqCst)
             && exit_code
@@ -537,13 +556,18 @@ fn attach_to_session(session: &SessionSnapshot, interrupted: &AtomicBool) -> i32
             thread::sleep(Duration::from_millis(25));
         }
         if interrupted.load(Ordering::SeqCst) {
-            let _ = send_worker_message(&writer, &WorkerClientMessage::Interrupt);
+            if !session.detachable {
+                let _ = send_worker_message(&writer, &WorkerClientMessage::Interrupt);
+            }
             130
         } else {
             0
         }
     };
 
+    if session.detachable && local_result == 130 {
+        let _ = shutdown_worker_connection(&writer);
+    }
     let _ = reader.join();
     let final_exit_code = exit_code
         .lock()
@@ -552,7 +576,11 @@ fn attach_to_session(session: &SessionSnapshot, interrupted: &AtomicBool) -> i32
     final_exit_code
 }
 
-fn run_remote_interactive(writer: Arc<Mutex<TcpStream>>, interrupted: &AtomicBool) -> i32 {
+fn run_remote_interactive(
+    writer: Arc<Mutex<TcpStream>>,
+    interrupted: &AtomicBool,
+    detachable: bool,
+) -> i32 {
     let _guard = match RawTerminalGuard::enter() {
         Ok(guard) => guard,
         Err(err) => {
@@ -565,7 +593,9 @@ fn run_remote_interactive(writer: Arc<Mutex<TcpStream>>, interrupted: &AtomicBoo
     };
     loop {
         if interrupted.load(Ordering::SeqCst) {
-            let _ = send_worker_message(&writer, &WorkerClientMessage::Interrupt);
+            if !detachable {
+                let _ = send_worker_message(&writer, &WorkerClientMessage::Interrupt);
+            }
             return 130;
         }
         match event::poll(Duration::from_millis(25)) {
@@ -582,6 +612,9 @@ fn run_remote_interactive(writer: Arc<Mutex<TcpStream>>, interrupted: &AtomicBoo
                         );
                     }
                     KeyAction::Interrupt => {
+                        if detachable {
+                            return 130;
+                        }
                         let _ = send_worker_message(&writer, &WorkerClientMessage::Interrupt);
                     }
                     KeyAction::Ignore => {}
@@ -770,6 +803,8 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
     let snapshot = SessionSnapshot {
         id: session_id.to_string(),
         kind: spec.kind.clone(),
+        cwd: spec.plan.cwd.clone(),
+        detachable: spec.detachable,
         daemon_pid,
         worker_pid: std::process::id(),
         worker_port,
@@ -1116,6 +1151,11 @@ fn send_worker_message(
     write_json_line(&mut guard, message)
 }
 
+fn shutdown_worker_connection(writer: &Arc<Mutex<TcpStream>>) -> io::Result<()> {
+    let guard = writer.lock().expect("writer mutex poisoned");
+    guard.shutdown(Shutdown::Both)
+}
+
 fn persist_snapshot(
     state_dir: &Path,
     session_id: &str,
@@ -1168,6 +1208,52 @@ fn session_snapshot_path(state_dir: &Path, session_id: &str) -> PathBuf {
 
 fn spec_path(state_dir: &Path, session_id: &str) -> PathBuf {
     specs_dir(state_dir).join(format!("{session_id}.json"))
+}
+
+fn run_list(state_dir: &Path) -> i32 {
+    let sessions = list_attachable_sessions(state_dir);
+    if sessions.is_empty() {
+        println!("No attachable sessions.");
+        return 0;
+    }
+
+    println!("SESSION ID\tPID\tCWD");
+    for session in sessions {
+        let pid = session
+            .root_pid
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let cwd = session.cwd.unwrap_or_else(|| "-".to_string());
+        println!("{}\t{}\t{}", session.id, pid, cwd);
+    }
+    0
+}
+
+fn list_attachable_sessions(state_dir: &Path) -> Vec<SessionSnapshot> {
+    let Ok(entries) = fs::read_dir(sessions_dir(state_dir)) else {
+        return Vec::new();
+    };
+    let mut sessions = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(session) = read_json_file::<SessionSnapshot>(&path) else {
+            continue;
+        };
+        if session.exit_code.is_some() {
+            continue;
+        }
+        if let Some(root_pid) = session.root_pid {
+            if !pid_is_alive(root_pid) {
+                continue;
+            }
+        }
+        sessions.push(session);
+    }
+    sessions.sort_by(|left, right| left.id.cmp(&right.id));
+    sessions
 }
 
 fn write_json_line<T: Serialize>(writer: &mut TcpStream, value: &T) -> io::Result<()> {

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -23,6 +23,12 @@ def _daemon_env(mock_env: dict[str, str], state_dir: Path) -> dict[str, str]:
     return env
 
 
+def _managed_env(mock_env: dict[str, str], state_dir: Path) -> dict[str, str]:
+    env = mock_env.copy()
+    env["CLUD_DAEMON_STATE_DIR"] = str(state_dir)
+    return env
+
+
 def _read_session_id(proc: subprocess.Popen[str], timeout: float = 10.0) -> str:
     assert proc.stderr is not None
     deadline = time.time() + timeout
@@ -33,6 +39,13 @@ def _read_session_id(proc: subprocess.Popen[str], timeout: float = 10.0) -> str:
         if proc.poll() is not None:
             raise AssertionError(f"clud exited early while waiting for session id: {line!r}")
     raise AssertionError("timed out waiting for daemon session id")
+
+
+def _read_session_id_from_text(stderr: str) -> str:
+    for line in stderr.splitlines():
+        if "daemon session" in line:
+            return line.strip().rsplit(" ", 1)[-1]
+    raise AssertionError(f"daemon session id not found in stderr: {stderr!r}")
 
 
 def _wait_for_file(path: Path, timeout: float = 10.0) -> None:
@@ -120,6 +133,200 @@ def _launch_daemonized(
     )
     session_id = _read_session_id(proc)
     return proc, session_id
+
+
+def _launch_detached(
+    clud_binary: Path,
+    env: dict[str, str],
+    *args: str,
+    cwd: Path | None = None,
+) -> tuple[subprocess.Popen[str], str]:
+    proc = subprocess.Popen(
+        [str(clud_binary), "--detach", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=cwd,
+    )
+    session_id = _read_session_id(proc)
+    return proc, session_id
+
+
+def _wait_for_exit(proc: subprocess.Popen[str], timeout: float = 10.0) -> int:
+    return proc.wait(timeout=timeout)
+
+
+def _kill_daemon_for_session(state_dir: Path, session_id: str) -> None:
+    metadata = _session_metadata(state_dir, session_id)
+    _kill_process(metadata["daemon_pid"])
+
+
+class TestDaemonManagedSessionFlags:
+    def test_detach_launch_returns_immediately_and_can_attach(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "hello-detach",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+
+            attached = subprocess.run(
+                [str(clud_binary), "attach", session_id],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                env=env,
+            )
+            assert attached.returncode == 0
+            report = json.loads(attached.stdout)
+            assert "hello-detach" in report["args"]
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_attach_without_session_id_lists_attachable_sessions(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        launch_cwd = tmp_path / "workspace"
+        launch_cwd.mkdir()
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "list-attachable",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+            cwd=launch_cwd,
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+
+            listed = subprocess.run(
+                [str(clud_binary), "attach"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert listed.returncode == 0
+            assert session_id in listed.stdout
+            assert str(launch_cwd) in listed.stdout
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_list_shows_attachable_pid_and_cwd(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        launch_cwd = tmp_path / "workspace"
+        launch_cwd.mkdir()
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "list-session",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+            cwd=launch_cwd,
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+            metadata = _session_metadata(state_dir, session_id)
+
+            listed = subprocess.run(
+                [str(clud_binary), "list"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert listed.returncode == 0
+            assert session_id in listed.stdout
+            assert str(metadata["root_pid"]) in listed.stdout
+            assert str(launch_cwd) in listed.stdout
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_detachable_ctrl_c_detaches_but_keeps_session_alive(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        kwargs: dict[str, object] = {}
+        if sys.platform == "win32":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+        proc = subprocess.Popen(
+            [
+                str(clud_binary),
+                "--detachable",
+                "--codex",
+                "-p",
+                "hello-detachable",
+                "--",
+                "--mock-sleep-ms",
+                "5000",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            **kwargs,
+        )
+
+        try:
+            session_id = _read_session_id(proc)
+            time.sleep(0.5)
+            if sys.platform == "win32":
+                proc.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                proc.send_signal(signal.SIGINT)
+            _wait_for_exit(proc, timeout=10)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        if sys.platform == "win32":
+            assert proc.returncode in (130, 3221225786)
+        else:
+            assert proc.returncode == 130
+
+        metadata = _session_metadata(state_dir, session_id)
+        assert metadata["exit_code"] is None
+        assert metadata["root_pid"] is not None
+        assert _pid_is_alive(metadata["root_pid"])
+
+        try:
+            attached = subprocess.run(
+                [str(clud_binary), "attach", session_id],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                env=env,
+            )
+            assert attached.returncode == 0
+            report = json.loads(attached.stdout)
+            assert "hello-detachable" in report["args"]
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
 
 
 class TestDaemonCentralizedPersistence:


### PR DESCRIPTION
## Summary
- add user-facing daemon session controls with --detach, --detachable, ttach, and list
- persist session cwd/pid metadata so attachable sessions can be discovered and reattached cleanly
- add integration coverage for detached launch, session discovery, and detachable Ctrl+C behavior

## Testing
- python -m ci.lint
- python -m ci.test --integration