### PR TITLE
fix(subprocess): enable VT input for drag-and-drop paste forwarding

### DIFF
--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -151,6 +151,11 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
 
     use running_process_core::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
 
+    // Enable VT input on the console before launching the child.
+    // This allows ANSI sequences (including bracketed paste for drag-and-drop)
+    // to flow through to the child process via inherited stdin.
+    let _console_guard = enable_console_vt_input();
+
     let env = child_env();
     let mut last_exit = 0i32;
 
@@ -277,6 +282,94 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
     }
 
     last_exit
+}
+
+/// RAII guard that restores the original console input mode on drop.
+struct ConsoleVtGuard {
+    #[cfg(windows)]
+    original_mode: Option<u32>,
+}
+
+impl Drop for ConsoleVtGuard {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        if let Some(mode) = self.original_mode {
+            restore_console_mode(mode);
+        }
+    }
+}
+
+/// Enable `ENABLE_VIRTUAL_TERMINAL_INPUT` on the Windows console so ANSI
+/// sequences (bracketed paste, etc.) pass through to the child process.
+/// Returns a guard that restores the original mode on drop.
+/// On non-Windows platforms this is a no-op.
+fn enable_console_vt_input() -> ConsoleVtGuard {
+    #[cfg(windows)]
+    {
+        use std::io::IsTerminal;
+        if !io::stdin().is_terminal() {
+            return ConsoleVtGuard {
+                original_mode: None,
+            };
+        }
+        match set_console_vt_input(true) {
+            Some(original) => ConsoleVtGuard {
+                original_mode: Some(original),
+            },
+            None => ConsoleVtGuard {
+                original_mode: None,
+            },
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        ConsoleVtGuard {}
+    }
+}
+
+#[cfg(windows)]
+fn set_console_vt_input(enable: bool) -> Option<u32> {
+    use std::os::windows::io::AsRawHandle;
+
+    // Windows console mode flag for virtual terminal input processing.
+    const ENABLE_VIRTUAL_TERMINAL_INPUT: u32 = 0x0200;
+
+    extern "system" {
+        fn GetConsoleMode(handle: isize, mode: *mut u32) -> i32;
+        fn SetConsoleMode(handle: isize, mode: u32) -> i32;
+    }
+
+    let handle = io::stdin().as_raw_handle() as isize;
+    unsafe {
+        let mut mode: u32 = 0;
+        if GetConsoleMode(handle, &mut mode) == 0 {
+            return None;
+        }
+        let original = mode;
+        if enable {
+            mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+        } else {
+            mode &= !ENABLE_VIRTUAL_TERMINAL_INPUT;
+        }
+        if SetConsoleMode(handle, mode) == 0 {
+            return None;
+        }
+        Some(original)
+    }
+}
+
+#[cfg(windows)]
+fn restore_console_mode(mode: u32) {
+    use std::os::windows::io::AsRawHandle;
+
+    extern "system" {
+        fn SetConsoleMode(handle: isize, mode: u32) -> i32;
+    }
+
+    let handle = io::stdin().as_raw_handle() as isize;
+    unsafe {
+        SetConsoleMode(handle, mode);
+    }
 }
 
 /// Check if stdin is a terminal (not piped).

--- a/testbins/mock-agent/src/main.rs
+++ b/testbins/mock-agent/src/main.rs
@@ -7,11 +7,12 @@
 //! - Writes received args as JSON to stdout
 //! - Reads stdin if available (for pipe mode testing)
 //! - Exits with the code specified by --mock-exit-code (default 0)
+//! - With --mock-read-stdin-ms, reads stdin for N ms (even if terminal) and reports it
 
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -19,8 +20,10 @@ fn main() {
     // Extract --mock-exit-code if present (our own flag, not forwarded by clud)
     let mut exit_code = 0i32;
     let mut sleep_ms = 0u64;
+    let mut read_stdin_ms = 0u64;
     let mut helper_role: Option<String> = None;
     let mut tree_log: Option<PathBuf> = None;
+    let mut report_file: Option<PathBuf> = None;
     let mut filtered_args: Vec<String> = Vec::new();
     let mut skip_next = false;
     for (i, arg) in args.iter().enumerate().skip(1) {
@@ -42,6 +45,13 @@ fn main() {
             skip_next = true;
             continue;
         }
+        if arg == "--mock-read-stdin-ms" {
+            if let Some(ms) = args.get(i + 1) {
+                read_stdin_ms = ms.parse().unwrap_or(0);
+            }
+            skip_next = true;
+            continue;
+        }
         if arg == "--mock-helper-role" {
             if let Some(role) = args.get(i + 1) {
                 helper_role = Some(role.clone());
@@ -52,6 +62,13 @@ fn main() {
         if arg == "--mock-spawn-tree-log" {
             if let Some(path) = args.get(i + 1) {
                 tree_log = Some(PathBuf::from(path));
+            }
+            skip_next = true;
+            continue;
+        }
+        if arg == "--mock-report-file" {
+            if let Some(path) = args.get(i + 1) {
+                report_file = Some(PathBuf::from(path));
             }
             skip_next = true;
             continue;
@@ -69,8 +86,12 @@ fn main() {
         spawn_helper(&args[0], "child", path, sleep_ms);
     }
 
-    // Read stdin if not a terminal
-    let stdin_content = if !io::stdin().is_terminal() {
+    let stdin_is_terminal = io::stdin().is_terminal();
+
+    // Read stdin: either timed read (--mock-read-stdin-ms) or pipe-mode read
+    let stdin_content = if read_stdin_ms > 0 {
+        read_stdin_timed(read_stdin_ms)
+    } else if !stdin_is_terminal {
         let mut buf = String::new();
         io::stdin().read_to_string(&mut buf).ok();
         if buf.is_empty() {
@@ -99,17 +120,65 @@ fn main() {
         "args": filtered_args,
         "cwd": cwd,
         "stdin": stdin_content,
+        "stdin_is_terminal": stdin_is_terminal,
         "exit_code": exit_code,
         "sleep_ms": sleep_ms,
-        "cwd": cwd,
         "env": {
             "IN_CLUD": in_clud,
             "RUNNING_PROCESS_ORIGINATOR": originator,
         },
     });
-    println!("{}", serde_json::to_string(&report).unwrap());
+
+    let report_str = serde_json::to_string(&report).unwrap();
+    println!("{}", report_str);
+
+    // Also write to file if requested (useful when stdout is captured by PTY)
+    if let Some(path) = report_file {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&path, &report_str);
+    }
 
     std::process::exit(exit_code);
+}
+
+/// Read from stdin for up to `timeout_ms` milliseconds, collecting whatever arrives.
+/// Works regardless of whether stdin is a terminal or pipe.
+fn read_stdin_timed(timeout_ms: u64) -> Option<String> {
+    let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        let stdin = io::stdin();
+        loop {
+            match stdin.lock().read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if tx.send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let mut collected = Vec::new();
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match rx.recv_timeout(remaining) {
+            Ok(data) => collected.extend(data),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    if collected.is_empty() {
+        None
+    } else {
+        Some(String::from_utf8_lossy(&collected).to_string())
+    }
 }
 
 fn run_helper(exe: &str, role: &str, tree_log: Option<&PathBuf>, sleep_ms: u64) {

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -395,3 +395,219 @@ class TestInterruptReporting:
 
         if proc.returncode == 130:
             assert "[clud] interrupted via Ctrl+C (pty)" in stderr
+
+
+class TestStdinForwarding:
+    """Verify stdin data reaches the backend in subprocess mode.
+
+    When clud is launched with an explicit prompt (-p), the pipe-mode stdin
+    detection is skipped.  Any data written to clud's stdin should be
+    inherited by the child process (subprocess mode uses StdinMode::Inherit).
+
+    The mock agent's --mock-read-stdin-ms flag makes it read from stdin for
+    a specified duration and report what it received.
+    """
+
+    def test_subprocess_stdin_forwarding(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        """Data written to clud's stdin reaches the child in subprocess mode."""
+        report_file = tmp_path / "report.json"
+        proc = subprocess.Popen(
+            [
+                str(clud_binary),
+                "-p",
+                "hello",
+                "--",
+                "--mock-read-stdin-ms",
+                "3000",
+                "--mock-report-file",
+                str(report_file),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=mock_env,
+        )
+
+        try:
+            # Give clud time to start the mock agent, then write to stdin
+            time.sleep(0.5)
+            assert proc.stdin is not None
+            proc.stdin.write("dropped-file.txt\n")
+            proc.stdin.flush()
+            proc.stdin.close()
+            stdout, stderr = proc.communicate(timeout=_TIMEOUT)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        assert proc.returncode == 0, f"stderr: {stderr}"
+
+        # Parse report from file (most reliable) or stdout
+        if report_file.exists():
+            report = json.loads(report_file.read_text())
+        else:
+            report = _parse_agent_report(
+                subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout=stdout, stderr=stderr
+                )
+            )
+
+        assert report["stdin"] is not None, "mock agent received no stdin data"
+        assert "dropped-file.txt" in report["stdin"]
+
+    def test_subprocess_stdin_is_not_terminal_when_piped(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        """When test pipes stdin, the child sees a pipe (not a terminal)."""
+        report_file = tmp_path / "report.json"
+        proc = subprocess.Popen(
+            [
+                str(clud_binary),
+                "-p",
+                "hello",
+                "--",
+                "--mock-read-stdin-ms",
+                "1000",
+                "--mock-report-file",
+                str(report_file),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=mock_env,
+        )
+
+        try:
+            assert proc.stdin is not None
+            proc.stdin.close()
+            stdout, stderr = proc.communicate(timeout=_TIMEOUT)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        assert proc.returncode == 0, f"stderr: {stderr}"
+
+        if report_file.exists():
+            report = json.loads(report_file.read_text())
+        else:
+            report = _parse_agent_report(
+                subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout=stdout, stderr=stderr
+                )
+            )
+
+        # With piped stdin, the child should NOT see a terminal
+        assert report["stdin_is_terminal"] is False
+
+    def test_subprocess_multiline_stdin(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        """Multi-line paste (simulated drag-and-drop of multiple files) works."""
+        report_file = tmp_path / "report.json"
+        payload = "file1.txt\nfile2.txt\npath/to/file3.txt\n"
+
+        proc = subprocess.Popen(
+            [
+                str(clud_binary),
+                "-p",
+                "hello",
+                "--",
+                "--mock-read-stdin-ms",
+                "3000",
+                "--mock-report-file",
+                str(report_file),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=mock_env,
+        )
+
+        try:
+            time.sleep(0.5)
+            assert proc.stdin is not None
+            proc.stdin.write(payload)
+            proc.stdin.flush()
+            proc.stdin.close()
+            stdout, stderr = proc.communicate(timeout=_TIMEOUT)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        assert proc.returncode == 0, f"stderr: {stderr}"
+
+        if report_file.exists():
+            report = json.loads(report_file.read_text())
+        else:
+            report = _parse_agent_report(
+                subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout=stdout, stderr=stderr
+                )
+            )
+
+        assert report["stdin"] is not None
+        assert "file1.txt" in report["stdin"]
+        assert "file2.txt" in report["stdin"]
+        assert "path/to/file3.txt" in report["stdin"]
+
+    def test_subprocess_bracketed_paste_forwarding(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        """Bracketed paste sequences are forwarded to the child."""
+        report_file = tmp_path / "report.json"
+        # Simulate bracketed paste: ESC[200~ ... ESC[201~
+        pasted = "\x1b[200~/path/to/dropped.txt\x1b[201~"
+
+        proc = subprocess.Popen(
+            [
+                str(clud_binary),
+                "-p",
+                "hello",
+                "--",
+                "--mock-read-stdin-ms",
+                "3000",
+                "--mock-report-file",
+                str(report_file),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=mock_env,
+        )
+
+        try:
+            time.sleep(0.5)
+            assert proc.stdin is not None
+            proc.stdin.write(pasted.encode())
+            proc.stdin.flush()
+            proc.stdin.close()
+            stdout, stderr = proc.communicate(timeout=_TIMEOUT)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        assert proc.returncode == 0, f"stderr: {stderr}"
+
+        if report_file.exists():
+            report = json.loads(report_file.read_text())
+        else:
+            cleaned = _strip_ansi(stdout.decode() if isinstance(stdout, bytes) else stdout)
+            for line in cleaned.splitlines():
+                line = line.strip()
+                if line.startswith("{"):
+                    report = json.loads(line)
+                    break
+            else:
+                report = json.loads(cleaned)
+
+        assert report["stdin"] is not None
+        assert "/path/to/dropped.txt" in report["stdin"]

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -408,54 +408,41 @@ class TestStdinForwarding:
     a specified duration and report what it received.
     """
 
+    def _parse_report(
+        self,
+        report_file: Path,
+        stdout: str,
+        stderr: str,
+    ) -> dict:
+        """Parse the mock agent report from file or stdout."""
+        if report_file.exists():
+            return json.loads(report_file.read_text())
+        return _parse_agent_report(
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=stdout, stderr=stderr
+            )
+        )
+
     def test_subprocess_stdin_forwarding(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
     ) -> None:
         """Data written to clud's stdin reaches the child in subprocess mode."""
         report_file = tmp_path / "report.json"
-        proc = subprocess.Popen(
-            [
-                str(clud_binary),
-                "-p",
-                "hello",
-                "--",
-                "--mock-read-stdin-ms",
-                "3000",
-                "--mock-report-file",
-                str(report_file),
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+        result = _run(
+            clud_binary,
+            "-p",
+            "hello",
+            "--",
+            "--mock-read-stdin-ms",
+            "3000",
+            "--mock-report-file",
+            str(report_file),
             env=mock_env,
+            input_data="dropped-file.txt\n",
         )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
 
-        try:
-            # Give clud time to start the mock agent, then write to stdin
-            time.sleep(0.5)
-            assert proc.stdin is not None
-            proc.stdin.write("dropped-file.txt\n")
-            proc.stdin.flush()
-            proc.stdin.close()
-            stdout, stderr = proc.communicate(timeout=_TIMEOUT)
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait(timeout=5)
-
-        assert proc.returncode == 0, f"stderr: {stderr}"
-
-        # Parse report from file (most reliable) or stdout
-        if report_file.exists():
-            report = json.loads(report_file.read_text())
-        else:
-            report = _parse_agent_report(
-                subprocess.CompletedProcess(
-                    args=[], returncode=0, stdout=stdout, stderr=stderr
-                )
-            )
-
+        report = self._parse_report(report_file, result.stdout, result.stderr)
         assert report["stdin"] is not None, "mock agent received no stdin data"
         assert "dropped-file.txt" in report["stdin"]
 
@@ -464,44 +451,21 @@ class TestStdinForwarding:
     ) -> None:
         """When test pipes stdin, the child sees a pipe (not a terminal)."""
         report_file = tmp_path / "report.json"
-        proc = subprocess.Popen(
-            [
-                str(clud_binary),
-                "-p",
-                "hello",
-                "--",
-                "--mock-read-stdin-ms",
-                "1000",
-                "--mock-report-file",
-                str(report_file),
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+        result = _run(
+            clud_binary,
+            "-p",
+            "hello",
+            "--",
+            "--mock-read-stdin-ms",
+            "1000",
+            "--mock-report-file",
+            str(report_file),
             env=mock_env,
+            input_data="",
         )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
 
-        try:
-            assert proc.stdin is not None
-            proc.stdin.close()
-            stdout, stderr = proc.communicate(timeout=_TIMEOUT)
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait(timeout=5)
-
-        assert proc.returncode == 0, f"stderr: {stderr}"
-
-        if report_file.exists():
-            report = json.loads(report_file.read_text())
-        else:
-            report = _parse_agent_report(
-                subprocess.CompletedProcess(
-                    args=[], returncode=0, stdout=stdout, stderr=stderr
-                )
-            )
-
+        report = self._parse_report(report_file, result.stdout, result.stderr)
         # With piped stdin, the child should NOT see a terminal
         assert report["stdin_is_terminal"] is False
 
@@ -512,47 +476,21 @@ class TestStdinForwarding:
         report_file = tmp_path / "report.json"
         payload = "file1.txt\nfile2.txt\npath/to/file3.txt\n"
 
-        proc = subprocess.Popen(
-            [
-                str(clud_binary),
-                "-p",
-                "hello",
-                "--",
-                "--mock-read-stdin-ms",
-                "3000",
-                "--mock-report-file",
-                str(report_file),
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+        result = _run(
+            clud_binary,
+            "-p",
+            "hello",
+            "--",
+            "--mock-read-stdin-ms",
+            "3000",
+            "--mock-report-file",
+            str(report_file),
             env=mock_env,
+            input_data=payload,
         )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
 
-        try:
-            time.sleep(0.5)
-            assert proc.stdin is not None
-            proc.stdin.write(payload)
-            proc.stdin.flush()
-            proc.stdin.close()
-            stdout, stderr = proc.communicate(timeout=_TIMEOUT)
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait(timeout=5)
-
-        assert proc.returncode == 0, f"stderr: {stderr}"
-
-        if report_file.exists():
-            report = json.loads(report_file.read_text())
-        else:
-            report = _parse_agent_report(
-                subprocess.CompletedProcess(
-                    args=[], returncode=0, stdout=stdout, stderr=stderr
-                )
-            )
-
+        report = self._parse_report(report_file, result.stdout, result.stderr)
         assert report["stdin"] is not None
         assert "file1.txt" in report["stdin"]
         assert "file2.txt" in report["stdin"]
@@ -566,48 +504,20 @@ class TestStdinForwarding:
         # Simulate bracketed paste: ESC[200~ ... ESC[201~
         pasted = "\x1b[200~/path/to/dropped.txt\x1b[201~"
 
-        proc = subprocess.Popen(
-            [
-                str(clud_binary),
-                "-p",
-                "hello",
-                "--",
-                "--mock-read-stdin-ms",
-                "3000",
-                "--mock-report-file",
-                str(report_file),
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        result = _run(
+            clud_binary,
+            "-p",
+            "hello",
+            "--",
+            "--mock-read-stdin-ms",
+            "3000",
+            "--mock-report-file",
+            str(report_file),
             env=mock_env,
+            input_data=pasted,
         )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
 
-        try:
-            time.sleep(0.5)
-            assert proc.stdin is not None
-            proc.stdin.write(pasted.encode())
-            proc.stdin.flush()
-            proc.stdin.close()
-            stdout, stderr = proc.communicate(timeout=_TIMEOUT)
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait(timeout=5)
-
-        assert proc.returncode == 0, f"stderr: {stderr}"
-
-        if report_file.exists():
-            report = json.loads(report_file.read_text())
-        else:
-            cleaned = _strip_ansi(stdout.decode() if isinstance(stdout, bytes) else stdout)
-            for line in cleaned.splitlines():
-                line = line.strip()
-                if line.startswith("{"):
-                    report = json.loads(line)
-                    break
-            else:
-                report = json.loads(cleaned)
-
+        report = self._parse_report(report_file, result.stdout, result.stderr)
         assert report["stdin"] is not None
         assert "/path/to/dropped.txt" in report["stdin"]


### PR DESCRIPTION
## Summary
- Enable `ENABLE_VIRTUAL_TERMINAL_INPUT` on the Windows console before launching the child in subprocess mode, so ANSI sequences (including bracketed paste for drag-and-drop) pass through to the child process
- RAII guard restores original console mode on exit; no-op on non-Windows
- Enhanced mock agent with `--mock-read-stdin-ms` and `--mock-report-file` flags for stdin forwarding tests
- Added 4 new integration tests: single-line, multi-line, bracketed paste forwarding, and terminal detection

## Test plan
- [x] All 76 Rust unit tests pass
- [x] All 20 Python unit tests pass
- [x] All 49 integration tests pass (including 4 new stdin forwarding tests)
- [x] `bash lint` passes clean
- [ ] Manual test: drag-and-drop a file onto Windows Terminal while running `clud` in subprocess mode

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)