### PR TITLE
fix(test): suppress Windows console popups in integration subprocesses

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,6 +71,53 @@ def _build_env_without_sccache() -> dict[str, str]:
     return env
 
 
+def _add_windows_create_no_window(kwargs: dict) -> None:
+    """Force child processes to start without a visible console on Windows."""
+    if sys.platform != "win32":
+        return
+    creationflags = kwargs.get("creationflags", 0)
+    if not isinstance(creationflags, int):
+        creationflags = 0
+    kwargs["creationflags"] = creationflags | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _suppress_windows_console_windows():
+    """Hide console windows for integration-test subprocesses on Windows.
+
+    The fixture is session-scoped so it applies to the build-time helpers as
+    well as the actual tests.
+    """
+    if sys.platform != "win32":
+        yield
+        return
+
+    patch = pytest.MonkeyPatch()
+    original_run = subprocess.run
+    original_popen = subprocess.Popen
+
+    def run(*args, **kwargs):
+        kwargs = dict(kwargs)
+        _add_windows_create_no_window(kwargs)
+        return original_run(*args, **kwargs)
+
+    def popen(*args, **kwargs):
+        kwargs = dict(kwargs)
+        # Keep process-group semantics intact for Ctrl+Break tests that already
+        # request CREATE_NEW_PROCESS_GROUP; only suppress the window for the
+        # ordinary noninteractive launches.
+        if "creationflags" not in kwargs:
+            _add_windows_create_no_window(kwargs)
+        return original_popen(*args, **kwargs)
+
+    patch.setattr(subprocess, "run", run)
+    patch.setattr(subprocess, "Popen", popen)
+    try:
+        yield
+    finally:
+        patch.undo()
+
+
 def _target_search_dirs() -> list[Path]:
     """Directories where a built binary might land, ordered by preference."""
     ext = ".exe" if sys.platform == "win32" else ""


### PR DESCRIPTION
Add a Windows-only integration-test fixture that ORs CREATE_NO_WINDOW into child-process launches. This keeps test subprocesses from flashing console windows while preserving existing process-group flags for Ctrl+Break tests.\n\nCloses #55.