### PR TITLE
WIP: address #59 / #55 / #61 (codex.cmd, test popups, loop --repeat)

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -469,6 +469,73 @@ mod tests {
         }
     }
 
+    /// Issue #61: --repeat + --done <path> must parse cleanly. The two flags
+    /// compose; --done overrides --repeat's implicit --no-done at the
+    /// command-builder layer, but at the args layer they're orthogonal.
+    #[test]
+    fn test_loop_repeat_with_done() {
+        let args = parse(&[
+            "clud",
+            "loop",
+            "--repeat",
+            "30m",
+            "--done",
+            "STATUS.md",
+            "task",
+        ]);
+        match args.command {
+            Some(Command::Loop {
+                ref repeat,
+                ref done,
+                no_done,
+                ..
+            }) => {
+                assert_eq!(repeat.as_deref(), Some("30m"));
+                assert_eq!(done.as_deref(), Some("STATUS.md"));
+                assert!(!no_done);
+            }
+            _ => panic!("expected Loop subcommand"),
+        }
+    }
+
+    /// Issue #61: --repeat + --no-done must parse cleanly even though the
+    /// command-builder treats them as overlapping (both suppress the
+    /// contract). Clap should not reject the combination.
+    #[test]
+    fn test_loop_repeat_with_no_done() {
+        let args = parse(&["clud", "loop", "--repeat", "5m", "--no-done", "task"]);
+        match args.command {
+            Some(Command::Loop {
+                ref repeat,
+                no_done,
+                ref done,
+                ..
+            }) => {
+                assert_eq!(repeat.as_deref(), Some("5m"));
+                assert!(no_done);
+                assert!(done.is_none());
+            }
+            _ => panic!("expected Loop subcommand"),
+        }
+    }
+
+    /// Issue #61: --done and --no-done are mutually exclusive (clap
+    /// `conflicts_with`). Supplying both must fail — we don't pin the exact
+    /// error message because clap formatting drifts between versions, but
+    /// `try_parse_from` must return `Err`.
+    #[test]
+    fn test_loop_done_and_no_done_conflict() {
+        let argv: Vec<String> = ["clud", "loop", "--done", "DONE.md", "--no-done", "task"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let result = Args::try_parse_from(argv);
+        assert!(
+            result.is_err(),
+            "clap should reject simultaneous --done and --no-done"
+        );
+    }
+
     #[test]
     fn test_up_subcommand() {
         let args = parse(&["clud", "up"]);

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -318,7 +318,23 @@ fn resolve_marker_paths(
     }
 }
 
-fn parse_repeat_interval(raw: &str) -> Result<u64, String> {
+/// Parse a `--repeat` duration string into seconds.
+///
+/// Accepted forms (issue #61): `30s`, `5m`, `1h`, `24h`. The unit is the
+/// only recognized suffix; anything more elaborate (compound durations,
+/// fractional units, ISO-8601 etc.) is intentionally out of scope.
+///
+/// Errors when:
+/// - input is empty or whitespace-only
+/// - integer part is missing (e.g. `s`)
+/// - unit part is missing (e.g. `30`)
+/// - integer is `0` (a zero interval would busy-loop)
+/// - fractional values (`1.5h`) — the `.` makes integer parsing fail
+/// - negative values (`-1h`) — the leading `-` is treated as the unit
+///   start, which fails the empty-integer check
+/// - unsupported units (`30d`, `1y`)
+/// - the multiplied result would overflow `u64` seconds
+pub(crate) fn parse_repeat_interval(raw: &str) -> Result<u64, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err("duration cannot be empty".to_string());
@@ -345,6 +361,47 @@ fn parse_repeat_interval(raw: &str) -> Result<u64, String> {
     };
     n.checked_mul(multiplier)
         .ok_or_else(|| "duration is too large".to_string())
+}
+
+/// Decide whether `clud loop` flags imply that done-marker injection should
+/// be disabled for this invocation. Issue #61.
+///
+/// Truth table (`repeat`, `no_done`, `done`):
+/// - (Some, false, None)  → warn + disable (the `--repeat` implies `--no-done` case)
+/// - (Some, true,  None)  → user already passed `--no-done`, no warning
+/// - (Some, _,    Some)   → `--done <path>` overrides; no warning, contract on
+/// - (None, _,    _)      → no `--repeat`, no warning emitted by this helper
+///
+/// Returns `Some(message)` to be printed to stderr when the warning should
+/// fire, otherwise `None`.
+pub fn repeat_implies_no_done_warning(
+    repeat: Option<&str>,
+    no_done: bool,
+    done: Option<&str>,
+) -> Option<&'static str> {
+    if repeat.is_some() && !no_done && done.is_none() {
+        Some(
+            "[clud] warning: `--repeat` implies `--no-done`; \
+             DONE marker injection/checking is disabled.",
+        )
+    } else {
+        None
+    }
+}
+
+/// Compute the wall-clock millis at which the next repeat run should fire,
+/// given the millis at which the previous run *completed*. Issue #61.
+///
+/// This is the load-bearing "no-overlap" invariant: the next run is
+/// scheduled **after the previous run completes**, not after the previous
+/// run started. So a run that takes longer than the repeat interval simply
+/// pushes the next run further into the future — runs serialize, never
+/// overlap.
+///
+/// Saturates at `u64::MAX` rather than panicking, mirroring the daemon's
+/// `saturating_mul` on the seconds→millis conversion.
+pub fn next_run_at_millis(completed_at_millis: u64, interval_secs: u64) -> u64 {
+    completed_at_millis.saturating_add(interval_secs.saturating_mul(1000))
 }
 
 pub fn summarize_task_name(input: &str, max_chars: usize) -> String {
@@ -973,5 +1030,398 @@ mod tests {
     fn test_build_up_prompt_publish() {
         let prompt = build_up_prompt(None, true);
         assert!(prompt.contains("-p"));
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #61: --repeat scheduling tests
+    // -----------------------------------------------------------------
+    //
+    // These cover three areas:
+    //   1. parse_repeat_interval: every accepted form + the rejection
+    //      cases the issue calls out (negative, fractional, unknown
+    //      unit, overflow, empty, zero, missing unit, missing value).
+    //   2. repeat_implies_no_done_warning: the precedence ladder
+    //      (--repeat alone fires; explicit --no-done suppresses;
+    //      --done <path> suppresses + restores contract).
+    //   3. next_run_at_millis: the no-overlap invariant. The next run
+    //      time is always derived from *completion*, so a long-running
+    //      iteration pushes the schedule out instead of overlapping.
+
+    #[test]
+    fn test_parse_repeat_interval_accepted_forms() {
+        // The four forms the issue explicitly calls out.
+        assert_eq!(parse_repeat_interval("30s").unwrap(), 30);
+        assert_eq!(parse_repeat_interval("5m").unwrap(), 5 * 60);
+        assert_eq!(parse_repeat_interval("1h").unwrap(), 60 * 60);
+        assert_eq!(parse_repeat_interval("24h").unwrap(), 24 * 60 * 60);
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_accepts_uppercase_unit() {
+        // Case-insensitivity is a small kindness; matches argparse-style ergonomics
+        // and the spec doesn't forbid it.
+        assert_eq!(parse_repeat_interval("30S").unwrap(), 30);
+        assert_eq!(parse_repeat_interval("2H").unwrap(), 7200);
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_trims_surrounding_whitespace() {
+        assert_eq!(parse_repeat_interval("  1h  ").unwrap(), 3600);
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_empty() {
+        let err = parse_repeat_interval("").unwrap_err();
+        assert!(err.contains("empty"), "expected empty-error, got: {err}");
+        let err = parse_repeat_interval("   ").unwrap_err();
+        assert!(err.contains("empty"), "expected empty-error, got: {err}");
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_zero() {
+        // A zero interval would busy-loop the scheduler.
+        let err = parse_repeat_interval("0s").unwrap_err();
+        assert!(
+            err.contains("greater than zero"),
+            "expected zero-error, got: {err}"
+        );
+        let err = parse_repeat_interval("0h").unwrap_err();
+        assert!(err.contains("greater than zero"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_missing_unit() {
+        let err = parse_repeat_interval("30").unwrap_err();
+        assert!(
+            err.to_lowercase().contains("unit"),
+            "expected unit-error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_missing_value() {
+        // "s" alone — split point at index 0 → leading-non-digit error.
+        let err = parse_repeat_interval("s").unwrap_err();
+        assert!(
+            err.contains("positive integer"),
+            "expected leading-digit error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_negative() {
+        // The leading `-` is non-digit; trips the "must start with positive integer"
+        // branch. We don't accept negatives at all.
+        let err = parse_repeat_interval("-1h").unwrap_err();
+        assert!(
+            err.contains("positive integer"),
+            "expected leading-digit error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_fractional() {
+        // "1.5h" — the `.` is non-digit, so we split into "1" + ".5h" and the
+        // unit ".5h" doesn't match s/m/h.
+        let err = parse_repeat_interval("1.5h").unwrap_err();
+        assert!(
+            err.to_lowercase().contains("unit"),
+            "expected unit-error for fractional input, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_unknown_unit() {
+        for bad in &["30d", "1y", "1w", "30sec", "1hr", "10ms"] {
+            let err = parse_repeat_interval(bad).unwrap_err();
+            assert!(
+                err.to_lowercase().contains("unit") || err.to_lowercase().contains("unsupported"),
+                "expected unit-error for {bad:?}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_overflow() {
+        // u64::MAX seconds * 3600 obviously overflows; we should bubble that up
+        // as a clean "too large" error, not panic.
+        let err = parse_repeat_interval("18446744073709551615h").unwrap_err();
+        assert!(
+            err.contains("too large") || err.contains("invalid"),
+            "expected overflow-error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_repeat_interval_rejects_garbage() {
+        for bad in &["abc", "1h2m", "h1", "1 h", " ", "0"] {
+            assert!(
+                parse_repeat_interval(bad).is_err(),
+                "expected error for {bad:?}"
+            );
+        }
+    }
+
+    // ---- Flag-precedence: repeat_implies_no_done_warning ----
+
+    #[test]
+    fn test_warning_fires_when_repeat_alone() {
+        // --repeat 1h with neither --no-done nor --done: warning + contract OFF.
+        let msg = repeat_implies_no_done_warning(Some("1h"), false, None);
+        assert!(msg.is_some(), "expected warning when --repeat is alone");
+        let text = msg.unwrap();
+        assert!(text.contains("--repeat"));
+        assert!(text.contains("--no-done"));
+        assert!(text.contains("DONE marker"));
+    }
+
+    #[test]
+    fn test_warning_suppressed_when_no_done_explicit() {
+        // User already opted out — no need to warn them.
+        let msg = repeat_implies_no_done_warning(Some("1h"), true, None);
+        assert!(
+            msg.is_none(),
+            "explicit --no-done must suppress the warning, got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn test_warning_suppressed_when_done_path_provided() {
+        // --done <path> overrides --repeat's implicit --no-done; no warning.
+        let msg = repeat_implies_no_done_warning(Some("1h"), false, Some("DONE.md"));
+        assert!(
+            msg.is_none(),
+            "--done <path> must suppress the warning, got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn test_warning_silent_without_repeat() {
+        // Plain `clud loop "task"` without --repeat: helper never warns.
+        let msg = repeat_implies_no_done_warning(None, false, None);
+        assert!(msg.is_none());
+        let msg = repeat_implies_no_done_warning(None, true, None);
+        assert!(msg.is_none());
+        let msg = repeat_implies_no_done_warning(None, false, Some("DONE.md"));
+        assert!(msg.is_none());
+    }
+
+    // ---- Flag-precedence: contract / loop_markers behavior in plan ----
+
+    #[test]
+    fn test_loop_explicit_no_done_honored_without_repeat() {
+        // Without --repeat, --no-done still suppresses the contract — this is
+        // the original #2 behavior preserved. Already covered by
+        // test_loop_no_done_omits_contract above; we add an explicit assert
+        // that loop_markers is None to make the contract crystal clear.
+        let p = plan(&["clud", "loop", "--no-done", "task"]);
+        assert!(p.loop_markers.is_none());
+        assert!(p.repeat_schedule.is_none());
+        let prompt = prompt_from_plan(&p);
+        assert!(!prompt.contains("DONE"));
+        assert!(!prompt.contains("BLOCKED"));
+    }
+
+    #[test]
+    fn test_loop_repeat_with_explicit_no_done_still_omits_contract() {
+        // Belt-and-suspenders: passing both --repeat and --no-done is
+        // idempotent — no contract injection, no markers.
+        let p = plan(&["clud", "loop", "--repeat", "30m", "--no-done", "task"]);
+        assert!(p.loop_markers.is_none());
+        assert_eq!(
+            p.repeat_schedule.as_ref().map(|s| s.interval_secs),
+            Some(30 * 60)
+        );
+        let prompt = prompt_from_plan(&p);
+        assert_eq!(prompt, "task");
+    }
+
+    #[test]
+    fn test_loop_done_path_uses_supplied_path_in_prompt() {
+        // --done <path> must thread the *supplied* path into the prompt
+        // contract, not the default `.clud/loop/DONE`.
+        let p = plan(&["clud", "loop", "--done", "custom/DONE.txt", "task"]);
+        let prompt = prompt_from_plan(&p);
+        assert!(
+            prompt.contains("custom/DONE.txt"),
+            "prompt missing custom DONE path: {prompt}"
+        );
+        // BLOCKED is derived from the DONE filename's extension (issue #61).
+        assert!(prompt.contains("custom/BLOCKED.txt"));
+        assert!(p.loop_markers.is_some());
+        let markers = p.loop_markers.unwrap();
+        assert!(markers.done_path.ends_with("DONE.txt"));
+        assert!(markers.blocked_path.ends_with("BLOCKED.txt"));
+    }
+
+    #[test]
+    fn test_loop_repeat_30s_parses() {
+        let p = plan(&["clud", "loop", "--repeat", "30s", "task"]);
+        assert_eq!(
+            p.repeat_schedule.as_ref().map(|s| s.interval_secs),
+            Some(30)
+        );
+    }
+
+    #[test]
+    fn test_loop_repeat_5m_parses() {
+        let p = plan(&["clud", "loop", "--repeat", "5m", "task"]);
+        assert_eq!(
+            p.repeat_schedule.as_ref().map(|s| s.interval_secs),
+            Some(5 * 60)
+        );
+    }
+
+    #[test]
+    fn test_loop_repeat_24h_parses() {
+        let p = plan(&["clud", "loop", "--repeat", "24h", "task"]);
+        assert_eq!(
+            p.repeat_schedule.as_ref().map(|s| s.interval_secs),
+            Some(24 * 60 * 60)
+        );
+    }
+
+    // ---- Scheduler: next-run computation + no-overlap invariant ----
+
+    #[test]
+    fn test_next_run_at_millis_basic() {
+        // Run completed at t=10000 ms with a 30s interval → next run at t=40000 ms.
+        assert_eq!(next_run_at_millis(10_000, 30), 40_000);
+        assert_eq!(next_run_at_millis(0, 1), 1_000);
+        assert_eq!(next_run_at_millis(0, 3600), 3_600_000);
+    }
+
+    #[test]
+    fn test_next_run_at_millis_long_run_pushes_schedule_out() {
+        // The no-overlap invariant in numerical form: if a run that started at
+        // t=0 takes 10 minutes (600_000 ms) and the interval is 1 minute
+        // (60 s), the next run is scheduled at completion + interval = 660_000 ms,
+        // *not* at 60_000 ms. Runs serialize; they never overlap.
+        let started_at = 0u64;
+        let duration_ms = 10 * 60 * 1000; // 10-minute run
+        let interval_secs = 60; // 1-minute repeat
+        let completed_at = started_at + duration_ms;
+        let next = next_run_at_millis(completed_at, interval_secs);
+        assert_eq!(
+            next,
+            completed_at + 60_000,
+            "next run must be `interval` after completion, never overlapping the previous run"
+        );
+        assert!(
+            next > started_at + (interval_secs * 1000),
+            "long-running iteration must push the schedule past the original interval"
+        );
+    }
+
+    #[test]
+    fn test_next_run_at_millis_short_run_respects_full_interval() {
+        // A 1-second run with a 60-second repeat still waits the full minute
+        // after completion before re-running.
+        let completed_at = 1_000u64;
+        let next = next_run_at_millis(completed_at, 60);
+        assert_eq!(next, 61_000);
+    }
+
+    #[test]
+    fn test_next_run_at_millis_saturates_on_overflow() {
+        // Pathological inputs must not panic — the daemon uses saturating
+        // arithmetic so we mirror it here.
+        assert_eq!(next_run_at_millis(u64::MAX, 1), u64::MAX);
+        assert_eq!(next_run_at_millis(u64::MAX - 1, 3600), u64::MAX);
+        assert_eq!(next_run_at_millis(0, u64::MAX), u64::MAX);
+    }
+
+    /// Higher-level scheduler simulation. Models the inner loop of
+    /// `run_repeat_worker` with synthetic clocks: the scheduler issues a
+    /// single run at a time, only sleeping between completions. This is a
+    /// pure-Rust simulation — we never spawn a real process — but it
+    /// exercises the same arithmetic the daemon uses.
+    fn simulate_repeat(
+        start_ms: u64,
+        run_durations_ms: &[u64],
+        interval_secs: u64,
+    ) -> Vec<(u64, u64)> {
+        // Returns Vec<(start_ms, end_ms)> for each iteration.
+        let mut now = start_ms;
+        let mut runs = Vec::new();
+        for &dur in run_durations_ms {
+            let started = now;
+            let ended = started + dur;
+            runs.push((started, ended));
+            now = next_run_at_millis(ended, interval_secs);
+        }
+        runs
+    }
+
+    #[test]
+    fn test_scheduler_first_run_is_immediate() {
+        let runs = simulate_repeat(1_000, &[5_000], 60);
+        // First run starts at start_ms exactly — no pre-sleep.
+        assert_eq!(runs[0].0, 1_000);
+        assert_eq!(runs[0].1, 6_000);
+    }
+
+    #[test]
+    fn test_scheduler_second_run_starts_interval_after_first_completes() {
+        // Two short runs, 60s interval — second must start at first.end + 60s.
+        let runs = simulate_repeat(0, &[1_000, 1_000], 60);
+        assert_eq!(runs.len(), 2);
+        let (first_start, first_end) = runs[0];
+        let (second_start, _) = runs[1];
+        assert_eq!(first_start, 0);
+        assert_eq!(first_end, 1_000);
+        assert_eq!(second_start, first_end + 60_000);
+    }
+
+    #[test]
+    fn test_scheduler_long_run_delays_second_run_no_overlap() {
+        // First run takes 5 minutes; interval is 1 minute; second run must
+        // NOT have overlapped the first.
+        let interval = 60;
+        let runs = simulate_repeat(0, &[5 * 60 * 1000, 1_000], interval);
+        let (_first_start, first_end) = runs[0];
+        let (second_start, _) = runs[1];
+        assert_eq!(first_end, 5 * 60 * 1000);
+        assert_eq!(
+            second_start,
+            first_end + interval * 1000,
+            "second run start must be after first completion + interval"
+        );
+        assert!(
+            second_start >= first_end,
+            "no-overlap invariant violated: second run started before first finished"
+        );
+    }
+
+    #[test]
+    fn test_scheduler_only_one_active_run_per_job() {
+        // The simulation is inherently single-active by construction (each
+        // iteration is processed sequentially). Assert that the runs are
+        // strictly non-overlapping and strictly monotonic in time.
+        let runs = simulate_repeat(0, &[100, 200, 50, 1_000], 30);
+        for window in runs.windows(2) {
+            let (_a_start, a_end) = window[0];
+            let (b_start, _b_end) = window[1];
+            assert!(
+                b_start >= a_end,
+                "runs overlapped: {:?} into {:?}",
+                window[0],
+                window[1]
+            );
+        }
+        // And each run's own end is after its start.
+        for (start, end) in runs {
+            assert!(end >= start);
+        }
+    }
+
+    #[test]
+    fn test_scheduler_3600s_interval_matches_1h_input() {
+        // Cross-check between parse + scheduler: the seconds returned by
+        // parse_repeat_interval drop directly into next_run_at_millis.
+        let secs = parse_repeat_interval("1h").unwrap();
+        assert_eq!(secs, 3600);
+        let next = next_run_at_millis(0, secs);
+        assert_eq!(next, 3_600_000);
     }
 }

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -23,6 +23,7 @@ use crate::capture::TerminalCapture;
 use crate::command::LaunchPlan;
 use crate::subprocess;
 use crate::trampoline;
+use crate::win_creation_flags::invisible_helper_creationflags;
 
 const ENV_FEATURE_FLAG: &str = "CLUD_EXPERIMENTAL_DAEMON";
 const ENV_STATE_DIR: &str = "CLUD_DAEMON_STATE_DIR";
@@ -1386,7 +1387,11 @@ fn daemon_create_session(
         env: Some(std::env::vars().collect()),
         capture: false,
         stderr_mode: StderrMode::Stdout,
-        creationflags: None,
+        // Issue #55: daemon-helper worker spawn — invisible by design.
+        // stdio is `Null` and the user never sees this child's output
+        // directly (output is forwarded via TCP to attaching clients),
+        // so suppress the conhost window on Windows. No-op elsewhere.
+        creationflags: invisible_helper_creationflags(),
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,
@@ -1720,7 +1725,12 @@ fn run_repeat_once(
         env: Some(child_env()),
         capture: true,
         stderr_mode: StderrMode::Stdout,
-        creationflags: None,
+        // Issue #55: repeat-job runs are invisible by design — stdio is
+        // captured into a TCP-broadcast log, the user never sees the
+        // child's console directly. Suppress the conhost window on
+        // Windows so each scheduled run doesn't pop a flash. No-op
+        // elsewhere.
+        creationflags: invisible_helper_creationflags(),
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,
@@ -1774,7 +1784,11 @@ fn start_subprocess_session(
         env: Some(child_env()),
         capture: true,
         stderr_mode: StderrMode::Stdout,
-        creationflags: None,
+        // Issue #55: daemon-managed subprocess session — stdio is fully
+        // piped and routed via TCP to attaching clients. The child's
+        // console would never be the user's interaction surface, so
+        // suppress the conhost window on Windows. No-op elsewhere.
+        creationflags: invisible_helper_creationflags(),
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -16,3 +16,4 @@ pub mod subprocess;
 pub mod trampoline;
 pub mod voice;
 pub mod wasm;
+pub mod win_creation_flags;

--- a/crates/clud-bin/src/loop_spec.rs
+++ b/crates/clud-bin/src/loop_spec.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use running_process_core::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
 
 use crate::subprocess;
+use crate::win_creation_flags::invisible_helper_creationflags;
 
 pub const LOOP_DIR: &str = ".clud/loop";
 pub const DONE_MARKER: &str = "DONE";
@@ -321,7 +322,11 @@ fn run_gh_capture(args: &[&str]) -> Result<(i32, String), String> {
         env: None,
         capture: true,
         stderr_mode: StderrMode::Stdout,
-        creationflags: None,
+        // Issue #55: `gh` invocation is a piped helper — output is
+        // captured and parsed; the user never interacts with this child's
+        // console. Suppress the conhost popup on Windows. No-op
+        // elsewhere.
+        creationflags: invisible_helper_creationflags(),
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -53,11 +53,9 @@ fn main() {
         ..
     }) = &args.command
     {
-        if let Some(msg) = command::repeat_implies_no_done_warning(
-            repeat.as_deref(),
-            *no_done,
-            done.as_deref(),
-        ) {
+        if let Some(msg) =
+            command::repeat_implies_no_done_warning(repeat.as_deref(), *no_done, done.as_deref())
+        {
             eprintln!("{}", msg);
         }
     }

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -47,15 +47,19 @@ fn main() {
     }
 
     if let Some(args::Command::Loop {
-        repeat: Some(_),
-        done: None,
-        no_done: false,
+        repeat,
+        done,
+        no_done,
         ..
     }) = &args.command
     {
-        eprintln!(
-            "[clud] warning: `--repeat` implies `--no-done`; DONE marker injection/checking is disabled."
-        );
+        if let Some(msg) = command::repeat_implies_no_done_warning(
+            repeat.as_deref(),
+            *no_done,
+            done.as_deref(),
+        ) {
+            eprintln!("{}", msg);
+        }
     }
 
     let interrupted = install_ctrl_c_flag();

--- a/crates/clud-bin/src/subprocess.rs
+++ b/crates/clud-bin/src/subprocess.rs
@@ -1,15 +1,36 @@
+//! Subprocess launch helpers.
+//!
+//! On Windows, Rust's `std::process::Command` cannot directly spawn `.cmd` /
+//! `.bat` files. Since Rust 1.77 (BatBadBat / CVE-2024-24576) the standard
+//! library refuses any batch invocation whose arguments don't round-trip
+//! losslessly through cmd.exe's idiosyncratic command-line parser; the visible
+//! failure mode is `failed to spawn process: batch file arguments are
+//! invalid`. That hits `clud --codex` because npm installs Codex as a `.cmd`
+//! shim at `C:\Users\<user>\AppData\Roaming\npm\codex.cmd` (see issue #59).
+//!
+//! The fix is to rewrite the launch as `cmd.exe /D /S /C "<bat-path>" <args>`
+//! so Windows is launching cmd.exe (a real `.exe`) and the batch invocation
+//! lives inside a shell command line where we control the quoting.
+//! `running-process-core` already provides exactly that wrapper via
+//! `CommandSpec::Shell`, which builds `cmd /D /S /C "<command>"` using
+//! `raw_arg` and therefore preserves our quoting verbatim.
+//!
+//! This module is the single place that decides whether a given backend argv
+//! needs the Windows batch rewrite. POSIX has no `.cmd` / `.bat` concept;
+//! every code path stays argv-based there.
+
 #[cfg(windows)]
 use std::path::Path;
 
 use running_process_core::CommandSpec;
 
-/// Convert an argv-style launch into the most compatible subprocess form for
+/// Translate an argv-style launch into the most compatible `CommandSpec` for
 /// the current platform.
 ///
-/// Windows `CreateProcess*` does not execute `.cmd` / `.bat` scripts directly;
-/// they must run through `cmd.exe`. `running-process-core` already provides a
-/// Windows shell path that wraps `cmd /D /S /C ...`, so batch wrappers are
-/// rendered as a shell command there while native executables stay argv-based.
+/// On Windows, when `argv[0]` is a `.cmd` / `.bat` script we route through
+/// `cmd.exe` (see module docs) by emitting [`CommandSpec::Shell`]. Native
+/// executables and every POSIX target stay as plain `Argv` so we keep the
+/// well-defined argv contract end-to-end.
 pub fn command_spec_for_subprocess(argv: Vec<String>) -> CommandSpec {
     #[cfg(windows)]
     if is_windows_batch_wrapper(argv.first().map(String::as_str)) {
@@ -19,6 +40,9 @@ pub fn command_spec_for_subprocess(argv: Vec<String>) -> CommandSpec {
     CommandSpec::Argv(argv)
 }
 
+/// True when `program` ends in `.cmd` or `.bat` (case-insensitive). Always
+/// false on non-Windows targets — POSIX never has to special-case batch
+/// wrappers.
 #[cfg(windows)]
 fn is_windows_batch_wrapper(program: Option<&str>) -> bool {
     let Some(program) = program else {
@@ -34,6 +58,23 @@ fn is_windows_batch_wrapper(program: Option<&str>) -> bool {
     )
 }
 
+/// Build the inner `<bat-path> <args>` command string that goes inside
+/// `cmd /D /S /C "..."`. Each token is quoted independently with
+/// [`quote_for_cmd`].
+///
+/// `running-process-core::shell_command` already prepends `cmd /D /S /C "`
+/// (and appends the matching close-quote) using `raw_arg`, so we only need
+/// to render the *contents* of that outer quoted region.
+///
+/// The flags it picks are intentional:
+///
+/// * `/D` skips `AutoRun` so a user `cmd.exe /K ...` registry key cannot
+///   inject extra commands ahead of ours.
+/// * `/S` makes cmd's quote handling predictable: the *outermost* `"..."`
+///   pair is stripped verbatim and what's inside is parsed as a normal
+///   command line. Without `/S`, cmd applies a different "first-and-last
+///   quote on the line" rule that breaks on paths with spaces.
+/// * `/C` runs the command and exits.
 #[cfg(windows)]
 fn render_windows_batch_command(argv: &[String]) -> String {
     argv.iter()
@@ -42,14 +83,31 @@ fn render_windows_batch_command(argv: &[String]) -> String {
         .join(" ")
 }
 
+/// Quote one argv token for cmd.exe.
+///
+/// Strategy: wrap the token in `"..."` and escape the two characters that
+/// matter inside a double-quoted region:
+///
+/// * `"` → `""`. Inside a quoted block, cmd.exe treats a doubled quote as a
+///   single embedded literal quote.
+/// * `%` → `%%`. cmd.exe expands `%FOO%` *before* it strips the outer
+///   quotes, even inside `"..."`. Doubling the `%` defangs that pass.
+///
+/// Other shell metacharacters (`& | < > ^ ( ) ;`) only matter outside quotes;
+/// once the whole argument is wrapped in `"..."`, cmd treats them as literal
+/// bytes and forwards them to the batch file unchanged.
+///
+/// `!` is special only when delayed expansion is enabled (`setlocal
+/// enabledelayedexpansion`), which is off by default. We intentionally do not
+/// escape it: doing so would corrupt prompts that legitimately contain `!`,
+/// and a `.cmd` shim that turned delayed expansion on for itself would
+/// already break in the same way regardless of how we quote.
 #[cfg(windows)]
 fn quote_for_cmd(arg: &str) -> String {
     let mut out = String::with_capacity(arg.len() + 2);
     out.push('"');
     for ch in arg.chars() {
         match ch {
-            // Prevent cmd.exe from treating `%FOO%` as env expansion before the
-            // batch wrapper receives the argument.
             '%' => out.push_str("%%"),
             '"' => out.push_str("\"\""),
             _ => out.push(ch),
@@ -75,38 +133,194 @@ mod tests {
         }
     }
 
+    // ---- Windows-only: `.cmd` / `.bat` wrapping (issue #59) ----
+    //
+    // We expect every Windows batch backend to come out as a `Shell` spec
+    // that running-process-core will hand to `cmd /D /S /C "..."`.
+
     #[cfg(windows)]
     #[test]
-    fn cmd_wrapper_uses_shell_command() {
-        let spec = command_spec_for_subprocess(vec![
-            r"C:\Users\me\AppData\Roaming\npm\codex.cmd".into(),
-            "exec".into(),
-            "100% \"quoted\" prompt".into(),
-        ]);
+    fn cmd_wrapper_with_no_args_routes_through_shell() {
+        // Just the `.cmd` path with no extra args: the rendered command is
+        // simply the quoted exe path, which still has to go through cmd.exe.
+        let spec =
+            command_spec_for_subprocess(vec![r"C:\Users\me\AppData\Roaming\npm\codex.cmd".into()]);
         match spec {
             running_process_core::CommandSpec::Shell(command) => {
-                assert!(
-                    command.starts_with(r#""C:\Users\me\AppData\Roaming\npm\codex.cmd" "exec" "#),
-                    "unexpected shell command: {command}"
-                );
-                assert!(
-                    command.contains(r#""100%% ""quoted"" prompt""#),
-                    "percent signs and quotes must be escaped for cmd.exe: {command}"
-                );
+                assert_eq!(command, r#""C:\Users\me\AppData\Roaming\npm\codex.cmd""#);
             }
             other => panic!("expected Shell for .cmd wrapper, got {other:?}"),
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cmd_wrapper_quotes_args_with_spaces() {
+        let spec = command_spec_for_subprocess(vec![
+            r"C:\path with spaces\codex.cmd".into(),
+            "exec".into(),
+            "hello world".into(),
+        ]);
+        let rendered = match spec {
+            running_process_core::CommandSpec::Shell(s) => s,
+            other => panic!("expected Shell, got {other:?}"),
+        };
+        assert!(
+            rendered.starts_with(r#""C:\path with spaces\codex.cmd" "exec" "hello world""#),
+            "spaces in exe path and arg must each be wrapped in quotes: {rendered}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cmd_wrapper_escapes_shell_metacharacters() {
+        // `&`, `|`, `<`, `>`, `^` are cmd metacharacters outside quoted
+        // regions. Wrapping each token in `"..."` plus the outer
+        // `cmd /S /C "..."` rule keeps them literal so the batch file
+        // receives them byte-for-byte.
+        let spec = command_spec_for_subprocess(vec![
+            r"C:\codex.cmd".into(),
+            "fix this & that".into(),
+            "left | right".into(),
+            "redirect < input > output".into(),
+            "caret ^ stays".into(),
+        ]);
+        let rendered = match spec {
+            running_process_core::CommandSpec::Shell(s) => s,
+            other => panic!("expected Shell, got {other:?}"),
+        };
+        assert!(
+            rendered.contains(r#""fix this & that""#),
+            "& must stay inside quotes: {rendered}"
+        );
+        assert!(
+            rendered.contains(r#""left | right""#),
+            "| must stay inside quotes: {rendered}"
+        );
+        assert!(
+            rendered.contains(r#""redirect < input > output""#),
+            "redirection chars must stay inside quotes: {rendered}"
+        );
+        assert!(
+            rendered.contains(r#""caret ^ stays""#),
+            "^ must stay inside quotes: {rendered}"
+        );
+        // Sanity: there must be no occurrence of an unescaped metacharacter
+        // appearing *outside* the quoted regions. We approximate this by
+        // checking that every metachar shows up only between matching quotes.
+        for needle in ["&", "|", "<", ">", "^"] {
+            // Each needle should appear at least once (it's in our input);
+            // the surrounding `" `... `"` from the join contract is the
+            // assurance it stays inside.
+            assert!(
+                rendered.contains(needle),
+                "expected `{needle}` to appear in rendered command: {rendered}"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn cmd_wrapper_escapes_percent_and_quote() {
+        // `%` would otherwise expand env vars before the batch sees it; `"`
+        // needs to be doubled to embed inside a quoted token.
+        let spec = command_spec_for_subprocess(vec![
+            r"C:\codex.cmd".into(),
+            "exec".into(),
+            r#"100% "quoted" prompt"#.into(),
+        ]);
+        let rendered = match spec {
+            running_process_core::CommandSpec::Shell(s) => s,
+            other => panic!("expected Shell, got {other:?}"),
+        };
+        assert!(
+            rendered.contains(r#""100%% ""quoted"" prompt""#),
+            "percent and quote escaping is wrong: {rendered}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn bat_extension_is_also_wrapped() {
+        // The check is case-insensitive: `.BAT`, `.Cmd`, etc. all have to
+        // hit the cmd.exe path.
+        let spec = command_spec_for_subprocess(vec![r"C:\tools\thing.BAT".into(), "go".into()]);
+        match spec {
+            running_process_core::CommandSpec::Shell(_) => {}
+            other => panic!("expected Shell for .BAT wrapper, got {other:?}"),
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn exe_path_is_not_wrapped() {
+        // `.exe` is a native executable; it must stay argv-based so we don't
+        // pay the cmd.exe parsing tax (and don't regress any quoting that
+        // already worked for non-batch backends).
+        let spec = command_spec_for_subprocess(vec![
+            r"C:\Program Files\Tool\codex.exe".into(),
+            "exec".into(),
+            "hello".into(),
+        ]);
+        match spec {
+            running_process_core::CommandSpec::Argv(argv) => {
+                assert_eq!(
+                    argv,
+                    vec![r"C:\Program Files\Tool\codex.exe", "exec", "hello"],
+                    ".exe paths must not be cmd-wrapped"
+                );
+            }
+            other => panic!("expected Argv passthrough for .exe, got {other:?}"),
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn extensionless_path_is_not_wrapped() {
+        // PATH lookup may hand us a bare program name on Windows too (e.g.
+        // for .exe files where the extension was already stripped by an
+        // earlier resolver). These must not be wrapped.
+        let spec = command_spec_for_subprocess(vec!["codex".into(), "exec".into()]);
+        match spec {
+            running_process_core::CommandSpec::Argv(argv) => {
+                assert_eq!(argv, vec!["codex", "exec"]);
+            }
+            other => panic!("expected Argv for extensionless path, got {other:?}"),
         }
     }
 
     #[cfg(not(windows))]
     #[test]
     fn cmd_suffix_is_not_special_off_windows() {
+        // POSIX doesn't have batch wrappers; even a file literally named
+        // `foo.cmd` is just an executable, and we must not invent a cmd.exe
+        // dependency on Linux/macOS.
         let spec = command_spec_for_subprocess(vec!["codex.cmd".into(), "exec".into()]);
         match spec {
             running_process_core::CommandSpec::Argv(argv) => {
                 assert_eq!(argv, vec!["codex.cmd", "exec"]);
             }
             other => panic!("expected Argv off Windows, got {other:?}"),
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn shell_script_path_is_not_wrapped() {
+        // `.sh` and extensionless POSIX paths must always pass through.
+        let spec = command_spec_for_subprocess(vec!["./run.sh".into(), "--flag".into()]);
+        match spec {
+            running_process_core::CommandSpec::Argv(argv) => {
+                assert_eq!(argv, vec!["./run.sh", "--flag"]);
+            }
+            other => panic!("expected Argv for .sh script, got {other:?}"),
+        }
+        let spec = command_spec_for_subprocess(vec!["/usr/bin/codex".into(), "exec".into()]);
+        match spec {
+            running_process_core::CommandSpec::Argv(argv) => {
+                assert_eq!(argv, vec!["/usr/bin/codex", "exec"]);
+            }
+            other => panic!("expected Argv for extensionless path, got {other:?}"),
         }
     }
 }

--- a/crates/clud-bin/src/win_creation_flags.rs
+++ b/crates/clud-bin/src/win_creation_flags.rs
@@ -90,7 +90,10 @@ mod tests {
         // hands to running-process-core.
         assert_eq!(invisible_helper_creationflags(), Some(0x0800_0000));
         // Both helpers must agree on the bit pattern.
-        assert_eq!(invisible_helper_creationflags(), Some(invisible_helper_flags()));
+        assert_eq!(
+            invisible_helper_creationflags(),
+            Some(invisible_helper_flags())
+        );
     }
 
     #[test]

--- a/crates/clud-bin/src/win_creation_flags.rs
+++ b/crates/clud-bin/src/win_creation_flags.rs
@@ -1,0 +1,134 @@
+//! Windows `CREATE_NO_WINDOW` helper for invisible daemon-helper spawns.
+//!
+//! Background — issue #55: on Windows, when `clud` runs as a parent that
+//! spawns daemon helper / worker / repeat-job subprocesses with fully piped
+//! stdio, Windows still allocates a console for each child unless we opt
+//! out via `CREATE_NO_WINDOW` (`0x0800_0000`). Each allocation is a
+//! visible conhost flash that steals focus from the developer's window
+//! during the integration test suite (and in production when running
+//! `clud --detach` on Windows).
+//!
+//! This helper is intentionally **opt-in**: only daemon-side spawns whose
+//! stdio is fully piped or null should call it. The user-facing
+//! `run_plan_subprocess` path in `main.rs` inherits the parent's console
+//! (so no new window is created) and must NOT be touched — the user
+//! actually wants to see that child's output. The PTY path goes through
+//! ConPTY, which manages its own pseudo-console and does not pop a window.
+//!
+//! On non-Windows platforms the value is `0`, making
+//! `creationflags: Some(invisible_helper_flags())` a portable no-op.
+
+/// Bit value of the Windows `CREATE_NO_WINDOW` process creation flag.
+///
+/// See <https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags>.
+#[cfg(windows)]
+pub const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Returns the creation-flags bitmask to apply to a daemon-helper spawn so
+/// that it does not pop a visible console window. On non-Windows, returns
+/// `0` (callers can pass it unconditionally).
+pub fn invisible_helper_flags() -> u32 {
+    #[cfg(windows)]
+    {
+        CREATE_NO_WINDOW
+    }
+    #[cfg(not(windows))]
+    {
+        0
+    }
+}
+
+/// `Some(CREATE_NO_WINDOW)` on Windows, `None` elsewhere — the shape that
+/// `running_process_core::ProcessConfig::creationflags` expects. Using
+/// `None` off-Windows lets the running-process-core priority-flag
+/// short-circuit stay intact (passing `Some(0)` would also work, but is
+/// semantically misleading).
+pub fn invisible_helper_creationflags() -> Option<u32> {
+    #[cfg(windows)]
+    {
+        Some(CREATE_NO_WINDOW)
+    }
+    #[cfg(not(windows))]
+    {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn create_no_window_value_matches_winapi() {
+        // Sanity: must be exactly 0x0800_0000 — that's the documented
+        // CREATE_NO_WINDOW bit (see Microsoft `winbase.h`). Anchoring the
+        // literal here means a refactor that quietly flips a digit fails
+        // CI instead of silently re-popping consoles in production.
+        assert_eq!(CREATE_NO_WINDOW, 0x0800_0000);
+        assert_eq!(invisible_helper_flags(), 0x0800_0000);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn invisible_helper_flags_is_zero_off_windows() {
+        // Spreading `creation_flags(invisible_helper_flags())` into a
+        // `std::process::Command` on Linux/macOS must be a true no-op:
+        // the bit pattern is zero, so `creation_flags(0)` leaves the
+        // `Command` semantically untouched. The `creationflags` field on
+        // `ProcessConfig` is `Option<u32>` and we return `None` to hit
+        // running-process-core's "no override" short-circuit.
+        assert_eq!(invisible_helper_flags(), 0);
+        assert!(invisible_helper_creationflags().is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn invisible_helper_creationflags_is_some_on_windows() {
+        // The Option<u32> form mirrors `ProcessConfig::creationflags`.
+        // `Some(CREATE_NO_WINDOW)` is what every daemon-helper spawn site
+        // hands to running-process-core.
+        assert_eq!(invisible_helper_creationflags(), Some(0x0800_0000));
+        // Both helpers must agree on the bit pattern.
+        assert_eq!(invisible_helper_creationflags(), Some(invisible_helper_flags()));
+    }
+
+    #[test]
+    fn invisible_helper_flags_does_not_collide_with_create_new_process_group() {
+        // CREATE_NEW_PROCESS_GROUP = 0x0000_0200. The two flags are
+        // independent and can be OR'd together — daemon helpers that
+        // need both (none today, but the Python test harness's Ctrl+Break
+        // tests do) must compose correctly without losing either bit.
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        let combined = invisible_helper_flags() | CREATE_NEW_PROCESS_GROUP;
+        assert_eq!(
+            combined & CREATE_NEW_PROCESS_GROUP,
+            CREATE_NEW_PROCESS_GROUP
+        );
+        #[cfg(windows)]
+        assert_eq!(combined & CREATE_NO_WINDOW, CREATE_NO_WINDOW);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn invisible_helper_flags_does_not_collide_with_detached_process() {
+        // DETACHED_PROCESS = 0x0000_0008. The trampoline uses this for the
+        // self-spawned daemon launch. CREATE_NO_WINDOW is reserved for the
+        // *child-process* helper paths; it is mutually meaningful with
+        // DETACHED_PROCESS but the bits don't overlap, so anyone composing
+        // them in the future won't lose either signal.
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        assert_eq!(invisible_helper_flags() & DETACHED_PROCESS, 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn invisible_helper_flags_is_idempotent_under_repeated_or() {
+        // OR'ing the same bit twice yields the same value — important
+        // because some call sites build `creationflags` incrementally and
+        // we don't want a future maintainer worrying about double-applies.
+        let once = invisible_helper_flags();
+        let twice = once | invisible_helper_flags();
+        assert_eq!(once, twice);
+    }
+}

--- a/tests/_subprocess_helpers.py
+++ b/tests/_subprocess_helpers.py
@@ -1,0 +1,68 @@
+"""Cross-platform subprocess-launch helpers shared by tests.
+
+Lives outside ``conftest.py`` so it can be imported as a regular module from
+both the integration-test conftest *and* lightweight unit tests that exist
+purely to assert the helper's contract on each platform — see issue #55.
+
+Keeping the helper here (rather than inline in ``conftest.py``) means a
+single source of truth for the Windows ``CREATE_NO_WINDOW`` value the suite
+applies to spawned subprocesses, and lets POSIX CI cover the no-op branch
+without needing the integration harness to be enabled.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+# Documented value of the Win32 ``CREATE_NO_WINDOW`` process-creation flag.
+# We hard-code it here (rather than only relying on ``subprocess.CREATE_NO_WINDOW``)
+# so the unit test can assert the *exact* bit pattern even when the test is
+# running off-Windows where the attribute does not exist.
+CREATE_NO_WINDOW: int = 0x0800_0000
+
+
+def windows_no_window_flags() -> dict[str, int]:
+    """Return ``{"creationflags": CREATE_NO_WINDOW}`` on Windows, ``{}`` else.
+
+    Use this helper when launching a piped, non-interactive child process
+    from the test suite (or from any harness code that wants to suppress
+    Windows' default conhost allocation). On POSIX the returned dict is
+    empty, so spreading ``**windows_no_window_flags()`` into a
+    ``subprocess.Popen``/``subprocess.run`` call is a portable no-op.
+
+    See issue #55: every subprocess the integration suite spawns on Windows
+    (clud, mock agents, daemon helpers, attach clients) inherits Windows'
+    default of allocating a fresh console window — each one a visible flash
+    that steals focus from the developer's editor during a ``pytest`` run.
+    Setting CREATE_NO_WINDOW on the parent's CreateProcess call suppresses
+    the allocation for piped/non-interactive children without changing any
+    other launch semantics.
+    """
+    if sys.platform != "win32":
+        return {}
+    # ``getattr`` keeps the helper safe on hypothetical Python builds where
+    # ``subprocess.CREATE_NO_WINDOW`` was not exposed; the documented bit
+    # pattern is the source of truth.
+    return {"creationflags": getattr(subprocess, "CREATE_NO_WINDOW", CREATE_NO_WINDOW)}
+
+
+def add_windows_create_no_window(kwargs: dict) -> None:
+    """OR ``CREATE_NO_WINDOW`` into ``kwargs["creationflags"]`` on Windows.
+
+    The OR is deliberate: callers may already have set
+    ``CREATE_NEW_PROCESS_GROUP`` (e.g. tests that send ``CTRL_BREAK_EVENT``
+    to a child). The two flags are independent bits and compose without
+    affecting Ctrl+Break delivery or process-group semantics.
+
+    No-op on non-Windows platforms.
+    """
+    if sys.platform != "win32":
+        return
+    creationflags = kwargs.get("creationflags", 0)
+    if not isinstance(creationflags, int):
+        creationflags = 0
+    kwargs["creationflags"] = creationflags | getattr(
+        subprocess, "CREATE_NO_WINDOW", CREATE_NO_WINDOW
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,14 +71,23 @@ def _build_env_without_sccache() -> dict[str, str]:
     return env
 
 
-def _add_windows_create_no_window(kwargs: dict) -> None:
-    """Force child processes to start without a visible console on Windows."""
-    if sys.platform != "win32":
-        return
-    creationflags = kwargs.get("creationflags", 0)
-    if not isinstance(creationflags, int):
-        creationflags = 0
-    kwargs["creationflags"] = creationflags | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+# Re-export the canonical helpers from _subprocess_helpers so the unit-test
+# file at the top of `tests/` can import the same implementation that the
+# integration suite uses — issue #55. The helpers live in a regular module
+# (rather than inline here) because pytest treats `conftest.py` as a special
+# plugin file, which is awkward to import from arbitrary tests.
+#
+# pytest puts each `conftest.py`'s directory on `sys.path` automatically, so
+# a top-level `import _subprocess_helpers` resolves to the file in this
+# directory.
+from _subprocess_helpers import (  # type: ignore[import-not-found]  # noqa: E402
+    add_windows_create_no_window as _add_windows_create_no_window,
+)
+from _subprocess_helpers import (  # type: ignore[import-not-found]  # noqa: E402
+    windows_no_window_flags,
+)
+
+__all__ = ["windows_no_window_flags"]
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -86,7 +95,12 @@ def _suppress_windows_console_windows():
     """Hide console windows for integration-test subprocesses on Windows.
 
     The fixture is session-scoped so it applies to the build-time helpers as
-    well as the actual tests.
+    well as the actual tests. Issue #55: OR's CREATE_NO_WINDOW into every
+    ``subprocess.run`` / ``subprocess.Popen`` call regardless of any
+    explicit ``creationflags`` the caller passed (e.g. Ctrl+Break tests
+    that need ``CREATE_NEW_PROCESS_GROUP``). The two flags are independent
+    bits and compose; suppressing the window does not affect signal
+    delivery or process-group semantics.
     """
     if sys.platform != "win32":
         yield
@@ -98,16 +112,19 @@ def _suppress_windows_console_windows():
 
     def run(*args, **kwargs):
         kwargs = dict(kwargs)
+        # Issue #55: always add CREATE_NO_WINDOW (OR'd with any caller-set
+        # creationflags) — the previous version skipped this when
+        # creationflags was explicit, leaving Ctrl+Break test launches
+        # popping windows.
         _add_windows_create_no_window(kwargs)
         return original_run(*args, **kwargs)
 
     def popen(*args, **kwargs):
         kwargs = dict(kwargs)
-        # Keep process-group semantics intact for Ctrl+Break tests that already
-        # request CREATE_NEW_PROCESS_GROUP; only suppress the window for the
-        # ordinary noninteractive launches.
-        if "creationflags" not in kwargs:
-            _add_windows_create_no_window(kwargs)
+        # Issue #55: same fix as `run` above. CREATE_NEW_PROCESS_GROUP and
+        # CREATE_NO_WINDOW are independent bits and may be OR'd together
+        # without affecting Ctrl+Break delivery.
+        _add_windows_create_no_window(kwargs)
         return original_popen(*args, **kwargs)
 
     patch.setattr(subprocess, "run", run)

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -256,6 +256,37 @@ def test_dry_run_loop_repeat_implies_no_done() -> None:
     assert data["repeat_interval_secs"] == 3600
 
 
+def test_dry_run_loop_repeat_emits_warning_to_stderr() -> None:
+    # Issue #61 acceptance: when `--repeat` is supplied without `--done`, the
+    # CLI must tell the user it's auto-disabling DONE-marker injection.
+    result = _run("--dry-run", "loop", "--repeat", "1h", "do stuff")
+    assert result.returncode == 0
+    assert "--repeat" in result.stderr
+    assert "--no-done" in result.stderr
+    assert "DONE marker" in result.stderr
+
+
+def test_dry_run_loop_repeat_with_done_path_no_warning() -> None:
+    # Issue #61: --done <path> overrides the implicit --no-done; no warning.
+    result = _run("--dry-run", "loop", "--repeat", "1h", "--done", "DONE.md", "do stuff")
+    assert result.returncode == 0
+    assert "implies `--no-done`" not in result.stderr
+
+
+def test_dry_run_loop_repeat_with_explicit_no_done_no_warning() -> None:
+    # Issue #61: explicit --no-done already opted out; don't badger the user.
+    result = _run("--dry-run", "loop", "--repeat", "1h", "--no-done", "do stuff")
+    assert result.returncode == 0
+    assert "implies `--no-done`" not in result.stderr
+
+
+def test_dry_run_loop_no_repeat_no_warning() -> None:
+    # Issue #61: plain `clud loop` without --repeat must not emit the warning.
+    result = _run("--dry-run", "loop", "do stuff")
+    assert result.returncode == 0
+    assert "implies `--no-done`" not in result.stderr
+
+
 def test_dry_run_loop_repeat_with_done_override() -> None:
     result = _run("--dry-run", "loop", "--repeat", "1h", "--done", "DONE.md", "do stuff")
     assert result.returncode == 0
@@ -265,6 +296,14 @@ def test_dry_run_loop_repeat_with_done_override() -> None:
     assert "BLOCKED.md" in prompt
     assert data["loop_markers"]["done_path"].replace("\\", "/").endswith("DONE.md")
     assert data["loop_markers"]["blocked_path"].replace("\\", "/").endswith("BLOCKED.md")
+
+
+def test_dry_run_loop_repeat_invalid_duration_errors() -> None:
+    # Issue #61: bogus duration values must fail with a clear error and a
+    # non-zero exit code, not crash or silently succeed.
+    result = _run("--dry-run", "loop", "--repeat", "30d", "do stuff")
+    assert result.returncode != 0
+    assert "invalid --repeat" in result.stderr or "unsupported" in result.stderr.lower()
 
 
 def test_dry_run_loop_default_count() -> None:

--- a/tests/test_windows_no_window_flags.py
+++ b/tests/test_windows_no_window_flags.py
@@ -1,0 +1,185 @@
+"""Unit tests for the Windows ``CREATE_NO_WINDOW`` test-suite helpers.
+
+Issue #55: the integration suite spawned a small flotilla of clud / mock /
+daemon-helper subprocesses, and on Windows each one popped a console
+window that stole focus from the developer's editor. The fix is a small
+helper (``windows_no_window_flags`` / ``add_windows_create_no_window``)
+that the suite threads into every spawn, gated on ``sys.platform ==
+"win32"``.
+
+These tests cover the helper's contract in isolation so it can be
+validated on POSIX CI without enabling the integration harness — and so a
+regression that flips the bit pattern (or turns the POSIX no-op into a
+no-op-but-with-a-key) gets caught at the cheapest layer.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# `tests/conftest.py` has no sibling `tests/__init__.py`, so pytest puts
+# `tests/` on `sys.path` automatically; this import is a backstop in case
+# the test is collected via a different mechanism.
+_TESTS_DIR = Path(__file__).resolve().parent
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
+from _subprocess_helpers import (  # type: ignore[import-not-found]  # noqa: E402
+    CREATE_NO_WINDOW,
+    add_windows_create_no_window,
+    windows_no_window_flags,
+)
+
+
+# ---- windows_no_window_flags ------------------------------------------------
+
+
+def test_create_no_window_constant_matches_win32_documentation() -> None:
+    """The bit pattern is documented as 0x0800_0000 in winbase.h.
+
+    Anchoring it as a literal here means a typo'd refactor that quietly
+    flips a digit fails the build instead of silently allocating consoles
+    again on Windows runners.
+    """
+    assert CREATE_NO_WINDOW == 0x0800_0000
+
+
+def test_windows_no_window_flags_returns_empty_dict_on_posix() -> None:
+    """On macOS / Linux the helper must be a true no-op.
+
+    A non-empty dict here would either crash ``subprocess.Popen`` (which
+    rejects ``creationflags`` on POSIX) or silently shadow a future
+    POSIX-only kwarg the caller wanted to thread through. The helper's
+    whole point is to be safely spreadable cross-platform.
+    """
+    if sys.platform == "win32":
+        # On Windows we expect the OPPOSITE branch — see the dedicated
+        # Windows-only test below. Skipping here keeps each test single-
+        # purpose and easy to read in CI logs.
+        import pytest
+
+        pytest.skip("Windows-only: covered by test_windows_no_window_flags_returns_create_no_window_on_windows")
+    assert windows_no_window_flags() == {}
+
+
+def test_windows_no_window_flags_returns_create_no_window_on_windows() -> None:
+    """On Windows the helper returns exactly the documented flag bit.
+
+    We deliberately compare against the literal 0x0800_0000 (rather than
+    just ``subprocess.CREATE_NO_WINDOW``) so a future Python that exposed
+    a different value under the same name would still fail the test.
+    """
+    if sys.platform != "win32":
+        import pytest
+
+        pytest.skip("POSIX-only: covered by test_windows_no_window_flags_returns_empty_dict_on_posix")
+    flags = windows_no_window_flags()
+    assert set(flags.keys()) == {"creationflags"}
+    assert flags["creationflags"] == 0x0800_0000
+    # The stdlib constant should agree (sanity check on the host Python).
+    assert flags["creationflags"] == subprocess.CREATE_NO_WINDOW
+
+
+def test_windows_no_window_flags_can_be_spread_into_subprocess_kwargs() -> None:
+    """``**windows_no_window_flags()`` must compose with arbitrary kwargs.
+
+    Real call sites look like ``subprocess.Popen(..., **other,
+    **windows_no_window_flags())``. The helper must never fight existing
+    keys — its empty-dict POSIX branch must leave every other key alone.
+    """
+    base = {"text": True, "stdin": subprocess.PIPE}
+    merged = {**base, **windows_no_window_flags()}
+    assert merged["text"] is True
+    assert merged["stdin"] is subprocess.PIPE
+    if sys.platform == "win32":
+        assert merged["creationflags"] == 0x0800_0000
+    else:
+        assert "creationflags" not in merged
+
+
+# ---- add_windows_create_no_window ------------------------------------------
+
+
+def test_add_windows_create_no_window_is_noop_on_posix() -> None:
+    """The mutator helper must not touch kwargs on POSIX."""
+    if sys.platform == "win32":
+        import pytest
+
+        pytest.skip("Windows-only path covered separately")
+    kwargs: dict = {"shell": False}
+    add_windows_create_no_window(kwargs)
+    assert kwargs == {"shell": False}
+
+
+def test_add_windows_create_no_window_sets_flag_on_windows() -> None:
+    """When no creationflags is set, the helper installs CREATE_NO_WINDOW."""
+    if sys.platform != "win32":
+        import pytest
+
+        pytest.skip("Windows-only behavior")
+    kwargs: dict = {}
+    add_windows_create_no_window(kwargs)
+    assert kwargs == {"creationflags": 0x0800_0000}
+
+
+def test_add_windows_create_no_window_ors_with_existing_flag() -> None:
+    """Composing with CREATE_NEW_PROCESS_GROUP is a hard requirement.
+
+    Some integration tests deliver Ctrl+Break to children and need
+    ``CREATE_NEW_PROCESS_GROUP`` (0x0000_0200) on the spawn. The two
+    flags are independent bits and must compose — if the helper
+    overwrote ``creationflags`` instead of OR'ing, those tests would
+    silently lose their process-group semantics and the Ctrl+Break
+    delivery would land on the test runner instead.
+    """
+    if sys.platform != "win32":
+        import pytest
+
+        pytest.skip("Windows-only behavior")
+    create_new_process_group = 0x0000_0200
+    kwargs: dict = {"creationflags": create_new_process_group}
+    add_windows_create_no_window(kwargs)
+    expected = create_new_process_group | 0x0800_0000
+    assert kwargs["creationflags"] == expected
+    # Re-running the helper is idempotent — OR'ing the same bit twice is
+    # the same bit pattern.
+    add_windows_create_no_window(kwargs)
+    assert kwargs["creationflags"] == expected
+
+
+def test_add_windows_create_no_window_recovers_from_non_int_creationflags() -> None:
+    """Defensive: if a caller stuffed a non-int into creationflags the
+    helper resets to a clean bitfield instead of raising. This matches
+    the conftest's existing tolerance — better to suppress the popup
+    than abort the whole pytest session over a stray ``None``."""
+    if sys.platform != "win32":
+        import pytest
+
+        pytest.skip("Windows-only behavior")
+    kwargs: dict = {"creationflags": None}
+    add_windows_create_no_window(kwargs)
+    assert kwargs["creationflags"] == 0x0800_0000
+
+
+def test_add_windows_create_no_window_does_not_strip_other_kwargs() -> None:
+    """The helper must touch only ``creationflags``, leaving every other
+    Popen/run kwarg untouched (otherwise threading it through real call
+    sites would silently drop ``stdin`` / ``cwd`` / ``env`` etc.)."""
+    if sys.platform != "win32":
+        import pytest
+
+        pytest.skip("Windows-only behavior")
+    kwargs: dict = {
+        "stdin": subprocess.PIPE,
+        "cwd": "/tmp",
+        "env": {"FOO": "bar"},
+        "text": True,
+    }
+    add_windows_create_no_window(kwargs)
+    assert kwargs["stdin"] is subprocess.PIPE
+    assert kwargs["cwd"] == "/tmp"
+    assert kwargs["env"] == {"FOO": "bar"}
+    assert kwargs["text"] is True
+    assert kwargs["creationflags"] == 0x0800_0000


### PR DESCRIPTION
## Summary

Bundles three issues:

- **#59** — Windows: `clud --codex loop` failing to spawn `codex.cmd` ("batch file arguments are invalid"). Root cause is Rust 1.77's BatBadBat (CVE-2024-24576) refusal to launch `.cmd`/`.bat` with raw argv. Fix: on Windows, render the command through `cmd.exe /D /S /C` via `running-process-core`'s `CommandSpec::Shell` so quoting is preserved verbatim. PTY launch path deliberately unchanged (out of scope per task; documented as a latent risk if a user reports interactive `.cmd` failures).
- **#55** — Tests popping up console windows on Windows. Adds `crates/clud-bin/src/win_creation_flags.rs` with `invisible_helper_flags()` / `invisible_helper_creationflags()`, applied at four daemon-helper / capture spawn sites (`daemon::daemon_create_session`, `daemon::run_repeat_once`, `daemon::start_subprocess_session`, `loop_spec::run_gh_capture`). Python side: `tests/_subprocess_helpers.py` plus a session-autouse fixture in `tests/integration/conftest.py` that monkey-patches `subprocess.run` / `Popen` to OR in `CREATE_NO_WINDOW` for every spawn. Production console-inheriting launches (`run_plan_subprocess`, `run_plan_pty`) and the already-`DETACHED_PROCESS` trampoline are deliberately untouched.
- **#61** — `clud loop ... --repeat <duration>` with implied `--no-done` (warning to stderr) and `--done <path>` re-enabling marker handling. Most of the runtime feature was already in main from PR #62; this branch adds the comprehensive unit-test coverage the issue asks for: ~30 tests across duration parsing (every accepted form + rejection cases), flag precedence (`--repeat` → `--no-done`, `--done` re-enables, explicit `--no-done` honored, clap conflict between `--done` and `--no-done`), warning emission, and scheduler arithmetic (`next_run_at_millis`, no-overlap simulation).

## Commits

- `d61c229` — fix(windows): wrap .cmd/.bat backends through cmd.exe /C (#59)
- `b801928` — fix(windows): suppress test console popups via CREATE_NO_WINDOW (#55)
- `7d44576` — feat(loop): add --repeat scheduler with --no-done / --done <path> overrides (#61)
- `72612f2` — style: cargo fmt fixups for #55 and #61 commits

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -D warnings`, `ruff check` (run via `bash lint`)
- [ ] CI: `bash test` — all Rust + Python suites across all 6 platforms
- [ ] Manual: `clud --codex loop "..."` on a Windows host with codex installed via npm (resolves to `codex.cmd`) successfully spawns Codex
- [ ] Manual: `CLUD_INTEGRATION_TESTS=1 python -m pytest tests/integration/test_daemon_centralized.py -k "noninteractive_ctrl_c or concurrent_attach"` — no visible console popups
- [ ] Manual: `clud loop "review the repo for flaky tests" --repeat 1h` runs immediately, sleeps for ~1h, then runs again; warning about implied `--no-done` is printed to stderr; the job appears in `clud list`

## Notes

- Sub-agent that handled #61 attempted a SQLite-based "session registry" out of scope (referencing a non-existent issue #73). Those uncommitted changes were reverted before push; only the legitimate #61 unit-test work remains.
- Pyright IDE diagnostics for `if sys.platform == "win32"` branches and pytest autouse fixtures are noise (cross-platform code, fixture decorator-based registration). `bash lint` uses ruff, not pyright; CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)