### PR TITLE
fix(loop): use PTY for claude in loop mode so output streams live (#32)

### DIFF
--- a/crates/clud-bin/src/backend.rs
+++ b/crates/clud-bin/src/backend.rs
@@ -67,10 +67,12 @@ pub fn resolve_backend(_claude: bool, codex: bool) -> Backend {
 ///
 /// Explicit `--pty` / `--subprocess` always wins. Otherwise:
 /// - Claude defaults to subprocess while PTY issues are being investigated,
-///   **except** in `clud loop` mode where we use PTY so the user sees live
-///   token streaming. Loop iterations take long enough that the
-///   subprocess-default's silent-until-EOF buffering makes it impossible to
-///   tell if the agent is working or hung — see #32.
+///   **except** in `clud loop` mode on non-Windows where we use PTY so the
+///   user sees live token streaming. Loop iterations take long enough that
+///   the subprocess-default's silent-until-EOF buffering makes it impossible
+///   to tell if the agent is working or hung — see #32. Windows stays on
+///   subprocess for now because ConPTY handle-inheritance under loops still
+///   hangs (see #38); once that's fixed, the gate can be removed.
 /// - Codex defaults to PTY for interactive TUI runs (Ink requires a real
 ///   pseudo-console to receive keyboard input) and subprocess for
 ///   non-interactive `codex exec` runs.
@@ -88,7 +90,7 @@ pub fn resolve_launch_mode(
         return LaunchMode::Subprocess;
     }
     match backend {
-        Backend::Claude if is_loop => LaunchMode::Pty,
+        Backend::Claude if is_loop && !cfg!(target_os = "windows") => LaunchMode::Pty,
         Backend::Claude => LaunchMode::Subprocess,
         Backend::Codex if codex_uses_exec => LaunchMode::Subprocess,
         Backend::Codex => LaunchMode::Pty,
@@ -136,10 +138,16 @@ mod tests {
     fn test_claude_loop_uses_pty_for_streaming() {
         // #32: subprocess silence during long loop iterations makes it
         // impossible to tell if claude is working or hung. Loop mode opts
-        // into PTY so token output streams live.
+        // into PTY so token output streams live. Gated to non-Windows
+        // until #38's Windows ConPTY handle-inheritance is fixed.
+        let expected = if cfg!(target_os = "windows") {
+            LaunchMode::Subprocess
+        } else {
+            LaunchMode::Pty
+        };
         assert_eq!(
             resolve_launch_mode(false, false, Backend::Claude, false, true),
-            LaunchMode::Pty
+            expected
         );
     }
 

--- a/crates/clud-bin/src/backend.rs
+++ b/crates/clud-bin/src/backend.rs
@@ -66,7 +66,11 @@ pub fn resolve_backend(_claude: bool, codex: bool) -> Backend {
 /// Resolve how the backend should be launched.
 ///
 /// Explicit `--pty` / `--subprocess` always wins. Otherwise:
-/// - Claude defaults to subprocess while PTY issues are being investigated.
+/// - Claude defaults to subprocess while PTY issues are being investigated,
+///   **except** in `clud loop` mode where we use PTY so the user sees live
+///   token streaming. Loop iterations take long enough that the
+///   subprocess-default's silent-until-EOF buffering makes it impossible to
+///   tell if the agent is working or hung — see #32.
 /// - Codex defaults to PTY for interactive TUI runs (Ink requires a real
 ///   pseudo-console to receive keyboard input) and subprocess for
 ///   non-interactive `codex exec` runs.
@@ -75,6 +79,7 @@ pub fn resolve_launch_mode(
     subprocess: bool,
     backend: Backend,
     codex_uses_exec: bool,
+    is_loop: bool,
 ) -> LaunchMode {
     if pty {
         return LaunchMode::Pty;
@@ -83,6 +88,7 @@ pub fn resolve_launch_mode(
         return LaunchMode::Subprocess;
     }
     match backend {
+        Backend::Claude if is_loop => LaunchMode::Pty,
         Backend::Claude => LaunchMode::Subprocess,
         Backend::Codex if codex_uses_exec => LaunchMode::Subprocess,
         Backend::Codex => LaunchMode::Pty,
@@ -117,11 +123,31 @@ mod tests {
     #[test]
     fn test_claude_defaults_to_subprocess() {
         assert_eq!(
-            resolve_launch_mode(false, false, Backend::Claude, false),
+            resolve_launch_mode(false, false, Backend::Claude, false, false),
             LaunchMode::Subprocess
         );
         assert_eq!(
-            resolve_launch_mode(false, false, Backend::Claude, true),
+            resolve_launch_mode(false, false, Backend::Claude, true, false),
+            LaunchMode::Subprocess
+        );
+    }
+
+    #[test]
+    fn test_claude_loop_uses_pty_for_streaming() {
+        // #32: subprocess silence during long loop iterations makes it
+        // impossible to tell if claude is working or hung. Loop mode opts
+        // into PTY so token output streams live.
+        assert_eq!(
+            resolve_launch_mode(false, false, Backend::Claude, false, true),
+            LaunchMode::Pty
+        );
+    }
+
+    #[test]
+    fn test_claude_loop_respects_explicit_subprocess_override() {
+        // --subprocess still wins for users who want the old behavior.
+        assert_eq!(
+            resolve_launch_mode(false, true, Backend::Claude, false, true),
             LaunchMode::Subprocess
         );
     }
@@ -130,7 +156,7 @@ mod tests {
     fn test_codex_interactive_defaults_to_pty() {
         // `clud --codex` with no prompt -> interactive TUI -> needs a pseudo-console.
         assert_eq!(
-            resolve_launch_mode(false, false, Backend::Codex, false),
+            resolve_launch_mode(false, false, Backend::Codex, false, false),
             LaunchMode::Pty
         );
     }
@@ -139,7 +165,7 @@ mod tests {
     fn test_codex_exec_defaults_to_subprocess() {
         // `clud --codex -p "..."` -> `codex exec` -> non-interactive, pipeable.
         assert_eq!(
-            resolve_launch_mode(false, false, Backend::Codex, true),
+            resolve_launch_mode(false, false, Backend::Codex, true, false),
             LaunchMode::Subprocess
         );
     }
@@ -147,11 +173,11 @@ mod tests {
     #[test]
     fn test_launch_mode_pty_override() {
         assert_eq!(
-            resolve_launch_mode(true, false, Backend::Claude, false),
+            resolve_launch_mode(true, false, Backend::Claude, false, false),
             LaunchMode::Pty
         );
         assert_eq!(
-            resolve_launch_mode(true, false, Backend::Codex, true),
+            resolve_launch_mode(true, false, Backend::Codex, true, false),
             LaunchMode::Pty
         );
     }
@@ -159,11 +185,11 @@ mod tests {
     #[test]
     fn test_launch_mode_subprocess_override() {
         assert_eq!(
-            resolve_launch_mode(false, true, Backend::Claude, false),
+            resolve_launch_mode(false, true, Backend::Claude, false, false),
             LaunchMode::Subprocess
         );
         assert_eq!(
-            resolve_launch_mode(false, true, Backend::Codex, false),
+            resolve_launch_mode(false, true, Backend::Codex, false, false),
             LaunchMode::Subprocess
         );
     }

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -229,8 +229,14 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
 
     cmd.extend(args.passthrough.iter().cloned());
 
-    let launch_mode =
-        crate::backend::resolve_launch_mode(args.pty, args.subprocess, backend, codex_uses_exec);
+    let is_loop = loop_markers.is_some();
+    let launch_mode = crate::backend::resolve_launch_mode(
+        args.pty,
+        args.subprocess,
+        backend,
+        codex_uses_exec,
+        is_loop,
+    );
 
     LaunchPlan {
         command: cmd,


### PR DESCRIPTION
Closes #32.

## Summary

Commit a4ef5f5 switched claude's default launch mode from PTY to subprocess for stability. That regressed live streaming in \`clud loop\`: subprocess stdio inheritance still reaches the terminal, but **claude itself detects non-tty stdout and buffers its output**. The user sees \`[clud] iteration 1/50\` followed by silence until the iteration finishes — no way to tell if the agent is working or hung.

Loop iterations take long enough (often minutes) that this silence is a real UX problem. For one-shot \`clud -p\` the final output-at-end is fine; for a 50-iteration loop it isn't.

## Fix

Add \`is_loop\` param to \`resolve_launch_mode\`. When backend is Claude AND loop mode AND no explicit \`--subprocess\`, pick PTY. Claude sees a real pseudo-console, streams tokens, user sees progress.

Explicit \`--subprocess\` still wins for users who want the old behavior. Codex and non-loop paths are untouched.

## Test plan

- [x] 157 Rust unit tests pass (2 new tests for loop carve-out)
- [x] \`bash lint\` clean
- [ ] CI green on all 6 platforms