### PR TITLE
feat(windows): set console title to "clud <cwd-name>" on launch

### DIFF
--- a/crates/clud-bin/src/console_title.rs
+++ b/crates/clud-bin/src/console_title.rs
@@ -1,0 +1,122 @@
+//! Set the console window title to `clud <cwd-name>` on launch.
+//!
+//! On Windows, when `clud` runs in cmd.exe / Windows Terminal, the title
+//! bar otherwise shows the host shell's title — usually a generic
+//! `Command Prompt` or the path to cmd.exe. Stamping `clud <cwd-name>`
+//! makes it obvious at a glance which window is the active session and
+//! which directory it's working in (especially helpful with multiple
+//! windows open at once).
+//!
+//! POSIX terminals are out of scope for this module; the issue
+//! requesting it was Windows-only. The cross-platform stub here is a
+//! no-op so the call site in `main.rs` doesn't need a `cfg`.
+
+/// Set the console title to `clud <cwd-basename>` for the current
+/// working directory. Best-effort — failures are silent.
+///
+/// Called once near the top of `main`. Does not attempt to restore the
+/// original title on exit; conhost / Windows Terminal generally clear
+/// or replace the title themselves when the foreground process exits.
+pub fn set_for_current_cwd() {
+    let basename = current_cwd_basename().unwrap_or_else(|| "?".to_string());
+    let title = title_for_cwd_name(&basename);
+    set_title(&title);
+}
+
+/// Format `<cwd-name>` into the canonical title string. Pure helper —
+/// unit-tested on every platform.
+pub fn title_for_cwd_name(cwd_name: &str) -> String {
+    format!("clud {}", cwd_name)
+}
+
+/// Best-effort lookup of the current working directory's leaf name.
+/// Returns `None` if `current_dir()` fails or the path has no final
+/// component (e.g. the filesystem root on Windows like `C:\`).
+fn current_cwd_basename() -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    cwd.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .or_else(|| {
+            // On `C:\` (drive root) there's no `file_name`; fall back to
+            // the drive letter so the title is still informative.
+            cwd.to_string_lossy()
+                .split(':')
+                .next()
+                .map(|s| s.to_string())
+        })
+}
+
+#[cfg(windows)]
+fn set_title(title: &str) {
+    // SetConsoleTitleW writes to the console window owning this
+    // process — which is the cmd.exe / Windows Terminal we want. Wide
+    // (UTF-16) form so non-ASCII cwd names render correctly.
+    extern "system" {
+        fn SetConsoleTitleW(lp_console_title: *const u16) -> i32;
+    }
+    let mut wide: Vec<u16> = title.encode_utf16().collect();
+    wide.push(0);
+    // SAFETY: `wide` is a properly null-terminated UTF-16 buffer with
+    // a stable address until the unsafe block ends.
+    unsafe {
+        let _ = SetConsoleTitleW(wide.as_ptr());
+    }
+}
+
+#[cfg(not(windows))]
+fn set_title(_title: &str) {
+    // Out of scope per the issue; intentional no-op.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn title_uses_clud_prefix_with_cwd_name() {
+        assert_eq!(title_for_cwd_name("clud"), "clud clud");
+        assert_eq!(title_for_cwd_name("my-app"), "clud my-app");
+    }
+
+    #[test]
+    fn title_handles_non_ascii_cwd_name() {
+        // Cyrillic + emoji to verify the formatter doesn't choke on
+        // non-ASCII paths (which then flow through SetConsoleTitleW's
+        // wide-string conversion on Windows).
+        assert_eq!(title_for_cwd_name("проект"), "clud проект");
+        assert_eq!(title_for_cwd_name("🚀"), "clud 🚀");
+    }
+
+    #[test]
+    fn title_passes_through_empty_name() {
+        // Defensive: even an empty cwd name produces a well-formed
+        // title rather than panicking.
+        assert_eq!(title_for_cwd_name(""), "clud ");
+    }
+
+    #[test]
+    fn title_does_not_trim_or_normalize_input() {
+        // We're explicit about what we format — no surprise trims, no
+        // case changes. The cwd basename is shown verbatim.
+        assert_eq!(title_for_cwd_name(" spaced "), "clud  spaced ");
+        assert_eq!(title_for_cwd_name("MIXED-Case"), "clud MIXED-Case");
+    }
+
+    #[test]
+    fn current_cwd_basename_returns_some_in_test_env() {
+        // Cargo runs tests with the manifest dir as cwd, which always
+        // has a leaf component (`clud-bin`). Smoke test the helper
+        // without asserting the specific value.
+        let got = current_cwd_basename();
+        assert!(got.is_some(), "expected Some(_) cwd basename in test env");
+        assert!(!got.unwrap().is_empty(), "basename should not be empty");
+    }
+
+    #[test]
+    fn set_for_current_cwd_does_not_panic() {
+        // Smoke test on every platform — the POSIX stub is a no-op,
+        // and on Windows SetConsoleTitleW returns silently when there
+        // is no console (e.g. inside `cargo test` under a CI runner).
+        set_for_current_cwd();
+    }
+}

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -8,6 +8,7 @@ pub mod args;
 pub mod backend;
 pub mod capture;
 pub mod command;
