### PR TITLE
test(#48): add coverage for `clud --codex loop`

### DIFF
--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -702,6 +702,89 @@ mod tests {
         assert!(p.loop_markers.is_none());
     }
 
+    // ---- Issue #48: `clud --codex loop "..."` must drive codex the same ----
+    // way `clud loop` drives claude: exec subcommand, positional prompt,
+    // DONE/BLOCKED contract appended, loop_markers populated, and the
+    // non-interactive launch mode (subprocess) selected.
+
+    #[test]
+    fn test_codex_loop_routes_through_exec() {
+        let p = plan(&["clud", "--codex", "loop", "--loop-count", "5", "do stuff"]);
+        assert_eq!(p.command[0], "codex");
+        assert_eq!(p.command[1], "exec");
+        assert!(p
+            .command
+            .contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
+        assert_eq!(p.iterations, 5);
+        assert_eq!(p.backend, Backend::Codex);
+    }
+
+    #[test]
+    fn test_codex_loop_prompt_is_positional_not_dash_p() {
+        // Codex's `-p` is `--profile`; the prompt must be the final positional.
+        let p = plan(&["clud", "--codex", "loop", "do stuff"]);
+        assert!(
+            p.command.iter().all(|a| a != "-p"),
+            "codex must not emit -p for the prompt; cmd={:?}",
+            p.command
+        );
+        let last = last_arg(&p);
+        assert!(
+            last.starts_with("do stuff"),
+            "codex prompt must be the last positional arg; got: {last:?}"
+        );
+    }
+
+    #[test]
+    fn test_codex_loop_appends_done_marker_contract() {
+        let p = plan(&["clud", "--codex", "loop", "do stuff"]);
+        let prompt = last_arg(&p);
+        assert!(prompt.contains(".clud/loop/DONE"));
+        assert!(prompt.contains(".clud/loop/BLOCKED"));
+        assert!(p.loop_markers.is_some());
+    }
+
+    #[test]
+    fn test_codex_loop_default_count() {
+        let p = plan(&["clud", "--codex", "loop", "task"]);
+        assert_eq!(p.iterations, 50);
+    }
+
+    #[test]
+    fn test_codex_loop_no_done_marker_omits_contract() {
+        let p = plan(&["clud", "--codex", "loop", "--no-done-marker", "task"]);
+        let prompt = last_arg(&p);
+        assert_eq!(prompt, "task");
+        assert!(p.loop_markers.is_none());
+    }
+
+    #[test]
+    fn test_codex_loop_uses_subprocess_launch_mode() {
+        // `codex exec` is non-interactive → subprocess (pipe-friendly),
+        // just like `clud --codex -p "..."`.
+        let p = plan(&["clud", "--codex", "loop", "task"]);
+        assert_eq!(p.launch_mode, LaunchMode::Subprocess);
+    }
+
+    #[test]
+    fn test_codex_loop_safe_mode_omits_bypass_flag() {
+        let p = plan(&["clud", "--codex", "--safe", "loop", "task"]);
+        assert!(!p
+            .command
+            .contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
+        assert_eq!(p.command[0], "codex");
+        assert_eq!(p.command[1], "exec");
+    }
+
+    #[test]
+    fn test_codex_loop_forwards_passthrough_flags() {
+        // `clud --codex loop "task" -- --verbose` must keep the passthrough
+        // flag so the test harness can inject mock-agent flags the same way
+        // it does for the claude path.
+        let p = plan(&["clud", "--codex", "loop", "task", "--", "--verbose"]);
+        assert!(p.command.contains(&"--verbose".to_string()));
+    }
+
     #[test]
     fn test_pty_override() {
         let p = plan(&["clud", "--pty", "-p", "hello"]);

--- a/tests/integration/test_loop_markers.py
+++ b/tests/integration/test_loop_markers.py
@@ -180,3 +180,34 @@ def test_loop_dry_run_includes_loop_markers(
     assert data["loop_markers"] is not None
     # git-root-from walks up; without .git anywhere, it returns the cwd.
     assert str(tmp_path).replace("\\", "/") in data["loop_markers"].replace("\\", "/")
+
+
+def test_codex_loop_stops_on_done_marker(
+    clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+) -> None:
+    """Codex loop honors the DONE marker contract just like claude."""
+    loop_dir = _marker_dir(tmp_path)
+    done = loop_dir / "DONE"
+
+    result = _run(
+        clud_binary,
+        "--codex",
+        "loop",
+        "--loop-count",
+        "10",
+        "resolve the task",
+        "--",
+        "--mock-write-done",
+        str(done),
+        "--mock-write-done-body",
+        "codex task resolved",
+        "--mock-write-marker-on-iter",
+        "2",
+        env=mock_env,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "iteration 2" in result.stderr
+    assert "DONE" in result.stderr
+    assert done.is_file()
+    assert done.read_text().strip() == "codex task resolved"

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -359,6 +359,62 @@ class TestLoopMode:
         json_lines = [line.strip() for line in cleaned.splitlines() if line.strip().startswith("{")]
         assert len(json_lines) == 1
 
+    # ---- Issue #48: `clud --codex loop "..."` must work against codex ----
+
+    def test_codex_loop_iterations(
+        self, clud_binary: Path, mock_env: dict[str, str]
+    ) -> None:
+        """`clud --codex loop ...` drives the codex backend for N iterations."""
+        result = _run(
+            clud_binary,
+            "--codex",
+            "loop",
+            "--loop-count",
+            "3",
+            "--no-done-marker",
+            "do stuff",
+            env=mock_env,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        cleaned = _strip_ansi(result.stdout)
+        json_lines = [
+            line.strip() for line in cleaned.splitlines() if line.strip().startswith("{")
+        ]
+        assert len(json_lines) == 3
+        for line in json_lines:
+            report = json.loads(line)
+            # Each iteration invoked the codex mock agent.
+            assert "codex" in report["program"].lower()
+            # Codex uses `exec` subcommand + positional prompt (no `-p` flag).
+            assert "exec" in report["args"]
+            assert "-p" not in report["args"]
+            assert "--dangerously-bypass-approvals-and-sandbox" in report["args"]
+            # The prompt appears as a positional arg somewhere in the args.
+            assert any("do stuff" in a for a in report["args"])
+
+    def test_codex_loop_dry_run(
+        self, clud_binary: Path, mock_env: dict[str, str]
+    ) -> None:
+        """`clud --codex --dry-run loop ...` emits the codex command."""
+        result = _run(
+            clud_binary,
+            "--codex",
+            "--dry-run",
+            "loop",
+            "task",
+            env=mock_env,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        report = json.loads(result.stdout)
+        assert report["backend"] == "codex"
+        assert report["launch_mode"] == "subprocess"
+        assert report["loop_markers"] is not None
+        assert report["iterations"] == 50
+        cmd = report["command"]
+        assert cmd[1] == "exec"
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+        assert "-p" not in cmd
+
 
 class TestInterruptReporting:
     """Verify Ctrl+C reports how clud was launched."""


### PR DESCRIPTION
## Summary

- The codex loop path was already wired correctly via `push_prompt` (positional prompt for codex) and `has_noninteractive_prompt` (routes Loop through `codex exec`). The gap was **test coverage**.
- Adds 8 Rust unit tests in `crates/clud-bin/src/command.rs` covering: exec routing, positional prompt (no `-p`), DONE/BLOCKED contract, default iterations, `--no-done-marker`, subprocess launch mode, `--safe`, passthrough flags.
- Adds 2 Python integration tests in `tests/integration/test_mock_agents.py`: 3-iteration codex loop + `--dry-run` output assertions.
- Adds 1 Python integration test in `tests/integration/test_loop_markers.py`: codex loop stops at DONE marker.

Closes #48.

## Test plan

- [x] `./_cargo test -p clud --lib codex_loop` — 8/8 pass
- [x] `bash lint` passes
- [x] `bash test` passes (26 unit)
- [x] `bash test --integration` passes (74 integration, 3 pre-existing xfails unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)