### PR TITLE
ci: assert Windows wheel has no MinGW runtime imports (#27)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -68,6 +68,10 @@ jobs:
         if: ${{ inputs.include-sdist }}
         run: uv run maturin sdist --out dist
 
+      - name: Verify Windows wheel has no MinGW runtime imports
+        if: ${{ runner.os == 'Windows' }}
+        run: uv run python -m ci.check_windows_wheel --dist-dir dist/
+
       - name: Upload dist artifacts
         if: ${{ inputs.artifact-name != '' }}
         uses: actions/upload-artifact@v4

--- a/ci/check_windows_wheel.py
+++ b/ci/check_windows_wheel.py
@@ -1,0 +1,204 @@
+"""Assert that a Windows wheel's clud.exe was built against MSVC, not MinGW.
+
+Issue #27: the test harness and dev workflow pin the MSVC toolchain via
+`ci/env.py::build_env()` and `soldr`, but nothing at the CI layer asserts
+the resulting binary actually has only MSVC runtime imports. If the pin
+ever slipped, we'd ship a wheel depending on `libstdc++-6.dll` /
+`libgcc_s_seh-1.dll` / `libwinpthread-1.dll` — none of which ship with
+Windows, so the binary would fail to start for any user who doesn't
+happen to have a MinGW install on PATH.
+
+This script opens a wheel, extracts `scripts/clud.exe`, and asserts its
+PE import table has no MinGW runtime entries. It reads the PE headers
+directly (no dumpbin / no VS tools needed), so it runs on any platform
+with Python stdlib — useful for local verification as well as CI.
+
+Usage:
+    python -m ci.check_windows_wheel <wheel_path>
+    python -m ci.check_windows_wheel --dist-dir dist/
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+import zipfile
+from pathlib import Path
+
+# MinGW runtime DLLs that MUST NOT appear in the import table of a clud.exe
+# we ship. Exact casing is matched case-insensitively when scanning.
+FORBIDDEN_DLL_PREFIXES = (
+    "libstdc++",
+    "libgcc_s",
+    "libwinpthread",
+)
+
+
+def iter_imported_dll_names(pe_bytes: bytes) -> list[str]:
+    """Return the list of DLL names in a PE file's import directory.
+
+    Minimal PE parser — covers what we need to walk IMAGE_IMPORT_DESCRIPTOR
+    and read the DLL name strings. Doesn't validate every PE field; a
+    malformed binary just raises and fails the check loudly.
+    """
+    if pe_bytes[:2] != b"MZ":
+        raise ValueError("not a PE/DOS executable (no MZ signature)")
+    pe_offset = struct.unpack_from("<I", pe_bytes, 0x3C)[0]
+    if pe_bytes[pe_offset : pe_offset + 4] != b"PE\x00\x00":
+        raise ValueError("missing PE signature at header offset")
+
+    coff_off = pe_offset + 4
+    # IMAGE_FILE_HEADER: 20 bytes. We need SizeOfOptionalHeader to skip past
+    # the optional header and find section headers.
+    (_, _, _, _, _, size_of_optional_header, _) = struct.unpack_from(
+        "<HHIIIHH", pe_bytes, coff_off
+    )
+
+    opt_off = coff_off + 20
+    # Magic 0x10b = PE32, 0x20b = PE32+. The offset of the DataDirectories
+    # and the size of RVA/Size entries are the same; what differs is where
+    # NumberOfRvaAndSizes lives and the widths of some fields in between.
+    magic = struct.unpack_from("<H", pe_bytes, opt_off)[0]
+    if magic == 0x10B:
+        num_rva_off = opt_off + 92
+    elif magic == 0x20B:
+        num_rva_off = opt_off + 108
+    else:
+        raise ValueError(f"unexpected optional header magic: 0x{magic:x}")
+    num_rva_sizes = struct.unpack_from("<I", pe_bytes, num_rva_off)[0]
+    data_dirs_off = num_rva_off + 4
+    if num_rva_sizes < 2:
+        return []  # no import directory
+    import_rva, _import_size = struct.unpack_from("<II", pe_bytes, data_dirs_off + 8)
+    if import_rva == 0:
+        return []
+
+    # Section headers start right after the optional header.
+    num_sections = struct.unpack_from("<H", pe_bytes, coff_off + 2)[0]
+    sections_off = opt_off + size_of_optional_header
+    sections: list[tuple[int, int, int]] = []  # (virtual_address, virtual_size, raw_offset)
+    for i in range(num_sections):
+        header_off = sections_off + i * 40
+        _name = pe_bytes[header_off : header_off + 8]
+        virtual_size = struct.unpack_from("<I", pe_bytes, header_off + 8)[0]
+        virtual_address = struct.unpack_from("<I", pe_bytes, header_off + 12)[0]
+        _size_of_raw_data = struct.unpack_from("<I", pe_bytes, header_off + 16)[0]
+        pointer_to_raw_data = struct.unpack_from("<I", pe_bytes, header_off + 20)[0]
+        sections.append((virtual_address, virtual_size, pointer_to_raw_data))
+
+    def rva_to_offset(rva: int) -> int | None:
+        for va, size, raw in sections:
+            if va <= rva < va + max(size, 1):
+                return raw + (rva - va)
+        return None
+
+    import_table_off = rva_to_offset(import_rva)
+    if import_table_off is None:
+        return []
+
+    names: list[str] = []
+    descriptor = import_table_off
+    while True:
+        entry = pe_bytes[descriptor : descriptor + 20]
+        if len(entry) < 20:
+            break
+        name_rva = struct.unpack_from("<I", entry, 12)[0]
+        if name_rva == 0:
+            break  # null descriptor terminates the table
+        name_off = rva_to_offset(name_rva)
+        if name_off is None:
+            break
+        end = pe_bytes.index(b"\x00", name_off)
+        names.append(pe_bytes[name_off:end].decode("ascii", errors="replace"))
+        descriptor += 20
+    return names
+
+
+def forbidden_imports(dll_names: list[str]) -> list[str]:
+    hits: list[str] = []
+    for name in dll_names:
+        lowered = name.lower()
+        for prefix in FORBIDDEN_DLL_PREFIXES:
+            if lowered.startswith(prefix):
+                hits.append(name)
+                break
+    return hits
+
+
+def check_wheel(wheel_path: Path) -> list[str]:
+    """Return a list of error messages; empty list means the wheel is clean."""
+    errors: list[str] = []
+    with zipfile.ZipFile(wheel_path) as archive:
+        exe_members = [
+            name
+            for name in archive.namelist()
+            if name.endswith("/clud.exe") or name.endswith("\\clud.exe")
+        ]
+        if not exe_members:
+            # Not a Windows wheel — skip silently; this script is for .whl
+            # files that actually carry clud.exe.
+            return []
+        for member in exe_members:
+            try:
+                pe_bytes = archive.read(member)
+                names = iter_imported_dll_names(pe_bytes)
+            except Exception as exc:
+                errors.append(f"{wheel_path.name}::{member}: failed to parse PE: {exc}")
+                continue
+            bad = forbidden_imports(names)
+            if bad:
+                errors.append(
+                    f"{wheel_path.name}::{member} has forbidden MinGW imports: {bad}. "
+                    f"Full import list: {names}"
+                )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify built Windows wheels don't depend on MinGW runtime DLLs"
+    )
+    parser.add_argument("wheels", nargs="*", help="wheel paths to check")
+    parser.add_argument(
+        "--dist-dir",
+        type=Path,
+        default=None,
+        help="check every *.whl in this directory",
+    )
+    args = parser.parse_args(argv)
+
+    paths: list[Path] = [Path(p) for p in args.wheels]
+    if args.dist_dir:
+        paths.extend(sorted(args.dist_dir.glob("*.whl")))
+    # Dedupe while preserving order.
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for path in paths:
+        key = str(path.resolve())
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    if not unique:
+        print("no wheels to check", file=sys.stderr)
+        return 0
+
+    all_errors: list[str] = []
+    for wheel in unique:
+        if not wheel.is_file():
+            all_errors.append(f"{wheel}: not a file")
+            continue
+        print(f"checking {wheel.name}", file=sys.stderr)
+        all_errors.extend(check_wheel(wheel))
+
+    if all_errors:
+        print("FAIL: Windows wheel check found MinGW imports:", file=sys.stderr)
+        for error in all_errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+    print("OK: no MinGW imports in any checked wheel", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_windows_wheel.py
+++ b/tests/test_check_windows_wheel.py
@@ -1,0 +1,172 @@
+"""Unit tests for ci/check_windows_wheel.py.
+
+The checker parses real PE binaries; to avoid shelling out to cargo here,
+the tests synthesize two in-memory wheels and run them through the same
+entry point the CI step uses.
+"""
+
+from __future__ import annotations
+
+import struct
+import zipfile
+from pathlib import Path
+
+from ci.check_windows_wheel import check_wheel, forbidden_imports, iter_imported_dll_names
+
+# A minimal PE32+ executable synthesized in-memory. The layout is chosen
+# so the import table is parseable but still tiny; the test doesn't care
+# about anything other than the import directory content.
+DOS_STUB = b"MZ" + b"\x00" * 0x3A + struct.pack("<I", 0x40)
+PE_SIG = b"PE\x00\x00"
+
+
+def _make_pe_with_imports(dll_names: list[str]) -> bytes:
+    """Build a bare-minimum PE32+ binary whose import table lists the given DLLs.
+
+    Only the fields the checker reads are filled in: headers, import directory
+    RVA + size, section table, and the embedded DLL name strings. Everything
+    else is zeroed.
+    """
+    # Section layout: headers at start, one .idata section containing the
+    # import descriptors + name strings, mapped at a fixed RVA.
+    section_rva = 0x1000
+    # Layout of the .idata section content:
+    #   [IMAGE_IMPORT_DESCRIPTOR x (N+1)]  -- N descriptors + terminating null
+    #   [dll name string x N]              -- zero-terminated ASCII
+    import_desc_size = 20
+    num_descriptors = len(dll_names) + 1  # +1 null terminator
+    desc_table_size = num_descriptors * import_desc_size
+    name_offsets_in_section: list[int] = []
+    name_blob = bytearray()
+    cursor = desc_table_size
+    for name in dll_names:
+        name_offsets_in_section.append(cursor)
+        encoded = name.encode("ascii") + b"\x00"
+        name_blob.extend(encoded)
+        cursor += len(encoded)
+
+    section_content = bytearray(b"\x00" * desc_table_size) + name_blob
+    for i, name_offset in enumerate(name_offsets_in_section):
+        descriptor_offset = i * import_desc_size
+        # Field layout (20 bytes): OriginalFirstThunk(4), TimeDateStamp(4),
+        # ForwarderChain(4), Name(4 RVA), FirstThunk(4). Only Name matters
+        # here.
+        struct.pack_into(
+            "<IIIII",
+            section_content,
+            descriptor_offset,
+            0,  # OriginalFirstThunk
+            0,  # TimeDateStamp
+            0,  # ForwarderChain
+            section_rva + name_offset,  # Name RVA (absolute)
+            0,  # FirstThunk
+        )
+
+    # File layout with raw offsets the checker can rva_to_offset.
+    # DOS header + PE sig + COFF header + optional header + section header.
+    pe_header_offset = 0x40
+    coff_offset = pe_header_offset + 4
+    optional_header_size = 240  # PE32+ has 240 bytes before NumberOfRvaAndSizes
+    opt_offset = coff_offset + 20
+    section_header_offset = opt_offset + optional_header_size
+    section_raw_offset = 0x200  # start of section data in file
+
+    total_size = section_raw_offset + len(section_content)
+    pe = bytearray(b"\x00" * total_size)
+    pe[0:2] = b"MZ"
+    struct.pack_into("<I", pe, 0x3C, pe_header_offset)
+    pe[pe_header_offset : pe_header_offset + 4] = PE_SIG
+
+    # COFF header: Machine(2), NumberOfSections(2), TimeDateStamp(4),
+    # PointerToSymbolTable(4), NumberOfSymbols(4), SizeOfOptionalHeader(2),
+    # Characteristics(2).
+    struct.pack_into(
+        "<HHIIIHH",
+        pe,
+        coff_offset,
+        0x8664,  # AMD64
+        1,  # NumberOfSections
+        0,
+        0,
+        0,
+        optional_header_size,
+        0,
+    )
+    # Optional header magic (PE32+).
+    struct.pack_into("<H", pe, opt_offset, 0x20B)
+    # NumberOfRvaAndSizes is at opt_offset + 108 for PE32+.
+    struct.pack_into("<I", pe, opt_offset + 108, 16)
+    # Data directories start right after. Index 1 = Import Table.
+    data_dirs_start = opt_offset + 112
+    struct.pack_into(
+        "<II",
+        pe,
+        data_dirs_start + 8,  # dir[1]
+        section_rva,  # Import Table RVA
+        desc_table_size,  # Import Table Size
+    )
+    # Section header (40 bytes).
+    section_name = b".idata\x00\x00"
+    pe[section_header_offset : section_header_offset + 8] = section_name
+    struct.pack_into("<I", pe, section_header_offset + 8, len(section_content))  # VirtualSize
+    struct.pack_into("<I", pe, section_header_offset + 12, section_rva)  # VirtualAddress
+    struct.pack_into("<I", pe, section_header_offset + 16, len(section_content))  # SizeOfRawData
+    struct.pack_into(
+        "<I", pe, section_header_offset + 20, section_raw_offset
+    )  # PointerToRawData
+
+    # Section content.
+    pe[section_raw_offset : section_raw_offset + len(section_content)] = section_content
+    return bytes(pe)
+
+
+def _make_wheel(tmp_path: Path, wheel_name: str, imports: list[str]) -> Path:
+    exe_bytes = _make_pe_with_imports(imports)
+    wheel_path = tmp_path / wheel_name
+    with zipfile.ZipFile(wheel_path, "w") as archive:
+        archive.writestr("clud-2.0.0.data/scripts/clud.exe", exe_bytes)
+        archive.writestr("clud-2.0.0.dist-info/RECORD", "")
+    return wheel_path
+
+
+def test_parses_imports_from_synthetic_pe():
+    pe = _make_pe_with_imports(["VCRUNTIME140.dll", "KERNEL32.dll"])
+    names = iter_imported_dll_names(pe)
+    assert "VCRUNTIME140.dll" in names
+    assert "KERNEL32.dll" in names
+
+
+def test_clean_wheel_passes(tmp_path: Path):
+    wheel = _make_wheel(tmp_path, "clud-2.0.0-py3-none-win_amd64.whl", ["VCRUNTIME140.dll"])
+    assert check_wheel(wheel) == []
+
+
+def test_mingw_wheel_flags_every_forbidden_dll(tmp_path: Path):
+    wheel = _make_wheel(
+        tmp_path,
+        "clud-2.0.0-py3-none-win_amd64.whl",
+        ["libstdc++-6.dll", "libgcc_s_seh-1.dll", "libwinpthread-1.dll", "KERNEL32.dll"],
+    )
+    errors = check_wheel(wheel)
+    assert len(errors) == 1
+    msg = errors[0]
+    assert "libstdc++-6.dll" in msg
+    assert "libgcc_s_seh-1.dll" in msg
+    assert "libwinpthread-1.dll" in msg
+    # Non-MinGW imports aren't flagged by themselves.
+    assert "KERNEL32.dll" not in forbidden_imports(["KERNEL32.dll"])
+
+
+def test_non_windows_wheel_is_skipped(tmp_path: Path):
+    wheel = tmp_path / "clud-2.0.0-py3-none-manylinux_2_17_x86_64.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("clud-2.0.0.data/scripts/clud", b"not-a-pe-binary")
+        archive.writestr("clud-2.0.0.dist-info/RECORD", "")
+    assert check_wheel(wheel) == []
+
+
+def test_forbidden_imports_is_case_insensitive():
+    assert forbidden_imports(["LIBSTDC++-6.DLL"]) == ["LIBSTDC++-6.DLL"]
+    assert forbidden_imports(["libgcc_s_dw2-1.dll"]) == ["libgcc_s_dw2-1.dll"]
+    assert forbidden_imports(["libgcc_s_sjlj-1.dll"]) == ["libgcc_s_sjlj-1.dll"]
+    assert forbidden_imports(["MSVCP140.dll"]) == []


### PR DESCRIPTION
Partial resolution for #27. Delivers the issue's concrete acceptance criterion — CI check asserting the published wheel's \`clud.exe\` has no MinGW imports — via a pure-stdlib PE parser, no \`dumpbin\` / VS Tools dependency.

## What's in

- \`ci/check_windows_wheel.py\` — walks the PE import directory of \`scripts/clud.exe\` inside a wheel, fails if any of \`libstdc++-6.dll\`, \`libgcc_s_seh-1.dll\`, \`libgcc_s_dw2-1.dll\`, \`libgcc_s_sjlj-1.dll\`, \`libwinpthread-1.dll\` appears.
- \`.github/workflows/_build.yml\` — Windows-only post-build step \`Verify Windows wheel has no MinGW runtime imports\`.
- \`tests/test_check_windows_wheel.py\` — 5 pytest cases: PE parser, clean wheel, MinGW wheel, non-Windows skip, case-insensitivity.

## What's not in

The issue also asks for the Windows build steps to invoke \`soldr cargo\` / \`soldr maturin\` directly. That's a bigger restructure (maturin doesn't take a cargo wrapper argument cleanly; would require either a PATH trampoline install or a custom build driver). I left that for a follow-up — the DLL check alone is enough to prevent the failure mode (MinGW wheel) the issue was worried about.

## Test plan

- [x] \`bash lint\` clean
- [x] \`bash test\` — 162 Rust + 26 Python (incl. 5 new) green
- [x] Local check against the current dist/ wheels confirms no MinGW imports in any platform
- [ ] Windows CI runs the new check step green