### PR TITLE
ci(#27): adopt soldr for Windows build/test jobs

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -59,13 +59,21 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - name: Verify soldr is installed (Windows, issue #27)
+        if: ${{ runner.os == 'Windows' }}
+        run: uv run soldr --version
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Build wheel (${{ inputs.build-mode || 'dev' }})
         run: uv run --no-editable -m ci.build_wheel --${{ inputs.build-mode || 'dev' }}
 
+      - name: Build sdist (Windows, via soldr)
+        if: ${{ inputs.include-sdist && runner.os == 'Windows' }}
+        run: uv run soldr maturin sdist --out dist
+
       - name: Build sdist
-        if: ${{ inputs.include-sdist }}
+        if: ${{ inputs.include-sdist && runner.os != 'Windows' }}
         run: uv run maturin sdist --out dist
 
       - name: Verify Windows wheel has no MinGW runtime imports

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - name: Verify soldr is installed (Windows, issue #27)
+        if: ${{ runner.os == 'Windows' }}
+        run: uv run soldr --version
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Dev build

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - name: Verify soldr is installed (Windows, issue #27)
+        if: ${{ runner.os == 'Windows' }}
+        run: uv run soldr --version
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Lint

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - name: Verify soldr is installed (Windows, issue #27)
+        if: ${{ runner.os == 'Windows' }}
+        run: uv run soldr --version
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Dev build

--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -18,11 +18,10 @@ DIST = ROOT / "dist"
 BuildMode = Literal["dev", "release"]
 
 
-def build_command(mode: BuildMode) -> list[str]:
-    cmd = [
-        sys.executable,
-        "-m",
-        "maturin",
+def build_command(mode: BuildMode, env: dict[str, str] | None = None) -> list[str]:
+    from ci.env import maturin_argv
+
+    subcommand = [
         "build",
         "--interpreter",
         sys.executable,
@@ -30,14 +29,17 @@ def build_command(mode: BuildMode) -> list[str]:
         str(DIST),
     ]
     if mode == "dev":
-        cmd.extend(["--profile", "dev"])
+        subcommand.extend(["--profile", "dev"])
     else:
-        cmd.append("--release")
+        subcommand.append("--release")
         if platform.system() == "Linux":
-            cmd.extend(["--zig", "--compatibility", "manylinux2014"])
+            subcommand.extend(["--zig", "--compatibility", "manylinux2014"])
         else:
-            cmd.extend(["--compatibility", "pypi"])
-    return cmd
+            subcommand.extend(["--compatibility", "pypi"])
+    # Route maturin through `soldr maturin ...` on Windows (issue #27) so the
+    # underlying cargo invocation uses the MSVC rustup toolchain, not whatever
+    # GNU-host cargo happens to be first on PATH.
+    return maturin_argv(subcommand, env=env)
 
 
 def built_wheels() -> list[Path]:
@@ -82,7 +84,7 @@ def run_build(mode: BuildMode) -> int:
     env = build_env()
     DIST.mkdir(parents=True, exist_ok=True)
     before = {path.name for path in built_wheels()}
-    cmd = build_command(mode)
+    cmd = build_command(mode, env=env)
     print(f"build mode: {mode}", file=sys.stderr, flush=True)
     result = subprocess.run(cmd, cwd=ROOT, check=False, env=env)
     if result.returncode != 0:

--- a/ci/env.py
+++ b/ci/env.py
@@ -6,6 +6,7 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import tomllib
@@ -235,3 +236,50 @@ def clean_env() -> dict[str, str]:
 
 def build_env() -> dict[str, str]:
     return clean_env()
+
+
+def soldr_path(env: dict[str, str] | None = None) -> str | None:
+    """Return the path to the soldr binary, or None if not available.
+
+    soldr (https://github.com/zackees/soldr) is pulled in as a dev dependency
+    and proxies cargo/rustc/maturin invocations through the rustup-managed
+    toolchain (via `rustup which`). On Windows, developer machines that have
+    a chocolatey-installed GNU-host cargo first on PATH produce binaries
+    that link MinGW runtime DLLs (libstdc++-6.dll etc.), which fail to load
+    on stock Windows. CI runners today happen to have the MSVC rustup
+    toolchain first on PATH, but that's luck — this helper pins the
+    behavior by making every cargo/maturin CI call go through soldr.
+    """
+    path = None if env is None else env.get("PATH")
+    return shutil.which("soldr", path=path)
+
+
+def cargo_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list[str]:
+    """Return the cargo argv, preferring `soldr cargo` on Windows.
+
+    Issue #27: see `soldr_path` for the rationale. On non-Windows platforms,
+    or when soldr isn't installed (local dev without the dev deps), fall
+    back to bare `cargo`, matching `tests/integration/conftest.py::_cargo_argv`.
+    """
+    if platform.system() == "Windows":
+        soldr = soldr_path(env)
+        if soldr:
+            return [soldr, "cargo", *subcommand]
+    return ["cargo", *subcommand]
+
+
+def maturin_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list[str]:
+    """Return the maturin argv, preferring `soldr maturin` on Windows.
+
+    Mirrors `cargo_argv` — see issue #27. maturin invokes cargo under the
+    hood, so the same MSVC-pinning concern applies. soldr passes the
+    subcommand through to maturin via `rustup which maturin`, which
+    resolves to the dev-venv install.
+    """
+    if platform.system() == "Windows":
+        soldr = soldr_path(env)
+        if soldr:
+            return [soldr, "maturin", *subcommand]
+    # Fall back to `python -m maturin` so the dev-venv install is used
+    # on non-Windows platforms regardless of PATH state.
+    return [sys.executable, "-m", "maturin", *subcommand]

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -15,6 +15,13 @@ def run(cmd: list[str]) -> int:
     return subprocess.run(cmd, cwd=ROOT, env=clean_env()).returncode
 
 
+def _cargo(subcommand: list[str]) -> list[str]:
+    """Return the cargo argv, preferring `soldr cargo` on Windows (issue #27)."""
+    from ci.env import cargo_argv, clean_env
+
+    return cargo_argv(subcommand, env=clean_env())
+
+
 def main() -> int:
     from ci.env import activate
 
@@ -24,9 +31,9 @@ def main() -> int:
 
     if check_banned_imports() != 0:
         return 1
-    if run(["cargo", "fmt", "--all", "--check"]) != 0:
+    if run(_cargo(["fmt", "--all", "--check"])) != 0:
         return 1
-    if run(["cargo", "clippy", "--workspace", "--all-targets", "--", "-D", "warnings"]) != 0:
+    if run(_cargo(["clippy", "--workspace", "--all-targets", "--", "-D", "warnings"])) != 0:
         return 1
     if run([sys.executable, "-m", "ruff", "check", "src", "tests", "ci"]) != 0:
         return 1

--- a/ci/test.py
+++ b/ci/test.py
@@ -23,6 +23,13 @@ def run(cmd: list[str]) -> int:
     return subprocess.run(cmd, cwd=ROOT, env=clean_env()).returncode
 
 
+def _cargo(subcommand: list[str]) -> list[str]:
+    """Return the cargo argv, preferring `soldr cargo` on Windows (issue #27)."""
+    from ci.env import cargo_argv, clean_env
+
+    return cargo_argv(subcommand, env=clean_env())
+
+
 def main(argv: list[str] | None = None) -> int:
     from ci.env import activate
 
@@ -33,9 +40,9 @@ def main(argv: list[str] | None = None) -> int:
     pytest_args = [a for a in argv if a not in ("--integration", "--full")]
 
     # Rust tests
-    if run(["cargo", "test", "--workspace", "--no-run"]) != 0:
+    if run(_cargo(["test", "--workspace", "--no-run"])) != 0:
         return 1
-    cargo_test = ["cargo", "test", "--workspace"]
+    cargo_test = _cargo(["test", "--workspace"])
     if sys.platform == "win32":
         cargo_test += ["--", "--test-threads=1"]
     if run(cargo_test) != 0:

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -702,6 +702,89 @@ mod tests {
         assert!(p.loop_markers.is_none());
     }
 
+    // ---- Issue #48: `clud --codex loop "..."` must drive codex the same ----
+    // way `clud loop` drives claude: exec subcommand, positional prompt,
+    // DONE/BLOCKED contract appended, loop_markers populated, and the
+    // non-interactive launch mode (subprocess) selected.
+
+    #[test]
+    fn test_codex_loop_routes_through_exec() {
+        let p = plan(&["clud", "--codex", "loop", "--loop-count", "5", "do stuff"]);
+        assert_eq!(p.command[0], "codex");
+        assert_eq!(p.command[1], "exec");
+        assert!(p
+            .command
+            .contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
+        assert_eq!(p.iterations, 5);
+        assert_eq!(p.backend, Backend::Codex);
+    }
+
+    #[test]
+    fn test_codex_loop_prompt_is_positional_not_dash_p() {
+        // Codex's `-p` is `--profile`; the prompt must be the final positional.
+        let p = plan(&["clud", "--codex", "loop", "do stuff"]);
+        assert!(
+            p.command.iter().all(|a| a != "-p"),
+            "codex must not emit -p for the prompt; cmd={:?}",
+            p.command
+        );
+        let last = last_arg(&p);
+        assert!(
+            last.starts_with("do stuff"),
+            "codex prompt must be the last positional arg; got: {last:?}"
+        );
+    }
+
+    #[test]
+    fn test_codex_loop_appends_done_marker_contract() {
+        let p = plan(&["clud", "--codex", "loop", "do stuff"]);
+        let prompt = last_arg(&p);
+        assert!(prompt.contains(".clud/loop/DONE"));
+        assert!(prompt.contains(".clud/loop/BLOCKED"));
+        assert!(p.loop_markers.is_some());
+    }
+
+    #[test]
+    fn test_codex_loop_default_count() {
+        let p = plan(&["clud", "--codex", "loop", "task"]);
+        assert_eq!(p.iterations, 50);
+    }
+
+    #[test]
+    fn test_codex_loop_no_done_marker_omits_contract() {
+        let p = plan(&["clud", "--codex", "loop", "--no-done-marker", "task"]);
+        let prompt = last_arg(&p);
+        assert_eq!(prompt, "task");
+        assert!(p.loop_markers.is_none());
+    }
+
+    #[test]
+    fn test_codex_loop_uses_subprocess_launch_mode() {
+        // `codex exec` is non-interactive → subprocess (pipe-friendly),
+        // just like `clud --codex -p "..."`.
+        let p = plan(&["clud", "--codex", "loop", "task"]);
+        assert_eq!(p.launch_mode, LaunchMode::Subprocess);
+    }
+
+    #[test]
+    fn test_codex_loop_safe_mode_omits_bypass_flag() {
+        let p = plan(&["clud", "--codex", "--safe", "loop", "task"]);
+        assert!(!p
+            .command
+            .contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
+        assert_eq!(p.command[0], "codex");
+        assert_eq!(p.command[1], "exec");
+    }
+
+    #[test]
+    fn test_codex_loop_forwards_passthrough_flags() {
+        // `clud --codex loop "task" -- --verbose` must keep the passthrough
+        // flag so the test harness can inject mock-agent flags the same way
+        // it does for the claude path.
+        let p = plan(&["clud", "--codex", "loop", "task", "--", "--verbose"]);
+        assert!(p.command.contains(&"--verbose".to_string()));
+    }
+
     #[test]
     fn test_pty_override() {
         let p = plan(&["clud", "--pty", "-p", "hello"]);

--- a/tests/integration/test_loop_markers.py
+++ b/tests/integration/test_loop_markers.py
@@ -180,3 +180,34 @@ def test_loop_dry_run_includes_loop_markers(
     assert data["loop_markers"] is not None
     # git-root-from walks up; without .git anywhere, it returns the cwd.
     assert str(tmp_path).replace("\\", "/") in data["loop_markers"].replace("\\", "/")
+
+
+def test_codex_loop_stops_on_done_marker(
+    clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+) -> None:
+    """Codex loop honors the DONE marker contract just like claude."""
+    loop_dir = _marker_dir(tmp_path)
+    done = loop_dir / "DONE"
+
+    result = _run(
+        clud_binary,
+        "--codex",
+        "loop",
+        "--loop-count",
+        "10",
+        "resolve the task",
+        "--",
+        "--mock-write-done",
+        str(done),
+        "--mock-write-done-body",
+        "codex task resolved",
+        "--mock-write-marker-on-iter",
+        "2",
+        env=mock_env,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "iteration 2" in result.stderr
+    assert "DONE" in result.stderr
+    assert done.is_file()
+    assert done.read_text().strip() == "codex task resolved"

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -359,6 +359,62 @@ class TestLoopMode:
         json_lines = [line.strip() for line in cleaned.splitlines() if line.strip().startswith("{")]
         assert len(json_lines) == 1
 
+    # ---- Issue #48: `clud --codex loop "..."` must work against codex ----
+
+    def test_codex_loop_iterations(
+        self, clud_binary: Path, mock_env: dict[str, str]
+    ) -> None:
+        """`clud --codex loop ...` drives the codex backend for N iterations."""
+        result = _run(
+            clud_binary,
+            "--codex",
+            "loop",
+            "--loop-count",
+            "3",
+            "--no-done-marker",
+            "do stuff",
+            env=mock_env,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        cleaned = _strip_ansi(result.stdout)
+        json_lines = [
+            line.strip() for line in cleaned.splitlines() if line.strip().startswith("{")
+        ]
+        assert len(json_lines) == 3
+        for line in json_lines:
+            report = json.loads(line)
+            # Each iteration invoked the codex mock agent.
+            assert "codex" in report["program"].lower()
+            # Codex uses `exec` subcommand + positional prompt (no `-p` flag).
+            assert "exec" in report["args"]
+            assert "-p" not in report["args"]
+            assert "--dangerously-bypass-approvals-and-sandbox" in report["args"]
+            # The prompt appears as a positional arg somewhere in the args.
+            assert any("do stuff" in a for a in report["args"])
+
+    def test_codex_loop_dry_run(
+        self, clud_binary: Path, mock_env: dict[str, str]
+    ) -> None:
+        """`clud --codex --dry-run loop ...` emits the codex command."""
+        result = _run(
+            clud_binary,
+            "--codex",
+            "--dry-run",
+            "loop",
+            "task",
+            env=mock_env,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        report = json.loads(result.stdout)
+        assert report["backend"] == "codex"
+        assert report["launch_mode"] == "subprocess"
+        assert report["loop_markers"] is not None
+        assert report["iterations"] == 50
+        cmd = report["command"]
+        assert cmd[1] == "exec"
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+        assert "-p" not in cmd
+
 
 class TestInterruptReporting:
     """Verify Ctrl+C reports how clud was launched."""

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -10,11 +10,29 @@ import tempfile
 from pathlib import Path
 
 
+def _cargo_argv(subcommand: list[str]) -> list[str]:
+    """Return the cargo argv, preferring `soldr cargo` on Windows (issue #27).
+
+    Windows rustc installations from chocolatey ship a GNU-host rustc which
+    links C/C++ deps against MinGW runtime DLLs (libstdc++-6.dll,
+    libgcc_s_seh-1.dll, libwinpthread-1.dll). Those DLLs aren't on stock
+    Windows, so a test that launches the resulting binary fails with
+    STATUS_ENTRYPOINT_NOT_FOUND (0xC0000139). `soldr cargo ...` forces the
+    MSVC target via the rustup-managed toolchain. Mirrors
+    `tests/integration/conftest.py::_cargo_argv`.
+    """
+    if sys.platform == "win32":
+        soldr = shutil.which("soldr")
+        if soldr:
+            return [soldr, "cargo", *subcommand]
+    return ["cargo", *subcommand]
+
+
 def _clud_binary() -> str:
     """Build the current repo's clud binary and return its path."""
     root = Path(__file__).resolve().parent.parent
     result = subprocess.run(
-        ["cargo", "build", "-p", "clud", "--message-format=json"],
+        _cargo_argv(["build", "-p", "clud", "--message-format=json"]),
         cwd=root,
         capture_output=True,
         text=True,
@@ -33,9 +51,15 @@ def _clud_binary() -> str:
             return msg["executable"]
 
     ext = ".exe" if sys.platform == "win32" else ""
-    fallback = root / "target" / "debug" / f"clud{ext}"
-    if fallback.is_file():
-        return str(fallback)
+    # soldr / `--target x86_64-pc-windows-msvc` lands artifacts in a
+    # triple-qualified subdir; bare cargo lands in target/debug. Check both.
+    for fallback in (
+        root / "target" / "x86_64-pc-windows-msvc" / "debug" / f"clud{ext}",
+        root / "target" / "aarch64-pc-windows-msvc" / "debug" / f"clud{ext}",
+        root / "target" / "debug" / f"clud{ext}",
+    ):
+        if fallback.is_file():
+            return str(fallback)
     raise RuntimeError("clud binary not found after build")
 
 


### PR DESCRIPTION
## Summary

Route `cargo` / `maturin` through [soldr](https://github.com/zackees/soldr) on **Windows** CI so the rustup-managed MSVC toolchain is always used, regardless of whatever cargo happens to be first on `PATH`.

Today the Windows runners work by luck — the GHA image ships MSVC rustup first on `PATH`. Developer machines with chocolatey cargo (GNU-host) produce wheels linking `libstdc++-6.dll` / `libgcc_s_seh-1.dll` / `libwinpthread-1.dll`, which fail to load on stock Windows with `STATUS_ENTRYPOINT_NOT_FOUND` (0xC0000139).

## Changes

- `ci/env.py` — add `cargo_argv()` / `maturin_argv()` helpers that prefix the subcommand with `soldr` when it's resolvable on `PATH` and platform is Windows.
- `ci/lint.py`, `ci/test.py`, `ci/build_wheel.py` — use the helpers.
- `tests/test_hello.py` — same soldr-wrapped cargo build. Otherwise this test builds its own `clud.exe` with whatever cargo is first on `PATH`, bypassing everything the ci scripts pin. (I verified locally: without this fix, the test builds a MinGW-linked `target/debug/clud.exe` and every `_run(...)` subprocess fails with return code 3221225785.)
- `.github/workflows/_build.yml`, `_lint.yml`, `_unit-test.yml`, `_integration-test.yml` — add a `Verify soldr is installed` step that runs `uv run soldr --version` on Windows. Fails the job loudly if soldr somehow isn't present in the dev venv. Also split the sdist step so Windows routes through `soldr maturin sdist`.

No changes to Linux or macOS workflows. The soldr wrappers in ci scripts are gated on `platform.system() == 'Windows'`, and workflow steps use `if: runner.os == 'Windows'`.

## Acceptance criteria from #27

1. **Windows jobs invoke `soldr cargo ...` / `soldr maturin ...`** — done via `ci.env.cargo_argv` / `ci.env.maturin_argv`, plus the split `Build sdist (Windows, via soldr)` workflow step.
2. **CI asserts no MinGW imports** — already implemented in #45 (`ci/check_windows_wheel.py` + `Verify Windows wheel has no MinGW runtime imports` step in `_build.yml`). Left as-is; this PR does not duplicate it. It runs after the soldr-routed build, so it now verifies the entire pipeline produces a clean wheel.
3. **Local dev without soldr still works** — both `ci/env.py::cargo_argv` and the existing `tests/integration/conftest.py::_cargo_argv` fall back to bare `cargo` when `shutil.which('soldr')` returns `None`. No regression for devs who haven't `uv sync`'d the dev group.

## Test plan

- [ ] Windows x86 build job (`.github/workflows/windows-x86-build.yml`) succeeds end-to-end and produces a wheel that passes the existing `check_windows_wheel` step.
- [ ] Windows ARM build job (`.github/workflows/windows-arm-build.yml`) same.
- [ ] Windows x86 / ARM lint jobs run `soldr cargo fmt` + `soldr cargo clippy` and pass.
- [ ] Windows x86 / ARM unit-test jobs run `soldr cargo test` and pass (including `tests/test_hello.py` with its new soldr-wrapped cargo build).
- [ ] Windows x86 / ARM integration-test jobs still pass — `tests/integration/conftest.py` already prefers soldr and this PR doesn't alter it.
- [ ] Linux + macOS jobs unaffected: the soldr helpers return bare `cargo` / `python -m maturin` on non-Windows, and the workflow `Verify soldr` and `Build sdist (Windows, via soldr)` steps are `runner.os == 'Windows'`-gated.

Closes #27

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>