### PR TITLE
docs: add Codex support section to README + bump to 2.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.8"
+version = "2.0.9"
 dependencies = [
  "base64",
  "clap",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.8"
+version = "2.0.9"
 dependencies = [
  "serde_json",
  "terminal_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.8"
+version = "2.0.9"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Unknown flags are forwarded directly to the backend agent.
 `clud` now defaults to subprocess launch mode for Claude and Codex. Use `--pty`
 to opt back into PTY while Claude PTY issues are being investigated.
 
+## Codex Support
+
+![codex-supported](https://github.com/user-attachments/assets/de1e23b4-4513-4c92-ba57-3d9dcd1060b6)
+
+The Rust version of `clud` supports Codex directly. Use `--codex` to switch
+backends for interactive runs, prompt-driven execution, resume flows, and
+detachable sessions.
+
 ## Detached Sessions
 
 Use daemon-managed sessions when you want to disconnect and reattach later.
@@ -215,6 +223,8 @@ bash lint                   # Lint (cargo fmt + clippy + ruff + banned imports)
 bash test                   # Unit tests (Rust + Python)
 bash test --integration     # Include integration tests with mock agents
 ```
+
+<img width="556" height="500" alt="image" src="https://github.com/user-attachments/assets/520f6131-5409-4b29-927a-2b946c4ecb79" />
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.8"
+version = "2.0.9"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clud/__init__.py
+++ b/src/clud/__init__.py
@@ -1,3 +1,3 @@
 """clud — Fast Rust CLI for running Claude Code and Codex in YOLO mode."""
 
-__version__ = "2.0.8"
+__version__ = "2.0.9"


### PR DESCRIPTION
## Summary
- Add a "Codex Support" section to the README documenting that the Rust `clud` supports Codex directly and how to use `--codex` for interactive runs, prompt execution, resume flows, and detachable sessions.
- Add a screenshot under the testing section.
- Bump version to 2.0.9 across `pyproject.toml`, `Cargo.toml`, `Cargo.lock`, and `src/clud/__init__.py`.

## Test plan
- [ ] `bash lint` passes
- [ ] `bash test` passes
- [ ] README renders correctly on GitHub (images load, sections nest properly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)