### PR TITLE
feat(loop): --repeat scheduler, --done path override, codex.cmd wrapper

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -85,8 +85,15 @@ pub enum Command {
         #[arg(long = "refresh")]
         refresh: bool,
         /// Do not inject the DONE/BLOCKED marker contract into the prompt.
-        #[arg(long = "no-done-marker")]
-        no_done_marker: bool,
+        #[arg(long = "no-done", alias = "no-done-marker", conflicts_with = "done")]
+        no_done: bool,
+        /// Re-enable the DONE/BLOCKED contract using a custom DONE marker path.
+        #[arg(long = "done", conflicts_with = "no_done")]
+        done: Option<String>,
+        /// Re-run the loop after it completes, sleeping for the given duration
+        /// between runs (for example `30s`, `5m`, `1h`).
+        #[arg(long = "repeat")]
+        repeat: Option<String>,
     },
     Up {
         #[arg(short = 'm', long = "message")]
@@ -173,6 +180,8 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--name",
         "--backlog-size",
         "--loop-count",
+        "--done",
+        "--repeat",
         "--daemon-state-dir",
     ];
     let short_value_flags: &[&str] = &["-p", "-m", "-r"];
@@ -191,6 +200,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--all",
         "--last",
         "--refresh",
+        "--no-done",
         "--no-done-marker",
         "--help",
         "--version",
@@ -354,12 +364,16 @@ mod tests {
                 ref task,
                 loop_count,
                 refresh,
-                no_done_marker,
+                no_done,
+                ref done,
+                ref repeat,
             }) => {
                 assert_eq!(task.as_deref(), Some("do the task"));
                 assert_eq!(loop_count, 50);
                 assert!(!refresh);
-                assert!(!no_done_marker);
+                assert!(!no_done);
+                assert!(done.is_none());
+                assert!(repeat.is_none());
             }
             _ => panic!("expected Loop subcommand"),
         }
@@ -393,23 +407,63 @@ mod tests {
             Some(Command::Loop {
                 ref task,
                 refresh,
-                no_done_marker,
+                no_done,
+                ref done,
+                ref repeat,
                 ..
             }) => {
                 assert_eq!(task.as_deref(), Some("https://github.com/o/r/issues/42"));
                 assert!(refresh);
-                assert!(!no_done_marker);
+                assert!(!no_done);
+                assert!(done.is_none());
+                assert!(repeat.is_none());
             }
             _ => panic!("expected Loop subcommand"),
         }
     }
 
     #[test]
