### PR TITLE
fix(daemon): harden session lifecycle — cleanup, kill, named sessions, heartbeat

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -90,6 +90,11 @@ pub enum Command {
     Attach {
         session_id: Option<String>,
     },
+    Kill {
+        session_id: Option<String>,
+        #[arg(long = "all")]
+        all: bool,
+    },
     List,
     #[command(name = "__daemon", hide = true)]
     InternalDaemon {
@@ -149,12 +154,13 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--detachable",
         "--verbose",
         "--experimental-daemon-centralized",
+        "--all",
         "--help",
         "--version",
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V"];
     let subcommands: &[&str] = &[
-        "loop", "up", "rebase", "fix", "wasm", "attach", "list", "__daemon", "__worker",
+        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -49,6 +49,9 @@ pub struct Args {
     #[arg(long = "detachable", conflicts_with = "dry_run")]
     pub detachable: bool,
 
+    #[arg(long = "name")]
+    pub session_name: Option<String>,
+
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
@@ -89,6 +92,8 @@ pub enum Command {
     },
     Attach {
         session_id: Option<String>,
+        #[arg(long = "last", short = 'l')]
+        last: bool,
     },
     Kill {
         session_id: Option<String>,
@@ -138,6 +143,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--message",
         "--resume",
         "--model",
+        "--name",
         "--loop-count",
         "--daemon-state-dir",
     ];
@@ -155,6 +161,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--verbose",
         "--experimental-daemon-centralized",
         "--all",
+        "--last",
         "--help",
         "--version",
     ];
@@ -453,8 +460,9 @@ mod tests {
     fn test_attach_without_session_id() {
         let args = parse(&["clud", "attach"]);
         match args.command {
-            Some(Command::Attach { session_id }) => {
+            Some(Command::Attach { session_id, last }) => {
                 assert!(session_id.is_none());
+                assert!(!last);
             }
             _ => panic!("expected Attach subcommand"),
         }
@@ -464,11 +472,55 @@ mod tests {
     fn test_attach_with_session_id() {
         let args = parse(&["clud", "attach", "sess-123"]);
         match args.command {
-            Some(Command::Attach { session_id }) => {
+            Some(Command::Attach { session_id, last }) => {
                 assert_eq!(session_id.as_deref(), Some("sess-123"));
+                assert!(!last);
             }
             _ => panic!("expected Attach subcommand"),
         }
+    }
+
+    #[test]
+    fn test_attach_with_last() {
+        let args = parse(&["clud", "attach", "--last"]);
+        match args.command {
+            Some(Command::Attach { session_id, last }) => {
+                assert!(session_id.is_none());
+                assert!(last);
+            }
+            _ => panic!("expected Attach subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_kill_subcommand() {
+        let args = parse(&["clud", "kill", "sess-123"]);
+        match args.command {
+            Some(Command::Kill { session_id, all }) => {
+                assert_eq!(session_id.as_deref(), Some("sess-123"));
+                assert!(!all);
+            }
+            _ => panic!("expected Kill subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_kill_all() {
+        let args = parse(&["clud", "kill", "--all"]);
+        match args.command {
+            Some(Command::Kill { session_id, all }) => {
+                assert!(session_id.is_none());
+                assert!(all);
+            }
+            _ => panic!("expected Kill subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_name_flag() {
+        let args = parse(&["clud", "--name", "my-session", "--detach", "-p", "hello"]);
+        assert_eq!(args.session_name.as_deref(), Some("my-session"));
+        assert!(args.detach);
     }
 
     #[test]

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -127,6 +127,7 @@ pub fn build_launch_plan(
             unreachable!("wasm execution is handled directly in main")
         }
         Some(Command::Attach { .. })
+        | Some(Command::Kill { .. })
         | Some(Command::List)
         | Some(Command::InternalDaemon { .. })
         | Some(Command::InternalWorker { .. }) => {}

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -386,7 +386,25 @@ pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i
             let state_dir = state_dir(args);
             Some(run_attach(session_id, &state_dir, interrupted))
         }
-        Some(Command::Attach { session_id: None }) | Some(Command::List) => {
+        Some(Command::Attach { session_id: None }) => {
+            let state_dir = state_dir(args);
+            let sessions = list_attachable_sessions(&state_dir);
+            if sessions.is_empty() {
+                println!("No active sessions.");
+                println!("Start one with: clud --detach -p <prompt>");
+                Some(0)
+            } else if sessions.len() == 1 {
+                eprintln!("[clud] auto-attaching to only session: {}", sessions[0].id);
+                Some(run_attach(&sessions[0].id, &state_dir, interrupted))
+            } else {
+                Some(run_list(&state_dir))
+            }
+        }
+        Some(Command::Kill { session_id, all }) => {
+            let state_dir = state_dir(args);
+            Some(run_kill(&state_dir, session_id.as_deref(), *all))
+        }
+        Some(Command::List) => {
             let state_dir = state_dir(args);
             Some(run_list(&state_dir))
         }
@@ -433,10 +451,13 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
 
     match response {
         DaemonResponse::Created { session } => {
-            eprintln!("[clud] daemon session {}", session.id);
             if args.detach {
-                0
-            } else {
+                eprintln!("[clud] session {} running in background", session.id);
+                eprintln!("[clud] attach with: clud attach {}", session.id);
+                return 0;
+            }
+            eprintln!("[clud] daemon session {}", session.id);
+            {
                 attach_to_session(&state_dir, &session, interrupted)
             }
         }
@@ -450,7 +471,8 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
 
 fn run_attach(session_id: &str, state_dir: &Path, interrupted: &AtomicBool) -> i32 {
     if let Err(err) = ensure_daemon(state_dir) {
-        eprintln!("[clud] failed to reach daemon: {}", err);
+        eprintln!("[clud] daemon is not running: {}", err);
+        eprintln!("[clud] start a session with: clud --detach -p <prompt>");
         return 1;
     }
     let response = match send_daemon_request(
@@ -482,10 +504,17 @@ fn attach_to_session(state_dir: &Path, session: &SessionSnapshot, interrupted: &
         let mut stream = match TcpStream::connect(("127.0.0.1", session.worker_port)) {
             Ok(stream) => stream,
             Err(err) => {
-                eprintln!(
-                    "[clud] failed to connect to daemon worker for session {}: {}",
-                    session.id, err
-                );
+                if !pid_is_alive(session.worker_pid) {
+                    eprintln!(
+                        "[clud] session {} worker has died (pid {})",
+                        session.id, session.worker_pid
+                    );
+                } else {
+                    eprintln!(
+                        "[clud] failed to connect to session {} worker on port {}: {}",
+                        session.id, session.worker_port, err
+                    );
+                }
                 return 1;
             }
         };
@@ -843,11 +872,72 @@ fn render_background_prompt(remaining: u64) {
     );
 }
 
+fn cleanup_stale_state(state_dir: &Path) {
+    // Clean stale session files: mark sessions whose worker is dead.
+    if let Ok(entries) = fs::read_dir(sessions_dir(state_dir)) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(mut session) = read_json_file::<SessionSnapshot>(&path) else {
+                continue;
+            };
+            if session.exit_code.is_some() {
+                continue;
+            }
+            if !pid_is_alive(session.worker_pid) {
+                session.exit_code = Some(137);
+                session.background = false;
+                let _ = write_json_file(&path, &session);
+            }
+        }
+    }
+
+    // Clean dangling spec files: specs with no corresponding session snapshot
+    // that are older than 10 seconds (grace period for worker startup).
+    if let Ok(entries) = fs::read_dir(specs_dir(state_dir)) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let session_id = path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            let snapshot_path = session_snapshot_path(state_dir, session_id);
+            if snapshot_path.exists() {
+                continue;
+            }
+            // Only remove if the spec is old enough (worker may still be starting).
+            let is_stale = path
+                .metadata()
+                .and_then(|m| m.modified())
+                .map(|modified| modified.elapsed().unwrap_or_default() > Duration::from_secs(10))
+                .unwrap_or(true);
+            if is_stale {
+                let _ = fs::remove_file(&path);
+            }
+        }
+    }
+
+    // Clean stale daemon.json if it refers to a dead process.
+    let daemon_path = daemon_info_path(state_dir);
+    if let Ok(info) = read_json_file::<DaemonInfo>(&daemon_path) {
+        if !pid_is_alive(info.pid) {
+            let _ = fs::remove_file(&daemon_path);
+        }
+    }
+}
+
 fn run_daemon(state_dir: &Path) -> i32 {
     if let Err(err) = fs::create_dir_all(state_dir) {
         eprintln!("[clud] failed to create daemon state dir: {}", err);
         return 1;
     }
+
+    cleanup_stale_state(state_dir);
 
     let listener = match TcpListener::bind(("127.0.0.1", 0)) {
         Ok(listener) => listener,
@@ -967,22 +1057,40 @@ fn daemon_create_session(
         .map_err(|err| io::Error::other(err.to_string()))?;
 
     let started = Instant::now();
-    loop {
+    let snapshot = loop {
         match read_json_file::<SessionSnapshot>(&session_snapshot_path(state_dir, &session_id)) {
-            Ok(snapshot) => {
-                workers
-                    .lock()
-                    .expect("workers mutex poisoned")
-                    .insert(session_id.clone(), worker);
-                return Ok(snapshot);
-            }
+            Ok(snapshot) => break snapshot,
             Err(err) if started.elapsed() < Duration::from_secs(5) => {
                 let _ = err;
                 thread::sleep(Duration::from_millis(25));
             }
             Err(err) => return Err(err),
         }
+    };
+
+    // Verify the worker's TCP listener is actually accepting connections
+    // before reporting the session as ready.
+    loop {
+        if TcpStream::connect(("127.0.0.1", snapshot.worker_port)).is_ok() {
+            break;
+        }
+        if started.elapsed() >= Duration::from_secs(5) {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "worker wrote snapshot but TCP port {} is not accepting connections",
+                    snapshot.worker_port
+                ),
+            ));
+        }
+        thread::sleep(Duration::from_millis(25));
     }
+
+    workers
+        .lock()
+        .expect("workers mutex poisoned")
+        .insert(session_id.clone(), worker);
+    Ok(snapshot)
 }
 
 fn daemon_terminate_session(
@@ -1015,6 +1123,7 @@ fn daemon_terminate_session(
     session.background = false;
     session.exit_code = Some(130);
     write_json_file(&path, &session)?;
+    let _ = fs::remove_file(spec_path(state_dir, session_id));
     Ok(session)
 }
 
@@ -1096,6 +1205,7 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
                 runtime.cleanup_tree();
                 shared.broadcast_exit(137);
                 let _ = persist_snapshot(&state_dir, &session_id, &shared);
+                let _ = fs::remove_file(spec_path(&state_dir, &session_id));
                 break;
             }
             thread::sleep(Duration::from_millis(200));
@@ -1121,6 +1231,7 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
         }
     }
     let _ = persist_snapshot(state_dir, session_id, &shared);
+    let _ = fs::remove_file(spec_path(state_dir, session_id));
     0
 }
 
@@ -1350,6 +1461,7 @@ fn read_worker_line(
 
 fn ensure_daemon(state_dir: &Path) -> io::Result<()> {
     fs::create_dir_all(state_dir)?;
+    cleanup_stale_state(state_dir);
     if let Ok(info) = read_json_file::<DaemonInfo>(&daemon_info_path(state_dir)) {
         if TcpStream::connect(("127.0.0.1", info.port)).is_ok() {
             return Ok(());
@@ -1473,6 +1585,51 @@ fn spec_path(state_dir: &Path, session_id: &str) -> PathBuf {
     specs_dir(state_dir).join(format!("{session_id}.json"))
 }
 
+fn run_kill(state_dir: &Path, session_id: Option<&str>, all: bool) -> i32 {
+    if let Err(err) = ensure_daemon(state_dir) {
+        eprintln!("[clud] failed to reach daemon: {}", err);
+        return 1;
+    }
+
+    if all {
+        let sessions = list_attachable_sessions(state_dir);
+        if sessions.is_empty() {
+            println!("No active sessions to kill.");
+            return 0;
+        }
+        let mut failed = 0;
+        for session in &sessions {
+            match request_session_termination(state_dir, &session.id) {
+                Ok(_) => eprintln!("[clud] killed session {}", session.id),
+                Err(err) => {
+                    eprintln!("[clud] failed to kill session {}: {}", session.id, err);
+                    failed += 1;
+                }
+            }
+        }
+        if failed > 0 {
+            return 1;
+        }
+        return 0;
+    }
+
+    let Some(session_id) = session_id else {
+        eprintln!("Usage: clud kill <session_id> or clud kill --all");
+        return 1;
+    };
+
+    match request_session_termination(state_dir, session_id) {
+        Ok(_) => {
+            eprintln!("[clud] killed session {}", session_id);
+            0
+        }
+        Err(err) => {
+            eprintln!("[clud] failed to kill session {}: {}", session_id, err);
+            1
+        }
+    }
+}
+
 fn run_list(state_dir: &Path) -> i32 {
     let sessions = list_attachable_sessions(state_dir);
     if sessions.is_empty() {
@@ -1506,6 +1663,9 @@ fn list_attachable_sessions(state_dir: &Path) -> Vec<SessionSnapshot> {
             continue;
         };
         if session.exit_code.is_some() || !session.background {
+            continue;
+        }
+        if !pid_is_alive(session.worker_pid) {
             continue;
         }
         if let Some(root_pid) = session.root_pid {

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -48,6 +48,10 @@ struct SessionSnapshot {
     #[serde(default)]
     cwd: Option<String>,
     #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    created_at: Option<u64>,
+    #[serde(default)]
     detachable: bool,
     #[serde(default)]
     background: bool,
@@ -62,6 +66,8 @@ struct SessionSnapshot {
 struct WorkerLaunchSpec {
     plan: LaunchPlan,
     kind: SessionKind,
+    #[serde(default)]
+    name: Option<String>,
     #[serde(default)]
     detachable: bool,
     #[serde(default)]
@@ -243,6 +249,8 @@ impl WorkerShared {
     }
 
     fn attach_client(&self, shutdown: TcpStream) -> Result<AttachClientResult, String> {
+        // First, try to evict any dead client before checking occupancy.
+        self.evict_dead_client();
         let mut guard = self.client.lock().expect("client mutex poisoned");
         if guard
             .as_ref()
@@ -296,6 +304,43 @@ impl WorkerShared {
 
     fn has_client(&self) -> bool {
         self.client.lock().expect("client mutex poisoned").is_some()
+    }
+
+    /// Check if the attached client's TCP connection is still alive.
+    /// If the peer has disconnected, evict the dead client so new attaches succeed.
+    fn evict_dead_client(&self) {
+        let mut guard = self.client.lock().expect("client mutex poisoned");
+        let should_evict = if let Some(client) = guard.as_ref() {
+            // Try a zero-byte peek to check if the connection is still alive.
+            // A connection-reset or broken-pipe error means the peer is gone.
+            let mut probe = [0u8; 1];
+            client.shutdown.set_nonblocking(true).ok();
+            let dead = match client.shutdown.peek(&mut probe) {
+                // EOF means peer closed the connection
+                Ok(0) => true,
+                // WouldBlock means the socket is alive but has no data
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => false,
+                Err(ref e) if e.kind() == io::ErrorKind::ConnectionReset => true,
+                Err(ref e) if e.kind() == io::ErrorKind::ConnectionAborted => true,
+                // Unknown error: consider stale after 10s
+                Err(_) => client.attached_at.elapsed() > Duration::from_secs(10),
+                // Data available means socket is alive
+                Ok(_) => false,
+            };
+            client.shutdown.set_nonblocking(false).ok();
+            dead
+        } else {
+            false
+        };
+        if should_evict {
+            if let Some(old) = guard.take() {
+                let _ = old.shutdown.shutdown(Shutdown::Both);
+            }
+            drop(guard);
+            if self.snapshot().exit_code.is_none() {
+                self.set_background(true);
+            }
+        }
     }
 
     fn push_output(&self, chunk: Vec<u8>) {
@@ -382,11 +427,42 @@ pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i
     match &args.command {
         Some(Command::Attach {
             session_id: Some(session_id),
-        }) => {
+            last,
+        }) if !last => {
             let state_dir = state_dir(args);
-            Some(run_attach(session_id, &state_dir, interrupted))
+            if session_id == "-" {
+                // "clud attach -" is shorthand for --last
+                match most_recent_session(&state_dir) {
+                    Some(session) => {
+                        eprintln!("[clud] attaching to most recent session: {}", session.id);
+                        Some(run_attach(&session.id, &state_dir, interrupted))
+                    }
+                    None => {
+                        println!("No active sessions.");
+                        Some(0)
+                    }
+                }
+            } else {
+                Some(run_attach(session_id, &state_dir, interrupted))
+            }
         }
-        Some(Command::Attach { session_id: None }) => {
+        Some(Command::Attach { last: true, .. }) => {
+            let state_dir = state_dir(args);
+            match most_recent_session(&state_dir) {
+                Some(session) => {
+                    eprintln!("[clud] attaching to most recent session: {}", session.id);
+                    Some(run_attach(&session.id, &state_dir, interrupted))
+                }
+                None => {
+                    println!("No active sessions.");
+                    Some(0)
+                }
+            }
+        }
+        Some(Command::Attach {
+            session_id: None,
+            last: false,
+        }) => {
             let state_dir = state_dir(args);
             let sessions = list_attachable_sessions(&state_dir);
             if sessions.is_empty() {
@@ -435,6 +511,7 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         spec: WorkerLaunchSpec {
             plan: plan.clone(),
             kind,
+            name: args.session_name.clone(),
             detachable: args.detach || args.detachable,
             background_on_launch: args.detach,
             rows,
@@ -475,10 +552,17 @@ fn run_attach(session_id: &str, state_dir: &Path, interrupted: &AtomicBool) -> i
         eprintln!("[clud] start a session with: clud --detach -p <prompt>");
         return 1;
     }
+    let resolved = match resolve_session_id(state_dir, session_id) {
+        Ok(id) => id,
+        Err(err) => {
+            eprintln!("[clud] {}", err);
+            return 1;
+        }
+    };
     let response = match send_daemon_request(
         state_dir,
         &DaemonRequest::Session {
-            session_id: session_id.to_string(),
+            session_id: resolved.clone(),
         },
     ) {
         Ok(response) => response,
@@ -1151,10 +1235,16 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
         }
     };
 
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
     let snapshot = SessionSnapshot {
         id: session_id.to_string(),
         kind: spec.kind.clone(),
         cwd: spec.plan.cwd.clone(),
+        name: spec.name.clone(),
+        created_at: Some(created_at),
         detachable: spec.detachable,
         background: spec.background_on_launch,
         daemon_pid,
@@ -1209,6 +1299,20 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
                 break;
             }
             thread::sleep(Duration::from_millis(200));
+        });
+    }
+
+    // Heartbeat thread: periodically probe the attached client's TCP connection.
+    // If the peer has disconnected (e.g. terminal crash, SSH drop), evict the
+    // dead client so new attach attempts succeed immediately.
+    {
+        let shared = Arc::clone(&shared);
+        thread::spawn(move || loop {
+            if shared.stop_accepting.load(Ordering::Acquire) {
+                break;
+            }
+            shared.evict_dead_client();
+            thread::sleep(Duration::from_secs(2));
         });
     }
 
@@ -1585,6 +1689,71 @@ fn spec_path(state_dir: &Path, session_id: &str) -> PathBuf {
     specs_dir(state_dir).join(format!("{session_id}.json"))
 }
 
+/// Resolve a user-provided session identifier to the canonical session ID.
+/// Tries exact match, then name match, then prefix match.
+fn resolve_session_id(state_dir: &Path, input: &str) -> Result<String, String> {
+    // Exact match
+    let exact_path = session_snapshot_path(state_dir, input);
+    if exact_path.exists() {
+        return Ok(input.to_string());
+    }
+
+    // Scan all sessions for name match or prefix match
+    let Ok(entries) = fs::read_dir(sessions_dir(state_dir)) else {
+        return Err(format!("session '{}' not found", input));
+    };
+
+    let mut name_matches = Vec::new();
+    let mut prefix_matches = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(session) = read_json_file::<SessionSnapshot>(&path) else {
+            continue;
+        };
+        if session.name.as_deref() == Some(input) {
+            name_matches.push(session.id.clone());
+        }
+        if session.id.starts_with(input) {
+            prefix_matches.push(session.id.clone());
+        }
+    }
+
+    if name_matches.len() == 1 {
+        return Ok(name_matches.into_iter().next().unwrap());
+    }
+    if name_matches.len() > 1 {
+        return Err(format!(
+            "ambiguous name '{}': matches {}",
+            input,
+            name_matches.join(", ")
+        ));
+    }
+    if prefix_matches.len() == 1 {
+        return Ok(prefix_matches.into_iter().next().unwrap());
+    }
+    if prefix_matches.len() > 1 {
+        return Err(format!(
+            "ambiguous prefix '{}': matches {}",
+            input,
+            prefix_matches.join(", ")
+        ));
+    }
+
+    Err(format!("session '{}' not found", input))
+}
+
+/// Return the most recently created active session.
+fn most_recent_session(state_dir: &Path) -> Option<SessionSnapshot> {
+    let sessions = list_attachable_sessions(state_dir);
+    sessions
+        .into_iter()
+        .max_by_key(|s| s.created_at.unwrap_or(0))
+}
+
 fn run_kill(state_dir: &Path, session_id: Option<&str>, all: bool) -> i32 {
     if let Err(err) = ensure_daemon(state_dir) {
         eprintln!("[clud] failed to reach daemon: {}", err);
@@ -1613,20 +1782,43 @@ fn run_kill(state_dir: &Path, session_id: Option<&str>, all: bool) -> i32 {
         return 0;
     }
 
-    let Some(session_id) = session_id else {
+    let Some(input) = session_id else {
         eprintln!("Usage: clud kill <session_id> or clud kill --all");
         return 1;
     };
 
-    match request_session_termination(state_dir, session_id) {
+    let resolved = match resolve_session_id(state_dir, input) {
+        Ok(id) => id,
+        Err(err) => {
+            eprintln!("[clud] {}", err);
+            return 1;
+        }
+    };
+
+    match request_session_termination(state_dir, &resolved) {
         Ok(_) => {
-            eprintln!("[clud] killed session {}", session_id);
+            eprintln!("[clud] killed session {}", resolved);
             0
         }
         Err(err) => {
-            eprintln!("[clud] failed to kill session {}: {}", session_id, err);
+            eprintln!("[clud] failed to kill session {}: {}", resolved, err);
             1
         }
+    }
+}
+
+fn format_duration_short(millis: u64) -> String {
+    let now_millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let elapsed_secs = now_millis.saturating_sub(millis) / 1000;
+    if elapsed_secs < 60 {
+        format!("{}s", elapsed_secs)
+    } else if elapsed_secs < 3600 {
+        format!("{}m", elapsed_secs / 60)
+    } else {
+        format!("{}h{}m", elapsed_secs / 3600, (elapsed_secs % 3600) / 60)
     }
 }
 
@@ -1637,14 +1829,23 @@ fn run_list(state_dir: &Path) -> i32 {
         return 0;
     }
 
-    println!("SESSION ID\tPID\tCWD");
+    println!("{:<30} {:<8} {:<8} CWD", "SESSION", "PID", "UPTIME");
     for session in sessions {
+        let display_name = session
+            .name
+            .as_deref()
+            .map(|n| format!("{} ({})", session.id, n))
+            .unwrap_or_else(|| session.id.clone());
         let pid = session
             .root_pid
             .map(|value| value.to_string())
             .unwrap_or_else(|| "-".to_string());
+        let uptime = session
+            .created_at
+            .map(format_duration_short)
+            .unwrap_or_else(|| "-".to_string());
         let cwd = session.cwd.unwrap_or_else(|| "-".to_string());
-        println!("{}\t{}\t{}", session.id, pid, cwd);
+        println!("{:<30} {:<8} {:<8} {}", display_name, pid, uptime, cwd);
     }
     0
 }

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -706,3 +706,177 @@ class TestDaemonSessionHardening:
             assert session_id_2 not in listed.stdout
         finally:
             _kill_daemon_for_session(state_dir, session_id_1)
+
+    def test_named_session_attach_by_name(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--name",
+            "my-refactor",
+            "--codex",
+            "-p",
+            "named-test",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+
+            # Attach by name instead of ID
+            attached = subprocess.run(
+                [str(clud_binary), "attach", "my-refactor"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                env=env,
+            )
+            assert attached.returncode == 0
+            report = json.loads(attached.stdout)
+            assert "named-test" in report["args"]
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_named_session_shows_in_list(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--name",
+            "my-task",
+            "--codex",
+            "-p",
+            "list-name",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+            listed = subprocess.run(
+                [str(clud_binary), "list"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert listed.returncode == 0
+            assert "my-task" in listed.stdout
+            assert session_id in listed.stdout
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_prefix_matching_attach(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "prefix-test",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+            # Use first 10 chars of session_id as prefix
+            prefix = session_id[:10]
+            attached = subprocess.run(
+                [str(clud_binary), "attach", prefix],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                env=env,
+            )
+            assert attached.returncode == 0
+            report = json.loads(attached.stdout)
+            assert "prefix-test" in report["args"]
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_kill_by_name(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--name",
+            "kill-by-name",
+            "--codex",
+            "-p",
+            "kill-name-test",
+            "--",
+            "--mock-sleep-ms",
+            "30000",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+            result = subprocess.run(
+                [str(clud_binary), "kill", "kill-by-name"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert result.returncode == 0
+            assert "killed session" in result.stderr
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_attach_last(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        # Create first session
+        proc1, session_id_1 = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "first-session",
+            "--",
+            "--mock-sleep-ms",
+            "5000",
+        )
+        assert _wait_for_exit(proc1, timeout=2) == 0
+        time.sleep(0.2)
+        # Create second session (most recent)
+        proc2, _session_id_2 = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "second-session",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+        )
+        assert _wait_for_exit(proc2, timeout=2) == 0
+        try:
+            # attach --last should get the second session
+            attached = subprocess.run(
+                [str(clud_binary), "attach", "--last"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                env=env,
+            )
+            assert attached.returncode == 0
+            report = json.loads(attached.stdout)
+            assert "second-session" in report["args"]
+        finally:
+            _kill_daemon_for_session(state_dir, session_id_1)

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -29,13 +29,25 @@ def _managed_env(mock_env: dict[str, str], state_dir: Path) -> dict[str, str]:
     return env
 
 
+def _extract_session_id(line: str) -> str | None:
+    """Extract session id from various stderr formats."""
+    # "[clud] daemon session sess-XXX"
+    if "daemon session" in line:
+        return line.strip().rsplit(" ", 1)[-1]
+    # "[clud] session sess-XXX running in background"
+    if "session" in line and "running in background" in line:
+        return line.strip().split("session ", 1)[-1].split(" running")[0]
+    return None
+
+
 def _read_session_id(proc: subprocess.Popen[str], timeout: float = 10.0) -> str:
     assert proc.stderr is not None
     deadline = time.time() + timeout
     while time.time() < deadline:
         line = proc.stderr.readline()
-        if "daemon session" in line:
-            return line.strip().rsplit(" ", 1)[-1]
+        session_id = _extract_session_id(line)
+        if session_id is not None:
+            return session_id
         if proc.poll() is not None:
             raise AssertionError(f"clud exited early while waiting for session id: {line!r}")
     raise AssertionError("timed out waiting for daemon session id")
@@ -43,8 +55,9 @@ def _read_session_id(proc: subprocess.Popen[str], timeout: float = 10.0) -> str:
 
 def _read_session_id_from_text(stderr: str) -> str:
     for line in stderr.splitlines():
-        if "daemon session" in line:
-            return line.strip().rsplit(" ", 1)[-1]
+        session_id = _extract_session_id(line)
+        if session_id is not None:
+            return session_id
     raise AssertionError(f"daemon session id not found in stderr: {stderr!r}")
 
 
@@ -539,3 +552,157 @@ class TestDaemonCentralizedCleanup:
 
         _kill_process(metadata["daemon_pid"])
         _wait_for_pids_to_exit(pids)
+
+
+class TestDaemonSessionHardening:
+    def test_detach_prints_attach_hint(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "hint-test",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+            stderr = proc.stderr.read() if proc.stderr else ""
+            assert "attach with: clud attach" in stderr
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_attach_no_sessions_shows_helpful_message(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        result = subprocess.run(
+            [str(clud_binary), "attach"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "No active sessions" in result.stdout
+
+    def test_attach_auto_attaches_single_session(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "auto-attach",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+            attached = subprocess.run(
+                [str(clud_binary), "attach"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                env=env,
+            )
+            assert attached.returncode == 0
+            report = json.loads(attached.stdout)
+            assert "auto-attach" in report["args"]
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_kill_session(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "kill-me",
+            "--",
+            "--mock-sleep-ms",
+            "30000",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=2) == 0
+            result = subprocess.run(
+                [str(clud_binary), "kill", session_id],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert result.returncode == 0
+            assert "killed session" in result.stderr
+
+            listed = subprocess.run(
+                [str(clud_binary), "list"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert session_id not in listed.stdout
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_kill_all_sessions(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        _, session_id_1 = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "kill-all-1",
+            "--",
+            "--mock-sleep-ms",
+            "30000",
+        )
+        _, session_id_2 = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "kill-all-2",
+            "--",
+            "--mock-sleep-ms",
+            "30000",
+        )
+        try:
+            result = subprocess.run(
+                [str(clud_binary), "kill", "--all"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert result.returncode == 0
+
+            listed = subprocess.run(
+                [str(clud_binary), "list"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert session_id_1 not in listed.stdout
+            assert session_id_2 not in listed.stdout
+        finally:
+            _kill_daemon_for_session(state_dir, session_id_1)

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -230,7 +230,8 @@ class TestDaemonManagedSessionFlags:
         env = _managed_env(mock_env, state_dir)
         launch_cwd = tmp_path / "workspace"
         launch_cwd.mkdir()
-        proc, session_id = _launch_detached(
+        # Create two sessions so attach (no args) lists instead of auto-attaching
+        proc1, session_id = _launch_detached(
             clud_binary,
             env,
             "--codex",
@@ -238,11 +239,21 @@ class TestDaemonManagedSessionFlags:
             "list-attachable",
             "--",
             "--mock-sleep-ms",
-            "3000",
+            "5000",
             cwd=launch_cwd,
         )
+        _proc2, _session_id_2 = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "list-attachable-2",
+            "--",
+            "--mock-sleep-ms",
+            "5000",
+        )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc1, timeout=2) == 0
 
             listed = subprocess.run(
                 [str(clud_binary), "attach"],

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -69,7 +69,7 @@ def test_version() -> None:
     result = _run("--version")
     assert result.returncode == 0
     assert "clud" in result.stdout
-    assert "2.0.3" in result.stdout
+    assert "2.0.4" in result.stdout
 
 
 def test_dry_run_prompt() -> None:


### PR DESCRIPTION
## Summary

Comprehensive hardening of the daemon session system from the audit in #24, tracked by #25. Two commits covering all planned PRs (1-6).

### Bug Fixes
- **Stale state cleanup on boot** — `cleanup_stale_state()` marks sessions with dead worker PIDs as exited, removes dangling specs, cleans stale `daemon.json`
- **Worker readiness validation** — daemon probes worker TCP port before returning `Created`, eliminating the startup race
- **Dead TCP client heartbeat** — worker probes attached client every 2s via `peek()`, evicts dead sockets automatically. Also probes on new attach attempts for instant recovery after terminal crashes
- **Phantom session filtering** — `list_attachable_sessions` checks `worker_pid` is alive
- **Spec file cleanup** — specs removed on worker exit, daemon death, and termination
- **Pre-existing test fix** — `test_version` updated from 2.0.3 to 2.0.4

### UX Improvements
- `--detach` prints: `session {id} running in background` + `attach with: clud attach {id}`
- `clud attach` auto-attaches when exactly one session exists
- `clud attach` with no sessions prints helpful guidance
- Error messages distinguish daemon down vs worker dead vs port unreachable
- Richer `clud list` output: SESSION (with name), PID, UPTIME, CWD

### New Commands & Features
- `clud kill <session>` — terminate a session without attaching
- `clud kill --all` — terminate all sessions
- `--name <name>` — set human-readable session alias
- Session ID resolution: attach/kill by name, ID prefix, or exact ID
- `clud attach --last` / `clud attach -` — attach to most recent session
- `created_at` timestamp on sessions for duration display and `--last` ordering

### New Args Tests
- `test_attach_with_last`, `test_kill_subcommand`, `test_kill_all`, `test_name_flag`

### New Integration Tests
- `test_detach_prints_attach_hint`
- `test_attach_no_sessions_shows_helpful_message`
- `test_attach_auto_attaches_single_session`
- `test_kill_session`, `test_kill_all_sessions`
- `test_named_session_attach_by_name`, `test_named_session_shows_in_list`
- `test_prefix_matching_attach`, `test_kill_by_name`
- `test_attach_last`

## Test plan
- [x] `bash lint` passes locally (fmt, clippy, ruff)
- [ ] CI passes on all 6 platforms

Refs: #24, #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)