### PR TITLE
Harden daemon attach lifecycle

### DIFF
--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::fs;
-use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
+use std::io::{self, BufRead, BufReader, IsTerminal, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -27,7 +27,6 @@ const ENV_FEATURE_FLAG: &str = "CLUD_EXPERIMENTAL_DAEMON";
 const ENV_STATE_DIR: &str = "CLUD_DAEMON_STATE_DIR";
 const ENV_BACKLOG_BYTES: &str = "CLUD_BACKLOG_BYTES";
 const DEFAULT_BACKLOG_LIMIT_BYTES: usize = 256 * 1024;
-const STALE_CLIENT_GRACE: Duration = Duration::from_secs(1);
 const BACKGROUND_PROMPT_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -369,24 +368,18 @@ impl WorkerShared {
         // First, try to evict any dead client before checking occupancy.
         self.evict_dead_client();
         let mut guard = self.client.lock().expect("client mutex poisoned");
-        if guard
-            .as_ref()
-            .is_some_and(|client| client.attached_at.elapsed() < STALE_CLIENT_GRACE)
-        {
+        if guard.is_some() {
             return Err("session already has an attached client".to_string());
         }
         let (tx, rx) = mpsc::channel();
         let client_id = self.next_client_id.fetch_add(1, Ordering::AcqRel);
-        let previous = guard.replace(AttachedClient {
+        guard.replace(AttachedClient {
             id: client_id,
             sender: tx,
             shutdown,
             attached_at: Instant::now(),
         });
         drop(guard);
-        if let Some(previous) = previous {
-            let _ = previous.shutdown.shutdown(Shutdown::Both);
-        }
         self.set_background(false);
         let snapshot = self.snapshot();
         // For PTY sessions with terminal capture, emit a single synthesized
@@ -1017,7 +1010,7 @@ fn prompt_continue_in_background(interrupted: &AtomicBool) -> BackgroundPromptDe
     if io::stdin().is_terminal() && io::stderr().is_terminal() {
         prompt_continue_in_background_terminal(interrupted)
     } else {
-        prompt_continue_in_background_stream(interrupted)
+        prompt_continue_in_background_noninteractive()
     }
 }
 
@@ -1076,44 +1069,9 @@ fn prompt_continue_in_background_terminal(interrupted: &AtomicBool) -> Backgroun
     }
 }
 
-fn prompt_continue_in_background_stream(interrupted: &AtomicBool) -> BackgroundPromptDecision {
-    let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        let mut stdin = io::stdin();
-        let mut buf = [0u8; 1];
-        if stdin.read(&mut buf).ok().is_some_and(|read| read > 0) {
-            let _ = tx.send(buf[0]);
-        }
-    });
-
-    let started = Instant::now();
-    let mut displayed_remaining = u64::MAX;
-    loop {
-        let remaining = BACKGROUND_PROMPT_TIMEOUT
-            .as_secs()
-            .saturating_sub(started.elapsed().as_secs());
-        if remaining != displayed_remaining {
-            displayed_remaining = remaining;
-            render_background_prompt(remaining);
-        }
-        if remaining == 0 {
-            return BackgroundPromptDecision::ContinueInBackground;
-        }
-        if interrupted.swap(false, Ordering::SeqCst) {
-            return BackgroundPromptDecision::EndSession;
-        }
-        match rx.recv_timeout(Duration::from_millis(100)) {
-            Ok(b'y') | Ok(b'Y') | Ok(b'\r') | Ok(b'\n') => {
-                return BackgroundPromptDecision::ContinueInBackground
-            }
-            Ok(b'n') | Ok(b'N') => return BackgroundPromptDecision::EndSession,
-            Ok(_) => return BackgroundPromptDecision::ContinueInBackground,
-            Err(mpsc::RecvTimeoutError::Timeout) => {}
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                return BackgroundPromptDecision::ContinueInBackground
-            }
-        }
-    }
+fn prompt_continue_in_background_noninteractive() -> BackgroundPromptDecision {
+    eprintln!("[clud] non-interactive attach interrupted; session continues in the background");
+    BackgroundPromptDecision::ContinueInBackground
 }
 
 fn render_background_prompt(remaining: u64) {
@@ -1340,8 +1298,26 @@ fn daemon_create_session(
     workers
         .lock()
         .expect("workers mutex poisoned")
-        .insert(session_id.clone(), worker);
+        .insert(session_id.clone(), Arc::clone(&worker));
+    reap_worker_when_done(Arc::clone(workers), session_id.clone(), worker);
     Ok(snapshot)
+}
+
+fn reap_worker_when_done(
+    workers: Arc<Mutex<HashMap<String, Arc<NativeProcess>>>>,
+    session_id: String,
+    worker: Arc<NativeProcess>,
+) {
+    thread::spawn(move || {
+        let _ = worker.wait(None);
+        let mut guard = workers.lock().expect("workers mutex poisoned");
+        if guard
+            .get(&session_id)
+            .is_some_and(|current| Arc::ptr_eq(current, &worker))
+        {
+            guard.remove(&session_id);
+        }
+    });
 }
 
 fn daemon_terminate_session(
@@ -2554,6 +2530,42 @@ mod capture_integration_tests {
         let c = p.screen().contents();
         assert!(c.contains("BEFORE"), "pre-detach content missing: {:?}", c);
         assert!(c.contains("AFTER"), "post-detach content missing: {:?}", c);
+    }
+
+    #[test]
+    fn live_attached_client_blocks_second_attach() {
+        let tmp = TempDir::new().expect("tempdir");
+        let shared = test_shared(tmp.path(), SessionKind::Subprocess);
+
+        let (_client1, server1) = loopback_pair();
+        let (_cid1, _, _, _) = shared.attach_client(server1).expect("first attach");
+        thread::sleep(Duration::from_millis(1050));
+
+        let (_client2, server2) = loopback_pair();
+        let err = shared.attach_client(server2).expect_err("second attach");
+        assert_eq!(err, "session already has an attached client");
+    }
+
+    #[test]
+    fn dead_attached_client_is_evicted_on_next_attach() {
+        let tmp = TempDir::new().expect("tempdir");
+        let shared = test_shared(tmp.path(), SessionKind::Subprocess);
+
+        let (client1, server1) = loopback_pair();
+        let (_cid1, _, _, _) = shared.attach_client(server1).expect("first attach");
+        drop(client1);
+        thread::sleep(Duration::from_millis(50));
+
+        let (_client2, server2) = loopback_pair();
+        shared.attach_client(server2).expect("reattach");
+    }
+
+    #[test]
+    fn noninteractive_background_prompt_always_backgrounds() {
+        assert_eq!(
+            prompt_continue_in_background_noninteractive(),
+            BackgroundPromptDecision::ContinueInBackground
+        );
     }
 
     #[test]

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -526,11 +526,12 @@ class TestDaemonManagedSessionFlags:
                 first_attach.wait(timeout=5)
             _kill_daemon_for_session(state_dir, session_id)
 
-    def test_detachable_ctrl_c_explicit_n_ends_session(
+    def test_detachable_noninteractive_ctrl_c_ignores_piped_n(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
     ) -> None:
-        # Issue #25: explicit 'n' at the background prompt still ends the
-        # session (so users who want the old default can opt into it).
+        # Issue #25: there is no safe prompt surface when stdin/stderr are
+        # pipes, so piped bytes must not be interpreted as background-prompt
+        # answers. Even a queued "n" should detach/background immediately.
         state_dir = tmp_path / "daemon-state"
         env = _managed_env(mock_env, state_dir)
         kwargs: dict[str, object] = {}
@@ -572,13 +573,16 @@ class TestDaemonManagedSessionFlags:
                 proc.kill()
                 proc.wait(timeout=5)
 
-        if sys.platform == "win32":
-            assert proc.returncode in (130, 3221225786)
-        else:
-            assert proc.returncode == 130
+        stderr_tail = proc.stderr.read() if proc.stderr else ""
+        assert proc.returncode == 0, (
+            f"expected 0 (backgrounded) got {proc.returncode}; stderr={stderr_tail}"
+        )
+        assert "non-interactive attach interrupted" in stderr_tail
 
-        metadata = _wait_for_session_exit(state_dir, session_id, timeout=12.0)
-        assert metadata["exit_code"] is not None or not _pid_is_alive(metadata["root_pid"])
+        metadata = _session_metadata(state_dir, session_id)
+        assert metadata["exit_code"] is None
+        assert metadata["root_pid"] is not None
+        assert _pid_is_alive(metadata["root_pid"])
 
         listed = subprocess.run(
             [str(clud_binary), "list"],
@@ -588,7 +592,9 @@ class TestDaemonManagedSessionFlags:
             env=env,
         )
         assert listed.returncode == 0
-        assert session_id not in listed.stdout
+        assert session_id in listed.stdout
+
+        _kill_daemon_for_session(state_dir, session_id)
 
 
 class TestDaemonCentralizedPersistence:

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -136,6 +136,18 @@ def _kill_process(pid: int) -> None:
         os.kill(pid, signal.SIGKILL)
 
 
+def _kill_process_only(pid: int) -> None:
+    if sys.platform == "win32":
+        subprocess.run(
+            ["taskkill", "/PID", str(pid), "/F"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    else:
+        os.kill(pid, signal.SIGKILL)
+
+
 def _pid_is_alive(pid: int) -> bool:
     if sys.platform == "win32":
         result = subprocess.run(
@@ -401,13 +413,12 @@ class TestDaemonManagedSessionFlags:
         finally:
             _kill_daemon_for_session(state_dir, session_id)
 
-    def test_detachable_ctrl_c_timeout_backgrounds_session(
+    def test_detachable_noninteractive_ctrl_c_backgrounds_session(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
     ) -> None:
-        # Issue #25: `--detachable` Ctrl+C countdown now defaults to
-        # *backgrounding* on timeout (user opted in), not ending. This test
-        # replaces the earlier `..._ends_session` variant that encoded the old
-        # default.
+        # Issue #25: a non-interactive attach has no safe prompt surface.
+        # Ctrl+C should detach/background immediately instead of treating
+        # arbitrary piped stdin as a yes/no answer.
         state_dir = tmp_path / "daemon-state"
         env = _managed_env(mock_env, state_dir)
         kwargs: dict[str, object] = {}
@@ -446,11 +457,11 @@ class TestDaemonManagedSessionFlags:
                 proc.kill()
                 proc.wait(timeout=5)
 
-        # Timeout now backgrounds, so the CLI should exit 0.
         stderr_tail = proc.stderr.read() if proc.stderr else ""
         assert proc.returncode == 0, (
             f"expected 0 (backgrounded) got {proc.returncode}; stderr={stderr_tail}"
         )
+        assert "non-interactive attach interrupted" in stderr_tail
 
         # Session metadata must still reflect a live worker.
         metadata = _session_metadata(state_dir, session_id)
@@ -470,6 +481,50 @@ class TestDaemonManagedSessionFlags:
         assert session_id in listed.stdout
 
         _kill_daemon_for_session(state_dir, session_id)
+
+    def test_concurrent_attach_attempt_is_rejected(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "concurrent-attach",
+            "--",
+            "--mock-sleep-ms",
+            "30000",
+        )
+
+        first_attach = subprocess.Popen(
+            [str(clud_binary), "attach", session_id],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+
+        try:
+            _wait_for_exit(proc, timeout=10)
+            time.sleep(1.0)
+            assert first_attach.poll() is None
+
+            second_attach = subprocess.run(
+                [str(clud_binary), "attach", session_id],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert second_attach.returncode != 0
+            assert "session already has an attached client" in second_attach.stderr
+        finally:
+            if first_attach.poll() is None:
+                first_attach.kill()
+                first_attach.wait(timeout=5)
+            _kill_daemon_for_session(state_dir, session_id)
 
     def test_detachable_ctrl_c_explicit_n_ends_session(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
@@ -537,6 +592,32 @@ class TestDaemonManagedSessionFlags:
 
 
 class TestDaemonCentralizedPersistence:
+    def test_daemon_crash_recovery_kills_worker_and_backend(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "daemon-crash-recovery",
+            "--",
+            "--mock-sleep-ms",
+            "30000",
+        )
+
+        _wait_for_exit(proc, timeout=10)
+        metadata = _session_metadata(state_dir, session_id)
+        daemon_pid = metadata["daemon_pid"]
+        worker_pid = metadata["worker_pid"]
+        root_pid = metadata["root_pid"]
+        assert root_pid is not None
+
+        _kill_process_only(daemon_pid)
+        _wait_for_pids_to_exit([worker_pid, root_pid], timeout=15)
+
     def test_subprocess_session_persists_and_reattaches(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- define non-interactive detachable Ctrl+C as immediate background/detach
- prevent a second live attach from stealing an attached session while still evicting dead clients
- reap daemon worker handles after worker exit
- add regression coverage for daemon crash recovery and concurrent attach attempts
- align the piped-stdin `n` regression test with the new non-interactive contract

Fixes part of #25.

## Tests

- `cargo test -p clud capture_integration_tests --lib`
- `cargo test -p clud --lib`
- `CLUD_INTEGRATION_TESTS=1 python -m pytest tests/integration/test_daemon_centralized.py -k "noninteractive_ctrl_c or concurrent_attach or daemon_crash_recovery"`