+pub mod console_title;
 pub mod daemon;
 pub mod dnd;
 pub mod loop_spec;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,6 +1,6 @@
 use clud::{
-    args, backend, command, daemon, dnd, loop_spec, session, session_registry, subprocess,
-    trampoline, voice, wasm,
+    args, backend, command, console_title, daemon, dnd, loop_spec, session, session_registry,
+    subprocess, trampoline, voice, wasm,
 };
 
 use std::io::{self, Read};
@@ -12,6 +12,11 @@ use std::sync::{
 fn main() {
     // Windows: rename ourselves so pip can always overwrite clud.exe.
     trampoline::unlock_exe();
+
+    // Stamp the console title with `clud <cwd-name>` so the active
+    // window is identifiable at a glance. Windows-only effective; a
+    // no-op on POSIX (out of scope per the originating request).
+    console_title::set_for_current_cwd();
 
     let mut args = args::Args::parse_with_passthrough();
 


### PR DESCRIPTION
## Summary

When \`clud\` runs in \`cmd.exe\` / Windows Terminal, the title bar otherwise shows the host shell's title — usually a generic "Command Prompt" or the path to \`cmd.exe\`. This PR stamps \`clud <cwd-name>\` on the title bar at launch so the active window is identifiable at a glance, especially helpful with multiple concurrent sessions across different directories.

Example: when \`clud\` is run from \`C:\Users\you\dev\my-app\`, the cmd.exe title bar reads \`clud my-app\`.

## Implementation

- New \`crates/clud-bin/src/console_title.rs\` (small focused module):
  - \`title_for_cwd_name(&str) -> String\` — pure formatter, returns \`"clud <name>"\`. Unit-tested on every platform.
  - \`set_for_current_cwd()\` — public entry point. On Windows calls \`SetConsoleTitleW\` with the UTF-16 wide form so non-ASCII basenames render correctly; on POSIX is an explicit no-op (out of scope per the request).
- Called once from \`main()\` immediately after the Windows trampoline rename, before arg parsing. Best-effort — failures are silent. The title is not restored on exit; conhost and Windows Terminal generally clear or replace the title themselves when the foreground process exits.

## Design choices

- **No \`windows-sys\` dep added.** The codebase already uses bare \`extern "system"\` blocks (see \`trampoline.rs\`, \`main.rs\` for prior examples). Following the existing convention keeps the diff small.
- **Drive-root fallback.** When cwd is a Windows drive root like \`C:\\`, \`Path::file_name()\` returns \`None\`. Fall back to the drive letter (\`C\`) so the title is still informative rather than \`"clud ?"\`.
- **No restore on exit.** Tracking and restoring the original title would require a guard struct + cleanup at every exit path (including panics, \`std::process::exit\`, signal-driven exits). The complexity isn't worth it for a cosmetic feature; conhost / WT replace the title automatically on shell return.

## Test plan

- [x] \`cargo build --bin clud\` — green
- [x] Manual smoke: \`./target/x86_64-pc-windows-msvc/debug/clud.exe --dry-run -p hello\` runs cleanly; title is set on Windows.
- [ ] CI: lint + unit + integration suites across all 6 platforms

## Notes

\`cargo test -p clud --lib\` is currently broken on \`main\` with \`STATUS_ENTRYPOINT_NOT_FOUND\` (a regression from PR #75's bundled rusqlite — the test EXE has unresolved imports at load time). I confirmed the same failure happens on \`main\` without my changes. CI runners use a different test invocation path (\`bash test\`) so they should be unaffected, but flagging it here as a separate issue worth tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)