-    fn test_loop_no_done_marker_flag() {
+    fn test_loop_no_done_flag() {
+        let args = parse(&["clud", "loop", "--no-done", "task"]);
+        match args.command {
+            Some(Command::Loop { no_done, .. }) => {
+                assert!(no_done);
+            }
+            _ => panic!("expected Loop subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_loop_no_done_marker_compat_alias() {
         let args = parse(&["clud", "loop", "--no-done-marker", "task"]);
         match args.command {
-            Some(Command::Loop { no_done_marker, .. }) => {
-                assert!(no_done_marker);
+            Some(Command::Loop { no_done, .. }) => {
+                assert!(no_done);
+            }
+            _ => panic!("expected Loop subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_loop_done_path() {
+        let args = parse(&["clud", "loop", "--done", "DONE.md", "task"]);
+        match args.command {
+            Some(Command::Loop {
+                ref done, no_done, ..
+            }) => {
+                assert_eq!(done.as_deref(), Some("DONE.md"));
+                assert!(!no_done);
+            }
+            _ => panic!("expected Loop subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_loop_repeat() {
+        let args = parse(&["clud", "loop", "--repeat", "1h", "task"]);
+        match args.command {
+            Some(Command::Loop { ref repeat, .. }) => {
+                assert_eq!(repeat.as_deref(), Some("1h"));
             }
             _ => panic!("expected Loop subcommand"),
         }

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -1,10 +1,11 @@
 use crate::args::{Args, Command};
 use crate::backend::{Backend, LaunchMode};
 use crate::loop_spec::{
-    self, cache_path, classify, ensure_loop_dir, fetch_via_gh, git_root_from, render_cache,
-    resolve_current_repo, GhKind, TaskSpec, DONE_MARKER_CONTRACT,
+    self, blocked_path_from_done, cache_path, classify, done_marker_contract, ensure_loop_dir,
+    fetch_via_gh, git_root_from, render_cache, resolve_current_repo, GhKind, MarkerPaths, TaskSpec,
 };
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
 const FIX_PROMPT: &str = "\
 Look for linting like ./lint, or npm or python, choose the most likely one, \
@@ -81,16 +82,25 @@ pub struct LaunchPlan {
     pub backend: Backend,
     pub launch_mode: LaunchMode,
     pub cwd: Option<String>,
+    #[serde(default)]
+    pub repeat_schedule: Option<RepeatSchedule>,
+    #[serde(default)]
+    pub task_summary: Option<String>,
     /// When set, the outer loop should poll for DONE/BLOCKED marker files
-    /// under `<git_root>/.clud/loop/` after each iteration and terminate
-    /// accordingly.
+    /// after each iteration and terminate accordingly.
     #[serde(default)]
     pub loop_markers: Option<LoopMarkers>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoopMarkers {
-    pub git_root: String,
+    pub done_path: String,
+    pub blocked_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepeatSchedule {
+    pub interval_secs: u64,
 }
 
 /// Returns true if `args` carries a prompt that should run non-interactively
@@ -109,6 +119,8 @@ pub fn has_noninteractive_prompt(args: &Args) -> bool {
 pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> LaunchPlan {
     let mut cmd = vec![backend_path.to_string()];
     let mut iterations = 1u32;
+    let mut repeat_schedule: Option<RepeatSchedule> = None;
+    let mut task_summary: Option<String> = None;
 
     let codex_uses_exec = matches!(backend, Backend::Codex) && has_noninteractive_prompt(args);
     let codex_uses_resume = matches!(backend, Backend::Codex)
@@ -152,23 +164,49 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
             task,
             loop_count,
             refresh,
-            no_done_marker,
+            no_done,
+            done,
+            repeat,
         }) => {
             iterations = *loop_count;
-            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
             let git_root = git_root_from(&cwd);
+            let repeat_interval_secs = repeat
+                .as_deref()
+                .map(parse_repeat_interval)
+                .transpose()
+                .unwrap_or_else(|err| {
+                    eprintln!("error: invalid --repeat value: {err}");
+                    std::process::exit(1);
+                });
+            repeat_schedule =
+                repeat_interval_secs.map(|interval_secs| RepeatSchedule { interval_secs });
+            let use_done_markers = done.is_some() || (!*no_done && repeat_schedule.is_none());
+            let marker_paths = if use_done_markers {
+                Some(resolve_marker_paths(&cwd, &git_root, done.as_deref()))
+            } else {
+                None
+            };
             if let Some(ref t) = task {
                 let prompt_text = resolve_loop_task(t, &git_root, *refresh);
-                let final_prompt = if *no_done_marker {
-                    prompt_text
-                } else {
-                    format!("{}{}", prompt_text, DONE_MARKER_CONTRACT)
-                };
+                task_summary = Some(summarize_task_name(&prompt_text, 50));
+                let final_prompt =
+                    if let Some((markers, display_done, display_blocked)) = marker_paths.as_ref() {
+                        let _ = markers;
+                        format!(
+                            "{}{}",
+                            prompt_text,
+                            done_marker_contract(display_done, display_blocked)
+                        )
+                    } else {
+                        prompt_text
+                    };
                 push_prompt(&mut cmd, backend, final_prompt);
             }
-            if !*no_done_marker {
+            if let Some((markers, _, _)) = marker_paths {
                 loop_markers = Some(LoopMarkers {
-                    git_root: git_root.to_string_lossy().to_string(),
+                    done_path: markers.done.to_string_lossy().to_string(),
+                    blocked_path: markers.blocked.to_string_lossy().to_string(),
                 });
             }
         }
@@ -229,7 +267,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
 
     cmd.extend(args.passthrough.iter().cloned());
 
-    let is_loop = loop_markers.is_some();
+    let is_loop = loop_markers.is_some() && repeat_schedule.is_none();
     let parent_has_tty = crate::session::terminals_are_interactive();
     let launch_mode = crate::backend::resolve_launch_mode(
         args.pty,
@@ -248,8 +286,75 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         cwd: std::env::current_dir()
             .ok()
             .map(|cwd| cwd.to_string_lossy().to_string()),
+        repeat_schedule,
+        task_summary,
         loop_markers,
     }
+}
+
+fn resolve_marker_paths(
+    cwd: &Path,
+    git_root: &Path,
+    done_override: Option<&str>,
+) -> (MarkerPaths, String, String) {
+    match done_override {
+        Some(raw) => {
+            let display_done = raw.to_string();
+            let display_blocked = blocked_path_from_done(Path::new(raw))
+                .to_string_lossy()
+                .to_string();
+            let done = cwd.join(raw);
+            let blocked = blocked_path_from_done(&done);
+            (MarkerPaths { done, blocked }, display_done, display_blocked)
+        }
+        None => {
+            let markers = loop_spec::default_marker_paths(git_root);
+            (
+                markers,
+                ".clud/loop/DONE".to_string(),
+                ".clud/loop/BLOCKED".to_string(),
+            )
+        }
+    }
+}
+
+fn parse_repeat_interval(raw: &str) -> Result<u64, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("duration cannot be empty".to_string());
+    }
+    let split_at = trimmed
+        .find(|c: char| !c.is_ascii_digit())
+        .ok_or_else(|| "duration must include a unit like s, m, or h".to_string())?;
+    if split_at == 0 {
+        return Err("duration must start with a positive integer".to_string());
+    }
+    let (num_part, unit_part) = trimmed.split_at(split_at);
+    let n: u64 = num_part
+        .parse()
+        .map_err(|_| format!("invalid duration value: {num_part}"))?;
+    if n == 0 {
+        return Err("duration must be greater than zero".to_string());
+    }
+    let unit = unit_part.trim().to_ascii_lowercase();
+    let multiplier = match unit.as_str() {
+        "s" => 1,
+        "m" => 60,
+        "h" => 60 * 60,
+        _ => return Err(format!("unsupported duration unit: {unit_part}")),
+    };
+    n.checked_mul(multiplier)
+        .ok_or_else(|| "duration is too large".to_string())
+}
+
+pub fn summarize_task_name(input: &str, max_chars: usize) -> String {
+    let normalized = input.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() || normalized.chars().count() <= max_chars {
+        return normalized;
+    }
+    let keep = max_chars.saturating_sub(3);
+    let prefix: String = normalized.chars().take(keep).collect();
+    format!("{prefix}...")
 }
 
 /// Resolve the `clud loop` positional to an actual prompt body.
@@ -695,11 +800,37 @@ mod tests {
     }
 
     #[test]
-    fn test_loop_no_done_marker_omits_contract() {
-        let p = plan(&["clud", "loop", "--no-done-marker", "task"]);
+    fn test_loop_no_done_omits_contract() {
+        let p = plan(&["clud", "loop", "--no-done", "task"]);
         let prompt = prompt_from_plan(&p);
         assert_eq!(prompt, "task");
         assert!(p.loop_markers.is_none());
+    }
+
+    #[test]
+    fn test_loop_repeat_implies_no_done_contract() {
+        let p = plan(&["clud", "loop", "--repeat", "1h", "task"]);
+        let prompt = prompt_from_plan(&p);
+        assert_eq!(prompt, "task");
+        assert!(p.loop_markers.is_none());
+        assert_eq!(
+            p.repeat_schedule.as_ref().map(|s| s.interval_secs),
+            Some(3600)
+        );
+    }
+
+    #[test]
+    fn test_loop_repeat_with_done_override_restores_contract() {
+        let p = plan(&[
+            "clud", "loop", "--repeat", "1h", "--done", "DONE.md", "task",
+        ]);
+        let prompt = prompt_from_plan(&p);
+        assert!(prompt.contains("DONE.md"));
+        assert!(prompt.contains("BLOCKED.md"));
+        assert!(p.loop_markers.is_some());
+        let markers = p.loop_markers.unwrap();
+        assert!(markers.done_path.ends_with("DONE.md"));
+        assert!(markers.blocked_path.ends_with("BLOCKED.md"));
     }
 
     // ---- Issue #48: `clud --codex loop "..."` must drive codex the same ----
@@ -751,8 +882,8 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_loop_no_done_marker_omits_contract() {
-        let p = plan(&["clud", "--codex", "loop", "--no-done-marker", "task"]);
+    fn test_codex_loop_no_done_omits_contract() {
+        let p = plan(&["clud", "--codex", "loop", "--no-done", "task"]);
         let prompt = last_arg(&p);
         assert_eq!(prompt, "task");
         assert!(p.loop_markers.is_none());

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -21,6 +21,7 @@ use crate::args::{Args, Command};
 use crate::backend::LaunchMode;
 use crate::capture::TerminalCapture;
 use crate::command::LaunchPlan;
+use crate::subprocess;
 use crate::trampoline;
 
 const ENV_FEATURE_FLAG: &str = "CLUD_EXPERIMENTAL_DAEMON";
@@ -28,6 +29,10 @@ const ENV_STATE_DIR: &str = "CLUD_DAEMON_STATE_DIR";
 const ENV_BACKLOG_BYTES: &str = "CLUD_BACKLOG_BYTES";
 const DEFAULT_BACKLOG_LIMIT_BYTES: usize = 256 * 1024;
 const BACKGROUND_PROMPT_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn default_attachable() -> bool {
+    true
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -56,6 +61,14 @@ struct SessionSnapshot {
     detachable: bool,
     #[serde(default)]
     background: bool,
+    #[serde(default = "default_attachable")]
+    attachable: bool,
+    #[serde(default)]
+    repeat_interval_secs: Option<u64>,
+    #[serde(default)]
+    repeat_next_run_at: Option<u64>,
+    #[serde(default)]
+    repeat_running: bool,
     daemon_pid: u32,
     worker_pid: u32,
     worker_port: u16,
@@ -73,8 +86,14 @@ struct WorkerLaunchSpec {
     detachable: bool,
     #[serde(default)]
     background_on_launch: bool,
+    #[serde(default = "default_attachable")]
+    attachable: bool,
     rows: u16,
     cols: u16,
+    #[serde(default)]
+    repeat_interval_secs: Option<u64>,
+    #[serde(default)]
+    repeat_run_command: Option<Vec<String>>,
     /// In-memory attach-replay backlog cap. `None` uses the compiled default
     /// (`DEFAULT_BACKLOG_LIMIT_BYTES`). Optional for wire compatibility with
     /// spec files written by older clud versions.
@@ -85,7 +104,7 @@ struct WorkerLaunchSpec {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 enum DaemonRequest {
-    Create { spec: WorkerLaunchSpec },
+    Create { spec: Box<WorkerLaunchSpec> },
     Session { session_id: String },
     Terminate { session_id: String },
 }
@@ -364,6 +383,16 @@ impl WorkerShared {
         let _ = self.persist_snapshot(&snapshot);
     }
 
+    fn set_repeat_state(&self, running: bool, next_run_at: Option<u64>) {
+        let snapshot = {
+            let mut guard = self.snapshot.lock().expect("snapshot mutex poisoned");
+            guard.repeat_running = running;
+            guard.repeat_next_run_at = next_run_at;
+            guard.clone()
+        };
+        let _ = self.persist_snapshot(&snapshot);
+    }
+
     fn attach_client(&self, shutdown: TcpStream) -> Result<AttachClientResult, String> {
         // First, try to evict any dead client before checking occupancy.
         self.evict_dead_client();
@@ -556,8 +585,16 @@ impl Drop for RawTerminalGuard {
 }
 
 pub fn experimental_enabled(args: &Args) -> bool {
+    let repeat_enabled = matches!(
+        args.command,
+        Some(Command::Loop {
+            repeat: Some(_),
+            ..
+        })
+    );
     args.detach
         || args.detachable
+        || repeat_enabled
         || args.experimental_daemon_centralized
         || std::env::var(ENV_FEATURE_FLAG)
             .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
@@ -657,23 +694,46 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         return 1;
     }
 
-    let kind = match plan.launch_mode {
-        LaunchMode::Subprocess => SessionKind::Subprocess,
-        LaunchMode::Pty => SessionKind::Pty,
+    let repeat_enabled = plan.repeat_schedule.is_some();
+    let kind = if repeat_enabled {
+        SessionKind::Subprocess
+    } else {
+        match plan.launch_mode {
+            LaunchMode::Subprocess => SessionKind::Subprocess,
+            LaunchMode::Pty => SessionKind::Pty,
+        }
     };
     let (rows, cols) = terminal_dimensions();
     let backlog_bytes = resolve_backlog_bytes(args.backlog_size.as_deref());
+    let name = args
+        .session_name
+        .clone()
+        .or_else(|| repeat_enabled.then(|| plan.task_summary.clone()).flatten());
+    let repeat_run_command = if repeat_enabled {
+        match build_repeat_once_command(args) {
+            Ok(command) => Some(command),
+            Err(err) => {
+                eprintln!("[clud] failed to build repeat command: {}", err);
+                return 1;
+            }
+        }
+    } else {
+        None
+    };
     let request = DaemonRequest::Create {
-        spec: WorkerLaunchSpec {
+        spec: Box::new(WorkerLaunchSpec {
             plan: plan.clone(),
             kind,
-            name: args.session_name.clone(),
+            name,
             detachable: args.detach || args.detachable,
-            background_on_launch: args.detach,
+            background_on_launch: args.detach || repeat_enabled,
+            attachable: !repeat_enabled,
             rows,
             cols,
+            repeat_interval_secs: plan.repeat_schedule.as_ref().map(|s| s.interval_secs),
+            repeat_run_command,
             backlog_bytes,
-        },
+        }),
     };
     let response = match send_daemon_request(&state_dir, &request) {
         Ok(response) => response,
@@ -685,6 +745,11 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
 
     match response {
         DaemonResponse::Created { session } => {
+            if repeat_enabled {
+                eprintln!("[clud] repeat job {} running in background", session.id);
+                eprintln!("[clud] list jobs with: clud list");
+                return 0;
+            }
             if args.detach {
                 eprintln!("[clud] session {} running in background", session.id);
                 eprintln!("[clud] attach with: clud attach {}", session.id);
@@ -701,6 +766,63 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         }
         DaemonResponse::Session { .. } | DaemonResponse::Terminated { .. } => 1,
     }
+}
+
+fn build_repeat_once_command(args: &Args) -> io::Result<Vec<String>> {
+    let exe = std::env::current_exe()?;
+    let mut command = vec![exe.to_string_lossy().to_string()];
+    if args.codex {
+        command.push("--codex".to_string());
+    } else if args.claude {
+        command.push("--claude".to_string());
+    }
+    if args.safe {
+        command.push("--safe".to_string());
+    }
+    if args.subprocess {
+        command.push("--subprocess".to_string());
+    }
+    if args.pty {
+        command.push("--pty".to_string());
+    }
+    if args.verbose {
+        command.push("--verbose".to_string());
+    }
+    if let Some(model) = args.model.as_deref() {
+        command.push("--model".to_string());
+        command.push(model.to_string());
+    }
+    command.push("loop".to_string());
+    if let Some(Command::Loop {
+        task,
+        loop_count,
+        refresh,
+        no_done,
+        done,
+        ..
+    }) = &args.command
+    {
+        command.push("--loop-count".to_string());
+        command.push(loop_count.to_string());
+        if *refresh {
+            command.push("--refresh".to_string());
+        }
+        if *no_done || done.is_none() {
+            command.push("--no-done".to_string());
+        }
+        if let Some(path) = done.as_deref() {
+            command.push("--done".to_string());
+            command.push(path.to_string());
+        }
+        if let Some(task) = task.as_deref() {
+            command.push(task.to_string());
+        }
+    }
+    if !args.passthrough.is_empty() {
+        command.push("--".to_string());
+        command.extend(args.passthrough.iter().cloned());
+    }
+    Ok(command)
 }
 
 fn run_attach(session_id: &str, state_dir: &Path, interrupted: &AtomicBool) -> i32 {
@@ -729,7 +851,16 @@ fn run_attach(session_id: &str, state_dir: &Path, interrupted: &AtomicBool) -> i
         }
     };
     match response {
-        DaemonResponse::Session { session } => attach_to_session(state_dir, &session, interrupted),
+        DaemonResponse::Session { session } => {
+            if !session.attachable {
+                eprintln!(
+                    "[clud] session {} is a repeat job and cannot be attached",
+                    session.id
+                );
+                return 1;
+            }
+            attach_to_session(state_dir, &session, interrupted)
+        }
         DaemonResponse::Error { message } => {
             eprintln!("[clud] daemon error: {}", message);
             1
@@ -1198,7 +1329,7 @@ fn handle_daemon_connection(
     let request: DaemonRequest = serde_json::from_str(&line)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
     let response = match request {
-        DaemonRequest::Create { spec } => match daemon_create_session(state_dir, workers, spec) {
+        DaemonRequest::Create { spec } => match daemon_create_session(state_dir, workers, *spec) {
             Ok(session) => DaemonResponse::Created { session },
             Err(err) => DaemonResponse::Error {
                 message: err.to_string(),
@@ -1278,21 +1409,24 @@ fn daemon_create_session(
     };
 
     // Verify the worker's TCP listener is actually accepting connections
-    // before reporting the session as ready.
-    loop {
-        if TcpStream::connect(("127.0.0.1", snapshot.worker_port)).is_ok() {
-            break;
+    // before reporting the session as ready. Repeat jobs intentionally don't
+    // expose an attach port, so `worker_port == 0` is valid there.
+    if snapshot.attachable {
+        loop {
+            if TcpStream::connect(("127.0.0.1", snapshot.worker_port)).is_ok() {
+                break;
+            }
+            if started.elapsed() >= Duration::from_secs(5) {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!(
+                        "worker wrote snapshot but TCP port {} is not accepting connections",
+                        snapshot.worker_port
+                    ),
+                ));
+            }
+            thread::sleep(Duration::from_millis(25));
         }
-        if started.elapsed() >= Duration::from_secs(5) {
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                format!(
-                    "worker wrote snapshot but TCP port {} is not accepting connections",
-                    snapshot.worker_port
-                ),
-            ));
-        }
-        thread::sleep(Duration::from_millis(25));
     }
 
     workers
@@ -1362,6 +1496,9 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
             return 1;
         }
     };
+    if spec.repeat_run_command.is_some() {
+        return run_repeat_worker(state_dir, session_id, daemon_pid, &spec);
+    }
     let listener = match TcpListener::bind(("127.0.0.1", 0)) {
         Ok(listener) => listener,
         Err(err) => {
@@ -1390,6 +1527,10 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
         created_at: Some(created_at),
         detachable: spec.detachable,
         background: spec.background_on_launch,
+        attachable: spec.attachable,
+        repeat_interval_secs: spec.repeat_interval_secs,
+        repeat_next_run_at: None,
+        repeat_running: spec.repeat_interval_secs.is_some(),
         daemon_pid,
         worker_pid: std::process::id(),
         worker_port,
@@ -1485,6 +1626,142 @@ fn run_worker(state_dir: &Path, session_id: &str, daemon_pid: u32, spec_file: &P
     0
 }
 
+fn run_repeat_worker(
+    state_dir: &Path,
+    session_id: &str,
+    daemon_pid: u32,
+    spec: &WorkerLaunchSpec,
+) -> i32 {
+    let repeat_interval_secs = spec.repeat_interval_secs.unwrap_or(0);
+    let repeat_run_command = spec.repeat_run_command.clone().unwrap_or_default();
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let snapshot = SessionSnapshot {
+        id: session_id.to_string(),
+        kind: SessionKind::Subprocess,
+        cwd: spec.plan.cwd.clone(),
+        name: spec.name.clone(),
+        created_at: Some(created_at),
+        detachable: false,
+        background: true,
+        attachable: false,
+        repeat_interval_secs: Some(repeat_interval_secs),
+        repeat_next_run_at: None,
+        repeat_running: true,
+        daemon_pid,
+        worker_pid: std::process::id(),
+        worker_port: 0,
+        root_pid: None,
+        exit_code: None,
+    };
+    let shared = Arc::new(WorkerShared::new_with_backlog(
+        state_dir.to_path_buf(),
+        session_id.to_string(),
+        snapshot,
+        spec.backlog_bytes.unwrap_or(DEFAULT_BACKLOG_LIMIT_BYTES),
+    ));
+    shared.init_log_file();
+    if let Err(err) = persist_snapshot(state_dir, session_id, &shared) {
+        eprintln!("[clud] failed to write repeat session metadata: {}", err);
+        return 1;
+    }
+
+    loop {
+        if !pid_is_alive(daemon_pid) {
+            shared.set_exit_code(137);
+            let _ = persist_snapshot(state_dir, session_id, &shared);
+            let _ = fs::remove_file(spec_path(state_dir, session_id));
+            return 0;
+        }
+
+        shared.set_repeat_state(true, None);
+        if !run_repeat_once(&repeat_run_command, spec, daemon_pid, &shared) {
+            let _ = persist_snapshot(state_dir, session_id, &shared);
+            let _ = fs::remove_file(spec_path(state_dir, session_id));
+            return 0;
+        }
+        shared.set_root_pid(None);
+
+        let next_run_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+            + repeat_interval_secs.saturating_mul(1000);
+        shared.set_repeat_state(false, Some(next_run_at));
+
+        while (SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64)
+            < next_run_at
+        {
+            if !pid_is_alive(daemon_pid) {
+                shared.set_exit_code(137);
+                let _ = persist_snapshot(state_dir, session_id, &shared);
+                let _ = fs::remove_file(spec_path(state_dir, session_id));
+                return 0;
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+    }
+}
+
+fn run_repeat_once(
+    command: &[String],
+    spec: &WorkerLaunchSpec,
+    daemon_pid: u32,
+    shared: &Arc<WorkerShared>,
+) -> bool {
+    let process = Arc::new(NativeProcess::new(ProcessConfig {
+        command: subprocess::command_spec_for_subprocess(command.to_vec()),
+        cwd: spec.plan.cwd.as_ref().map(PathBuf::from),
+        env: Some(child_env()),
+        capture: true,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Null,
+        nice: None,
+        containment: Some(Containment::Contained),
+    }));
+    if let Err(err) = process.start() {
+        shared
+            .push_output(format!("[clud repeat] failed to start child run: {err}\n").into_bytes());
+        return true;
+    }
+    shared.set_root_pid(process.pid());
+
+    loop {
+        if !pid_is_alive(daemon_pid) {
+            let _ = process.kill();
+            let _ = process.wait(Some(Duration::from_secs(2)));
+            shared.set_exit_code(137);
+            return false;
+        }
+        match process.read_combined(Some(Duration::from_millis(100))) {
+            ReadStatus::Line(event) => {
+                let mut chunk = event.line;
+                chunk.push(b'\n');
+                shared.push_output(chunk);
+            }
+            ReadStatus::Timeout => {
+                if process.returncode().is_some() {
+                    break;
+                }
+            }
+            ReadStatus::Eof => {
+                if process.returncode().is_some() {
+                    break;
+                }
+            }
+        }
+    }
+    let _ = process.wait(Some(Duration::from_secs(2)));
+    true
+}
+
 fn start_subprocess_session(
     spec: &WorkerLaunchSpec,
     shared: &Arc<WorkerShared>,
@@ -1492,7 +1769,7 @@ fn start_subprocess_session(
     use std::path::PathBuf;
 
     let process = Arc::new(NativeProcess::new(ProcessConfig {
-        command: CommandSpec::Argv(spec.plan.command.clone()),
+        command: subprocess::command_spec_for_subprocess(spec.plan.command.clone()),
         cwd: spec.plan.cwd.as_ref().map(PathBuf::from),
         env: Some(child_env()),
         capture: true,
@@ -1922,7 +2199,7 @@ fn run_kill(state_dir: &Path, session_id: Option<&str>, all: bool) -> i32 {
     }
 
     if all {
-        let sessions = list_attachable_sessions(state_dir);
+        let sessions = list_background_sessions(state_dir);
         if sessions.is_empty() {
             println!("No active sessions to kill.");
             return 0;
@@ -1984,31 +2261,78 @@ fn format_duration_short(millis: u64) -> String {
 }
 
 fn run_list(state_dir: &Path) -> i32 {
-    let sessions = list_attachable_sessions(state_dir);
+    let sessions = list_background_sessions(state_dir);
     if sessions.is_empty() {
         println!("No background sessions.");
         return 0;
     }
 
-    println!("{:<30} {:<8} {:<8} CWD", "SESSION", "PID", "UPTIME");
-    for session in sessions {
-        let display_name = session
-            .name
-            .as_deref()
-            .map(|n| format!("{} ({})", session.id, n))
-            .unwrap_or_else(|| session.id.clone());
-        let pid = session
-            .root_pid
-            .map(|value| value.to_string())
-            .unwrap_or_else(|| "-".to_string());
-        let uptime = session
-            .created_at
-            .map(format_duration_short)
-            .unwrap_or_else(|| "-".to_string());
-        let cwd = session.cwd.unwrap_or_else(|| "-".to_string());
-        println!("{:<30} {:<8} {:<8} {}", display_name, pid, uptime, cwd);
+    let (repeat_jobs, attachable_sessions): (Vec<_>, Vec<_>) = sessions
+        .into_iter()
+        .partition(|session| session.repeat_interval_secs.is_some());
+
+    if !repeat_jobs.is_empty() {
+        println!("{:<53} {:<10} {:<18} ID", "TASK", "STATUS", "NEXT RUN");
+        for session in &repeat_jobs {
+            let task = session.name.clone().unwrap_or_else(|| session.id.clone());
+            let status = if session.repeat_running {
+                "running".to_string()
+            } else {
+                "sleeping".to_string()
+            };
+            let next_run = session
+                .repeat_next_run_at
+                .map(format_next_run_short)
+                .unwrap_or_else(|| "-".to_string());
+            println!(
+                "{:<53} {:<10} {:<18} {}",
+                task, status, next_run, session.id
+            );
+        }
+    }
+
+    if !attachable_sessions.is_empty() {
+        if !repeat_jobs.is_empty() {
+            println!();
+        }
+        println!("{:<30} {:<8} {:<8} CWD", "SESSION", "PID", "UPTIME");
+        for session in attachable_sessions {
+            let display_name = session
+                .name
+                .as_deref()
+                .map(|n| format!("{} ({})", session.id, n))
+                .unwrap_or_else(|| session.id.clone());
+            let pid = session
+                .root_pid
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let uptime = session
+                .created_at
+                .map(format_duration_short)
+                .unwrap_or_else(|| "-".to_string());
+            let cwd = session.cwd.unwrap_or_else(|| "-".to_string());
+            println!("{:<30} {:<8} {:<8} {}", display_name, pid, uptime, cwd);
+        }
     }
     0
+}
+
+fn format_next_run_short(run_at_millis: u64) -> String {
+    let now_millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    if run_at_millis <= now_millis {
+        return "now".to_string();
+    }
+    let secs = (run_at_millis - now_millis) / 1000;
+    if secs < 60 {
+        format!("in {}s", secs)
+    } else if secs < 3600 {
+        format!("in {}m", secs / 60)
+    } else {
+        format!("in {}h{}m", secs / 3600, (secs % 3600) / 60)
+    }
 }
 
 /// pm2-style log viewer. No id → list sessions with their last log line.
@@ -2184,7 +2508,7 @@ fn follow_read(path: &Path, offset: u64) -> io::Result<(u64, Vec<u8>)> {
     Ok((len, buf))
 }
 
-fn list_attachable_sessions(state_dir: &Path) -> Vec<SessionSnapshot> {
+fn list_background_sessions(state_dir: &Path) -> Vec<SessionSnapshot> {
     let Ok(entries) = fs::read_dir(sessions_dir(state_dir)) else {
         return Vec::new();
     };
@@ -2212,6 +2536,13 @@ fn list_attachable_sessions(state_dir: &Path) -> Vec<SessionSnapshot> {
     }
     sessions.sort_by(|left, right| left.id.cmp(&right.id));
     sessions
+}
+
+fn list_attachable_sessions(state_dir: &Path) -> Vec<SessionSnapshot> {
+    list_background_sessions(state_dir)
+        .into_iter()
+        .filter(|session| session.attachable)
+        .collect()
 }
 
 fn write_json_line<T: Serialize>(writer: &mut TcpStream, value: &T) -> io::Result<()> {
@@ -2456,6 +2787,10 @@ mod capture_integration_tests {
             created_at: Some(0),
             detachable: true,
             background: false,
+            attachable: true,
+            repeat_interval_secs: None,
+            repeat_next_run_at: None,
+            repeat_running: false,
             daemon_pid: 0,
             worker_pid: 0,
             worker_port: 0,
@@ -2608,6 +2943,10 @@ mod log_tests {
             created_at: Some(0),
             detachable: true,
             background: false,
+            attachable: true,
+            repeat_interval_secs: None,
+            repeat_next_run_at: None,
+            repeat_running: false,
             daemon_pid: 0,
             worker_pid: 0,
             worker_port: 0,
@@ -2767,6 +3106,10 @@ mod backlog_size_tests {
             created_at: Some(0),
             detachable: false,
             background: false,
+            attachable: true,
+            repeat_interval_secs: None,
+            repeat_next_run_at: None,
+            repeat_running: false,
             daemon_pid: 0,
             worker_pid: 0,
             worker_port: 0,

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -11,6 +11,7 @@ pub mod command;
 pub mod daemon;
 pub mod loop_spec;
 pub mod session;
+pub mod subprocess;
 pub mod trampoline;
 pub mod voice;
 pub mod wasm;

--- a/crates/clud-bin/src/loop_spec.rs
+++ b/crates/clud-bin/src/loop_spec.rs
@@ -14,13 +14,19 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use running_process_core::{
-    CommandSpec, NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode,
-};
+use running_process_core::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
+
+use crate::subprocess;
 
 pub const LOOP_DIR: &str = ".clud/loop";
 pub const DONE_MARKER: &str = "DONE";
 pub const BLOCKED_MARKER: &str = "BLOCKED";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkerPaths {
+    pub done: PathBuf,
+    pub blocked: PathBuf,
+}
 
 /// How to interpret the positional argument passed to `clud loop`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -142,6 +148,26 @@ pub fn blocked_path(git_root: &Path) -> PathBuf {
     loop_dir(git_root).join(BLOCKED_MARKER)
 }
 
+/// Derive the BLOCKED marker path from a custom DONE marker path.
+///
+/// `DONE.md` becomes `BLOCKED.md`; `DONE` becomes `BLOCKED`.
+pub fn blocked_path_from_done(done: &Path) -> PathBuf {
+    let parent = done.parent().unwrap_or_else(|| Path::new("."));
+    let ext = done.extension().and_then(|s| s.to_str());
+    let file_name = match ext {
+        Some(ext) if !ext.is_empty() => format!("{BLOCKED_MARKER}.{ext}"),
+        _ => BLOCKED_MARKER.to_string(),
+    };
+    parent.join(file_name)
+}
+
+pub fn default_marker_paths(git_root: &Path) -> MarkerPaths {
+    MarkerPaths {
+        done: done_path(git_root),
+        blocked: blocked_path(git_root),
+    }
+}
+
 /// Marker state observed after an iteration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MarkerState {
@@ -153,14 +179,17 @@ pub enum MarkerState {
 /// Read the marker state from `<git-root>/.clud/loop/`. DONE wins if both
 /// exist (the agent's last word that the task resolved).
 pub fn read_markers(git_root: &Path) -> MarkerState {
-    let done = done_path(git_root);
-    if done.is_file() {
-        let body = std::fs::read_to_string(&done).unwrap_or_default();
+    let paths = default_marker_paths(git_root);
+    read_markers_at(&paths)
+}
+
+pub fn read_markers_at(paths: &MarkerPaths) -> MarkerState {
+    if paths.done.is_file() {
+        let body = std::fs::read_to_string(&paths.done).unwrap_or_default();
         return MarkerState::Done(body.trim().to_string());
     }
-    let blocked = blocked_path(git_root);
-    if blocked.is_file() {
-        let body = std::fs::read_to_string(&blocked).unwrap_or_default();
+    if paths.blocked.is_file() {
+        let body = std::fs::read_to_string(&paths.blocked).unwrap_or_default();
         return MarkerState::Blocked(body.trim().to_string());
     }
     MarkerState::None
@@ -168,8 +197,13 @@ pub fn read_markers(git_root: &Path) -> MarkerState {
 
 /// Remove stale DONE/BLOCKED markers so we start from a clean slate.
 pub fn clear_markers(git_root: &Path) {
-    let _ = std::fs::remove_file(done_path(git_root));
-    let _ = std::fs::remove_file(blocked_path(git_root));
+    let paths = default_marker_paths(git_root);
+    clear_markers_at(&paths);
+}
+
+pub fn clear_markers_at(paths: &MarkerPaths) {
+    let _ = std::fs::remove_file(&paths.done);
+    let _ = std::fs::remove_file(&paths.blocked);
 }
 
 /// Ensure the `.clud/loop/` dir exists under the given git root.
@@ -282,7 +316,7 @@ fn run_gh_capture(args: &[&str]) -> Result<(i32, String), String> {
     let mut argv = vec!["gh".to_string()];
     argv.extend(args.iter().map(|s| s.to_string()));
     let config = ProcessConfig {
-        command: CommandSpec::Argv(argv),
+        command: subprocess::command_spec_for_subprocess(argv),
         cwd: None,
         env: None,
         capture: true,
@@ -436,19 +470,23 @@ pub fn render_cache(doc: &IssueDoc, fetched_at: &str) -> String {
 
 /// Default prompt instructions appended to every loop-driven task when the
 /// DONE/BLOCKED marker contract is active.
-pub const DONE_MARKER_CONTRACT: &str = "\n\n---\n\
+pub fn done_marker_contract(done_path: &str, blocked_path: &str) -> String {
+    format!(
+        "\n\n---\n\
 You are running in a ralph loop. The loop will re-invoke you up to N times \
 with the same task until you complete it.\n\
 \n\
 When the task is fully resolved and verified (tests pass, lint clean where \
-applicable), write `.clud/loop/DONE` with a one-line summary of what you \
+applicable), write `{done_path}` with a one-line summary of what you \
 did. Do not write DONE prematurely — only after you are confident the work \
 is complete.\n\
 \n\
 If you cannot make progress (missing info, external dependency, needs \
-human input), write `.clud/loop/BLOCKED` with a one-line reason and stop.\n\
+human input), write `{blocked_path}` with a one-line reason and stop.\n\
 \n\
-Otherwise, continue working — you will be re-invoked.\n";
+Otherwise, continue working — you will be re-invoked.\n"
+    )
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,4 +1,6 @@
-use clud::{args, backend, command, daemon, loop_spec, session, trampoline, voice, wasm};
+use clud::{
+    args, backend, command, daemon, loop_spec, session, subprocess, trampoline, voice, wasm,
+};
 
 use std::io::{self, Read};
 use std::sync::{
@@ -44,6 +46,18 @@ fn main() {
         }
     }
 
+    if let Some(args::Command::Loop {
+        repeat: Some(_),
+        done: None,
+        no_done: false,
+        ..
+    }) = &args.command
+    {
+        eprintln!(
+            "[clud] warning: `--repeat` implies `--no-done`; DONE marker injection/checking is disabled."
+        );
+    }
+
     let interrupted = install_ctrl_c_flag();
     if let Some(exit_code) = daemon::handle_special_command(&args, interrupted.as_ref()) {
         std::process::exit(exit_code);
@@ -73,7 +87,11 @@ fn main() {
             "iterations": plan.iterations,
             "backend": backend.executable_name(),
             "launch_mode": plan.launch_mode.as_str(),
-            "loop_markers": plan.loop_markers.as_ref().map(|m| &m.git_root),
+            "repeat_interval_secs": plan.repeat_schedule.as_ref().map(|s| s.interval_secs),
+            "loop_markers": plan.loop_markers.as_ref().map(|m| serde_json::json!({
+                "done_path": m.done_path,
+                "blocked_path": m.blocked_path,
+            })),
         });
         println!("{}", serde_json::to_string_pretty(&json).unwrap());
         std::process::exit(0);
@@ -82,7 +100,10 @@ fn main() {
     // Clear stale DONE/BLOCKED markers from a prior run so that loops don't
     // short-circuit on iteration 1. See loop_spec for semantics.
     if let Some(ref markers) = plan.loop_markers {
-        loop_spec::clear_markers(std::path::Path::new(&markers.git_root));
+        loop_spec::clear_markers_at(&loop_spec::MarkerPaths {
+            done: std::path::PathBuf::from(&markers.done_path),
+            blocked: std::path::PathBuf::from(&markers.blocked_path),
+        });
     }
 
     let exit_code = if daemon::experimental_enabled(&args) {
@@ -156,9 +177,7 @@ fn normalize_exit_code(code: i32) -> i32 {
 fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicBool) -> i32 {
     use std::path::PathBuf;
 
-    use running_process_core::{
-        CommandSpec, Containment, NativeProcess, ProcessConfig, StderrMode, StdinMode,
-    };
+    use running_process_core::{Containment, NativeProcess, ProcessConfig, StderrMode, StdinMode};
 
     let env = child_env();
     let mut last_exit = 0i32;
@@ -173,7 +192,7 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
         }
 
         let config = ProcessConfig {
-            command: CommandSpec::Argv(plan.command.clone()),
+            command: subprocess::command_spec_for_subprocess(plan.command.clone()),
             cwd: plan.cwd.as_ref().map(PathBuf::from),
             env: Some(env.clone()),
             capture: false,
@@ -320,8 +339,10 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
 /// terminal exit code to return from the runner, or `None` to continue.
 fn check_loop_markers(plan: &command::LaunchPlan, iteration: u32) -> Option<i32> {
     let markers = plan.loop_markers.as_ref()?;
-    let root = std::path::Path::new(&markers.git_root);
-    match loop_spec::read_markers(root) {
+    match loop_spec::read_markers_at(&loop_spec::MarkerPaths {
+        done: std::path::PathBuf::from(&markers.done_path),
+        blocked: std::path::PathBuf::from(&markers.blocked_path),
+    }) {
         loop_spec::MarkerState::Done(summary) => {
             if summary.is_empty() {
                 eprintln!(

--- a/crates/clud-bin/src/subprocess.rs
+++ b/crates/clud-bin/src/subprocess.rs
@@ -1,0 +1,111 @@
+use std::path::Path;
+
+use running_process_core::CommandSpec;
+
+/// Convert an argv-style launch into the most compatible subprocess form for
+/// the current platform.
+///
+/// Windows `CreateProcess*` does not execute `.cmd` / `.bat` scripts directly;
+/// they must run through `cmd.exe`. `running-process-core` already provides a
+/// Windows shell path that wraps `cmd /D /S /C ...`, so batch wrappers are
+/// rendered as a shell command there while native executables stay argv-based.
+pub fn command_spec_for_subprocess(argv: Vec<String>) -> CommandSpec {
+    #[cfg(windows)]
+    if is_windows_batch_wrapper(argv.first().map(String::as_str)) {
+        return CommandSpec::Shell(render_windows_batch_command(&argv));
+    }
+
+    CommandSpec::Argv(argv)
+}
+
+#[cfg(windows)]
+fn is_windows_batch_wrapper(program: Option<&str>) -> bool {
+    let Some(program) = program else {
+        return false;
+    };
+    matches!(
+        Path::new(program)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_ascii_lowercase())
+            .as_deref(),
+        Some("cmd" | "bat")
+    )
+}
+
+#[cfg(windows)]
+fn render_windows_batch_command(argv: &[String]) -> String {
+    argv.iter()
+        .map(|arg| quote_for_cmd(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(windows)]
+fn quote_for_cmd(arg: &str) -> String {
+    let mut out = String::with_capacity(arg.len() + 2);
+    out.push('"');
+    for ch in arg.chars() {
+        match ch {
+            // Prevent cmd.exe from treating `%FOO%` as env expansion before the
+            // batch wrapper receives the argument.
+            '%' => out.push_str("%%"),
+            '"' => out.push_str("\"\""),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::command_spec_for_subprocess;
+
+    #[test]
+    fn native_executable_stays_argv() {
+        let spec =
+            command_spec_for_subprocess(vec!["codex.exe".into(), "exec".into(), "hello".into()]);
+        match spec {
+            running_process_core::CommandSpec::Argv(argv) => {
+                assert_eq!(argv, vec!["codex.exe", "exec", "hello"]);
+            }
+            other => panic!("expected Argv for native executable, got {other:?}"),
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cmd_wrapper_uses_shell_command() {
+        let spec = command_spec_for_subprocess(vec![
+            r"C:\Users\me\AppData\Roaming\npm\codex.cmd".into(),
+            "exec".into(),
+            "100% \"quoted\" prompt".into(),
+        ]);
+        match spec {
+            running_process_core::CommandSpec::Shell(command) => {
+                assert!(
+                    command.starts_with(r#""C:\Users\me\AppData\Roaming\npm\codex.cmd" "exec" "#),
+                    "unexpected shell command: {command}"
+                );
+                assert!(
+                    command.contains(r#""100%% ""quoted"" prompt""#),
+                    "percent signs and quotes must be escaped for cmd.exe: {command}"
+                );
+            }
+            other => panic!("expected Shell for .cmd wrapper, got {other:?}"),
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn cmd_suffix_is_not_special_off_windows() {
+        let spec = command_spec_for_subprocess(vec!["codex.cmd".into(), "exec".into()]);
+        match spec {
+            running_process_core::CommandSpec::Argv(argv) => {
+                assert_eq!(argv, vec!["codex.cmd", "exec"]);
+            }
+            other => panic!("expected Argv off Windows, got {other:?}"),
+        }
+    }
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -229,6 +229,35 @@ def mock_env(mock_agent_binary: Path, tmp_path: Path) -> dict[str, str]:
 
 
 @pytest.fixture
+def mock_env_codex_cmd(mock_agent_binary: Path, tmp_path: Path) -> dict[str, str]:
+    """Windows-only env where `codex` resolves to a `.cmd` wrapper.
+
+    Reproduces the npm-installed Codex layout: a `codex.cmd` launcher that
+    shells out to a real executable with `%*`.
+    """
+    if sys.platform != "win32":
+        pytest.skip("Windows-only codex.cmd wrapper fixture")
+
+    mock_agent_name = f"mock-agent{'.exe' if sys.platform == 'win32' else ''}"
+    mock_agent_path = tmp_path / mock_agent_name
+    shutil.copy2(mock_agent_binary, mock_agent_path)
+
+    codex_wrapper = tmp_path / "codex.cmd"
+    codex_wrapper.write_text(
+        "@echo off\r\n"
+        "\"%~dp0mock-agent.exe\" %*\r\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path) + os.pathsep + env.get("PATH", "")
+    env.pop("VIRTUAL_ENV", None)
+    env["RUNNING_PROCESS_CHILD_PID_LOG_PATH"] = str(tmp_path / "child_pids.log")
+    env["CLUD_NO_UNLOCK"] = "1"
+    return env
+
+
+@pytest.fixture
 def clud_binary() -> Path:
     """Return the path to the current repo's clud binary."""
     return _find_clud()

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -48,6 +48,9 @@ def _extract_session_id(line: str) -> str | None:
     # "[clud] session sess-XXX running in background"
     if "session" in line and "running in background" in line:
         return line.strip().split("session ", 1)[-1].split(" running")[0]
+    # "[clud] repeat job sess-XXX running in background"
+    if "repeat job" in line and "running in background" in line:
+        return line.strip().split("repeat job ", 1)[-1].split(" running")[0]
     return None
 
 
@@ -479,6 +482,58 @@ class TestDaemonManagedSessionFlags:
         )
         assert listed.returncode == 0
         assert session_id in listed.stdout
+
+        _kill_daemon_for_session(state_dir, session_id)
+
+    def test_loop_repeat_registers_background_job_and_lists_status(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+
+        result = subprocess.run(
+            [
+                str(clud_binary),
+                "loop",
+                "--loop-count",
+                "1",
+                "--repeat",
+                "1s",
+                "repeat background task",
+                "--",
+                "--mock-sleep-ms",
+                "50",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        session_id = _read_session_id_from_text(result.stderr)
+
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            metadata = _session_metadata(state_dir, session_id)
+            if metadata["repeat_interval_secs"] == 1:
+                break
+            time.sleep(0.05)
+        else:
+            raise AssertionError(f"repeat metadata not populated: {metadata}")
+
+        listed = subprocess.run(
+            [str(clud_binary), "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+            cwd=tmp_path,
+        )
+        assert listed.returncode == 0, f"stderr: {listed.stderr}"
+        assert session_id in listed.stdout
+        assert "repeat background task" in listed.stdout
+        assert ("running" in listed.stdout) or ("sleeping" in listed.stdout)
 
         _kill_daemon_for_session(state_dir, session_id)
 

--- a/tests/integration/test_loop_markers.py
+++ b/tests/integration/test_loop_markers.py
@@ -111,10 +111,10 @@ def test_loop_no_markers_exhausts_iterations(
     assert "iteration 3" in result.stderr
 
 
-def test_loop_no_done_marker_flag_keeps_old_semantics(
+def test_loop_no_done_flag_keeps_old_semantics(
     clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
 ) -> None:
-    """With --no-done-marker the loop runs all iterations and exits 0.
+    """With --no-done the loop runs all iterations and exits 0.
 
     This preserves pre-marker behavior for scripts that don't want the
     DONE-marker contract injected.
@@ -124,7 +124,7 @@ def test_loop_no_done_marker_flag_keeps_old_semantics(
         "loop",
         "--loop-count",
         "2",
-        "--no-done-marker",
+        "--no-done",
         "task",
         env=mock_env,
         cwd=tmp_path,
@@ -164,7 +164,7 @@ def test_loop_clears_stale_done_marker(
 def test_loop_dry_run_includes_loop_markers(
     clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
 ) -> None:
-    """--dry-run output reports the loop_markers git root when active."""
+    """--dry-run output reports the active DONE/BLOCKED marker paths."""
     import json
 
     result = _run(
@@ -178,8 +178,8 @@ def test_loop_dry_run_includes_loop_markers(
     assert result.returncode == 0
     data = json.loads(result.stdout)
     assert data["loop_markers"] is not None
-    # git-root-from walks up; without .git anywhere, it returns the cwd.
-    assert str(tmp_path).replace("\\", "/") in data["loop_markers"].replace("\\", "/")
+    assert data["loop_markers"]["done_path"].replace("\\", "/").endswith(".clud/loop/DONE")
+    assert data["loop_markers"]["blocked_path"].replace("\\", "/").endswith(".clud/loop/BLOCKED")
 
 
 def test_codex_loop_stops_on_done_marker(

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -87,6 +87,23 @@ class TestBackendSelection:
         report = _parse_agent_report(result)
         assert report["cwd"] == str(Path.cwd())
 
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only codex.cmd repro")
+    def test_codex_cmd_wrapper_launches_noninteractive_exec(
+        self, clud_binary: Path, mock_env_codex_cmd: dict[str, str]
+    ) -> None:
+        result = _run(
+            clud_binary,
+            "--codex",
+            "-p",
+            "hello from codex.cmd",
+            env=mock_env_codex_cmd,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        report = _parse_agent_report(result)
+        assert "exec" in report["args"]
+        assert "--dangerously-bypass-approvals-and-sandbox" in report["args"]
+        assert "hello from codex.cmd" in report["args"]
+
     def test_claude_preserves_cwd(self, clud_binary: Path, mock_env: dict[str, str]) -> None:
         result = _run(clud_binary, "--claude", "-p", "hello", env=mock_env)
         assert result.returncode == 0
@@ -320,7 +337,7 @@ class TestLoopMode:
     """Verify loop mode runs multiple iterations."""
 
     def test_loop_iterations(self, clud_binary: Path, mock_env: dict[str, str]) -> None:
-        # --no-done-marker: this test only verifies the loop runs N times;
+        # --no-done: this test only verifies the loop runs N times;
         # without it, the DONE-marker contract would make exit code 2 (not
         # converged) the expected outcome when no marker is written.
         result = _run(
@@ -328,7 +345,7 @@ class TestLoopMode:
             "loop",
             "--loop-count",
             "3",
-            "--no-done-marker",
+            "--no-done",
             "do stuff",
             env=mock_env,
         )
@@ -371,7 +388,7 @@ class TestLoopMode:
             "loop",
             "--loop-count",
             "3",
-            "--no-done-marker",
+            "--no-done",
             "do stuff",
             env=mock_env,
         )
@@ -409,11 +426,38 @@ class TestLoopMode:
         assert report["backend"] == "codex"
         assert report["launch_mode"] == "subprocess"
         assert report["loop_markers"] is not None
+        assert report["loop_markers"]["done_path"].replace("\\", "/").endswith(".clud/loop/DONE")
         assert report["iterations"] == 50
         cmd = report["command"]
         assert cmd[1] == "exec"
         assert "--dangerously-bypass-approvals-and-sandbox" in cmd
         assert "-p" not in cmd
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only codex.cmd repro")
+    def test_codex_loop_with_cmd_wrapper(
+        self, clud_binary: Path, mock_env_codex_cmd: dict[str, str]
+    ) -> None:
+        result = _run(
+            clud_binary,
+            "--codex",
+            "loop",
+            "--loop-count",
+            "2",
+            "--no-done",
+            "batch wrapper loop",
+            env=mock_env_codex_cmd,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        cleaned = _strip_ansi(result.stdout)
+        json_lines = [
+            line.strip() for line in cleaned.splitlines() if line.strip().startswith("{")
+        ]
+        assert len(json_lines) == 2
+        for line in json_lines:
+            report = json.loads(line)
+            assert "exec" in report["args"]
+            assert "--dangerously-bypass-approvals-and-sandbox" in report["args"]
+            assert any("batch wrapper loop" in arg for arg in report["args"])
 
 
 class TestInterruptReporting:

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -233,14 +233,38 @@ def test_dry_run_loop() -> None:
     assert ".clud/loop/DONE" in prompt
     assert ".clud/loop/BLOCKED" in prompt
     assert data["loop_markers"] is not None
+    assert data["loop_markers"]["done_path"].replace("\\", "/").endswith(".clud/loop/DONE")
+    assert data["loop_markers"]["blocked_path"].replace("\\", "/").endswith(
+        ".clud/loop/BLOCKED"
+    )
 
 
-def test_dry_run_loop_no_done_marker() -> None:
-    result = _run("--dry-run", "loop", "--no-done-marker", "do stuff")
+def test_dry_run_loop_no_done() -> None:
+    result = _run("--dry-run", "loop", "--no-done", "do stuff")
     assert result.returncode == 0
     data = json.loads(result.stdout)
     assert data["command"][-1] == "do stuff"
     assert data["loop_markers"] is None
+
+
+def test_dry_run_loop_repeat_implies_no_done() -> None:
+    result = _run("--dry-run", "loop", "--repeat", "1h", "do stuff")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["command"][-1] == "do stuff"
+    assert data["loop_markers"] is None
+    assert data["repeat_interval_secs"] == 3600
+
+
+def test_dry_run_loop_repeat_with_done_override() -> None:
+    result = _run("--dry-run", "loop", "--repeat", "1h", "--done", "DONE.md", "do stuff")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    prompt = data["command"][-1]
+    assert "DONE.md" in prompt
+    assert "BLOCKED.md" in prompt
+    assert data["loop_markers"]["done_path"].replace("\\", "/").endswith("DONE.md")
+    assert data["loop_markers"]["blocked_path"].replace("\\", "/").endswith("BLOCKED.md")
 
 
 def test_dry_run_loop_default_count() -> None:


### PR DESCRIPTION
## Summary

Three related changes to the loop / centralized-daemon path:

- **`clud loop --repeat <dur>`** — schedules a loop job that runs repeatedly in the background via the daemon (`30s`, `5m`, `1h`). Daemon tracks `interval_secs`, `next_run_at`, and `running` state; `clud list` renders repeat jobs in their own table alongside attachable sessions. `--repeat` implies no DONE contract unless a custom `--done` path is supplied.
- **`--done <path>` + `--no-done` rename** — lets you relocate the DONE/BLOCKED markers (e.g. `DONE.md` → `BLOCKED.md`). `--no-done-marker` is kept as an alias. The plan's `loop_markers` now carries explicit `done_path`/`blocked_path` rather than a `git_root`; the marker-contract prompt is generated from those paths.
- **Windows `codex.cmd` fix** — new `subprocess` module routes `.cmd`/`.bat` programs through `cmd.exe` via `CommandSpec::Shell` (with proper `%` and `"` escaping). Fixes `clud --codex` when Codex is installed as an npm `.cmd` wrapper. Native executables still take the argv path.

Also boxes `DaemonRequest::Create.spec` to satisfy `clippy::large_enum_variant` after the new `WorkerLaunchSpec` fields (`attachable`, `repeat_interval_secs`, `repeat_run_command`).

## Test plan

- [x] `bash lint` — cargo fmt, clippy -D warnings, ruff all clean
- [x] `bash test` — 181 Rust lib + 13 PTY + 4 bin + 28 Python unit tests pass
- [ ] CI green on all 6 platforms × 4 jobs
- [ ] Integration tests on Windows: `test_codex_cmd_wrapper_launches_noninteractive_exec`, `test_codex_loop_with_cmd_wrapper` (Windows-only, gated by `mock_env_codex_cmd` fixture)
- [ ] Integration test: `test_loop_repeat_registers_background_job_and_lists_status`
- [ ] Manual: `clud loop --repeat 10s "task"` backgrounds and shows in `clud list` with repeat state
- [ ] Manual: `clud loop --done DONE.md "task"` writes to repo root and exits on marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)