### PR TITLE
ci: migrate Rust CI stack to zackees/setup-soldr@v0 (#68)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
     steps:
       - uses: actions/checkout@v4
@@ -47,34 +45,26 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
-
-      - uses: dtolnay/rust-toolchain@master
+      # Issue #68: replace dtolnay/rust-toolchain + mozilla-actions/sccache-action
+      # + Swatinem/rust-cache with setup-soldr. soldr pins the MSVC toolchain on
+      # Windows (issue #27) and owns build + target caching for every platform.
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          version: "0.7.11"
+          cache: true
+          build-cache-mode: thin
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
-      - name: Verify soldr is installed (Windows, issue #27)
-        if: ${{ runner.os == 'Windows' }}
-        run: uv run soldr --version
-
-      - uses: Swatinem/rust-cache@v2
-
       - name: Build wheel (${{ inputs.build-mode || 'dev' }})
         run: uv run --no-editable -m ci.build_wheel --${{ inputs.build-mode || 'dev' }}
 
-      - name: Build sdist (Windows, via soldr)
-        if: ${{ inputs.include-sdist && runner.os == 'Windows' }}
-        run: uv run soldr maturin sdist --out dist
-
       - name: Build sdist
-        if: ${{ inputs.include-sdist && runner.os != 'Windows' }}
-        run: uv run maturin sdist --out dist
+        if: ${{ inputs.include-sdist }}
+        run: uv run soldr maturin sdist --out dist
 
       - name: Verify Windows wheel has no MinGW runtime imports
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
       CLUD_INTEGRATION_TESTS: "1"
     steps:
@@ -36,23 +34,20 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
-
-      - uses: dtolnay/rust-toolchain@master
+      # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
+      # `build-cache-mode: thin` avoids the setup-soldr#53 pitfall where the
+      # dev build + cargo test --no-run + cargo test pipeline shares one
+      # target dir.
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          version: "0.7.11"
+          cache: true
+          build-cache-mode: thin
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
-
-      - name: Verify soldr is installed (Windows, issue #27)
-        if: ${{ runner.os == 'Windows' }}
-        run: uv run soldr --version
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Dev build
         run: uv run --no-editable -m ci.build_wheel --dev

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
     steps:
       - uses: actions/checkout@v4
@@ -35,23 +33,17 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
-
-      - uses: dtolnay/rust-toolchain@master
+      # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          version: "0.7.11"
+          cache: true
+          build-cache-mode: thin
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
-
-      - name: Verify soldr is installed (Windows, issue #27)
-        if: ${{ runner.os == 'Windows' }}
-        run: uv run soldr --version
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Lint
         run: uv run --no-editable -m ci.lint

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
     steps:
       - uses: actions/checkout@v4
@@ -35,23 +33,20 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
-
-      - uses: dtolnay/rust-toolchain@master
+      # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
+      # `build-cache-mode: thin` avoids the setup-soldr#53 pitfall where
+      # ci/test.py's back-to-back cargo build / cargo test --no-run / cargo
+      # test invocations share a single target dir.
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          version: "0.7.11"
+          cache: true
+          build-cache-mode: thin
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
-
-      - name: Verify soldr is installed (Windows, issue #27)
-        if: ${{ runner.os == 'Windows' }}
-        run: uv run soldr --version
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Dev build
         run: uv run --no-editable -m ci.build_wheel --dev

--- a/ci/env.py
+++ b/ci/env.py
@@ -255,31 +255,29 @@ def soldr_path(env: dict[str, str] | None = None) -> str | None:
 
 
 def cargo_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list[str]:
-    """Return the cargo argv, preferring `soldr cargo` on Windows.
+    """Return the cargo argv, preferring `soldr cargo` on every platform.
 
-    Issue #27: see `soldr_path` for the rationale. On non-Windows platforms,
-    or when soldr isn't installed (local dev without the dev deps), fall
-    back to bare `cargo`, matching `tests/integration/conftest.py::_cargo_argv`.
+    Issue #27 pinned this on Windows; issue #68 extends it to all platforms
+    so that local dev and CI (via `zackees/setup-soldr@v0`) go through the
+    same rustup-resolved toolchain. Falls back to bare `cargo` when soldr
+    isn't on PATH — matches `tests/integration/conftest.py::_cargo_argv`.
     """
-    if platform.system() == "Windows":
-        soldr = soldr_path(env)
-        if soldr:
-            return [soldr, "cargo", *subcommand]
+    soldr = soldr_path(env)
+    if soldr:
+        return [soldr, "cargo", *subcommand]
     return ["cargo", *subcommand]
 
 
 def maturin_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list[str]:
-    """Return the maturin argv, preferring `soldr maturin` on Windows.
+    """Return the maturin argv, preferring `soldr maturin` on every platform.
 
-    Mirrors `cargo_argv` — see issue #27. maturin invokes cargo under the
-    hood, so the same MSVC-pinning concern applies. soldr passes the
-    subcommand through to maturin via `rustup which maturin`, which
-    resolves to the dev-venv install.
+    Mirrors `cargo_argv` — see issues #27 and #68. maturin invokes cargo
+    under the hood, so routing through soldr keeps the MSVC pin on Windows
+    and makes the cargo cache lineage uniform across CI platforms. soldr
+    resolves `maturin` via `rustup which maturin`, which points at the
+    dev-venv install.
     """
-    if platform.system() == "Windows":
-        soldr = soldr_path(env)
-        if soldr:
-            return [soldr, "maturin", *subcommand]
-    # Fall back to `python -m maturin` so the dev-venv install is used
-    # on non-Windows platforms regardless of PATH state.
+    soldr = soldr_path(env)
+    if soldr:
+        return [soldr, "maturin", *subcommand]
     return [sys.executable, "-m", "maturin", *subcommand]


### PR DESCRIPTION
## Summary

Resolves #68. Replaces the `dtolnay/rust-toolchain` + `mozilla-actions/sccache-action` + `Swatinem/rust-cache` trio with a single `zackees/setup-soldr@v0` step in every template workflow, and routes `cargo` / `maturin` shell-outs in `ci/env.py` through `soldr` on all platforms (not just Windows).

- `.github/workflows/_build.yml`, `_lint.yml`, `_unit-test.yml`, `_integration-test.yml` — swap the old stack for `zackees/setup-soldr@v0` pinned to `version: "0.7.11"` with `cache: true` and `build-cache-mode: thin`. Drop `SCCACHE_GHA_ENABLED` / `RUSTC_WRAPPER: sccache` env. Unify the Windows/non-Windows sdist step onto `uv run soldr maturin sdist`.
- `ci/env.py` — `cargo_argv` and `maturin_argv` now prefer `soldr cargo` / `soldr maturin` on every platform when soldr is on `PATH` (local dev has soldr via dev deps; CI has it from `setup-soldr`). Bare-`cargo` / `python -m maturin` fallback is preserved for environments without soldr.

### Why `build-cache-mode: thin`
`ci/test.py` does three cargo invocations (`cargo build -p mock-agent`, `cargo test --no-run`, `cargo test`) against one shared `target/` dir per job. The default `once` mode has a known pitfall in that layout (see [setup-soldr#53](https://github.com/zackees/setup-soldr/issues/53)); `thin` sidesteps it.

### Acceptance checks (per issue #68)
- [x] All four templates use `zackees/setup-soldr@v0`; no references to `dtolnay/rust-toolchain`, `mozilla-actions/sccache-action`, `Swatinem/rust-cache`, or `RUSTC_WRAPPER: sccache` in workflow files (only one historical mention in a comment).
- [x] `cargo` / `maturin` calls in CI route through `soldr` via `ci/env.py::cargo_argv` / `maturin_argv`.
- [x] Windows MSVC guarantee from #27 preserved — soldr resolves via `rustup which` using the `rust-toolchain.toml`-pinned `1.94.1` channel; `ci/check_windows_wheel.py` still runs on Windows build jobs.
- [x] `rust-toolchain.toml` already present and pins `1.94.1`; also passed via the `toolchain:` input for clarity.
- [x] Local `bash build` / `bash lint` / `bash test` untouched — soldr is already a dev dep.
- [ ] Warm-cache hit rate (`build-cache-hit` / `target-cache-hit` outputs) — observable on the second run of this branch.

## Test plan

- [x] `bash lint` passes locally on Windows (cargo fmt + clippy through soldr).
- [x] `bash test` passes locally on Windows — 104 Rust tests + 28 Python unit tests green.
- [ ] Confirm all six platform × four job-type CI runs pass on this branch.
- [ ] Confirm warm-cache hits on a re-run of the same branch.
- [ ] Confirm Windows wheel still has no MinGW imports (`ci/check_windows_wheel.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)