### PR TITLE
ci(test): pre-build mock-agent so pty_behavior tests aren't flaky

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -39,7 +39,15 @@ def main(argv: list[str] | None = None) -> int:
     run_integration = "--integration" in argv or "--full" in argv
     pytest_args = [a for a in argv if a not in ("--integration", "--full")]
 
-    # Rust tests
+    # Rust tests. The pty_behavior integration tests need the `mock-agent`
+    # binary on disk at `target/.../debug/mock-agent`, but `cargo test --no-run`
+    # only compiles test binaries, not workspace bins. Without an explicit
+    # pre-build the test falls back to a self-issued `cargo build -p mock-agent`
+    # whose `--message-format json` parsing has been seen to flake under
+    # sccache (issue: macos-x86 unit-test job, run 24694769083). Build the
+    # bin up front so the test path that needs it always finds it.
+    if run(_cargo(["build", "-p", "mock-agent"])) != 0:
+        return 1
     if run(_cargo(["test", "--workspace", "--no-run"])) != 0:
         return 1
     cargo_test = _cargo(["test", "--workspace"])


### PR DESCRIPTION
## Summary

PR #52's macOS x86 unit-test job (run [24694769083](https://github.com/zackees/clud/actions/runs/24694769083/job/72224917986?pr=52)) flaked on `raw_pump_applies_resize_from_channel` with:

> mock-agent binary not found after build

It passed on retry, so PR #52 was merged. This PR fixes the underlying flake.

## Root cause

`crates/clud-bin/tests/pty_behavior.rs::mock_agent_path()` expects `target/.../debug/mock-agent` on disk, but `cargo test --workspace --no-run` only builds **test** binaries — the workspace's `mock-agent` **bin** is never produced by that command (no test references `env!(\"CARGO_BIN_EXE_mock-agent\")`).

The test falls back to a self-issued `cargo build -p mock-agent --message-format json` and parses the JSON for the executable path. Under sccache that fallback proved unreliable on macOS x86.

## Fix

`ci/test.py` now runs `cargo build -p mock-agent` once before the test cycle, so `target/.../debug/mock-agent` is always populated when tests start.

The in-test fallback in `mock_agent_path()` is left in place as a safety net for local `cargo test` invocations that bypass `ci.test`.

## Test plan

- [ ] CI passes on first attempt across all unit-test runners (no retries needed for this race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)