### PR TITLE
fix(ci): pin maturin to fix Linux Build asset-mismatch

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build sdist
         if: ${{ inputs.include-sdist }}
-        run: uv run soldr maturin sdist --out dist
+        run: uv run python -m maturin sdist --out dist
 
       - name: Verify Windows wheel has no MinGW runtime imports
         if: ${{ runner.os == 'Windows' }}

--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -36,9 +36,10 @@ def build_command(mode: BuildMode, env: dict[str, str] | None = None) -> list[st
             subcommand.extend(["--zig", "--compatibility", "manylinux2014"])
         else:
             subcommand.extend(["--compatibility", "pypi"])
-    # Route maturin through `soldr maturin ...` on Windows (issue #27) so the
-    # underlying cargo invocation uses the MSVC rustup toolchain, not whatever
-    # GNU-host cargo happens to be first on PATH.
+    # Use the dev-venv maturin via `python -m maturin`. The MSVC rustup-toolchain
+    # pin from issue #27 is preserved by `_windows_build_env` exporting CARGO/
+    # RUSTC/RUSTUP_TOOLCHAIN; routing maturin itself through soldr fails on
+    # Linux because PyO3/maturin only publishes musl Linux release assets.
     return maturin_argv(subcommand, env=env)
 
 

--- a/ci/env.py
+++ b/ci/env.py
@@ -269,15 +269,25 @@ def cargo_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list
 
 
 def maturin_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list[str]:
-    """Return the maturin argv, preferring `soldr maturin` on every platform.
+    """Return the maturin argv, always using the dev-venv install.
 
-    Mirrors `cargo_argv` — see issues #27 and #68. maturin invokes cargo
-    under the hood, so routing through soldr keeps the MSVC pin on Windows
-    and makes the cargo cache lineage uniform across CI platforms. soldr
-    resolves `maturin` via `rustup which maturin`, which points at the
-    dev-venv install.
+    Originally this routed through `soldr maturin` (issues #27, #68) on the
+    assumption that soldr would resolve maturin via the venv. In practice,
+    `soldr <tool>` always tries to fetch the tool from GitHub Releases,
+    and PyO3/maturin only publishes `x86_64-unknown-linux-musl.tar.gz` /
+    `aarch64-unknown-linux-musl.tar.gz` for Linux — there is no
+    `*-unknown-linux-gnu` asset. soldr's asset matcher rejects the musl
+    archives on GNU Linux runners (its musl→gnu fallback rule does not
+    fire here), producing `tool not found: no asset matches target
+    x86_64-unknown-linux-gnu` and breaking every Linux Build job.
+
+    maturin is already pinned in pyproject.toml dev deps and installed
+    into the uv-managed venv on every runner, so `python -m maturin`
+    works uniformly across platforms without any GitHub-Releases lookup.
+    The Windows MSVC pin from issue #27 is preserved through the cargo
+    side: `_windows_build_env` exports `CARGO`/`RUSTC`/`RUSTUP_TOOLCHAIN`
+    + prepends the MSVC toolchain bin to PATH, so when this maturin
+    invocation spawns cargo it picks up the same MSVC toolchain that
+    `soldr cargo` would have given it.
     """
-    soldr = soldr_path(env)
-    if soldr:
-        return [soldr, "maturin", *subcommand]
     return [sys.executable, "-m", "maturin", *subcommand]


### PR DESCRIPTION
## Summary

Linux Build jobs (x86 + ARM) have been failing on `main` since the soldr migration in 371aea5. Failing CI run: https://github.com/zackees/clud/actions/runs/24925980359

```
soldr: fetching maturin...
soldr: tool not found: no asset matches target x86_64-unknown-linux-gnu
##[error]Process completed with exit code 1.
```

## Root cause

`ci/env.py::maturin_argv` routes maturin through `soldr maturin` on every platform, on the assumption (per the prior docstring) that soldr would resolve maturin via `rustup which`. In practice `soldr <tool>` always tries to fetch from GitHub Releases.

PyO3/maturin only ships `x86_64-unknown-linux-musl.tar.gz` / `aarch64-unknown-linux-musl.tar.gz` for Linux — there is no `*-unknown-linux-gnu` asset, and has not been for the entire history of the v1.x release series. soldr's `match_asset` in `crates/soldr-fetch/src/lib.rs` requires Linux/Gnu targets to find a `gnu`-named asset; the musl→gnu fallback rule does not fire for that match path, so the fetch hard-fails on every GNU Linux runner. Same failure on `main` (runs `24924794564`, `24924794574`).

## Fix

Drop the soldr wrapper from `maturin_argv` and from `_build.yml`'s sdist step. maturin is already pinned in `pyproject.toml` dev deps (`maturin[zig]>=1.7,<2`) and installed into the uv-managed venv on every runner, so `python -m maturin` works uniformly across all six CI platforms with no GitHub-Releases lookup.

## Why this over alternatives

- **Pinning a maturin version with a `-gnu` asset**: not possible — PyO3/maturin has shipped musl-only Linux assets for years (verified back to v1.8.7 and forward to v1.13.1).
- **Bumping setup-soldr to a newer SHA**: does not help. `match_asset` still requires `gnu`-named assets for Linux/Gnu targets; this is upstream behaviour, not a config knob.
- **The chosen fix**: smallest diff, no upstream dependency, works on every platform. Windows MSVC pin from #27 is preserved through the cargo side — `_windows_build_env` already exports `CARGO`, `RUSTC`, `RUSTUP_TOOLCHAIN` and prepends the MSVC toolchain bin to PATH, so maturin spawns the same MSVC cargo that `soldr cargo` would have given it. `cargo_argv` (used elsewhere) is unchanged and still goes through soldr.

## Test plan

- [ ] CI passes Linux x86 Build (currently failing on main)
- [ ] CI passes Linux ARM Build (currently failing on main)
- [ ] CI passes Windows x86/ARM Build (verify MSVC pin still works without soldr-wrapping maturin)
- [ ] CI passes macOS x86/ARM Build
- [ ] CI passes the sdist build step on the platform that has `include-sdist: true`

## Follow-up TODOs (out of scope for this PR)

- Consider filing an upstream issue against `zackees/soldr` to extend its Linux/Gnu→musl fallback to cover plain `<crate>-<triple>.tar.gz` archive layouts (currently the fallback only kicks in for the named-archive variant), so future "soldr <python-packaged-tool>" calls don't hit the same trap.
- The `_build.yml` step uses `build-cache-mode: thin` (line 57) but `setup-soldr@v0`'s `action.yml` declares the input as `target-cache-mode`. Likely silently ignored; worth a separate trivial cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)