### PR TITLE
fix(#25): detachable-timeout default + configurable backlog size

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -52,6 +52,12 @@ pub struct Args {
     #[arg(long = "name")]
     pub session_name: Option<String>,
 
+    /// Override the in-memory attach-replay backlog cap. Accepts bytes
+    /// (`262144`), or SI/binary suffixes (`256k`, `256KiB`, `1mb`). The
+    /// compiled default is 256 KiB. Also honored as `CLUD_BACKLOG_BYTES`.
+    #[arg(long = "backlog-size")]
+    pub backlog_size: Option<String>,
+
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
@@ -165,6 +171,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--resume",
         "--model",
         "--name",
+        "--backlog-size",
         "--loop-count",
         "--daemon-state-dir",
     ];

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -25,7 +25,8 @@ use crate::trampoline;
 
 const ENV_FEATURE_FLAG: &str = "CLUD_EXPERIMENTAL_DAEMON";
 const ENV_STATE_DIR: &str = "CLUD_DAEMON_STATE_DIR";
-const BACKLOG_LIMIT_BYTES: usize = 256 * 1024;
+const ENV_BACKLOG_BYTES: &str = "CLUD_BACKLOG_BYTES";
+const DEFAULT_BACKLOG_LIMIT_BYTES: usize = 256 * 1024;
 const STALE_CLIENT_GRACE: Duration = Duration::from_secs(1);
 const BACKGROUND_PROMPT_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -75,6 +76,11 @@ struct WorkerLaunchSpec {
     background_on_launch: bool,
     rows: u16,
     cols: u16,
+    /// In-memory attach-replay backlog cap. `None` uses the compiled default
+    /// (`DEFAULT_BACKLOG_LIMIT_BYTES`). Optional for wire compatibility with
+    /// spec files written by older clud versions.
+    #[serde(default)]
+    backlog_bytes: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -201,6 +207,7 @@ struct WorkerShared {
     session_id: String,
     snapshot: Mutex<SessionSnapshot>,
     backlog: Mutex<BacklogState>,
+    backlog_limit_bytes: usize,
     /// Server-side terminal emulator for PTY sessions. `Some` when the session
     /// kind is `Pty` and issue #34 attach-replay is active. The parser tracks
     /// grid + cursor + alt-screen state so a mid-session attach can emit a
@@ -209,7 +216,7 @@ struct WorkerShared {
     capture: Mutex<Option<TerminalCapture>>,
     /// Append-only log file for this session. Every output chunk is written
     /// here in addition to the in-memory backlog, so `clud logs <id>` can
-    /// pm2-style tail / follow output that has scrolled off the 256 KiB
+    /// pm2-style tail / follow output that has scrolled off the in-memory
     /// backlog or from sessions that have fully exited.
     log_file: Mutex<Option<fs::File>>,
     client: Mutex<Option<AttachedClient>>,
@@ -218,12 +225,23 @@ struct WorkerShared {
 }
 
 impl WorkerShared {
+    #[cfg(test)]
     fn new(state_dir: PathBuf, session_id: String, snapshot: SessionSnapshot) -> Self {
+        Self::new_with_backlog(state_dir, session_id, snapshot, DEFAULT_BACKLOG_LIMIT_BYTES)
+    }
+
+    fn new_with_backlog(
+        state_dir: PathBuf,
+        session_id: String,
+        snapshot: SessionSnapshot,
+        backlog_limit_bytes: usize,
+    ) -> Self {
         Self {
             state_dir,
             session_id,
             snapshot: Mutex::new(snapshot),
             backlog: Mutex::new(BacklogState::default()),
+            backlog_limit_bytes: backlog_limit_bytes.max(1),
             capture: Mutex::new(None),
             log_file: Mutex::new(None),
             client: Mutex::new(None),
@@ -462,7 +480,7 @@ impl WorkerShared {
             let mut backlog = self.backlog.lock().expect("backlog mutex poisoned");
             backlog.total_bytes += chunk.len();
             backlog.chunks.push_back(chunk.clone());
-            while backlog.total_bytes > BACKLOG_LIMIT_BYTES {
+            while backlog.total_bytes > self.backlog_limit_bytes {
                 if let Some(front) = backlog.chunks.pop_front() {
                     backlog.total_bytes = backlog.total_bytes.saturating_sub(front.len());
                 } else {
@@ -651,6 +669,7 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         LaunchMode::Pty => SessionKind::Pty,
     };
     let (rows, cols) = terminal_dimensions();
+    let backlog_bytes = resolve_backlog_bytes(args.backlog_size.as_deref());
     let request = DaemonRequest::Create {
         spec: WorkerLaunchSpec {
             plan: plan.clone(),
@@ -660,6 +679,7 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
             background_on_launch: args.detach,
             rows,
             cols,
+            backlog_bytes,
         },
     };
     let response = match send_daemon_request(&state_dir, &request) {
@@ -1004,7 +1024,7 @@ fn prompt_continue_in_background(interrupted: &AtomicBool) -> BackgroundPromptDe
 fn prompt_continue_in_background_terminal(interrupted: &AtomicBool) -> BackgroundPromptDecision {
     let _guard = match RawTerminalGuard::enter() {
         Ok(guard) => guard,
-        Err(_) => return BackgroundPromptDecision::EndSession,
+        Err(_) => return BackgroundPromptDecision::ContinueInBackground,
     };
     let started = Instant::now();
     let mut displayed_remaining = u64::MAX;
@@ -1018,7 +1038,7 @@ fn prompt_continue_in_background_terminal(interrupted: &AtomicBool) -> Backgroun
         }
         if remaining == 0 {
             eprintln!();
-            return BackgroundPromptDecision::EndSession;
+            return BackgroundPromptDecision::ContinueInBackground;
         }
         if interrupted.swap(false, Ordering::SeqCst) {
             eprintln!();
@@ -1027,15 +1047,15 @@ fn prompt_continue_in_background_terminal(interrupted: &AtomicBool) -> Backgroun
         match event::poll(Duration::from_millis(100)) {
             Ok(true) => match event::read() {
                 Ok(Event::Key(key)) => match key.code {
-                    KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
                         eprintln!();
                         return BackgroundPromptDecision::ContinueInBackground;
                     }
-                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                         eprintln!();
                         return BackgroundPromptDecision::EndSession;
                     }
-                    KeyCode::Enter | KeyCode::Esc => {
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         eprintln!();
                         return BackgroundPromptDecision::EndSession;
                     }
@@ -1044,13 +1064,13 @@ fn prompt_continue_in_background_terminal(interrupted: &AtomicBool) -> Backgroun
                 Ok(_) => {}
                 Err(_) => {
                     eprintln!();
-                    return BackgroundPromptDecision::EndSession;
+                    return BackgroundPromptDecision::ContinueInBackground;
                 }
             },
             Ok(false) => {}
             Err(_) => {
                 eprintln!();
-                return BackgroundPromptDecision::EndSession;
+                return BackgroundPromptDecision::ContinueInBackground;
             }
         }
     }
@@ -1077,17 +1097,20 @@ fn prompt_continue_in_background_stream(interrupted: &AtomicBool) -> BackgroundP
             render_background_prompt(remaining);
         }
         if remaining == 0 {
-            return BackgroundPromptDecision::EndSession;
+            return BackgroundPromptDecision::ContinueInBackground;
         }
         if interrupted.swap(false, Ordering::SeqCst) {
             return BackgroundPromptDecision::EndSession;
         }
         match rx.recv_timeout(Duration::from_millis(100)) {
-            Ok(b'y') | Ok(b'Y') => return BackgroundPromptDecision::ContinueInBackground,
-            Ok(_) => return BackgroundPromptDecision::EndSession,
+            Ok(b'y') | Ok(b'Y') | Ok(b'\r') | Ok(b'\n') => {
+                return BackgroundPromptDecision::ContinueInBackground
+            }
+            Ok(b'n') | Ok(b'N') => return BackgroundPromptDecision::EndSession,
+            Ok(_) => return BackgroundPromptDecision::ContinueInBackground,
             Err(mpsc::RecvTimeoutError::Timeout) => {}
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                return BackgroundPromptDecision::EndSession
+                return BackgroundPromptDecision::ContinueInBackground
             }
         }
     }
@@ -1095,7 +1118,7 @@ fn prompt_continue_in_background_stream(interrupted: &AtomicBool) -> BackgroundP
 
 fn render_background_prompt(remaining: u64) {
     eprintln!(
-        "[clud] continue session in the background? [y/N] auto-ending in {}s",
+        "[clud] continue session in the background? [Y/n] auto-backgrounding in {}s",
         remaining
     );
 }
@@ -1397,10 +1420,12 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
         root_pid: None,
         exit_code: None,
     };
-    let shared = Arc::new(WorkerShared::new(
+    let backlog_limit = spec.backlog_bytes.unwrap_or(DEFAULT_BACKLOG_LIMIT_BYTES);
+    let shared = Arc::new(WorkerShared::new_with_backlog(
         state_dir.to_path_buf(),
         session_id.to_string(),
         snapshot,
+        backlog_limit,
     ));
     shared.init_log_file();
 
@@ -2261,6 +2286,59 @@ fn terminal_dimensions() -> (u16, u16) {
     }
 }
 
+/// Resolve the attach-replay backlog cap in bytes. Precedence: explicit CLI
+/// flag (`--backlog-size`) > `CLUD_BACKLOG_BYTES` env var > compiled default.
+/// Returns `None` when no override was set, so the worker spec stays
+/// wire-compatible with older daemons.
+fn resolve_backlog_bytes(cli: Option<&str>) -> Option<usize> {
+    if let Some(raw) = cli {
+        return parse_byte_size(raw);
+    }
+    if let Ok(raw) = std::env::var(ENV_BACKLOG_BYTES) {
+        return parse_byte_size(&raw);
+    }
+    None
+}
+
+/// Parse a human-friendly byte count: `256`, `256k`, `1mb`, `2MiB`, etc.
+/// Returns `None` when the input is unparseable or non-positive so we fall
+/// back to the compiled default instead of misconfiguring the cap.
+fn parse_byte_size(raw: &str) -> Option<usize> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    let (num_part, mult) = if let Some(rest) = lower
+        .strip_suffix("kib")
+        .or_else(|| lower.strip_suffix("kb"))
+        .or_else(|| lower.strip_suffix("k"))
+    {
+        (rest, 1024usize)
+    } else if let Some(rest) = lower
+        .strip_suffix("mib")
+        .or_else(|| lower.strip_suffix("mb"))
+        .or_else(|| lower.strip_suffix("m"))
+    {
+        (rest, 1024 * 1024)
+    } else if let Some(rest) = lower
+        .strip_suffix("gib")
+        .or_else(|| lower.strip_suffix("gb"))
+        .or_else(|| lower.strip_suffix("g"))
+    {
+        (rest, 1024 * 1024 * 1024)
+    } else if let Some(rest) = lower.strip_suffix("b") {
+        (rest, 1usize)
+    } else {
+        (lower.as_str(), 1usize)
+    };
+    let n: usize = num_part.trim().parse().ok()?;
+    if n == 0 {
+        return None;
+    }
+    n.checked_mul(mult)
+}
+
 fn pid_is_alive(pid: u32) -> bool {
     let system = System::new_all();
     system.process(Pid::from_u32(pid)).is_some()
@@ -2596,5 +2674,156 @@ mod log_tests {
         let (new_off, new) = follow_read(&path, off).unwrap();
         assert_eq!(new_off, 5);
         assert_eq!(new, b"short");
+    }
+}
+
+#[cfg(test)]
+mod backlog_size_tests {
+    //! Issue #25: configurable attach-replay backlog cap.
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parse_byte_size_raw_bytes() {
+        assert_eq!(parse_byte_size("262144"), Some(262144));
+        assert_eq!(parse_byte_size("1024b"), Some(1024));
+        assert_eq!(parse_byte_size("  2048  "), Some(2048));
+    }
+
+    #[test]
+    fn parse_byte_size_with_kb_suffix() {
+        assert_eq!(parse_byte_size("256k"), Some(256 * 1024));
+        assert_eq!(parse_byte_size("256kb"), Some(256 * 1024));
+        assert_eq!(parse_byte_size("256KiB"), Some(256 * 1024));
+        assert_eq!(parse_byte_size("256KB"), Some(256 * 1024));
+    }
+
+    #[test]
+    fn parse_byte_size_with_mb_suffix() {
+        assert_eq!(parse_byte_size("1m"), Some(1024 * 1024));
+        assert_eq!(parse_byte_size("1MB"), Some(1024 * 1024));
+        assert_eq!(parse_byte_size("1MiB"), Some(1024 * 1024));
+        assert_eq!(parse_byte_size("2MB"), Some(2 * 1024 * 1024));
+    }
+
+    #[test]
+    fn parse_byte_size_with_gb_suffix() {
+        assert_eq!(parse_byte_size("1g"), Some(1024 * 1024 * 1024));
+        assert_eq!(parse_byte_size("1gib"), Some(1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn parse_byte_size_rejects_garbage() {
+        assert_eq!(parse_byte_size(""), None);
+        assert_eq!(parse_byte_size("abc"), None);
+        assert_eq!(parse_byte_size("0"), None);
+        assert_eq!(parse_byte_size("0k"), None);
+        assert_eq!(parse_byte_size("-5"), None);
+    }
+
+    #[test]
+    fn resolve_backlog_bytes_prefers_cli_over_env() {
+        let guard = EnvGuard::set(ENV_BACKLOG_BYTES, "2mb");
+        assert_eq!(resolve_backlog_bytes(Some("128k")), Some(128 * 1024));
+        drop(guard);
+    }
+
+    #[test]
+    fn resolve_backlog_bytes_falls_back_to_env() {
+        let guard = EnvGuard::set(ENV_BACKLOG_BYTES, "512k");
+        assert_eq!(resolve_backlog_bytes(None), Some(512 * 1024));
+        drop(guard);
+    }
+
+    #[test]
+    fn resolve_backlog_bytes_none_when_unset() {
+        let guard = EnvGuard::unset(ENV_BACKLOG_BYTES);
+        assert_eq!(resolve_backlog_bytes(None), None);
+        drop(guard);
+    }
+
+    #[test]
+    fn worker_shared_honors_backlog_override() {
+        // With a 10-byte cap, pushing three 5-byte chunks should evict the
+        // oldest so only the most-recent chunks remain resident.
+        let tmp = TempDir::new().unwrap();
+        let snap = SessionSnapshot {
+            id: "s".into(),
+            kind: SessionKind::Subprocess,
+            cwd: None,
+            name: None,
+            created_at: Some(0),
+            detachable: false,
+            background: false,
+            daemon_pid: 0,
+            worker_pid: 0,
+            worker_port: 0,
+            root_pid: None,
+            exit_code: None,
+        };
+        let shared = Arc::new(WorkerShared::new_with_backlog(
+            tmp.path().to_path_buf(),
+            "s".into(),
+            snap,
+            10,
+        ));
+        shared.push_output(b"AAAAA".to_vec());
+        shared.push_output(b"BBBBB".to_vec());
+        shared.push_output(b"CCCCC".to_vec());
+        let backlog = shared.backlog.lock().unwrap();
+        assert!(
+            backlog.total_bytes <= 10,
+            "backlog exceeded cap: {} > 10",
+            backlog.total_bytes
+        );
+    }
+
+    /// RAII env-var guard so tests that read `CLUD_BACKLOG_BYTES` don't
+    /// contaminate each other or the outer process. Serial by mutex since
+    /// `std::env` is process-global.
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn lock() -> std::sync::MutexGuard<'static, ()> {
+            static M: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+            M.get_or_init(|| std::sync::Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+        }
+
+        fn set(key: &'static str, value: &str) -> Self {
+            let lock = Self::lock();
+            let prior = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self {
+                key,
+                prior,
+                _lock: lock,
+            }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let lock = Self::lock();
+            let prior = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self {
+                key,
+                prior,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
     }
 }

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -401,9 +401,13 @@ class TestDaemonManagedSessionFlags:
         finally:
             _kill_daemon_for_session(state_dir, session_id)
 
-    def test_detachable_ctrl_c_timeout_ends_session(
+    def test_detachable_ctrl_c_timeout_backgrounds_session(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
     ) -> None:
+        # Issue #25: `--detachable` Ctrl+C countdown now defaults to
+        # *backgrounding* on timeout (user opted in), not ending. This test
+        # replaces the earlier `..._ends_session` variant that encoded the old
+        # default.
         state_dir = tmp_path / "daemon-state"
         env = _managed_env(mock_env, state_dir)
         kwargs: dict[str, object] = {}
@@ -436,6 +440,77 @@ class TestDaemonManagedSessionFlags:
                 proc.send_signal(signal.CTRL_BREAK_EVENT)
             else:
                 proc.send_signal(signal.SIGINT)
+            _wait_for_exit(proc, timeout=15)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+        # Timeout now backgrounds, so the CLI should exit 0.
+        stderr_tail = proc.stderr.read() if proc.stderr else ""
+        assert proc.returncode == 0, (
+            f"expected 0 (backgrounded) got {proc.returncode}; stderr={stderr_tail}"
+        )
+
+        # Session metadata must still reflect a live worker.
+        metadata = _session_metadata(state_dir, session_id)
+        assert metadata["exit_code"] is None
+        assert metadata["root_pid"] is not None
+        assert _pid_is_alive(metadata["root_pid"])
+
+        # `clud list` must show the backgrounded session.
+        listed = subprocess.run(
+            [str(clud_binary), "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert listed.returncode == 0
+        assert session_id in listed.stdout
+
+        _kill_daemon_for_session(state_dir, session_id)
+
+    def test_detachable_ctrl_c_explicit_n_ends_session(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        # Issue #25: explicit 'n' at the background prompt still ends the
+        # session (so users who want the old default can opt into it).
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        kwargs: dict[str, object] = {}
+        if sys.platform == "win32":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+        proc = subprocess.Popen(
+            [
+                str(clud_binary),
+                "--detachable",
+                "--codex",
+                "-p",
+                "hello-explicit-no",
+                "--",
+                "--mock-sleep-ms",
+                "30000",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            text=True,
+            env=env,
+            **kwargs,
+        )
+
+        try:
+            session_id = _read_session_id(proc)
+            time.sleep(0.5)
+            if sys.platform == "win32":
+                proc.send_signal(signal.CTRL_BREAK_EVENT)
+            else:
+                proc.send_signal(signal.SIGINT)
+            assert proc.stdin is not None
+            proc.stdin.write("n\n")
+            proc.stdin.flush()
             _wait_for_exit(proc, timeout=15)
         finally:
             if proc.poll() is None:

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -7,7 +7,20 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import tomllib
 from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _project_version() -> str:
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        data = tomllib.load(handle)
+    version = data.get("project", {}).get("version")
+    if not isinstance(version, str) or not version:
+        raise RuntimeError("project.version missing from pyproject.toml")
+    return version
 
 
 def _cargo_argv(subcommand: list[str]) -> list[str]:
@@ -30,10 +43,9 @@ def _cargo_argv(subcommand: list[str]) -> list[str]:
 
 def _clud_binary() -> str:
     """Build the current repo's clud binary and return its path."""
-    root = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         _cargo_argv(["build", "-p", "clud", "--message-format=json"]),
-        cwd=root,
+        cwd=ROOT,
         capture_output=True,
         text=True,
         timeout=120,
@@ -54,9 +66,9 @@ def _clud_binary() -> str:
     # soldr / `--target x86_64-pc-windows-msvc` lands artifacts in a
     # triple-qualified subdir; bare cargo lands in target/debug. Check both.
     for fallback in (
-        root / "target" / "x86_64-pc-windows-msvc" / "debug" / f"clud{ext}",
-        root / "target" / "aarch64-pc-windows-msvc" / "debug" / f"clud{ext}",
-        root / "target" / "debug" / f"clud{ext}",
+        ROOT / "target" / "x86_64-pc-windows-msvc" / "debug" / f"clud{ext}",
+        ROOT / "target" / "aarch64-pc-windows-msvc" / "debug" / f"clud{ext}",
+        ROOT / "target" / "debug" / f"clud{ext}",
     ):
         if fallback.is_file():
             return str(fallback)
@@ -64,6 +76,7 @@ def _clud_binary() -> str:
 
 
 CLUD = _clud_binary()
+PROJECT_VERSION = _project_version()
 
 
 def _run(*args: str, input_data: str | None = None) -> subprocess.CompletedProcess[str]:
@@ -92,8 +105,7 @@ def test_help() -> None:
 def test_version() -> None:
     result = _run("--version")
     assert result.returncode == 0
-    assert "clud" in result.stdout
-    assert "2.0.8" in result.stdout
+    assert result.stdout.strip() == f"clud {PROJECT_VERSION}"
 
 
 def test_dry_run_prompt() -> None:

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -3,24 +3,27 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
-import tomllib
 from pathlib import Path
-
 
 ROOT = Path(__file__).resolve().parent.parent
 
+# Don't use tomllib: it's py311-only and `requires-python = ">=3.10"` promises
+# py310 works. A regex is sufficient for the trivial `version = "x.y.z"` line
+# in [project] and avoids the tomli backport dep.
+_VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+
 
 def _project_version() -> str:
-    with (ROOT / "pyproject.toml").open("rb") as handle:
-        data = tomllib.load(handle)
-    version = data.get("project", {}).get("version")
-    if not isinstance(version, str) or not version:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = _VERSION_RE.search(text)
+    if match is None:
         raise RuntimeError("project.version missing from pyproject.toml")
-    return version
+    return match.group(1)
 
 
 def _cargo_argv(subcommand: list[str]) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.8"
+version = "2.0.9"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Two leaf items from the daemon-session tracking issue [#25](https://github.com/zackees/clud/issues/25), plus a pre-existing test fix so CI can pass.

### 1. `--detachable` Ctrl+C timeout now defaults to *backgrounding*

Previously, the Ctrl+C countdown prompt on a `--detachable` session defaulted to *ending* after 5s. The user explicitly opted into backgroundability — the default should be to honor that signal, not discard the session.

- Prompt text flipped: `[y/N] auto-ending in Ns` → `[Y/n] auto-backgrounding in Ns`
- Timeout + Enter now resolve to `ContinueInBackground`
- Explicit `n`/`N`/`Esc`/second-Ctrl+C still end the session
- Stream/non-interactive path mirrors the same convention

### 2. Configurable backlog size

Attach-replay backlog was hardcoded at 256 KiB. Now configurable:

- `--backlog-size` CLI flag: accepts `256k`, `1mb`, `2MiB`, or raw bytes
- `CLUD_BACKLOG_BYTES` env var: same format, lower precedence than the flag
- Default unchanged at 256 KiB
- Threaded through `WorkerLaunchSpec.backlog_bytes` (optional field — wire-compatible with older daemons)

### 3. Pre-existing test fix (included so CI is green)

`tests/test_hello.py::test_version` hardcoded `"2.0.8"` and broke the moment `pyproject.toml` bumped to `2.0.9` in #51. It now reads the version from `pyproject.toml` at test-collection time. `uv.lock` refreshed to match.

## Test plan

- [x] `bash lint` clean (cargo fmt + clippy -D warnings + ruff)
- [x] `bash test` — 168 Rust tests pass, 26 Python unit tests pass
- [x] New unit coverage: `parse_byte_size` (raw/K/M/G, garbage rejection), `resolve_backlog_bytes` (CLI vs env precedence), worker backlog eviction respects the override
- [ ] Manual: `clud --detachable -p "..."` + Ctrl+C + wait 5s → session goes to background (not killed)
- [ ] Manual: `clud --backlog-size 1mb -p "..."` + inspect attach-replay cap

## Issue checklist (tracking #25)

Ticks the following boxes from the tracking issue:

- [x] Background prompt default — `--detachable` Ctrl+C timeout now defaults to backgrounding
- [x] Configurable backlog size — `--backlog-size` flag + `CLUD_BACKLOG_BYTES` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)