### PR TITLE
feat(daemon): server-side terminal capture for attach replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "sysinfo 0.37.2",
  "tempfile",
  "terminal_size",
+ "vt100",
  "wasmi",
  "which",
  "whisper-rs",
@@ -1734,6 +1735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +1751,27 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "tempfile",
  "terminal_size",
  "vt100",
+ "vte",
  "wasmi",
  "which",
  "whisper-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "base64",
  "clap",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "serde_json",
  "terminal_size",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "base64",
  "clap",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "serde_json",
  "terminal_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.6"
+version = "2.0.7"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.5"
+version = "2.0.6"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1"
 sysinfo = "0.37"
 terminal_size = "0.4"
 vt100 = "0.16"
+vte = "0.15"
 wasmi = "0.40.0"
 which = "7"
 

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.37"
 terminal_size = "0.4"
+vt100 = "0.16"
 wasmi = "0.40.0"
 which = "7"
 

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -108,6 +108,20 @@ pub enum Command {
         all: bool,
     },
     List,
+    /// pm2-style log viewer: dump or tail a session's captured output.
+    ///
+    /// With no session id, lists all sessions that have log files and prints
+    /// the last line of each. With an id, prints the log (last `--lines` or
+    /// all) and optionally keeps following new output via `--follow`.
+    Logs {
+        session_id: Option<String>,
+        /// Keep watching the file and print new output as it arrives.
+        #[arg(long = "follow", short = 'f')]
+        follow: bool,
+        /// Print only the last N lines from the file. Default: all.
+        #[arg(long = "lines", short = 'n')]
+        lines: Option<usize>,
+    },
     #[command(name = "__daemon", hide = true)]
     InternalDaemon {
         #[arg(long = "state-dir")]
@@ -176,7 +190,8 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V"];
     let subcommands: &[&str] = &[
-        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "__daemon", "__worker",
+        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "__daemon",
+        "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/capture.rs
+++ b/crates/clud-bin/src/capture.rs
@@ -1,0 +1,229 @@
+//! Server-side terminal emulator state for detachable PTY sessions.
+//!
+//! The daemon worker feeds every PTY output chunk into a `TerminalCapture`.
+//! When a client (local `clud attach`, or a future xterm.js frontend) connects,
+//! the capture emits a **synthesized repaint** — an ANSI byte stream that, when
+//! played into a freshly-initialized terminal, reproduces the exact screen the
+//! backend (codex / claude) is currently rendering: cells, SGR attributes,
+//! cursor position, alt-screen state, window title, and mode flags.
+//!
+//! Without this layer, a mid-session attach sees raw bytes since launch —
+//! fine for line-oriented CLIs but wrong for TUIs that use cursor moves,
+//! partial redraws, and the alternate screen buffer. See issue #34.
+
+use vt100::Parser;
+
+/// Scrollback kept inside the parser. The attach snapshot only replays the
+/// visible screen, so this buffer is for future features (e.g. history-aware
+/// clients); keeping it small bounds memory.
+const SCROLLBACK_LINES: usize = 1024;
+
+pub struct TerminalCapture {
+    parser: Parser,
+    rows: u16,
+    cols: u16,
+}
+
+impl TerminalCapture {
+    pub fn new(rows: u16, cols: u16) -> Self {
+        Self {
+            parser: Parser::new(rows, cols, SCROLLBACK_LINES),
+            rows,
+            cols,
+        }
+    }
+
+    pub fn feed(&mut self, bytes: &[u8]) {
+        self.parser.process(bytes);
+    }
+
+    pub fn resize(&mut self, rows: u16, cols: u16) {
+        if rows == self.rows && cols == self.cols {
+            return;
+        }
+        self.parser.screen_mut().set_size(rows, cols);
+        self.rows = rows;
+        self.cols = cols;
+    }
+
+    #[cfg(test)]
+    pub fn size(&self) -> (u16, u16) {
+        (self.rows, self.cols)
+    }
+
+    /// Build an ANSI byte stream that, when fed to a fresh terminal emulator
+    /// of size `(rows, cols)`, reproduces the current display state: cells,
+    /// SGR, cursor, alt-screen, title, mouse/bracketed-paste modes.
+    ///
+    /// `vt100::Screen::contents_formatted` already emits cells + SGR + cursor
+    /// positioning as a replay stream for the active screen. We prepend a
+    /// terminal reset so the client starts from a clean slate, and re-assert
+    /// alt-screen + title since those are "sticky" modes a fresh terminal
+    /// won't have set.
+    pub fn snapshot_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(4096);
+        // RIS — full reset. Clears SGR, modes, scroll region, cursor style,
+        // and the primary screen. Alt-screen is handled explicitly below.
+        out.extend_from_slice(b"\x1bc");
+
+        let screen = self.parser.screen();
+
+        // If the app is on the alternate screen, enter it *before* painting
+        // cells so the paint lands on the alt buffer and the primary buffer
+        // stays empty (matching the source terminal). `contents_formatted`
+        // paints only the active grid and does not emit this mode switch
+        // itself.
+        if screen.alternate_screen() {
+            out.extend_from_slice(b"\x1b[?1049h");
+        }
+
+        // `state_formatted` = cells + SGR + cursor position/visibility +
+        // input mode (bracketed paste, app cursor keys, app keypad, mouse
+        // protocol). Emits absolute cursor moves, so the client doesn't need
+        // a separate repositioning step.
+        out.extend(screen.state_formatted());
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feed a scripted sequence, snapshot, feed the snapshot into a fresh
+    /// parser, and assert the two screens render identically. This is the
+    /// core guarantee for mid-session attach.
+    fn assert_replay_equivalent(rows: u16, cols: u16, script: &[u8]) {
+        let mut source = TerminalCapture::new(rows, cols);
+        source.feed(script);
+        let snapshot = source.snapshot_bytes();
+
+        let mut replay = Parser::new(rows, cols, SCROLLBACK_LINES);
+        replay.process(&snapshot);
+
+        let src = source.parser.screen();
+        let dst = replay.screen();
+
+        assert_eq!(
+            src.contents(),
+            dst.contents(),
+            "cell contents diverge after replay"
+        );
+        assert_eq!(
+            src.cursor_position(),
+            dst.cursor_position(),
+            "cursor position diverges after replay"
+        );
+        assert_eq!(
+            src.alternate_screen(),
+            dst.alternate_screen(),
+            "alt-screen flag diverges after replay"
+        );
+        assert_eq!(
+            src.hide_cursor(),
+            dst.hide_cursor(),
+            "cursor visibility diverges after replay"
+        );
+    }
+
+    #[test]
+    fn replay_round_trip_plain_text() {
+        assert_replay_equivalent(24, 80, b"hello world");
+    }
+
+    #[test]
+    fn replay_round_trip_sgr_and_cursor() {
+        // Red "ERR" at row 3, col 5, then reset + green "ok" somewhere else.
+        let script = b"\x1b[3;5H\x1b[31mERR\x1b[0m\x1b[10;1H\x1b[32mok\x1b[0m";
+        assert_replay_equivalent(24, 80, script);
+    }
+
+    #[test]
+    fn replay_round_trip_alt_screen() {
+        // Enter alt screen, paint something, stay on alt screen.
+        let script = b"\x1b[?1049h\x1b[2J\x1b[1;1Hhello-alt";
+        assert_replay_equivalent(24, 80, script);
+    }
+
+    #[test]
+    fn replay_round_trip_hidden_cursor() {
+        let script = b"\x1b[?25lhidden";
+        assert_replay_equivalent(24, 80, script);
+    }
+
+    #[test]
+    fn resize_updates_parser_dims() {
+        let mut cap = TerminalCapture::new(24, 80);
+        cap.resize(40, 120);
+        assert_eq!(cap.size(), (40, 120));
+        // Noop resize should not panic or change anything.
+        cap.resize(40, 120);
+        assert_eq!(cap.size(), (40, 120));
+    }
+
+    /// Feeding the parser in multiple small chunks (as the daemon does, one
+    /// per PTY read) must produce the same final state as one big feed. This
+    /// is the invariant that lets `push_output` call `capture.feed` on every
+    /// chunk without needing to buffer.
+    #[test]
+    fn chunked_feed_matches_single_feed() {
+        let script: &[u8] = b"\x1b[1;1Hhello \x1b[31mworld\x1b[0m\x1b[5;10H!";
+        let mut whole = TerminalCapture::new(24, 80);
+        whole.feed(script);
+        let mut chunked = TerminalCapture::new(24, 80);
+        for byte in script {
+            chunked.feed(std::slice::from_ref(byte));
+        }
+        assert_eq!(
+            whole.parser.screen().contents(),
+            chunked.parser.screen().contents()
+        );
+        assert_eq!(whole.snapshot_bytes(), chunked.snapshot_bytes());
+    }
+
+    /// A mid-session attach scenario: a TUI does several partial redraws
+    /// (clear line, rewrite). A naive raw-byte replay would layer all three
+    /// stages and look wrong; the grid-based snapshot shows only the final
+    /// frame, and a fresh parser fed the snapshot ends up at the same state.
+    #[test]
+    fn mid_session_attach_reproduces_final_frame() {
+        let mut source = TerminalCapture::new(24, 80);
+        // Frame 1: three lines
+        source.feed(b"\x1b[1;1HLine1\x1b[2;1HLine2\x1b[3;1HLine3");
+        // Frame 2: clear line 2 and rewrite
+        source.feed(b"\x1b[2;1H\x1b[K\x1b[2;1Hreplaced");
+        // Frame 3: add a status line
+        source.feed(b"\x1b[24;1H\x1b[7mstatus\x1b[0m");
+
+        let snapshot = source.snapshot_bytes();
+
+        let mut replay = Parser::new(24, 80, SCROLLBACK_LINES);
+        replay.process(&snapshot);
+
+        let src = source.parser.screen();
+        let dst = replay.screen();
+        // The final frame has "Line1", "replaced" (not "Line2"), "Line3",
+        // blank rows, and "status" in inverse on row 24.
+        assert_eq!(src.contents(), dst.contents());
+        assert!(dst.contents().contains("Line1"));
+        assert!(dst.contents().contains("replaced"));
+        assert!(!dst.contents().contains("Line2"));
+        assert!(dst.contents().contains("status"));
+    }
+
+    #[test]
+    fn replay_round_trip_partial_clear_and_redraw() {
+        // Simulate a TUI doing a partial redraw: fill, clear a region,
+        // repaint part of it. A raw-byte replay would show all three stages
+        // layered; the grid-based replay shows only the final frame.
+        let script = b"\
+            \x1b[1;1HLine1\
+            \x1b[2;1HLine2\
+            \x1b[3;1HLine3\
+            \x1b[2;1H\x1b[K\
+            \x1b[2;1Hreplaced\
+        ";
+        assert_replay_equivalent(24, 80, script);
+    }
+}

--- a/crates/clud-bin/src/capture.rs
+++ b/crates/clud-bin/src/capture.rs
@@ -213,6 +213,49 @@ mod tests {
     }
 
     #[test]
+    fn replay_round_trip_utf8_multibyte() {
+        // Box-drawing + emoji. A raw-byte replay would be fine here, but the
+        // grid path has to keep UTF-8 sequences intact across parser state.
+        let script = "\x1b[1;1H┌─┐\n│ai│\n└─┘\x1b[5;1H🚀 launch".as_bytes();
+        assert_replay_equivalent(24, 80, script);
+    }
+
+    #[test]
+    fn replay_round_trip_extended_sgr() {
+        // Bold, italic, underline, inverse, and a 256-color background.
+        let script = b"\x1b[1;1H\
+            \x1b[1mBOLD\x1b[0m \
+            \x1b[3mitalic\x1b[0m \
+            \x1b[4munder\x1b[0m \
+            \x1b[7minv\x1b[0m \
+            \x1b[48;5;27mbg256\x1b[0m\
+            \x1b[2;1H\x1b[38;2;255;128;0mtruecolor\x1b[0m";
+        assert_replay_equivalent(24, 80, script);
+    }
+
+    #[test]
+    fn replay_round_trip_scroll_region() {
+        // DECSTBM: set scroll region to rows 2-5, write, scroll.
+        let script = b"\x1b[2;5r\x1b[2;1Ha\n\x1b[3;1Hb\n\x1b[4;1Hc\n\x1b[5;1Hd\n";
+        assert_replay_equivalent(24, 80, script);
+    }
+
+    #[test]
+    fn replay_round_trip_byte_by_byte_feed() {
+        // Pathological case: one byte at a time, including through the middle
+        // of multi-byte UTF-8 and CSI sequences. The parser is a streaming
+        // VTE, so this must be equivalent to a single feed.
+        let script = "\x1b[31m重要: \x1b[1;4mheads\x1b[0m ok".as_bytes();
+        let mut whole = TerminalCapture::new(24, 80);
+        whole.feed(script);
+        let mut drip = TerminalCapture::new(24, 80);
+        for b in script {
+            drip.feed(std::slice::from_ref(b));
+        }
+        assert_eq!(whole.snapshot_bytes(), drip.snapshot_bytes());
+    }
+
+    #[test]
     fn replay_round_trip_partial_clear_and_redraw() {
         // Simulate a TUI doing a partial redraw: fill, clear a region,
         // repaint part of it. A raw-byte replay would show all three stages

--- a/crates/clud-bin/src/capture.rs
+++ b/crates/clud-bin/src/capture.rs
@@ -12,6 +12,7 @@
 //! partial redraws, and the alternate screen buffer. See issue #34.
 
 use vt100::Parser;
+use vte::{Params, Parser as VteParser, Perform};
 
 /// Scrollback kept inside the parser. The attach snapshot only replays the
 /// visible screen, so this buffer is for future features (e.g. history-aware
@@ -22,6 +23,68 @@ pub struct TerminalCapture {
     parser: Parser,
     rows: u16,
     cols: u16,
+    /// Sticky modes vt100 tracks internally but does not expose / round-trip
+    /// through `state_formatted`. Sniffed from the byte stream in parallel
+    /// with vt100's own parse, then re-emitted in `snapshot_bytes`. See #36.
+    sticky: StickyModes,
+    /// Separate vte::Parser driving `sticky` — vt100 already uses vte for
+    /// its own state, this one only watches the handful of sequences we
+    /// need to restore after RIS.
+    sniffer: VteParser,
+}
+
+/// Modes vt100 0.16 doesn't round-trip through `state_formatted`.
+#[derive(Default)]
+struct StickyModes {
+    /// DECSTBM (`\x1b[<top>;<bot>r`), 1-indexed. `None` = full screen.
+    decstbm: Option<(u16, u16)>,
+    /// DECAWM off flag (`\x1b[?7l`). `false` = default (autowrap on).
+    decawm_off: bool,
+}
+
+struct StickySniffer<'a> {
+    modes: &'a mut StickyModes,
+}
+
+impl<'a> Perform for StickySniffer<'a> {
+    fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], _ignore: bool, action: char) {
+        let private = intermediates.first() == Some(&b'?');
+        match action {
+            // DECSTBM (`\x1b[<top>;<bot>r`). vte always pushes at least one
+            // param on CSI dispatch (even an empty param becomes `0`), so
+            // `is_empty()` alone doesn't reliably detect "reset to full
+            // screen". We treat "no valid top+bottom pair" as reset, which
+            // matches ECMA-48 semantics.
+            'r' if !private => {
+                let mut iter = params.iter();
+                let top = iter.next().and_then(|p| p.first().copied());
+                let bot = iter.next().and_then(|p| p.first().copied());
+                match (top, bot) {
+                    (Some(t), Some(b)) if t >= 1 && b > t => {
+                        self.modes.decstbm = Some((t, b));
+                    }
+                    _ => {
+                        self.modes.decstbm = None;
+                    }
+                }
+            }
+            // Private-mode set / reset.
+            'h' | 'l' => {
+                if !private {
+                    return;
+                }
+                let on = action == 'h';
+                for p in params.iter() {
+                    if let Some(&pv) = p.first() {
+                        if pv == 7 {
+                            self.modes.decawm_off = !on;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 impl TerminalCapture {
@@ -30,11 +93,17 @@ impl TerminalCapture {
             parser: Parser::new(rows, cols, SCROLLBACK_LINES),
             rows,
             cols,
+            sticky: StickyModes::default(),
+            sniffer: VteParser::new(),
         }
     }
 
     pub fn feed(&mut self, bytes: &[u8]) {
         self.parser.process(bytes);
+        let mut sniffer = StickySniffer {
+            modes: &mut self.sticky,
+        };
+        self.sniffer.advance(&mut sniffer, bytes);
     }
 
     pub fn resize(&mut self, rows: u16, cols: u16) {
@@ -75,6 +144,22 @@ impl TerminalCapture {
         // itself.
         if screen.alternate_screen() {
             out.extend_from_slice(b"\x1b[?1049h");
+        }
+
+        // Re-assert sticky modes that RIS clears and `state_formatted`
+        // doesn't re-emit. vt100 0.16 doesn't expose these publicly, so we
+        // sniff them from the byte stream in `feed`. Issue #36.
+        if let Some((top, bot)) = self.sticky.decstbm {
+            // DECSTBM (scroll region). Without this a TUI with a narrow
+            // scroll region would lose it on reattach and subsequent scrolls
+            // would scroll the whole screen.
+            out.extend_from_slice(format!("\x1b[{};{}r", top, bot).as_bytes());
+        }
+        if self.sticky.decawm_off {
+            // DECAWM off. Without this, a TUI that had disabled autowrap
+            // (e.g. a drawing app using absolute moves) would start wrapping
+            // text after reattach — garbled layout.
+            out.extend_from_slice(b"\x1b[?7l");
         }
 
         // `state_formatted` = cells + SGR + cursor position/visibility +
@@ -268,5 +353,558 @@ mod tests {
             \x1b[2;1Hreplaced\
         ";
         assert_replay_equivalent(24, 80, script);
+    }
+}
+
+#[cfg(test)]
+mod adversarial_tests {
+    //! Tests that actively try to break the replay synthesis — scroll
+    //! regions, DECSC/DECRC, alt-screen toggles with state, wide/zero-width
+    //! glyphs, wrap-at-margin SGR continuity, malformed input, resize mid-
+    //! alt-screen. Each test either locks in correct behavior or documents a
+    //! known limitation with an inline note linking to issue #36.
+    //!
+    //! The helper `adv_replay` differs from `assert_replay_equivalent` above:
+    //! it returns the two screens so individual tests can assert only the
+    //! properties they care about (cell content, cursor position, specific
+    //! cells) rather than full equivalence. Some terminal state that vt100
+    //! doesn't track (titles, OSC-4 palette) will never survive a round-trip;
+    //! the tests for those cases assert the limit, not the wish.
+    use super::*;
+    use vt100::Parser;
+
+    /// Feed `script` into a capture, take the snapshot, feed it into a fresh
+    /// parser. Return the (source, replay) parsers so callers can pick their
+    /// assertions.
+    fn adv_replay(rows: u16, cols: u16, script: &[u8]) -> (Parser, Parser) {
+        let mut source = TerminalCapture::new(rows, cols);
+        source.feed(script);
+        let snapshot = source.snapshot_bytes();
+
+        // Move parser out of TerminalCapture for inspection. The simplest way
+        // is to reconstruct a fresh parser and re-feed the original script
+        // — vt100 doesn't expose Parser by value, only by reference.
+        let mut src_parser = Parser::new(rows, cols, SCROLLBACK_LINES);
+        src_parser.process(script);
+
+        let mut replay = Parser::new(rows, cols, SCROLLBACK_LINES);
+        replay.process(&snapshot);
+
+        (src_parser, replay)
+    }
+
+    // ─── Scroll region (DECSTBM) ────────────────────────────────────────────
+
+    #[test]
+    fn scroll_region_is_reflected_in_final_contents() {
+        // Set scroll region to rows 3-20 (1-indexed), then paint several
+        // lines. The source and replay should show the same final frame even
+        // though the scroll region affects where newlines wrap.
+        let script = b"\x1b[3;20r\x1b[3;1Ha\x1b[4;1Hb\x1b[5;1Hc";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert_eq!(src.screen().contents(), dst.screen().contents());
+        assert_eq!(
+            src.screen().cursor_position(),
+            dst.screen().cursor_position()
+        );
+    }
+
+    // ─── Save / restore cursor (DECSC / DECRC) ──────────────────────────────
+
+    #[test]
+    fn saved_cursor_not_preserved_by_snapshot_known_limitation() {
+        // Source uses \x1b7 to save cursor at row 5, paints elsewhere, then
+        // \x1b8 to restore. By the time we snapshot, cursor IS back at row 5
+        // and the grid reflects a correct final position. What we CANNOT
+        // preserve is the "saved-cursor register" itself: if the app issues
+        // another \x1b8 AFTER the reattach, our replay doesn't carry the
+        // saved position forward.
+        //
+        // This test documents the limit: post-snapshot \x1b8 in the source
+        // still returns to (5, 5), but in the replayed parser it returns to
+        // (0, 0) because we never re-saved. Filed under #36.
+        let script = b"\x1b[5;5H\x1b7\x1b[20;20Htail";
+        let (mut src, mut dst) = adv_replay(24, 80, script);
+        src.process(b"\x1b8");
+        dst.process(b"\x1b8");
+        assert_eq!(
+            src.screen().cursor_position(),
+            (4, 4),
+            "source DECRC returns to saved"
+        );
+        assert_ne!(
+            dst.screen().cursor_position(),
+            (4, 4),
+            "replay DECRC loses the saved cursor — known limitation"
+        );
+    }
+
+    // ─── Alt-screen toggle with state on both buffers ───────────────────────
+
+    #[test]
+    fn alt_screen_round_trip_when_active() {
+        // Enter alt, paint, stay on alt. Primary is irrelevant.
+        let script = b"\x1b[?1049h\x1b[2J\x1b[1;1HALT_VIEW";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert!(src.screen().alternate_screen());
+        assert!(dst.screen().alternate_screen());
+        assert!(dst.screen().contents().contains("ALT_VIEW"));
+    }
+
+    #[test]
+    fn primary_content_visible_after_leaving_alt() {
+        // Paint primary, enter alt + paint, leave alt — primary content must
+        // be what's shown in the replay.
+        let script = b"\x1b[1;1HPRIMARY\x1b[?1049h\x1b[2J\x1b[1;1HALT\x1b[?1049l";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert!(!src.screen().alternate_screen());
+        assert!(!dst.screen().alternate_screen());
+        assert!(
+            dst.screen().contents().contains("PRIMARY"),
+            "PRIMARY missing from replay: {:?}",
+            dst.screen().contents()
+        );
+        // ALT content should NOT bleed through.
+        assert!(!dst.screen().contents().contains("ALT"));
+    }
+
+    // ─── SGR across wrapped rows ────────────────────────────────────────────
+
+    #[test]
+    fn sgr_preserved_across_line_wrap() {
+        // Narrow grid so text wraps. Assert SGR color lands on the right cell
+        // on the wrapped row — vt100's contents_formatted must re-emit SGR
+        // on each row where it's active.
+        let script = b"\x1b[31mAAAAAAAAAA"; // 10 red As on a 5-col grid → wraps
+        let (src, dst) = adv_replay(4, 5, script);
+        // Assert same red-vs-default pattern on both parsers.
+        for row in 0..2u16 {
+            for col in 0..5u16 {
+                let sc = src.screen().cell(row, col).expect("src cell");
+                let dc = dst.screen().cell(row, col).expect("dst cell");
+                assert_eq!(
+                    sc.fgcolor(),
+                    dc.fgcolor(),
+                    "fgcolor differs at ({},{})",
+                    row,
+                    col
+                );
+                assert_eq!(sc.contents(), dc.contents());
+            }
+        }
+    }
+
+    // ─── Wide / CJK glyphs ──────────────────────────────────────────────────
+
+    #[test]
+    fn wide_glyphs_land_at_same_cells() {
+        // CJK chars take 2 columns. Place them near the right margin and
+        // verify cell-by-cell equivalence.
+        let script = "\x1b[1;1H日本語test".as_bytes();
+        let (src, dst) = adv_replay(24, 80, script);
+        assert_eq!(src.screen().contents(), dst.screen().contents());
+        // Each CJK glyph should occupy 2 cells in vt100's model.
+        assert_eq!(
+            src.screen().cell(0, 0).map(|c| c.contents()),
+            dst.screen().cell(0, 0).map(|c| c.contents())
+        );
+    }
+
+    // ─── Zero-width / combining characters ─────────────────────────────────
+
+    #[test]
+    fn combining_marks_round_trip() {
+        // é as e + combining acute (U+0301).
+        let script = "\x1b[1;1Hcaf\u{0065}\u{0301}".as_bytes();
+        let (src, dst) = adv_replay(24, 80, script);
+        assert_eq!(src.screen().contents(), dst.screen().contents());
+    }
+
+    // ─── Cursor past right margin ──────────────────────────────────────────
+
+    #[test]
+    fn cursor_at_right_margin_parks_consistently() {
+        // Fill exactly to the right margin; cursor should park at col=cols
+        // (one-past-last, DECAWM pending-wrap state).
+        let script = b"\x1b[1;1Habcde"; // 5 cols grid
+        let (src, dst) = adv_replay(4, 5, script);
+        assert_eq!(
+            src.screen().cursor_position(),
+            dst.screen().cursor_position(),
+            "pending-wrap cursor position diverges"
+        );
+    }
+
+    // ─── Tab stops ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn custom_tab_stops_surface_in_layout() {
+        // Clear all tab stops, set one at col 10, then TAB and write.
+        let script = b"\x1b[1;1H\x1b[3g\x1b[1;10H\x1bH\x1b[1;1H\tX";
+        let (src, dst) = adv_replay(24, 80, script);
+        // The `X` glyph should land at the same column in both parsers.
+        assert_eq!(src.screen().contents(), dst.screen().contents());
+    }
+
+    // ─── BEL handling ──────────────────────────────────────────────────────
+
+    #[test]
+    fn bel_does_not_corrupt_stream() {
+        let script = b"before\x07after";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert_eq!(src.screen().contents(), dst.screen().contents());
+        assert!(dst.screen().contents().contains("beforeafter"));
+    }
+
+    // ─── Malformed CSI must not corrupt subsequent state ───────────────────
+
+    #[test]
+    fn malformed_csi_is_recovered_from() {
+        // Garbage in the middle shouldn't prevent the "GOOD" text from
+        // rendering at the right position.
+        let script = b"\x1b[1;1Hbefore\x1b[~~~invalid\x1b[2;1HGOOD";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert!(dst.screen().contents().contains("GOOD"));
+        assert_eq!(src.screen().contents(), dst.screen().contents());
+    }
+
+    // ─── Partial UTF-8 across chunks ────────────────────────────────────────
+
+    #[test]
+    fn utf8_split_across_chunks_still_reconstructs() {
+        // 4-byte emoji 🚀 split 2/2.
+        let rocket = "🚀".as_bytes(); // 4 bytes: 0xF0 0x9F 0x9A 0x80
+        assert_eq!(rocket.len(), 4);
+        let mut cap = TerminalCapture::new(24, 80);
+        cap.feed(b"\x1b[1;1H");
+        cap.feed(&rocket[..2]);
+        cap.feed(&rocket[2..]);
+        cap.feed(b"_tail");
+        let snapshot = cap.snapshot_bytes();
+        let mut dst = Parser::new(24, 80, SCROLLBACK_LINES);
+        dst.process(&snapshot);
+        assert!(
+            dst.screen().contents().contains("🚀_tail"),
+            "replay lost the emoji: {:?}",
+            dst.screen().contents()
+        );
+    }
+
+    // ─── Very long line ────────────────────────────────────────────────────
+
+    #[test]
+    fn very_long_line_does_not_overflow_or_crash() {
+        let long = vec![b'x'; 10_000];
+        let mut cap = TerminalCapture::new(24, 80);
+        cap.feed(b"\x1b[1;1H");
+        cap.feed(&long);
+        // Survives; snapshot is bounded in size regardless of input length.
+        let snapshot = cap.snapshot_bytes();
+        assert!(
+            snapshot.len() < 100_000,
+            "snapshot grew unexpectedly: {} bytes",
+            snapshot.len()
+        );
+    }
+
+    // ─── Title (OSC 0/2) — known limitation ────────────────────────────────
+
+    #[test]
+    fn window_title_not_persisted_known_limitation() {
+        // vt100 0.16 does not track the window title. The app's OSC 0 / 2
+        // sequences silently vanish across a reattach. Documented in #36;
+        // fix would be either upgrading to a vt100 fork that tracks title or
+        // adding our own title sniffer on top of the raw byte stream.
+        let script = b"\x1b]0;myapp-v1\x07\x1b[1;1Hbody";
+        let (_src, dst) = adv_replay(24, 80, script);
+        // Body text makes it through:
+        assert!(dst.screen().contents().contains("body"));
+        // But there's no way to observe title in vt100; the assertion is
+        // simply "this compiles and doesn't corrupt other state".
+    }
+
+    // ─── Resize during alt-screen ──────────────────────────────────────────
+
+    #[test]
+    fn resize_while_on_alt_screen_preserves_mode() {
+        let mut cap = TerminalCapture::new(24, 80);
+        cap.feed(b"\x1b[?1049h\x1b[2J\x1b[1;1HALT");
+        cap.resize(40, 120);
+        let snapshot = cap.snapshot_bytes();
+        let mut dst = Parser::new(40, 120, SCROLLBACK_LINES);
+        dst.process(&snapshot);
+        assert!(
+            dst.screen().alternate_screen(),
+            "alt-screen flag lost on resize"
+        );
+        assert!(dst.screen().contents().contains("ALT"));
+    }
+
+    // ─── Mouse protocol mode — input-mode round-trip ───────────────────────
+
+    #[test]
+    fn mouse_sgr_mode_replayed() {
+        // Enable ButtonMotion + SGR encoding.
+        let script = b"\x1b[?1002h\x1b[?1006h\x1b[1;1Hready";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert_eq!(
+            src.screen().mouse_protocol_mode(),
+            dst.screen().mouse_protocol_mode(),
+            "mouse protocol mode diverges"
+        );
+        assert_eq!(
+            src.screen().mouse_protocol_encoding(),
+            dst.screen().mouse_protocol_encoding(),
+            "mouse protocol encoding diverges"
+        );
+    }
+
+    // ─── Bracketed paste mode ──────────────────────────────────────────────
+
+    #[test]
+    fn bracketed_paste_mode_replayed() {
+        let script = b"\x1b[?2004h\x1b[1;1Hprompt>";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert_eq!(
+            src.screen().bracketed_paste(),
+            dst.screen().bracketed_paste()
+        );
+        assert!(dst.screen().bracketed_paste());
+    }
+
+    // ─── Application cursor keys mode ──────────────────────────────────────
+
+    #[test]
+    fn application_cursor_mode_replayed() {
+        let script = b"\x1b[?1h\x1b[1;1Hreadline";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert_eq!(
+            src.screen().application_cursor(),
+            dst.screen().application_cursor()
+        );
+        assert!(dst.screen().application_cursor());
+    }
+
+    // ─── Hidden cursor across alt-screen toggle ────────────────────────────
+
+    #[test]
+    fn hidden_cursor_persists_across_alt_toggle() {
+        // A TUI typically hides cursor before drawing. That state must
+        // survive a detach/reattach cycle regardless of alt-screen flips.
+        let script = b"\x1b[?25l\x1b[?1049h\x1b[2J\x1b[1;1HtuiALT";
+        let (src, dst) = adv_replay(24, 80, script);
+        assert_eq!(src.screen().hide_cursor(), dst.screen().hide_cursor());
+        assert!(dst.screen().hide_cursor());
+        assert!(dst.screen().alternate_screen());
+    }
+
+    // ─── Scroll region (DECSTBM) survives replay, checked by behavior ──────
+    //
+    // The checks above only compared final frames. This one drives both
+    // parsers further AFTER the snapshot round-trip: if the replay restored
+    // DECSTBM, a subsequent overflow below the region should not scroll rows
+    // outside the region. If the replay lost DECSTBM (RIS resets it, and
+    // state_formatted may not re-emit), the source and replay will diverge
+    // on the next paint.
+
+    /// Read a row as a trimmed string (for readable assertion diffs).
+    fn row_text(parser: &Parser, row: u16) -> String {
+        let cols = parser.screen().size().1;
+        let s = (0..cols)
+            .filter_map(|c| parser.screen().cell(row, c).map(|x| x.contents()))
+            .collect::<String>();
+        s.trim_end().to_string()
+    }
+
+    #[test]
+    fn scroll_region_behavior_survives_replay() {
+        // Set DECSTBM to rows 3-5 (1-indexed). Paint anchors at row 1 and
+        // row 5. After replay, drive a LF at row 5: if DECSTBM is still
+        // active, the region scrolls up (row 5 "bottom" moves to row 4,
+        // new content lands at row 5). If DECSTBM was lost through RIS,
+        // the cursor just advances to row 6 — row 4 stays empty and row 6
+        // gets the new content.
+        //
+        // Assertion: row 4 must contain "bottom" (region scrolled it up) and
+        // row 5 must contain "new-last". A divergence here exposes DECSTBM
+        // not surviving replay. Tracked in #36.
+        let setup = b"\x1b[3;5r\x1b[1;1Hanchor\x1b[5;1Hbottom";
+        let (mut src, mut dst) = adv_replay(10, 20, setup);
+
+        let trigger = b"\x1b[5;1H\nnew-last";
+        src.process(trigger);
+        dst.process(trigger);
+
+        assert_eq!(row_text(&src, 0), "anchor");
+        assert_eq!(
+            row_text(&src, 3),
+            "bottom",
+            "source: region must scroll row 5 up"
+        );
+        assert_eq!(
+            row_text(&src, 4),
+            "new-last",
+            "source: new content on region bottom"
+        );
+
+        assert_eq!(row_text(&dst, 0), row_text(&src, 0), "row 1 diverges");
+        assert_eq!(
+            row_text(&dst, 3),
+            row_text(&src, 3),
+            "row 4 diverges — DECSTBM not preserved through replay"
+        );
+        assert_eq!(
+            row_text(&dst, 4),
+            row_text(&src, 4),
+            "row 5 diverges — DECSTBM not preserved through replay"
+        );
+    }
+
+    // ─── Charset (DEC Special Graphics) survives replay, checked by behavior
+
+    #[test]
+    fn dec_graphics_charset_survives_replay() {
+        // Switch G0 to DEC Special Graphics. In that mode, ASCII `q` renders
+        // as a horizontal line (U+2500). If the replay doesn't restore the
+        // charset state, post-replay `q` reverts to the letter q.
+        let setup = b"\x1b[1;1H\x1b(0qqq"; // G0 → graphics, write 3 glyphs
+        let (mut src, mut dst) = adv_replay(5, 10, setup);
+
+        // Now write 3 more chars in both. If charset is still active, they
+        // render as line drawings; if replay dropped charset, they render as
+        // plain 'q'.
+        src.process(b"qqq");
+        dst.process(b"qqq");
+
+        let src_row0 = (0..6u16)
+            .filter_map(|c| src.screen().cell(0, c).map(|x| x.contents()))
+            .collect::<String>();
+        let dst_row0 = (0..6u16)
+            .filter_map(|c| dst.screen().cell(0, c).map(|x| x.contents()))
+            .collect::<String>();
+        assert_eq!(
+            src_row0, dst_row0,
+            "DEC graphics charset not preserved — post-replay 'q' renders \
+             differently in src vs dst (src={:?} dst={:?}). Tracked in #36.",
+            src_row0, dst_row0
+        );
+    }
+
+    // ─── DECSCNM (reverse video screen mode) ───────────────────────────────
+
+    #[test]
+    fn decscnm_reverse_video_mode() {
+        // Reverse video is a whole-screen flag: it inverts fg/bg for every
+        // cell. If the app is in reverse video, the replay must either
+        // preserve DECSCNM OR pre-invert every cell's SGR. vt100 doesn't
+        // expose DECSCNM as a getter, so we check by rendering behavior:
+        // paint with default SGR, enable reverse, then compare cell attrs.
+        let script = b"\x1b[1;1Hplain\x1b[?5h";
+        let (src, dst) = adv_replay(5, 10, script);
+        // We cannot directly observe mode, so we assert cells match.
+        assert_eq!(src.screen().contents(), dst.screen().contents());
+        // And a post-replay paint should look the same on both sides.
+    }
+
+    // ─── Cursor shape (DECSCUSR) — likely a known limitation ───────────────
+
+    #[test]
+    fn cursor_shape_limitation_documented() {
+        // \x1b[5 q = blinking bar. vt100 0.16 doesn't track cursor shape, so
+        // the replay cannot restore it. Documented for future upgrade. If
+        // vt100 ever adds cursor_shape(), this test should gain an assertion
+        // that it's preserved; for now, just ensure nothing else corrupts.
+        let script = b"\x1b[5 q\x1b[1;1Hready";
+        let (_src, dst) = adv_replay(5, 10, script);
+        assert!(dst.screen().contents().contains("ready"));
+    }
+
+    // ─── Detach → write → attach: raw backlog vs grid divergence ───────────
+
+    #[test]
+    fn capture_accumulates_while_detached() {
+        // Simulate "client detaches, worker keeps running, new output
+        // arrives". Multiple feed() calls between snapshots — the grid must
+        // reflect the cumulative state, not just the last feed.
+        let mut cap = TerminalCapture::new(5, 20);
+        cap.feed(b"\x1b[1;1HA");
+        cap.feed(b"\x1b[2;1HB");
+        cap.feed(b"\x1b[3;1HC");
+        let mut dst = Parser::new(5, 20, SCROLLBACK_LINES);
+        dst.process(&cap.snapshot_bytes());
+        let contents = dst.screen().contents();
+        assert!(contents.contains("A"));
+        assert!(contents.contains("B"));
+        assert!(contents.contains("C"));
+    }
+
+    // ─── DECAWM (autowrap) behavior survives replay ────────────────────────
+
+    /// DECAWM is not implemented by vt100 0.16 (only 5 DEC modes are — see
+    /// `MODE_*` constants in vt100 screen.rs). That means both source and
+    /// replay parsers wrap regardless of `\x1b[?7l`, so we can't verify
+    /// end-to-end behavior with vt100 playing both roles. What we CAN verify
+    /// is that the sniffer captured DECAWM-off and the snapshot re-emits
+    /// `\x1b[?7l` — a real xterm / iTerm / kitty / Windows Terminal on the
+    /// client side will then honor it. Locked with a snapshot-bytes check.
+    #[test]
+    fn decawm_off_is_re_emitted_in_snapshot() {
+        let mut cap = TerminalCapture::new(5, 5);
+        cap.feed(b"\x1b[?7l\x1b[1;1H");
+        assert!(cap.sticky.decawm_off, "sniffer missed DECAWM off");
+        let snap = cap.snapshot_bytes();
+        assert!(
+            snap.windows(5).any(|w| w == b"\x1b[?7l"),
+            "snapshot missing \\x1b[?7l. bytes: {:?}",
+            String::from_utf8_lossy(&snap)
+        );
+    }
+
+    /// DECSTBM reset (`\x1b[r` with no params) must clear the sticky region
+    /// so the next snapshot doesn't lie about a region the app has cleared.
+    #[test]
+    fn decstbm_reset_clears_sticky_region() {
+        let mut cap = TerminalCapture::new(10, 20);
+        cap.feed(b"\x1b[3;7r");
+        assert_eq!(cap.sticky.decstbm, Some((3, 7)));
+        cap.feed(b"\x1b[r");
+        assert_eq!(
+            cap.sticky.decstbm, None,
+            "DECSTBM reset did not clear sticky region"
+        );
+    }
+
+    /// Re-enabling autowrap should clear the sticky-off flag so a
+    /// subsequent snapshot doesn't lie to the client.
+    #[test]
+    fn decawm_re_enabled_clears_sticky_flag() {
+        let mut cap = TerminalCapture::new(5, 5);
+        cap.feed(b"\x1b[?7l\x1b[1;1H");
+        assert!(cap.sticky.decawm_off);
+        cap.feed(b"\x1b[?7h");
+        assert!(!cap.sticky.decawm_off);
+        let snap = cap.snapshot_bytes();
+        assert!(
+            !snap.windows(5).any(|w| w == b"\x1b[?7l"),
+            "snapshot wrongly still emits DECAWM-off after app re-enabled wrap"
+        );
+    }
+
+    // ─── Reverse of the RIS-eats-mode problem: a pre-reset mode must still
+    //     be re-asserted after RIS in the snapshot ──────────────────────────
+
+    #[test]
+    fn modes_set_before_rendering_are_re_asserted_after_ris() {
+        // Bracketed paste mode on, then some rendering. snapshot_bytes starts
+        // with \x1bc (RIS) which clears bracketed paste. The replay path must
+        // re-emit \x1b[?2004h or the flag gets dropped. This locks in the
+        // expectation that our snapshot emits input-mode AFTER the RIS.
+        let script = b"\x1b[?2004h\x1b[1;1Hprompt";
+        let (src, dst) = adv_replay(5, 20, script);
+        assert!(src.screen().bracketed_paste());
+        assert!(
+            dst.screen().bracketed_paste(),
+            "bracketed paste lost — RIS cleared it and snapshot didn't re-emit"
+        );
     }
 }

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -189,6 +189,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         Some(Command::Attach { .. })
         | Some(Command::Kill { .. })
         | Some(Command::List)
+        | Some(Command::Logs { .. })
         | Some(Command::InternalDaemon { .. })
         | Some(Command::InternalWorker { .. }) => {}
         None => {

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -189,6 +189,13 @@ type AttachClientResult = (
     Vec<Vec<u8>>,
 );
 
+/// pm2-style per-session log file. Soft cap at 10 MiB; exceeding rolls the
+/// current file to `<id>.log.1` (overwriting any prior backup). Keeping only
+/// one backup is deliberate — clud sessions are ephemeral and the on-disk
+/// footprint shouldn't grow unboundedly for a stale session nobody
+/// reattaches to.
+const LOG_ROTATE_BYTES: u64 = 10 * 1024 * 1024;
+
 struct WorkerShared {
     state_dir: PathBuf,
     session_id: String,
@@ -200,6 +207,11 @@ struct WorkerShared {
     /// synthesized repaint instead of a raw byte dump, which would leave a
     /// TUI-attached client staring at a garbled frame.
     capture: Mutex<Option<TerminalCapture>>,
+    /// Append-only log file for this session. Every output chunk is written
+    /// here in addition to the in-memory backlog, so `clud logs <id>` can
+    /// pm2-style tail / follow output that has scrolled off the 256 KiB
+    /// backlog or from sessions that have fully exited.
+    log_file: Mutex<Option<fs::File>>,
     client: Mutex<Option<AttachedClient>>,
     next_client_id: AtomicU64,
     stop_accepting: AtomicBool,
@@ -213,9 +225,69 @@ impl WorkerShared {
             snapshot: Mutex::new(snapshot),
             backlog: Mutex::new(BacklogState::default()),
             capture: Mutex::new(None),
+            log_file: Mutex::new(None),
             client: Mutex::new(None),
             next_client_id: AtomicU64::new(1),
             stop_accepting: AtomicBool::new(false),
+        }
+    }
+
+    /// Open the session's log file for append. Called once during worker
+    /// startup. A failure here is non-fatal: we log a warning and continue
+    /// without a log file rather than killing the session.
+    fn init_log_file(&self) {
+        let path = session_log_path(&self.state_dir, &self.session_id);
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        match fs::OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(file) => {
+                *self.log_file.lock().expect("log_file mutex poisoned") = Some(file);
+            }
+            Err(err) => {
+                eprintln!(
+                    "[clud] warning: cannot open session log {}: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
+    }
+
+    /// Append `chunk` to the session log, rotating at the soft size cap.
+    fn append_log(&self, chunk: &[u8]) {
+        let mut guard = self.log_file.lock().expect("log_file mutex poisoned");
+        let Some(file) = guard.as_mut() else { return };
+        if file.write_all(chunk).is_err() {
+            return;
+        }
+        let _ = file.flush();
+        if let Ok(meta) = file.metadata() {
+            if meta.len() >= LOG_ROTATE_BYTES {
+                drop(guard);
+                self.rotate_log();
+            }
+        }
+    }
+
+    fn rotate_log(&self) {
+        let primary = session_log_path(&self.state_dir, &self.session_id);
+        let backup = primary.with_extension("log.1");
+        // Close the current handle first so Windows lets us rename it.
+        {
+            let mut guard = self.log_file.lock().expect("log_file mutex poisoned");
+            *guard = None;
+        }
+        let _ = fs::remove_file(&backup);
+        if fs::rename(&primary, &backup).is_err() {
+            // Rename failed (file in use, etc.) — reopen primary anyway.
+        }
+        if let Ok(file) = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&primary)
+        {
+            *self.log_file.lock().expect("log_file mutex poisoned") = Some(file);
         }
     }
 
@@ -410,6 +482,10 @@ impl WorkerShared {
         {
             capture.feed(&chunk);
         }
+        // pm2-style persistent log: every byte that the session produces gets
+        // appended to `<state_dir>/logs/<session_id>.log`, so `clud logs` can
+        // show output that scrolled off the 256 KiB in-memory backlog.
+        self.append_log(&chunk);
         self.send_to_client(WorkerServerMessage::Output {
             data_b64: base64::engine::general_purpose::STANDARD.encode(chunk),
         });
@@ -537,6 +613,20 @@ pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i
         Some(Command::List) => {
             let state_dir = state_dir(args);
             Some(run_list(&state_dir))
+        }
+        Some(Command::Logs {
+            session_id,
+            follow,
+            lines,
+        }) => {
+            let state_dir = state_dir(args);
+            Some(run_logs(
+                &state_dir,
+                session_id.as_deref(),
+                *follow,
+                *lines,
+                interrupted,
+            ))
         }
         Some(Command::InternalDaemon { state_dir }) => Some(run_daemon(state_dir)),
         Some(Command::InternalWorker {
@@ -1312,6 +1402,7 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
         session_id.to_string(),
         snapshot,
     ));
+    shared.init_log_file();
 
     let runtime = match spec.kind {
         SessionKind::Subprocess => match start_subprocess_session(&spec, &shared) {
@@ -1747,6 +1838,14 @@ fn session_snapshot_path(state_dir: &Path, session_id: &str) -> PathBuf {
     sessions_dir(state_dir).join(format!("{session_id}.json"))
 }
 
+fn logs_dir(state_dir: &Path) -> PathBuf {
+    state_dir.join("logs")
+}
+
+pub(crate) fn session_log_path(state_dir: &Path, session_id: &str) -> PathBuf {
+    logs_dir(state_dir).join(format!("{session_id}.log"))
+}
+
 fn spec_path(state_dir: &Path, session_id: &str) -> PathBuf {
     specs_dir(state_dir).join(format!("{session_id}.json"))
 }
@@ -1910,6 +2009,179 @@ fn run_list(state_dir: &Path) -> i32 {
         println!("{:<30} {:<8} {:<8} {}", display_name, pid, uptime, cwd);
     }
     0
+}
+
+/// pm2-style log viewer. No id → list sessions with their last log line.
+/// With an id → dump the log, then optionally follow.
+fn run_logs(
+    state_dir: &Path,
+    session_id: Option<&str>,
+    follow: bool,
+    lines: Option<usize>,
+    interrupted: &AtomicBool,
+) -> i32 {
+    let Some(input) = session_id else {
+        return run_logs_summary(state_dir);
+    };
+    let resolved = match resolve_session_id(state_dir, input) {
+        Ok(id) => id,
+        Err(_) => {
+            // Allow viewing logs for sessions whose snapshot file has been
+            // cleaned up but whose .log remains on disk. If a raw .log exists
+            // at the given name, use that.
+            let raw = session_log_path(state_dir, input);
+            if raw.is_file() {
+                input.to_string()
+            } else {
+                eprintln!("[clud] no session or log found for {}", input);
+                return 1;
+            }
+        }
+    };
+    let path = session_log_path(state_dir, &resolved);
+    if !path.exists() {
+        eprintln!(
+            "[clud] no log file for session {}: {}",
+            resolved,
+            path.display()
+        );
+        return 1;
+    }
+    let mut offset = match print_log_tail(&path, lines) {
+        Ok(offset) => offset,
+        Err(err) => {
+            eprintln!("[clud] failed to read log {}: {}", path.display(), err);
+            return 1;
+        }
+    };
+    if !follow {
+        return 0;
+    }
+    // pm2-style follow: poll for new bytes at the last known offset. A
+    // short sleep on "no new data" keeps CPU low without requiring a file-
+    // watch API that differs per OS.
+    loop {
+        if interrupted.load(Ordering::SeqCst) {
+            return 130;
+        }
+        match follow_read(&path, offset) {
+            Ok((new_offset, chunk)) => {
+                if !chunk.is_empty() {
+                    let _ = io::stdout().write_all(&chunk);
+                    let _ = io::stdout().flush();
+                }
+                offset = new_offset;
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                // Rotation race: file was renamed out from under us.
+                // Sleep briefly and the rotated primary will reappear.
+            }
+            Err(err) => {
+                eprintln!("[clud] follow error: {}", err);
+                return 1;
+            }
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+}
+
+fn run_logs_summary(state_dir: &Path) -> i32 {
+    let dir = logs_dir(state_dir);
+    let Ok(entries) = fs::read_dir(&dir) else {
+        println!("No log files. Start a session with: clud --detach -p <prompt>");
+        return 0;
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("log"))
+        .collect();
+    if paths.is_empty() {
+        println!("No log files in {}", dir.display());
+        return 0;
+    }
+    paths.sort();
+    println!("{:<30} {:>10} LAST LINE", "SESSION", "BYTES");
+    for path in paths {
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        let last = last_line_of(&path).unwrap_or_default();
+        println!(
+            "{:<30} {:>10} {}",
+            stem,
+            size,
+            last.trim_end_matches(['\r', '\n'])
+        );
+    }
+    0
+}
+
+fn last_line_of(path: &Path) -> io::Result<String> {
+    // Read the tail in a modest chunk and return the last non-empty line.
+    // Cheap for typical log files; good enough for a summary listing.
+    let mut file = fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    let start = len.saturating_sub(4096);
+    use std::io::{Read, Seek, SeekFrom};
+    file.seek(SeekFrom::Start(start))?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    let text = String::from_utf8_lossy(&buf);
+    Ok(text
+        .lines()
+        .rfind(|line| !line.is_empty())
+        .unwrap_or("")
+        .to_string())
+}
+
+fn print_log_tail(path: &Path, lines: Option<usize>) -> io::Result<u64> {
+    let data = fs::read(path)?;
+    let slice: &[u8] = match lines {
+        None => &data,
+        Some(n) => {
+            let mut count = 0usize;
+            let mut split = data.len();
+            for (i, &b) in data.iter().enumerate().rev() {
+                if b == b'\n' && i + 1 != data.len() {
+                    count += 1;
+                    if count > n {
+                        split = i + 1;
+                        break;
+                    }
+                }
+            }
+            if count <= n {
+                // File has <= n lines; show the whole thing.
+                &data
+            } else {
+                &data[split..]
+            }
+        }
+    };
+    io::stdout().write_all(slice)?;
+    io::stdout().flush()?;
+    Ok(data.len() as u64)
+}
+
+fn follow_read(path: &Path, offset: u64) -> io::Result<(u64, Vec<u8>)> {
+    let meta = fs::metadata(path)?;
+    let len = meta.len();
+    if len < offset {
+        // File was truncated or rotated — start from the new beginning.
+        let data = fs::read(path)?;
+        return Ok((data.len() as u64, data));
+    }
+    if len == offset {
+        return Ok((offset, Vec::new()));
+    }
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = fs::File::open(path)?;
+    file.seek(SeekFrom::Start(offset))?;
+    let mut buf = Vec::with_capacity((len - offset) as usize);
+    file.read_to_end(&mut buf)?;
+    Ok((len, buf))
 }
 
 fn list_attachable_sessions(state_dir: &Path) -> Vec<SessionSnapshot> {
@@ -2229,5 +2501,101 @@ mod capture_integration_tests {
             "E",
             "'E' of EDGE should land at col 99 after resize"
         );
+    }
+}
+
+#[cfg(test)]
+mod log_tests {
+    //! Tests for the pm2-style persistent log file.
+    use super::*;
+    use tempfile::TempDir;
+
+    fn shared_with_log(tmp: &TempDir, id: &str) -> Arc<WorkerShared> {
+        let snap = SessionSnapshot {
+            id: id.into(),
+            kind: SessionKind::Subprocess,
+            cwd: None,
+            name: None,
+            created_at: Some(0),
+            detachable: true,
+            background: false,
+            daemon_pid: 0,
+            worker_pid: 0,
+            worker_port: 0,
+            root_pid: None,
+            exit_code: None,
+        };
+        let shared = Arc::new(WorkerShared::new(tmp.path().to_path_buf(), id.into(), snap));
+        shared.init_log_file();
+        shared
+    }
+
+    #[test]
+    fn push_output_appends_to_log_file() {
+        let tmp = TempDir::new().unwrap();
+        let shared = shared_with_log(&tmp, "s1");
+        shared.push_output(b"line one\n".to_vec());
+        shared.push_output(b"line two\n".to_vec());
+        // Drop so the file flushes / releases on Windows.
+        drop(shared);
+
+        let path = session_log_path(tmp.path(), "s1");
+        let contents = fs::read(&path).expect("read log");
+        assert_eq!(contents, b"line one\nline two\n");
+    }
+
+    #[test]
+    fn rotation_moves_oversize_log_to_backup() {
+        let tmp = TempDir::new().unwrap();
+        let shared = shared_with_log(&tmp, "s2");
+        let chunk = vec![b'x'; (LOG_ROTATE_BYTES / 4) as usize];
+        // Push enough chunks to exceed the rotate threshold.
+        for _ in 0..6 {
+            shared.push_output(chunk.clone());
+        }
+        drop(shared);
+
+        let primary = session_log_path(tmp.path(), "s2");
+        let backup = primary.with_extension("log.1");
+        assert!(
+            backup.exists(),
+            "rotation should have produced a .log.1 backup"
+        );
+        // Primary may exist (post-rotation reopened) but be smaller than the cap.
+        if primary.exists() {
+            let len = fs::metadata(&primary).unwrap().len();
+            assert!(len < LOG_ROTATE_BYTES, "primary grew past the rotation cap");
+        }
+    }
+
+    #[test]
+    fn follow_read_returns_new_bytes_since_offset() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("x.log");
+        fs::write(&path, b"hello").unwrap();
+        let (off, new) = follow_read(&path, 0).unwrap();
+        assert_eq!(off, 5);
+        assert_eq!(new, b"hello");
+
+        // Append and re-read from offset 5; only new bytes come back.
+        let mut f = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        f.write_all(b" world").unwrap();
+        drop(f);
+
+        let (off2, new2) = follow_read(&path, off).unwrap();
+        assert_eq!(off2, 11);
+        assert_eq!(new2, b" world");
+    }
+
+    #[test]
+    fn follow_read_detects_truncation_and_rereads_from_zero() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("t.log");
+        fs::write(&path, b"longlong").unwrap();
+        let (off, _) = follow_read(&path, 0).unwrap();
+        fs::write(&path, b"short").unwrap();
+        let (new_off, new) = follow_read(&path, off).unwrap();
+        assert_eq!(new_off, 5);
+        assert_eq!(new, b"short");
     }
 }

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -2102,3 +2102,132 @@ fn ctrl_char_to_byte(ch: char) -> Option<u8> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod capture_integration_tests {
+    //! Tests that the terminal-capture layer is wired correctly through
+    //! `WorkerShared`. Complements the pure-unit tests in `capture.rs`: those
+    //! prove the parser can round-trip any given byte stream; these prove the
+    //! daemon calls `init_capture`, `feed`, `resize`, and `snapshot_bytes` at
+    //! the right points so an attach actually delivers the current screen.
+    use super::*;
+    use std::net::TcpListener;
+    use tempfile::TempDir;
+
+    fn loopback_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local_addr").port();
+        let client = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+        let (server, _) = listener.accept().expect("accept");
+        (client, server)
+    }
+
+    fn test_shared(state_dir: &Path, kind: SessionKind) -> Arc<WorkerShared> {
+        let snap = SessionSnapshot {
+            id: "test-session".into(),
+            kind,
+            cwd: None,
+            name: None,
+            created_at: Some(0),
+            detachable: true,
+            background: false,
+            daemon_pid: 0,
+            worker_pid: 0,
+            worker_port: 0,
+            root_pid: None,
+            exit_code: None,
+        };
+        Arc::new(WorkerShared::new(
+            state_dir.to_path_buf(),
+            "test-session".into(),
+            snap,
+        ))
+    }
+
+    #[test]
+    fn pty_attach_returns_single_synthesized_snapshot() {
+        let tmp = TempDir::new().expect("tempdir");
+        let shared = test_shared(tmp.path(), SessionKind::Pty);
+        shared.init_capture(24, 80);
+        shared.push_output(b"\x1b[1;1HHEADER\x1b[5;1HFOOTER".to_vec());
+
+        let (_client, server) = loopback_pair();
+        let (_id, _rx, _snap, replay) = shared.attach_client(server).expect("attach");
+
+        assert_eq!(
+            replay.len(),
+            1,
+            "PTY attach must deliver exactly one synthesized snapshot chunk"
+        );
+        let mut p = vt100::Parser::new(24, 80, 0);
+        p.process(&replay[0]);
+        let contents = p.screen().contents();
+        assert!(contents.contains("HEADER"), "HEADER missing from replay");
+        assert!(contents.contains("FOOTER"), "FOOTER missing from replay");
+    }
+
+    #[test]
+    fn subprocess_attach_returns_raw_backlog_unchanged() {
+        // Back-compat guarantee: subprocess sessions are line-oriented, users
+        // attaching mid-run want history, not a repaint. `init_capture` is
+        // never called in that code path, so `attach_client` must fall back
+        // to the raw-chunk replay that pre-dated issue #34.
+        let tmp = TempDir::new().expect("tempdir");
+        let shared = test_shared(tmp.path(), SessionKind::Subprocess);
+        shared.push_output(b"line1\n".to_vec());
+        shared.push_output(b"line2\n".to_vec());
+
+        let (_client, server) = loopback_pair();
+        let (_id, _rx, _snap, replay) = shared.attach_client(server).expect("attach");
+        assert_eq!(replay, vec![b"line1\n".to_vec(), b"line2\n".to_vec()]);
+    }
+
+    #[test]
+    fn reattach_after_detach_delivers_current_frame() {
+        // Output arriving *between* detach and reattach must still make it
+        // into the second snapshot — the capture keeps feeding even with no
+        // client connected.
+        let tmp = TempDir::new().expect("tempdir");
+        let shared = test_shared(tmp.path(), SessionKind::Pty);
+        shared.init_capture(24, 80);
+        shared.push_output(b"\x1b[1;1HBEFORE".to_vec());
+
+        let (_c1, s1) = loopback_pair();
+        let (cid1, _, _, _) = shared.attach_client(s1).expect("first attach");
+        shared.detach_client(cid1);
+
+        shared.push_output(b"\x1b[2;1HAFTER".to_vec());
+
+        let (_c2, s2) = loopback_pair();
+        let (_, _, _, replay) = shared.attach_client(s2).expect("second attach");
+        let mut p = vt100::Parser::new(24, 80, 0);
+        p.process(&replay[0]);
+        let c = p.screen().contents();
+        assert!(c.contains("BEFORE"), "pre-detach content missing: {:?}", c);
+        assert!(c.contains("AFTER"), "post-detach content missing: {:?}", c);
+    }
+
+    #[test]
+    fn resize_capture_takes_effect_for_subsequent_paint() {
+        // Pre-resize the parser grid isn't wide enough to hold col 100.
+        // After resize, a paint at col 100 lands correctly and the attach
+        // replay reflects it.
+        let tmp = TempDir::new().expect("tempdir");
+        let shared = test_shared(tmp.path(), SessionKind::Pty);
+        shared.init_capture(24, 80);
+        shared.resize_capture(40, 120);
+        shared.push_output(b"\x1b[1;100HEDGE".to_vec());
+
+        let (_c, s) = loopback_pair();
+        let (_, _, _, replay) = shared.attach_client(s).expect("attach");
+
+        let mut p = vt100::Parser::new(40, 120, 0);
+        p.process(&replay[0]);
+        let cell = p.screen().cell(0, 99).expect("cell 0,99 in 120-col grid");
+        assert_eq!(
+            cell.contents(),
+            "E",
+            "'E' of EDGE should land at col 99 after resize"
+        );
+    }
+}

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -19,6 +19,7 @@ use sysinfo::{Pid, Signal, System};
 
 use crate::args::{Args, Command};
 use crate::backend::LaunchMode;
+use crate::capture::TerminalCapture;
 use crate::command::LaunchPlan;
 use crate::trampoline;
 
@@ -193,6 +194,12 @@ struct WorkerShared {
     session_id: String,
     snapshot: Mutex<SessionSnapshot>,
     backlog: Mutex<BacklogState>,
+    /// Server-side terminal emulator for PTY sessions. `Some` when the session
+    /// kind is `Pty` and issue #34 attach-replay is active. The parser tracks
+    /// grid + cursor + alt-screen state so a mid-session attach can emit a
+    /// synthesized repaint instead of a raw byte dump, which would leave a
+    /// TUI-attached client staring at a garbled frame.
+    capture: Mutex<Option<TerminalCapture>>,
     client: Mutex<Option<AttachedClient>>,
     next_client_id: AtomicU64,
     stop_accepting: AtomicBool,
@@ -205,9 +212,29 @@ impl WorkerShared {
             session_id,
             snapshot: Mutex::new(snapshot),
             backlog: Mutex::new(BacklogState::default()),
+            capture: Mutex::new(None),
             client: Mutex::new(None),
             next_client_id: AtomicU64::new(1),
             stop_accepting: AtomicBool::new(false),
+        }
+    }
+
+    /// Activate terminal capture for a PTY session. No-op for subprocess
+    /// sessions, whose output is line-oriented and doesn't benefit from grid
+    /// replay (and would pay parser cost for nothing).
+    fn init_capture(&self, rows: u16, cols: u16) {
+        *self.capture.lock().expect("capture mutex poisoned") =
+            Some(TerminalCapture::new(rows, cols));
+    }
+
+    fn resize_capture(&self, rows: u16, cols: u16) {
+        if let Some(capture) = self
+            .capture
+            .lock()
+            .expect("capture mutex poisoned")
+            .as_mut()
+        {
+            capture.resize(rows, cols);
         }
     }
 
@@ -272,15 +299,30 @@ impl WorkerShared {
         }
         self.set_background(false);
         let snapshot = self.snapshot();
-        let backlog = self
-            .backlog
-            .lock()
-            .expect("backlog mutex poisoned")
-            .chunks
-            .iter()
-            .cloned()
-            .collect();
-        Ok((client_id, rx, snapshot, backlog))
+        // For PTY sessions with terminal capture, emit a single synthesized
+        // repaint — cells + cursor + alt-screen + mode flags — that reproduces
+        // the current display on a fresh terminal. Raw backlog cannot do this
+        // for TUIs because cursor moves and partial redraws stack into garbage
+        // when played from the middle of a session. See issue #34.
+        //
+        // For subprocess (line-oriented) sessions we keep the raw-backlog
+        // replay: each line is complete on its own and a history dump is
+        // what a user attaching mid-run actually wants to see.
+        let replay = {
+            let capture = self.capture.lock().expect("capture mutex poisoned");
+            if let Some(capture) = capture.as_ref() {
+                vec![capture.snapshot_bytes()]
+            } else {
+                self.backlog
+                    .lock()
+                    .expect("backlog mutex poisoned")
+                    .chunks
+                    .iter()
+                    .cloned()
+                    .collect()
+            }
+        };
+        Ok((client_id, rx, snapshot, replay))
     }
 
     fn detach_client(&self, client_id: u64) {
@@ -355,6 +397,18 @@ impl WorkerShared {
                     break;
                 }
             }
+        }
+        // Feed the server-side terminal emulator so the grid stays in sync
+        // with what the backend is rendering. Cheap enough to do on the hot
+        // path (vt100 is a streaming VTE-based parser); the expensive part,
+        // snapshot synthesis, only runs on attach.
+        if let Some(capture) = self
+            .capture
+            .lock()
+            .expect("capture mutex poisoned")
+            .as_mut()
+        {
+            capture.feed(&chunk);
         }
         self.send_to_client(WorkerServerMessage::Output {
             data_b64: base64::engine::general_purpose::STANDARD.encode(chunk),
@@ -1410,6 +1464,11 @@ fn start_pty_session(
         .map_err(|err| io::Error::other(err.to_string()))?,
     );
     process.set_echo(false);
+    // Start the terminal emulator at the same dims as the PTY so early output
+    // (launch banners, first frame of a TUI) lands in the grid from byte 0.
+    // Without this, a client that attaches before any resize happens would
+    // see a repaint of an empty 0x0 grid.
+    shared.init_capture(spec.rows, spec.cols);
     process
         .start_impl()
         .map_err(|err| io::Error::other(err.to_string()))?;
@@ -1527,7 +1586,10 @@ fn handle_worker_client(
                             runtime.write(&data, submit);
                         }
                     }
-                    WorkerClientMessage::Resize { rows, cols } => runtime.resize(rows, cols),
+                    WorkerClientMessage::Resize { rows, cols } => {
+                        runtime.resize(rows, cols);
+                        shared.resize_capture(rows, cols);
+                    }
                     WorkerClientMessage::Interrupt => runtime.interrupt(),
                 }
             }

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,5 +1,6 @@
 mod args;
 mod backend;
+mod capture;
 mod command;
 mod daemon;
 mod loop_spec;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.6"
+version = "2.0.7"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.5"
+version = "2.0.6"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clud/__init__.py
+++ b/src/clud/__init__.py
@@ -1,3 +1,3 @@
 """clud — Fast Rust CLI for running Claude Code and Codex in YOLO mode."""
 
-__version__ = "2.0.6"
+__version__ = "2.0.7"

--- a/src/clud/__init__.py
+++ b/src/clud/__init__.py
@@ -1,3 +1,3 @@
 """clud — Fast Rust CLI for running Claude Code and Codex in YOLO mode."""
 
-__version__ = "2.0.5"
+__version__ = "2.0.6"

--- a/testbins/mock-agent/src/main.rs
+++ b/testbins/mock-agent/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
     let mut pty_size_report_to: Option<PathBuf> = None;
     let mut pty_size_samples: u32 = 0;
     let mut pty_size_interval_ms: u64 = 100;
+    let mut ansi_script: Option<PathBuf> = None;
     let mut filtered_args: Vec<String> = Vec::new();
     let mut skip_next = false;
     for (i, arg) in args.iter().enumerate().skip(1) {
@@ -149,7 +150,25 @@ fn main() {
             skip_next = true;
             continue;
         }
+        if arg == "--mock-ansi-script" {
+            if let Some(path) = args.get(i + 1) {
+                ansi_script = Some(PathBuf::from(path));
+            }
+            skip_next = true;
+            continue;
+        }
         filtered_args.push(arg.clone());
+    }
+
+    // Emit scripted ANSI bytes before everything else so they land in the
+    // PTY / terminal capture first. Used by the attach-replay integration
+    // test to paint a known frame whose presence we can verify in a
+    // post-detach reattach's snapshot.
+    if let Some(path) = ansi_script.as_ref() {
+        if let Ok(bytes) = std::fs::read(path) {
+            let _ = io::stdout().write_all(&bytes);
+            let _ = io::stdout().flush();
+        }
     }
 
     if let Some(path) = pty_size_report_to.as_ref() {

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -508,6 +508,54 @@ class TestDaemonCentralizedPersistence:
         report = json.loads(cleaned.splitlines()[-1])
         assert "hello-pty" in report["args"]
 
+    def test_pty_attach_replay_paints_current_frame(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        # Issue #34: mid-session attach on a PTY session must replay the
+        # current frame, not a raw byte dump. Paint a known TUI frame via
+        # mock-agent's --mock-ansi-script, detach, reattach, assert both
+        # markers are in the attach's output (they are absolute-positioned,
+        # so a working replay places them at the right cells).
+        paint_path = tmp_path / "paint.ansi"
+        paint_path.write_bytes(
+            b"\x1b[2J\x1b[1;1H__HEADER__\x1b[5;1H__FOOTER__"
+        )
+        env = _daemon_env(mock_env, tmp_path / "daemon-state")
+        proc, session_id = _launch_daemonized(
+            clud_binary,
+            env,
+            "--pty",
+            "-p",
+            "paint-test",
+            "--",
+            "--mock-ansi-script",
+            str(paint_path),
+            "--mock-sleep-ms",
+            "3000",
+        )
+        # Give the PTY worker time to ingest the paint bytes into its
+        # TerminalCapture before we disconnect. Without this, the reattach
+        # might win the race and see an empty grid.
+        time.sleep(0.5)
+        proc.kill()
+        proc.wait(timeout=10)
+
+        result = subprocess.run(
+            [str(clud_binary), "attach", session_id],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+        assert result.returncode == 0
+        cleaned = _strip_ansi(result.stdout)
+        assert "__HEADER__" in cleaned, (
+            f"HEADER missing from attach replay: {cleaned!r}"
+        )
+        assert "__FOOTER__" in cleaned, (
+            f"FOOTER missing from attach replay: {cleaned!r}"
+        )
+
 
 class TestDaemonCentralizedCleanup:
     def test_subprocess_tree_dies_when_daemon_dies(

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -567,6 +567,78 @@ class TestDaemonCentralizedPersistence:
             f"FOOTER missing from attach replay: {cleaned!r}"
         )
 
+    def test_clud_logs_dumps_session_log(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        # pm2-style: after a session runs, `clud logs <id>` should print the
+        # captured output from the persistent log file, independent of
+        # whether any client is still attached.
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "logme-tag",
+            "--",
+            "--mock-sleep-ms",
+            "500",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=5) == 0
+            # Give the worker a beat to finish appending to the log file.
+            time.sleep(0.6)
+
+            result = subprocess.run(
+                [str(clud_binary), "logs", session_id],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert result.returncode == 0, result.stderr
+            # The mock agent writes a JSON report to stdout with the args it
+            # received; our prompt-tag must appear in the captured log.
+            assert "logme-tag" in result.stdout, (
+                f"prompt tag missing from logs output: {result.stdout!r}"
+            )
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
+    def test_clud_logs_with_no_id_lists_sessions(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "list-me",
+            "--",
+            "--mock-sleep-ms",
+            "400",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=5) == 0
+            time.sleep(0.5)
+
+            result = subprocess.run(
+                [str(clud_binary), "logs"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert result.returncode == 0, result.stderr
+            assert session_id in result.stdout, (
+                f"session id missing from summary: {result.stdout!r}"
+            )
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
 
 class TestDaemonCentralizedCleanup:
     def test_subprocess_tree_dies_when_daemon_dies(

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -13,7 +13,18 @@ import pytest
 
 pytestmark = pytest.mark.integration
 
-_ANSI_RE = re.compile(r"\x1b(?:\[[^a-zA-Z]*[a-zA-Z]|\][^\x07]*\x07)")
+_ANSI_RE = re.compile(
+    # CSI: \x1b[ + params + final letter
+    r"\x1b(?:\[[^a-zA-Z]*[a-zA-Z]"
+    # OSC: \x1b] + string + BEL or ST (\x1b\\)
+    r"|\][^\x07]*(?:\x07|\x1b\\)"
+    # Bare ESC + single printable byte. Covers RIS (\x1bc), keypad
+    # normal/application (\x1b=, \x1b>), save/restore cursor (\x1b7, \x1b8),
+    # index / reverse index / next line (\x1bD, \x1bM, \x1bE), etc.
+    # Issue #34: attach-replay snapshot emits these so the client's terminal
+    # restores full state; the test must strip them before parsing JSON.
+    r"|[\x30-\x7e])"
+)
 
 
 def _daemon_env(mock_env: dict[str, str], state_dir: Path) -> dict[str, str]:

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -69,7 +69,7 @@ def test_version() -> None:
     result = _run("--version")
     assert result.returncode == 0
     assert "clud" in result.stdout
-    assert "2.0.6" in result.stdout
+    assert "2.0.7" in result.stdout
 
 
 def test_dry_run_prompt() -> None:

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -69,7 +69,7 @@ def test_version() -> None:
     result = _run("--version")
     assert result.returncode == 0
     assert "clud" in result.stdout
-    assert "2.0.5" in result.stdout
+    assert "2.0.6" in result.stdout
 
 
 def test_dry_run_prompt() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.6"
+version = "2.0.7"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.5"
+version = "2.0.6"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Track PTY output in a server-side vt100 grid so a mid-session attach (local `clud attach`, future xterm.js over websocket) gets a synthesized repaint of the current frame instead of a raw byte dump since launch.
- Raw backlog replay is fine for line-oriented CLIs but wrong for TUIs (codex/ratatui, claude/Ink): cursor moves and partial redraws stack into garbage when played from the middle of a session.
- Subprocess sessions keep the raw-backlog replay unchanged — line-oriented output wants history, not a repaint. Only PTY sessions activate the grid.

Closes #34.

## How it works

- New `capture.rs` module wraps `vt100::Parser` with a `TerminalCapture` type: `feed` / `resize` / `snapshot_bytes`.
- `snapshot_bytes` emits RIS + optional alt-screen entry + `Screen::state_formatted()` (cells + SGR + cursor + input-mode flags) — a byte stream that repaints the current display on a fresh terminal.
- `WorkerShared` gains a `Mutex<Option<TerminalCapture>>`. `init_capture(rows, cols)` activates it in `start_pty_session`; subprocess sessions never construct one.
- `push_output` feeds every PTY chunk into the capture alongside the existing raw backlog.
- `attach_client` returns a single synthesized snapshot chunk when capture is active, the raw backlog chunks otherwise — wire-compatible (still `Output { data_b64 }` frames).
- `Resize` is routed into the parser so a later attach gets correct dims.

## Test plan

- [x] `bash lint` — cargo fmt, clippy -D warnings, ruff clean
- [x] `bash test` — 115 Rust unit tests + 5 PTY integration + 21 Python pass
- [x] New unit tests in `capture.rs`:
  - [x] Plain text round-trip
  - [x] SGR + cursor positioning round-trip
  - [x] Alternate-screen round-trip
  - [x] Hidden cursor round-trip
  - [x] Resize noop + change
  - [x] Partial clear + redraw (only final frame replays)
  - [x] Chunked feed matches single feed (hot-path invariant)
  - [x] Mid-session attach scenario: three partial redraws, replay shows only final frame
- [ ] Manual smoke: `clud --detachable codex`, drive through a render, `^D`, reattach in another shell; confirm display is the current frame, not a raw log. (Local manual verification pending since I can't run interactive TUI inside this harness.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)