### PR TITLE
fix(zombies): contain direct subprocess tree (#9)

### DIFF
--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -165,7 +165,9 @@ fn normalize_exit_code(code: i32) -> i32 {
 fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicBool) -> i32 {
     use std::path::PathBuf;
 
-    use running_process_core::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+    use running_process_core::{
+        CommandSpec, Containment, NativeProcess, ProcessConfig, StderrMode, StdinMode,
+    };
 
     // Enable VT input on the console before launching the child.
     // This allows ANSI sequences (including bracketed paste for drag-and-drop)
@@ -194,7 +196,14 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
-            containment: None,
+            // Issue #9: Claude/Codex spawn tool subprocesses (cargo test,
+            // npm test, long builds) that leak as zombies when a clud
+            // session dies abnormally (crash, terminal close, Task Manager
+            // kill). `Containment::Contained` binds the child tree's
+            // lifetime to ours: PR_SET_PDEATHSIG(SIGKILL) on Linux, a
+            // kill-on-close Job Object on Windows. The daemon path already
+            // sets this (daemon.rs); direct subprocess runs now do too.
+            containment: Some(Containment::Contained),
         };
 
         let process = NativeProcess::new(config);


### PR DESCRIPTION
Closes #9.

## Problem

Claude Code / Codex spawn tool subprocesses (cargo test, npm test, long builds). When \`clud\` dies abnormally — crash, terminal close, Task Manager kill — the child tree is orphaned and those tools linger as zombies. Over a day of active use this accumulates a pile of rustc / cargo / node processes.

## Why this wasn't already fixed

The **daemon path** (daemon.rs:1503) already uses \`Containment::Contained\` when spawning subprocess-kind sessions. The **direct path** (\`run_plan_subprocess\` in main.rs, the default for \`clud -p\` on Claude) still had \`containment: None\`.

## Fix

Switch \`run_plan_subprocess\` to \`Containment::Contained\`. On Linux this sets \`PR_SET_PDEATHSIG(SIGKILL)\` so the child dies when we do. On Windows it binds the child tree to a kill-on-close Job Object so Windows itself terminates the whole tree when clud exits, crashes, or is killed.

## Test plan

- [x] 157 Rust unit + 5 PTY integration + 21 Python pytest green
- [x] \`bash lint\` clean
- [ ] CI green across all 6 platforms