### PR TITLE
fix(ci): clean up ruff lint errors in test_windows_no_window_flags

### DIFF
--- a/tests/test_windows_no_window_flags.py
+++ b/tests/test_windows_no_window_flags.py
@@ -32,7 +32,6 @@ from _subprocess_helpers import (  # type: ignore[import-not-found]  # noqa: E40
     windows_no_window_flags,
 )
 
-
 # ---- windows_no_window_flags ------------------------------------------------
 
 
@@ -60,7 +59,7 @@ def test_windows_no_window_flags_returns_empty_dict_on_posix() -> None:
         # purpose and easy to read in CI logs.
         import pytest
 
-        pytest.skip("Windows-only: covered by test_windows_no_window_flags_returns_create_no_window_on_windows")
+        pytest.skip("Windows-only: see returns_create_no_window_on_windows")
     assert windows_no_window_flags() == {}
 
 
@@ -74,7 +73,7 @@ def test_windows_no_window_flags_returns_create_no_window_on_windows() -> None:
     if sys.platform != "win32":
         import pytest
 
-        pytest.skip("POSIX-only: covered by test_windows_no_window_flags_returns_empty_dict_on_posix")
+        pytest.skip("POSIX-only: see returns_empty_dict_on_posix")
     flags = windows_no_window_flags()
     assert set(flags.keys()) == {"creationflags"}
     assert flags["creationflags"] == 0x0800_0000


### PR DESCRIPTION
## Summary

Fixes three ruff lint failures on `tests/test_windows_no_window_flags.py` that were breaking the Lint job across every platform on the parent branch (`feat/issues-59-55-61`).

CI run that triggered this fix: https://github.com/zackees/clud/actions/runs/24925980370

### Errors fixed

- **I001** (auto-fix): removed a stray blank line between the `_subprocess_helpers` import block and the section banner that ruff's import sorter flagged as un-formatted.
- **E501** at line 63 (was 112 > 100): shortened the Windows-branch `pytest.skip` message from the full sibling test name to its unique tail (`returns_create_no_window_on_windows`).
- **E501** at line 77 (was 102 > 100): same treatment for the POSIX-branch skip (`returns_empty_dict_on_posix`).

No test semantics change — only the human-readable skip strings and import-block whitespace are touched.

## Test plan

- [x] `ruff check tests/test_windows_no_window_flags.py` passes locally (`All checks passed!`)
- [x] `ruff check tests/` is clean for this file (one pre-existing I001 in `tests/_subprocess_helpers.py` is unrelated to this PR and lives on the base branch).
- [ ] CI Lint job (Windows / Linux / macOS) goes green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)