### PR TITLE
chore: bump version to 2.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "base64",
  "clap",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "serde_json",
  "terminal_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.7"
+version = "2.0.8"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.7"
+version = "2.0.8"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clud/__init__.py
+++ b/src/clud/__init__.py
@@ -1,3 +1,3 @@
 """clud — Fast Rust CLI for running Claude Code and Codex in YOLO mode."""
 
-__version__ = "2.0.7"
+__version__ = "2.0.8"

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -69,7 +69,7 @@ def test_version() -> None:
     result = _run("--version")
     assert result.returncode == 0
     assert "clud" in result.stdout
-    assert "2.0.7" in result.stdout
+    assert "2.0.8" in result.stdout
 
 
 def test_dry_run_prompt() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.7"
+version = "2.0.8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Ships the Windows CI unblock work and the detached-spawn handle guard.

- **#37 Windows CI unblock** — 45-min silent cancellation → 2m50s full run. pytest-timeout, \`-v\` per-test names, pipe-free cargo fixture, 6 minimum-surface probes, \`CLUD_NO_UNLOCK\` escape hatch.
- **#39 \`NonInheritableStdioGuard\`** in \`spawn_detached_self\` — clears \`HANDLE_FLAG_INHERIT\` on our 3 stdio handles around \`CreateProcess\` so detached daemon/worker children don't inherit parent-supervisor pipe handles. Benefits any Windows user running \`clud --detach\` under a subprocess supervisor.
- 3 Windows PTY tests marked \`@pytest.mark.xfail(strict=True)\` — the deeper ConPTY / CreateProcess bug tracked as #38 for a follow-up fix.

## Test plan

- [x] 155 Rust unit + 5 PTY integration + 23 Python all green locally
- [x] \`bash lint\` clean
- [ ] CI green across all 6 platforms