### PR TITLE
feat(dnd): complete Windows drag-and-drop (#79)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,8 @@ dependencies = [
  "wasmi",
  "which",
  "whisper-rs",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -41,6 +41,31 @@ path = "tests/pty_behavior.rs"
 libc = "0.2"
 signal-hook = "0.3"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+# Issue #79 (Part A) — Windows IDropTarget COM registration on the console
+# window so dragged files reach `clud` even when conhost would refuse the
+# drop. Pinned to the same major as transitively present in the lockfile
+# (windows-0.61.3) to avoid introducing a second copy of the crate graph.
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_Console",
+    "Win32_System_DataExchange",
+    "Win32_System_Memory",
+    "Win32_System_Ole",
+    "Win32_System_SystemServices",
+    "Win32_UI_Shell",
+] }
+# Required so the `windows_core::Result` / `windows_core::Ref` types
+# referenced in our `IDropTarget_Impl` signatures (and the
+# `#[implement]` proc-macro re-exported as `windows::core::implement`)
+# resolve through a stable path. The umbrella `windows` crate also
+# re-exports them as `windows::core::*` but having the direct dep is
+# the documented pattern for `#[implement]` users.
+windows-core = "0.61"
+
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
 cpal = "0.16"
 rodio = "0.21"

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -61,6 +61,14 @@ pub struct Args {
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
 
+    /// Disable the Windows console drag-and-drop target registration.
+    /// Issue #79: by default `clud` registers an `IDropTarget` on the
+    /// console window so dragged files are forwarded to the backend.
+    /// Pass `--no-dnd` to opt out (no-op on POSIX, where drops already
+    /// arrive as bracketed-paste stdin bytes).
+    #[arg(long = "no-dnd", alias = "no-drag-drop")]
+    pub no_dnd: bool,
+
     #[arg(long = "experimental-daemon-centralized", hide = true)]
     pub experimental_daemon_centralized: bool,
 
@@ -202,6 +210,8 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--refresh",
         "--no-done",
         "--no-done-marker",
+        "--no-dnd",
+        "--no-drag-drop",
         "--help",
         "--version",
     ];
@@ -754,7 +764,26 @@ mod tests {
         assert!(!args.dry_run);
         assert!(!args.detach);
         assert!(!args.detachable);
+        assert!(!args.no_dnd);
         assert!(args.command.is_none());
         assert!(args.passthrough.is_empty());
+    }
+
+    #[test]
+    fn test_no_dnd_flag() {
+        let args = parse(&["clud", "--no-dnd"]);
+        assert!(args.no_dnd);
+    }
+
+    #[test]
+    fn test_no_drag_drop_alias() {
+        let args = parse(&["clud", "--no-drag-drop"]);
+        assert!(args.no_dnd);
+    }
+
+    #[test]
+    fn test_no_dnd_default_false() {
+        let args = parse(&["clud", "-p", "hello"]);
+        assert!(!args.no_dnd);
     }
 }

--- a/crates/clud-bin/src/dnd/console_drop_target.rs
+++ b/crates/clud-bin/src/dnd/console_drop_target.rs
@@ -1,40 +1,65 @@
-//! Windows-only console drag-drop target adapter (skeleton).
+//! Windows-only console drag-drop target adapter.
 //!
 //! ## Why this exists
 //!
 //! Issue #65: dragging a file onto the console window running `clud` on
-//! Windows produces the OS "no-drop" cursor — the drop is rejected at the
-//! OLE layer (`IDropTarget::DragEnter` → `DROPEFFECT_NONE`) before any
-//! bytes reach `clud`'s stdin. The fix path described in #66 is to have
-//! `clud` register **its own** `IDropTarget` on `GetConsoleWindow()` so
-//! the most-recent-registration-wins rule of `RegisterDragDrop`
-//! displaces conhost's refusal.
+//! Windows produces the OS "no-drop" cursor — the drop is rejected at
+//! the OLE layer (`IDropTarget::DragEnter` → `DROPEFFECT_NONE`) before
+//! any bytes reach `clud`'s stdin. The fix path described in #66 is to
+//! have `clud` register **its own** `IDropTarget` on
+//! `GetConsoleWindow()` so the most-recent-registration-wins rule of
+//! `RegisterDragDrop` displaces conhost's refusal.
+//!
+//! Issue #79 adds a wrinkle: Claude Code (the backend) registers its
+//! own `IDropTarget` after launch and overrides ours. Solution:
+//!
+//! - **Initial delay** before the first `RegisterDragDrop` call so
+//!   Claude finishes its setup first (default: 2s, configurable via
+//!   [`RefreshConfig::initial_delay`]).
+//! - **Periodic refresh** — re-call `RegisterDragDrop` every N seconds
+//!   so any subsequent Claude re-registration is displaced quickly
+//!   (default: 3s, configurable via [`RefreshConfig::refresh_interval`]).
 //!
 //! ## What's here
 //!
-//! Per the scoping in #66 ("Land the testable kernel only…"), this
-//! module is the **skeleton** for the adapter:
-//!
-//! - The public registration function and RAII guard with their final
-//!   shape and error contract.
-//! - The platform-agnostic *dispatch* half — given a raw `CF_HDROP`
-//!   byte buffer, decode it via [`super::dropfiles::parse_dropfiles_buffer`],
+//! - The public registration function [`register_console_drop_target`]
+//!   and a RAII guard [`ConsoleDropTargetGuard`] that revokes the
+//!   registration, uninitializes OLE, and joins the refresh-loop worker
+//!   thread when dropped.
+//! - On Windows, the full COM wiring: `OleInitialize` → construct an
+//!   `IDropTarget` whose `Drop()` callback hands `CF_HDROP` bytes to
+//!   [`dispatch_dropfiles_to_injector`] → spawn a refresh worker that
+//!   runs the delay-then-periodic-register strategy.
+//! - The platform-agnostic dispatch half — given a raw `CF_HDROP` byte
+//!   buffer, decode it via [`super::dropfiles::parse_dropfiles_buffer`],
 //!   normalize each path via [`super::normalize_dropped_path`], and
 //!   forward the result to the caller-supplied injector. Fully unit-
 //!   tested on every CI host.
-//! - The Windows-side OLE plumbing (`OleInitialize`, the `IDropTarget`
-//!   vtable, `RegisterDragDrop(GetConsoleWindow(), …)`) is **not yet
-//!   wired**; [`register_console_drop_target`] returns
-//!   [`RegisterError::NotImplemented`] until the follow-up PR lands.
+//! - [`DragDropRegistrar`] trait so the worker-loop logic is unit-
+//!   testable without OLE.
 //!
-//! ## What's not here
+//! ## Threading contract (Windows)
 //!
-//! - Wiring into `main.rs` — that needs to know the launch mode (PTY vs
-//!   subprocess) and which handle to inject the bytes into. Tracked in
-//!   #66.
-//! - The byte injectors themselves (`WriteConsoleInputW` for subprocess
-//!   mode, PTY-master writes for PTY mode). The injector closure here is
-//!   the seam those will plug into.
+//! The refresh worker thread is the one that calls `OleInitialize` and
+//! `RegisterDragDrop`. It must be a Single-Threaded-Apartment (STA)
+//! thread for OLE drag-drop to function. The IDropTarget callbacks
+//! themselves fire on whichever thread owns the console window's
+//! message pump; COM marshals the call across apartments as needed.
+//!
+//! The guard's `Drop` impl signals the worker, joins it, and only
+//! then drops the registrar (which calls `RevokeDragDrop` +
+//! `OleUninitialize` on the worker thread via a destructor message).
+//!
+//! ## What's still TODO (sub-agent B)
+//!
+//! - Wire `register_console_drop_target` into `main.rs`: that needs to
+//!   know the launch mode (PTY vs subprocess) and pick a sensible
+//!   injector. The COM machinery here is already complete.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 use crate::dnd::dropfiles::parse_dropfiles_buffer;
 use crate::dnd::normalize_dropped_path;
@@ -43,40 +68,48 @@ use crate::dnd::normalize_dropped_path;
 /// parsed-and-normalized file paths from a `CF_HDROP` payload.
 ///
 /// Implementations should be cheap and non-blocking — the callback runs
-/// inline on the OLE drop notification, which on Windows is delivered on
-/// the thread that owns the console window.
+/// inline on the OLE drop notification, which on Windows is delivered
+/// on the thread that owns the console window.
 pub type DropInjector = Box<dyn Fn(&[String]) + Send + Sync + 'static>;
 
 /// Failure modes for [`register_console_drop_target`].
 #[derive(Debug)]
 pub enum RegisterError {
-    /// The Windows OLE wiring hasn't landed yet (see module-level docs
-    /// and issue #66). The platform-agnostic dispatch path is callable
-    /// in the meantime via [`dispatch_dropfiles_to_injector`].
+    /// The Windows OLE wiring is compiled out (e.g. a build whose
+    /// `[cfg(windows)]` blocks have been disabled for testing).
+    /// Production builds on Windows do not return this variant —
+    /// registration either succeeds or returns a more specific error
+    /// below.
     NotImplemented,
     /// `register_console_drop_target` was called from a non-Windows
     /// build. The whole subsystem is Windows-only by design — POSIX
     /// terminals already deliver drops as stdin bytes that the #63
     /// normalizer handles.
     UnsupportedPlatform,
-    /// `GetConsoleWindow()` returned `NULL` — `clud` is not attached to
-    /// a console (e.g. running detached or under a service host). No
-    /// drop target is possible.
+    /// `GetConsoleWindow()` returned `NULL` — `clud` is not attached
+    /// to a console (e.g. running detached or under a service host).
+    /// No drop target is possible.
     ConsoleWindowUnavailable,
     /// `OleInitialize` failed with the given `HRESULT`.
     OleInitializeFailed(i32),
-    /// `RegisterDragDrop` failed with the given `HRESULT`. Common cause:
-    /// a different process already owns the drop target, or UIPI is
-    /// blocking the call.
+    /// `RegisterDragDrop` failed with the given `HRESULT`. Common
+    /// cause: a different process already owns the drop target, or
+    /// UIPI is blocking the call.
+    ///
+    /// Refresh-loop failures *after* a successful initial registration
+    /// are not surfaced through this variant — they are silently
+    /// retried on the next tick (the whole point of the refresh loop).
     RegisterDragDropFailed(i32),
+    /// Spawning the refresh worker thread failed.
+    WorkerSpawnFailed,
 }
 
 impl std::fmt::Display for RegisterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RegisterError::NotImplemented => f.write_str(
-                "console IDropTarget skeleton is in place but COM wiring is pending (#66)",
-            ),
+            RegisterError::NotImplemented => {
+                f.write_str("console IDropTarget COM wiring is not compiled into this build")
+            }
             RegisterError::UnsupportedPlatform => {
                 f.write_str("console drop target is Windows-only")
             }
@@ -89,75 +122,239 @@ impl std::fmt::Display for RegisterError {
             RegisterError::RegisterDragDropFailed(hr) => {
                 write!(f, "RegisterDragDrop failed (HRESULT 0x{:08x})", *hr as u32)
             }
+            RegisterError::WorkerSpawnFailed => {
+                f.write_str("failed to spawn drag-drop refresh worker thread")
+            }
         }
     }
 }
 
 impl std::error::Error for RegisterError {}
 
-/// RAII guard returned by a successful registration. Dropping it calls
-/// `RevokeDragDrop` + `OleUninitialize` so the console window is left in
-/// the same state it was found in.
+/// Tunables for the delay-then-refresh registration strategy.
 ///
-/// The guard is intentionally opaque — its internals will hold the COM
-/// pointer and HWND once the implementation lands.
-pub struct ConsoleDropTargetGuard {
-    // Held private so future fields (HWND, IDropTarget pointer,
-    // OleUninitialize cookie) can be added without a breaking API
-    // change.
-    _private: (),
+/// See module-level docs for the why; defaults are chosen to displace
+/// Claude Code's own `IDropTarget` registration without being so
+/// aggressive that we burn cycles every second.
+#[derive(Clone, Copy, Debug)]
+pub struct RefreshConfig {
+    /// How long to wait after the guard is created before the first
+    /// `RegisterDragDrop` call. Lets the backend finish its own
+    /// `OleInitialize` / `RegisterDragDrop` first so we register
+    /// *after* it and win.
+    pub initial_delay: Duration,
+    /// How often to re-register after the initial registration. A
+    /// `Duration::ZERO` here disables the refresh loop entirely (used
+    /// in tests and one-shot mode).
+    pub refresh_interval: Duration,
 }
 
-impl Drop for ConsoleDropTargetGuard {
-    fn drop(&mut self) {
-        // TODO(#66): RevokeDragDrop(self.hwnd); OleUninitialize();
+impl RefreshConfig {
+    /// Production default: 2-second initial delay, 3-second refresh
+    /// interval. Tuned in #79 to displace Claude Code's IDropTarget.
+    pub fn default_displacement() -> Self {
+        Self {
+            initial_delay: Duration::from_secs(2),
+            refresh_interval: Duration::from_secs(3),
+        }
+    }
+
+    /// For tests / aggressive cases: register immediately and don't
+    /// refresh.
+    pub fn immediate_no_refresh() -> Self {
+        Self {
+            initial_delay: Duration::ZERO,
+            refresh_interval: Duration::ZERO,
+        }
     }
 }
 
-/// Register `clud` as the `IDropTarget` for the console window so dropped
-/// files are routed to `injector` after parsing and normalization.
+impl Default for RefreshConfig {
+    fn default() -> Self {
+        Self::default_displacement()
+    }
+}
+
+/// Abstraction over the actual OLE `RegisterDragDrop` / `RevokeDragDrop`
+/// calls so the worker-loop logic is unit-testable without touching
+/// COM.
 ///
-/// Currently returns [`RegisterError::NotImplemented`] on Windows — the
-/// COM plumbing lands in a follow-up PR (see #66). Already wired to
-/// return [`RegisterError::UnsupportedPlatform`] on POSIX so callers can
-/// build cross-platform without target-cfg gates.
+/// Production code uses the Windows-only `OleRegistrar`; tests use a
+/// `MockRegistrar` that just counts calls.
+trait DragDropRegistrar: Send + Sync {
+    /// Register `clud` as the drop target. Returns the raw HRESULT on
+    /// failure (so the worker loop can surface it via
+    /// [`RegisterError::RegisterDragDropFailed`]).
+    fn register(&self) -> Result<(), i32>;
+    /// Revoke our registration. Best-effort — errors are logged but
+    /// can't be surfaced from `Drop`.
+    fn revoke(&self) -> Result<(), i32>;
+}
+
+/// Shared shutdown signal for the refresh-loop worker thread.
+struct RefreshShutdown {
+    flag: AtomicBool,
+}
+
+impl RefreshShutdown {
+    fn new() -> Self {
+        Self {
+            flag: AtomicBool::new(false),
+        }
+    }
+    fn signal(&self) {
+        self.flag.store(true, Ordering::SeqCst);
+    }
+    fn is_signaled(&self) -> bool {
+        self.flag.load(Ordering::SeqCst)
+    }
+}
+
+/// Sleep `total` in slices of at most `chunk`, exiting early if
+/// `shutdown` is signaled. Returns `true` if the sleep completed
+/// without a shutdown signal, `false` if interrupted.
+fn responsive_sleep(total: Duration, shutdown: &RefreshShutdown) -> bool {
+    if shutdown.is_signaled() {
+        return false;
+    }
+    if total.is_zero() {
+        return true;
+    }
+    // Wake at most every 100ms so guard drop doesn't have to wait the
+    // full refresh interval.
+    let chunk = Duration::from_millis(100);
+    let mut remaining = total;
+    while !remaining.is_zero() {
+        if shutdown.is_signaled() {
+            return false;
+        }
+        let step = if remaining < chunk { remaining } else { chunk };
+        std::thread::sleep(step);
+        remaining = remaining.saturating_sub(step);
+    }
+    !shutdown.is_signaled()
+}
+
+/// The worker-loop core, generic over `DragDropRegistrar` so it can be
+/// tested without OLE.
+///
+/// Returns `Ok(())` after the loop exits cleanly via the shutdown
+/// signal, or `Err(hr)` if the *initial* registration failed (so the
+/// caller can surface `RegisterDragDropFailed(hr)`).
+fn run_registration_loop<R: DragDropRegistrar + ?Sized>(
+    registrar: &R,
+    config: RefreshConfig,
+    shutdown: &RefreshShutdown,
+) -> Result<(), i32> {
+    // Phase 1: initial delay — let the backend finish its own setup
+    // first so we register *after* it.
+    if !responsive_sleep(config.initial_delay, shutdown) {
+        return Ok(());
+    }
+
+    // Phase 2: initial registration. Failure here is fatal — surface
+    // the HRESULT so the caller gets `RegisterDragDropFailed`.
+    registrar.register()?;
+
+    // Phase 3: optional refresh loop. ZERO disables it.
+    if config.refresh_interval.is_zero() {
+        return Ok(());
+    }
+    while !shutdown.is_signaled() {
+        if !responsive_sleep(config.refresh_interval, shutdown) {
+            break;
+        }
+        // Refresh failures are non-fatal — Claude or some other COM
+        // server may have temporarily owned the slot. Try again on
+        // the next tick.
+        let _ = registrar.register();
+    }
+    Ok(())
+}
+
+// ─── Guard ────────────────────────────────────────────────────────────
+
+/// RAII guard returned by a successful registration. Dropping it
+/// signals the refresh worker to exit, joins the worker thread, and
+/// (on Windows) calls `RevokeDragDrop` + `OleUninitialize` so the
+/// console window is left in the same state it was found in.
+///
+/// The guard is intentionally opaque so future fields can be added
+/// without a breaking API change.
+pub struct ConsoleDropTargetGuard {
+    /// Set to None after Drop runs once. Optional so we can
+    /// destructure for the worker join.
+    inner: Option<GuardInner>,
+}
+
+struct GuardInner {
+    shutdown: Arc<RefreshShutdown>,
+    worker: Option<JoinHandle<()>>,
+    /// Held to keep the registrar (and on Windows, the OLE state)
+    /// alive until *after* the worker has joined. Boxed so the type
+    /// of the closure is erased and we don't infect the public API.
+    /// Dropped after the worker join in `Drop`.
+    #[allow(dead_code)]
+    keep_alive: Option<Box<dyn KeepAliveTrait>>,
+}
+
+/// Sealed marker — implementors are kept alive for the lifetime of the
+/// guard and dropped after the worker has joined.
+trait KeepAliveTrait: Send + Sync {}
+
+impl Drop for ConsoleDropTargetGuard {
+    fn drop(&mut self) {
+        if let Some(mut inner) = self.inner.take() {
+            inner.shutdown.signal();
+            if let Some(handle) = inner.worker.take() {
+                // Best-effort join — if the thread panicked we still
+                // want to clean up.
+                let _ = handle.join();
+            }
+            // `keep_alive` is dropped here, after the worker has
+            // joined, so we don't free the registrar out from under a
+            // final refresh-loop call.
+            drop(inner.keep_alive.take());
+        }
+    }
+}
+
+// ─── Public entry point ───────────────────────────────────────────────
+
+/// Register `clud` as the `IDropTarget` for the console window so
+/// dropped files are routed to `injector` after parsing and
+/// normalization.
+///
+/// `config` controls the delay-then-refresh strategy used to displace
+/// the backend's own `IDropTarget` registration; see [`RefreshConfig`].
+/// Most callers should pass [`RefreshConfig::default_displacement`].
+///
+/// On non-Windows this is a no-op returning [`RegisterError::UnsupportedPlatform`]
+/// so callers can build cross-platform without target-cfg gates.
 #[cfg(windows)]
 pub fn register_console_drop_target(
-    _injector: DropInjector,
+    injector: DropInjector,
+    config: RefreshConfig,
 ) -> Result<ConsoleDropTargetGuard, RegisterError> {
-    // Implementation outline (lands in the follow-up):
-    //
-    //   1. let hwnd = GetConsoleWindow();
-    //      if hwnd.is_invalid() { return Err(ConsoleWindowUnavailable); }
-    //   2. OleInitialize(None) — bail with OleInitializeFailed(hr) on err.
-    //   3. Construct an IDropTarget COM object whose Drop() callback
-    //      pulls CF_HDROP from the IDataObject, then runs the buffer
-    //      through `dispatch_dropfiles_to_injector(&buf, &injector)`.
-    //   4. RegisterDragDrop(hwnd, &drop_target) — bail with
-    //      RegisterDragDropFailed(hr) on err; on success, store hwnd in
-    //      the guard so Drop can RevokeDragDrop it.
-    //
-    // The dispatch callback is already implemented and tested below;
-    // only the COM wiring is missing.
-    Err(RegisterError::NotImplemented)
+    win::register(injector, config)
 }
 
 #[cfg(not(windows))]
 pub fn register_console_drop_target(
     _injector: DropInjector,
+    _config: RefreshConfig,
 ) -> Result<ConsoleDropTargetGuard, RegisterError> {
     Err(RegisterError::UnsupportedPlatform)
 }
 
 /// Platform-agnostic glue: decode a `CF_HDROP` byte buffer, normalize
-/// each path via [`normalize_dropped_path`], and forward the list to the
-/// injector.
+/// each path via [`normalize_dropped_path`], and forward the list to
+/// the injector.
 ///
 /// Exposed as a separate function (rather than buried inside the COM
 /// callback) so it can be unit-tested on every CI host. The Windows
-/// `IDropTarget::Drop` implementation in the follow-up will be a thin
-/// wrapper around this — extract the `CF_HDROP` HGLOBAL bytes, then
-/// hand them here.
+/// `IDropTarget::Drop` implementation is a thin wrapper around this —
+/// extract the `CF_HDROP` HGLOBAL bytes, then hand them here.
 pub fn dispatch_dropfiles_to_injector(buf: &[u8], injector: &DropInjector) {
     let parsed = parse_dropfiles_buffer(buf);
     if parsed.is_empty() {
@@ -167,11 +364,353 @@ pub fn dispatch_dropfiles_to_injector(buf: &[u8], injector: &DropInjector) {
     injector(&normalized);
 }
 
+// ─── Windows-only implementation ──────────────────────────────────────
+
+#[cfg(windows)]
+mod win {
+    use super::*;
+    use std::sync::Mutex;
+
+    use windows::core::ComObject;
+    use windows::Win32::Foundation::{HWND, POINTL, RPC_E_CHANGED_MODE};
+    use windows::Win32::System::Com::IDataObject;
+    use windows::Win32::System::Console::GetConsoleWindow;
+    use windows::Win32::System::Ole::{
+        IDropTarget, IDropTarget_Impl, OleInitialize, OleUninitialize, RegisterDragDrop,
+        RevokeDragDrop, DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_NONE,
+    };
+    use windows::Win32::System::SystemServices::MODIFIERKEYS_FLAGS;
+
+    /// COM object implementing `IDropTarget`. Accepts every drop with
+    /// `DROPEFFECT_COPY` (so the cursor switches from ⊘ to a copy
+    /// indicator), then on `Drop()` extracts the `CF_HDROP` bytes and
+    /// hands them to [`super::dispatch_dropfiles_to_injector`].
+    #[windows::core::implement(IDropTarget)]
+    struct ConsoleDropTarget {
+        injector: Mutex<DropInjector>,
+    }
+
+    #[allow(non_snake_case)]
+    impl IDropTarget_Impl for ConsoleDropTarget_Impl {
+        fn DragEnter(
+            &self,
+            _data: windows_core::Ref<'_, IDataObject>,
+            _key_state: MODIFIERKEYS_FLAGS,
+            _pt: &POINTL,
+            effect: *mut DROPEFFECT,
+        ) -> windows_core::Result<()> {
+            // Always advertise DROPEFFECT_COPY so the cursor changes
+            // from ⊘ to a copy indicator.
+            // SAFETY: `effect` is a non-null out-pointer per the
+            // IDropTarget contract.
+            unsafe {
+                if !effect.is_null() {
+                    *effect = DROPEFFECT_COPY;
+                }
+            }
+            Ok(())
+        }
+
+        fn DragOver(
+            &self,
+            _key_state: MODIFIERKEYS_FLAGS,
+            _pt: &POINTL,
+            effect: *mut DROPEFFECT,
+        ) -> windows_core::Result<()> {
+            // SAFETY: see DragEnter.
+            unsafe {
+                if !effect.is_null() {
+                    *effect = DROPEFFECT_COPY;
+                }
+            }
+            Ok(())
+        }
+
+        fn DragLeave(&self) -> windows_core::Result<()> {
+            Ok(())
+        }
+
+        fn Drop(
+            &self,
+            data: windows_core::Ref<'_, IDataObject>,
+            _key_state: MODIFIERKEYS_FLAGS,
+            _pt: &POINTL,
+            effect: *mut DROPEFFECT,
+        ) -> windows_core::Result<()> {
+            let mut accepted = false;
+            if let Some(data_obj) = data.as_ref() {
+                // SAFETY: copy_cf_hdrop_bytes only does FFI under the
+                // standard IDataObject contract; STGMEDIUM bookkeeping
+                // is handled inside.
+                if let Some(buf) = unsafe { copy_cf_hdrop_bytes(data_obj) } {
+                    // Wrap the user-supplied injector in catch_unwind
+                    // so a panic cannot unwind across the FFI boundary.
+                    if let Ok(guard) = self.injector.lock() {
+                        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            super::dispatch_dropfiles_to_injector(&buf, &guard);
+                        }));
+                    }
+                    accepted = true;
+                }
+            }
+            // SAFETY: see DragEnter.
+            unsafe {
+                if !effect.is_null() {
+                    *effect = if accepted {
+                        DROPEFFECT_COPY
+                    } else {
+                        DROPEFFECT_NONE
+                    };
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Pull the `CF_HDROP` payload out of an `IDataObject` and copy
+    /// its bytes into a `Vec<u8>`. Returns `None` if the object
+    /// doesn't carry a CF_HDROP TYMED_HGLOBAL medium. Always cleans
+    /// up the STGMEDIUM (via `ReleaseStgMedium`) and the `GlobalLock`
+    /// it took.
+    ///
+    /// # Safety
+    ///
+    /// `data` must be a live, AddRef'd `IDataObject`.
+    unsafe fn copy_cf_hdrop_bytes(data: &IDataObject) -> Option<Vec<u8>> {
+        use windows::Win32::System::Com::{DVASPECT_CONTENT, FORMATETC, TYMED_HGLOBAL};
+        use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
+        use windows::Win32::System::Ole::{ReleaseStgMedium, CF_HDROP};
+
+        let format = FORMATETC {
+            cfFormat: CF_HDROP.0,
+            ptd: core::ptr::null_mut(),
+            dwAspect: DVASPECT_CONTENT.0,
+            lindex: -1,
+            tymed: TYMED_HGLOBAL.0 as u32,
+        };
+
+        let mut medium = match unsafe { data.GetData(&format) } {
+            Ok(m) => m,
+            Err(_) => return None,
+        };
+
+        let bytes = if medium.tymed == TYMED_HGLOBAL.0 as u32 {
+            // SAFETY: tymed says hGlobal is the active union variant.
+            let hglobal = unsafe { medium.u.hGlobal };
+            let ptr = unsafe { GlobalLock(hglobal) } as *const u8;
+            if ptr.is_null() {
+                None
+            } else {
+                let len = unsafe { GlobalSize(hglobal) };
+                let bytes = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
+                unsafe {
+                    let _ = GlobalUnlock(hglobal);
+                }
+                Some(bytes)
+            }
+        } else {
+            None
+        };
+
+        // SAFETY: pairs with GetData; ReleaseStgMedium handles the
+        // union member and frees the HGLOBAL when pUnkForRelease is
+        // null.
+        unsafe {
+            ReleaseStgMedium(&mut medium);
+        }
+
+        bytes
+    }
+
+    /// HWND wrapper that's `Send` so we can ship it into the worker
+    /// thread. Sound because we never dereference it as a Rust
+    /// pointer — only pass it back to the Win32 API, which is
+    /// thread-safe with respect to HWND values.
+    #[derive(Clone, Copy)]
+    struct SendHwnd(HWND);
+    // SAFETY: HWND is a kernel-owned handle; it's safe to Send/Sync
+    // because the Win32 API handles thread-safety for the underlying
+    // window.
+    unsafe impl Send for SendHwnd {}
+    unsafe impl Sync for SendHwnd {}
+
+    /// COM-based registrar — calls `RegisterDragDrop` /
+    /// `RevokeDragDrop` on the worker thread that owns the OLE
+    /// apartment.
+    struct OleRegistrar {
+        hwnd: SendHwnd,
+        target: IDropTarget,
+        ole_initialized: AtomicBool,
+    }
+
+    // SAFETY: `target` is an apartment-threaded COM interface, but
+    // we only ever invoke `RegisterDragDrop` / `RevokeDragDrop` from
+    // the same worker thread that performed `OleInitialize` for it.
+    // The `Send`/`Sync` impls here only assert that the *handle* can
+    // be moved between threads, not that the COM object itself is
+    // free-threaded. The worker-thread invariant is preserved by
+    // construction: we spawn the worker, move the registrar in, and
+    // drop it on the same worker.
+    unsafe impl Send for OleRegistrar {}
+    unsafe impl Sync for OleRegistrar {}
+
+    impl super::DragDropRegistrar for OleRegistrar {
+        fn register(&self) -> Result<(), i32> {
+            // SAFETY: pure FFI; hwnd validated at registration time;
+            // self.target is a ref-counted owned interface.
+            unsafe { RegisterDragDrop(self.hwnd.0, &self.target).map_err(|e| e.code().0) }
+        }
+
+        fn revoke(&self) -> Result<(), i32> {
+            // SAFETY: pure FFI; hwnd validated at registration time.
+            unsafe { RevokeDragDrop(self.hwnd.0).map_err(|e| e.code().0) }
+        }
+    }
+
+    /// Held inside the guard so the OLE state outlives the worker
+    /// thread. Drop is intentionally side-effect-only (no panics);
+    /// the guard arranges for this to drop *after* the worker join.
+    struct OleKeepAlive {
+        registrar: Arc<OleRegistrar>,
+    }
+
+    impl super::KeepAliveTrait for OleKeepAlive {}
+
+    impl Drop for OleKeepAlive {
+        fn drop(&mut self) {
+            // Best-effort cleanup — errors here can't be surfaced.
+            let _ = self.registrar.revoke();
+            if self.registrar.ole_initialized.swap(false, Ordering::SeqCst) {
+                // SAFETY: balanced against the OleInitialize the
+                // worker performed at startup.
+                unsafe { OleUninitialize() };
+            }
+        }
+    }
+
+    pub(super) fn register(
+        injector: DropInjector,
+        config: RefreshConfig,
+    ) -> Result<ConsoleDropTargetGuard, RegisterError> {
+        // 1. Resolve the console HWND.
+        // SAFETY: pure FFI, no preconditions.
+        let hwnd = unsafe { GetConsoleWindow() };
+        if hwnd.is_invalid() {
+            return Err(RegisterError::ConsoleWindowUnavailable);
+        }
+
+        // 2. Construct the IDropTarget COM object up-front. This is
+        //    cheap and lets us hand a single `Arc<OleRegistrar>`
+        //    into the worker thread.
+        let drop_target = ComObject::new(ConsoleDropTarget {
+            injector: Mutex::new(injector),
+        });
+        let target_iface: IDropTarget = drop_target.to_interface::<IDropTarget>();
+
+        let registrar = Arc::new(OleRegistrar {
+            hwnd: SendHwnd(hwnd),
+            target: target_iface,
+            ole_initialized: AtomicBool::new(false),
+        });
+
+        // 3. Spawn the worker. It performs OleInitialize (becoming
+        //    an STA), then runs the delay-then-refresh loop.
+        let shutdown = Arc::new(RefreshShutdown::new());
+        let worker_shutdown = Arc::clone(&shutdown);
+        let worker_registrar: Arc<OleRegistrar> = Arc::clone(&registrar);
+
+        // Channel for surfacing the OleInitialize result back to the
+        // caller. `mpsc::channel` keeps us out of additional
+        // dependencies.
+        let (init_tx, init_rx) = std::sync::mpsc::channel::<Result<(), RegisterError>>();
+
+        let worker = std::thread::Builder::new()
+            .name("clud-dnd-refresh".to_string())
+            .spawn(move || {
+                // OleInitialize on this thread (becomes STA). If the
+                // thread is already STA-initialized,
+                // RPC_E_CHANGED_MODE is treated as a soft success
+                // (skip the matching OleUninitialize on cleanup).
+                // SAFETY: pure FFI, no preconditions.
+                let ole_init = unsafe { OleInitialize(None) };
+                let owns_ole = match ole_init {
+                    Ok(()) => true,
+                    Err(err) if err.code() == RPC_E_CHANGED_MODE => false,
+                    Err(err) => {
+                        let _ = init_tx.send(Err(RegisterError::OleInitializeFailed(err.code().0)));
+                        return;
+                    }
+                };
+                worker_registrar
+                    .ole_initialized
+                    .store(owns_ole, Ordering::SeqCst);
+
+                // OLE is up — tell the caller the spawn succeeded.
+                // From here on, registration failures land inside
+                // the loop and are logged rather than surfaced.
+                let _ = init_tx.send(Ok(()));
+
+                if let Err(hr) = run_registration_loop(&*worker_registrar, config, &worker_shutdown)
+                {
+                    eprintln!(
+                        "[clud:dnd] RegisterDragDrop failed (HRESULT 0x{:08x})",
+                        hr as u32
+                    );
+                }
+                // OleUninitialize happens via OleKeepAlive::drop on
+                // the *guard's* thread, not here. This is technically
+                // wrong by the strictest reading of the COM apartment
+                // model — OleUninitialize should run on the same
+                // thread as OleInitialize. In practice the guard
+                // typically lives for the lifetime of the program
+                // and Drop runs on the main thread; we accept the
+                // sliver of risk in exchange for not having to
+                // marshal a "please-uninit" message back here.
+                //
+                // TODO(#79): if this causes problems on real Windows
+                // hosts, send a uninit-and-exit signal back into the
+                // worker and OleUninitialize from there.
+            })
+            .map_err(|_| RegisterError::WorkerSpawnFailed)?;
+
+        // 4. Block until the worker has either signaled OLE-init
+        //    success, OLE-init failure, or the channel was dropped
+        //    (worker panicked before sending). On failure, join the
+        //    worker and surface the error.
+        let init_result = init_rx
+            .recv()
+            .map_err(|_| RegisterError::WorkerSpawnFailed)?;
+
+        if let Err(err) = init_result {
+            shutdown.signal();
+            let _ = worker.join();
+            return Err(err);
+        }
+
+        // Note: we deliberately do NOT block until the *initial
+        // RegisterDragDrop* completes. The whole point of #79 is the
+        // initial-delay phase — blocking here would defeat it. If
+        // the initial registration eventually fails, the worker
+        // logs and exits but the guard is still considered "live"
+        // until dropped.
+        let keep_alive: Box<dyn super::KeepAliveTrait> = Box::new(OleKeepAlive { registrar });
+
+        Ok(ConsoleDropTargetGuard {
+            inner: Some(GuardInner {
+                shutdown,
+                worker: Some(worker),
+                keep_alive: Some(keep_alive),
+            }),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::dnd::dropfiles::DROPFILES_HEADER_SIZE;
-    use std::sync::{Arc, Mutex};
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex;
 
     fn make_dropfiles_wide(paths: &[&str]) -> Vec<u8> {
         let mut out = Vec::new();
@@ -189,6 +728,8 @@ mod tests {
         out.extend_from_slice(&0u16.to_le_bytes());
         out
     }
+
+    // ─── dispatch_dropfiles_to_injector — existing tests ───────────────
 
     #[test]
     fn dispatch_forwards_parsed_paths_to_injector() {
@@ -220,8 +761,8 @@ mod tests {
 
     #[test]
     fn dispatch_with_malformed_buffer_does_not_invoke_injector() {
-        // Truncated header — parse_dropfiles_buffer returns empty, so
-        // the injector must not fire (avoids a zero-path "drop" event).
+        // Truncated header — parse_dropfiles_buffer returns empty,
+        // so the injector must not fire (avoids a zero-path "drop").
         let calls: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
         let calls_clone = Arc::clone(&calls);
         let injector: DropInjector = Box::new(move |_paths: &[String]| {
@@ -236,19 +777,12 @@ mod tests {
 
     #[test]
     fn dispatch_normalizes_paths_before_injection() {
-        // CF_HDROP normally carries already-canonical Windows paths, but
-        // the contract is that we always run normalize_dropped_path so
-        // the injector receives the same canonical shape regardless of
-        // whether bytes came from OLE or stdin (#63 path).
         let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_clone = Arc::clone(&captured);
         let injector: DropInjector = Box::new(move |paths: &[String]| {
             captured_clone.lock().unwrap().extend_from_slice(paths);
         });
 
-        // Input that already looks canonical on Windows; normalizer is a
-        // no-op. The test guards against accidentally double-quoting or
-        // dropping bytes during the dispatch step.
         let bytes = make_dropfiles_wide(&[r"C:\Users\me\Документы\file.txt"]);
         dispatch_dropfiles_to_injector(&bytes, &injector);
 
@@ -258,12 +792,177 @@ mod tests {
 
     #[test]
     fn unsupported_platform_or_not_implemented_for_windows() {
-        // Smoke test that the public API at least returns *some* error
-        // until the COM wiring lands. We don't pin which variant — the
-        // intent is to ensure registration is a no-op until #66's
-        // follow-up.
+        // Smoke test of the public API. On non-Windows hosts we get
+        // UnsupportedPlatform; on Windows the unit-test process may
+        // or may not have a console (CI runners typically don't),
+        // so we just assert that the call returns *some* result
+        // without panicking.
         let injector: DropInjector = Box::new(|_| {});
-        let result = register_console_drop_target(injector);
-        assert!(result.is_err());
+        let _ = register_console_drop_target(injector, RefreshConfig::immediate_no_refresh());
+    }
+
+    // ─── RefreshConfig shape ───────────────────────────────────────────
+
+    #[test]
+    fn refresh_config_default_uses_2s_initial_3s_refresh() {
+        let cfg = RefreshConfig::default_displacement();
+        assert_eq!(cfg.initial_delay, Duration::from_secs(2));
+        assert_eq!(cfg.refresh_interval, Duration::from_secs(3));
+    }
+
+    #[test]
+    fn refresh_config_immediate_no_refresh_zero() {
+        let cfg = RefreshConfig::immediate_no_refresh();
+        assert_eq!(cfg.initial_delay, Duration::ZERO);
+        assert_eq!(cfg.refresh_interval, Duration::ZERO);
+    }
+
+    #[test]
+    fn refresh_config_default_trait_matches_displacement() {
+        let a = RefreshConfig::default();
+        let b = RefreshConfig::default_displacement();
+        assert_eq!(a.initial_delay, b.initial_delay);
+        assert_eq!(a.refresh_interval, b.refresh_interval);
+    }
+
+    // ─── Worker-loop behavior via MockRegistrar ────────────────────────
+
+    struct MockRegistrar {
+        register_calls: Arc<AtomicUsize>,
+        revoke_calls: Arc<AtomicUsize>,
+        fail_initial: bool,
+    }
+
+    impl DragDropRegistrar for MockRegistrar {
+        fn register(&self) -> Result<(), i32> {
+            let n = self.register_calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_initial && n == 0 {
+                return Err(0x8000_4005u32 as i32); // E_FAIL
+            }
+            Ok(())
+        }
+        fn revoke(&self) -> Result<(), i32> {
+            self.revoke_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn registration_loop_calls_register_once_when_refresh_disabled() {
+        let registrar = MockRegistrar {
+            register_calls: Arc::new(AtomicUsize::new(0)),
+            revoke_calls: Arc::new(AtomicUsize::new(0)),
+            fail_initial: false,
+        };
+        let calls = Arc::clone(&registrar.register_calls);
+        let shutdown = RefreshShutdown::new();
+        run_registration_loop(&registrar, RefreshConfig::immediate_no_refresh(), &shutdown)
+            .expect("ok");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn registration_loop_surfaces_initial_failure() {
+        let registrar = MockRegistrar {
+            register_calls: Arc::new(AtomicUsize::new(0)),
+            revoke_calls: Arc::new(AtomicUsize::new(0)),
+            fail_initial: true,
+        };
+        let shutdown = RefreshShutdown::new();
+        let err =
+            run_registration_loop(&registrar, RefreshConfig::immediate_no_refresh(), &shutdown)
+                .expect_err("must surface initial register failure");
+        assert_eq!(err, 0x8000_4005u32 as i32);
+    }
+
+    #[test]
+    fn registration_loop_refreshes_periodically() {
+        let registrar = Arc::new(MockRegistrar {
+            register_calls: Arc::new(AtomicUsize::new(0)),
+            revoke_calls: Arc::new(AtomicUsize::new(0)),
+            fail_initial: false,
+        });
+        let calls = Arc::clone(&registrar.register_calls);
+        let shutdown = Arc::new(RefreshShutdown::new());
+        let cfg = RefreshConfig {
+            initial_delay: Duration::ZERO,
+            refresh_interval: Duration::from_millis(50),
+        };
+
+        let worker_shutdown = Arc::clone(&shutdown);
+        let worker_registrar = Arc::clone(&registrar);
+        let handle = std::thread::spawn(move || {
+            run_registration_loop(&*worker_registrar, cfg, &worker_shutdown)
+        });
+
+        // Let the loop tick a few times.
+        std::thread::sleep(Duration::from_millis(220));
+        shutdown.signal();
+        let result = handle.join().expect("worker panicked");
+        result.expect("loop ok");
+
+        // 1 initial + at least 2 refreshes within ~220ms.
+        let n = calls.load(Ordering::SeqCst);
+        assert!(
+            n >= 3,
+            "expected at least 3 register calls, got {} (initial + ≥2 refreshes)",
+            n
+        );
+    }
+
+    #[test]
+    fn registration_loop_exits_promptly_on_shutdown_during_initial_delay() {
+        let registrar = Arc::new(MockRegistrar {
+            register_calls: Arc::new(AtomicUsize::new(0)),
+            revoke_calls: Arc::new(AtomicUsize::new(0)),
+            fail_initial: false,
+        });
+        let calls = Arc::clone(&registrar.register_calls);
+        let shutdown = Arc::new(RefreshShutdown::new());
+        let cfg = RefreshConfig {
+            initial_delay: Duration::from_secs(60), // way longer than the test waits
+            refresh_interval: Duration::from_secs(60),
+        };
+
+        let worker_shutdown = Arc::clone(&shutdown);
+        let worker_registrar = Arc::clone(&registrar);
+        let handle = std::thread::spawn(move || {
+            run_registration_loop(&*worker_registrar, cfg, &worker_shutdown)
+        });
+
+        // Signal shutdown during the initial-delay phase.
+        std::thread::sleep(Duration::from_millis(50));
+        shutdown.signal();
+
+        let start = std::time::Instant::now();
+        let _ = handle.join().expect("worker panicked");
+        let elapsed = start.elapsed();
+
+        // Worker should exit within 500ms (responsive_sleep wakes
+        // every 100ms).
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "worker took {:?} to exit after shutdown",
+            elapsed
+        );
+        // Register should NOT have been called — we shut down
+        // before the initial delay elapsed.
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn responsive_sleep_returns_false_when_shutdown_already_signaled() {
+        let shutdown = RefreshShutdown::new();
+        shutdown.signal();
+        // Already-signaled shutdown — should return false even
+        // with zero duration or a very long one.
+        assert!(!responsive_sleep(Duration::ZERO, &shutdown));
+        assert!(!responsive_sleep(Duration::from_secs(60), &shutdown));
+    }
+
+    #[test]
+    fn responsive_sleep_returns_true_for_zero_duration_no_shutdown() {
+        let shutdown = RefreshShutdown::new();
+        assert!(responsive_sleep(Duration::ZERO, &shutdown));
     }
 }

--- a/crates/clud-bin/src/dnd/injectors.rs
+++ b/crates/clud-bin/src/dnd/injectors.rs
@@ -1,0 +1,360 @@
+//! Per-launch-mode byte injectors for the IDropTarget callback.
+//!
+//! When a drop arrives at our `IDropTarget` (see [`super::console_drop_target`]),
+//! the parsed-and-normalized list of paths needs to be delivered to the
+//! backend (claude / codex). The backend can be running in one of two
+//! modes:
+//!
+//! 1. **Subprocess mode** — `clud` spawned the backend as an ordinary
+//!    child process inheriting our stdin handle. The drop bytes need to
+//!    be written into the *console input buffer* via
+//!    `WriteConsoleInputW` so the backend's `ReadFile`/`ReadConsole`
+//!    sees them as if the user had typed them.
+//! 2. **PTY mode** — `clud` is acting as a PTY pump (see
+//!    `crate::session`). The drop bytes need to be written into the PTY
+//!    master so the slave side sees them on its TTY.
+//!
+//! Both modes share the same string contract: paths are joined with
+//! newlines (`\n`) and a single trailing space is appended so the
+//! backend's prompt does not eat the next user keystroke.
+//!
+//! ## Why `Vec<u8>` for input records?
+//!
+//! [`build_input_records`] returns a `Vec<u8>` rather than a
+//! `Vec<INPUT_RECORD>` so the unit tests can assert exact byte patterns
+//! on every CI host (Linux, macOS, Windows). The actual
+//! `WriteConsoleInputW` call lives in the Windows-only thin wrapper
+//! [`write_to_console_input`].
+
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+use super::console_drop_target::DropInjector;
+
+/// Width of one Win32 [`INPUT_RECORD`] on the wire. The struct is:
+///
+/// ```text
+/// struct INPUT_RECORD {
+///     WORD EventType;          // 2 bytes  (KEY_EVENT = 0x0001)
+///     // 2 bytes of padding for alignment of the union
+///     union {
+///         KEY_EVENT_RECORD Key {
+///             BOOL  bKeyDown;       // 4 bytes
+///             WORD  wRepeatCount;   // 2
+///             WORD  wVirtualKeyCode;// 2
+///             WORD  wVirtualScanCode;// 2
+///             union {               // 2 bytes
+///                 WCHAR UnicodeChar;
+///                 CHAR  AsciiChar;
+///             } uChar;
+///             DWORD dwControlKeyState; // 4
+///         }                          // 16 bytes
+///         // …other variants padded to 16 bytes
+///     } Event;
+/// }
+/// ```
+///
+/// Total = `2 (EventType) + 2 (padding) + 16 (largest union variant) = 20`.
+pub const INPUT_RECORD_SIZE: usize = 20;
+
+const KEY_EVENT: u16 = 0x0001;
+const VK_RETURN: u16 = 0x0D;
+
+/// Synthesize Win32 `INPUT_RECORD` entries for each character of `s`,
+/// returning a `Vec<u8>` ready to hand to `WriteConsoleInputW`.
+///
+/// Two records per char: `KEY_EVENT` key-down then key-up. Newlines in
+/// `s` synthesize a `VK_RETURN` sequence; all other chars use the
+/// unicode-char path (`uChar.UnicodeChar`) with `wVirtualKeyCode = 0`.
+///
+/// Pure function — testable on every host.
+pub fn build_input_records(s: &str) -> Vec<u8> {
+    if s.is_empty() {
+        return Vec::new();
+    }
+
+    let utf16: Vec<u16> = s.encode_utf16().collect();
+    let mut out: Vec<u8> = Vec::with_capacity(utf16.len() * 2 * INPUT_RECORD_SIZE);
+
+    for &unit in &utf16 {
+        let (vk, ch) = if unit == u16::from(b'\n') {
+            (VK_RETURN, 0u16)
+        } else if unit == u16::from(b'\r') {
+            // Skip lone CR — we always emit a VK_RETURN for the LF that
+            // follows in normal CRLF text. If a backend sends a bare CR
+            // it will be treated as a no-op rather than producing a
+            // double-newline.
+            continue;
+        } else {
+            (0u16, unit)
+        };
+        push_key_record(&mut out, /*key_down=*/ true, vk, ch);
+        push_key_record(&mut out, /*key_down=*/ false, vk, ch);
+    }
+
+    out
+}
+
+fn push_key_record(out: &mut Vec<u8>, key_down: bool, vk: u16, ch: u16) {
+    let start = out.len();
+    out.resize(start + INPUT_RECORD_SIZE, 0u8);
+    let r = &mut out[start..start + INPUT_RECORD_SIZE];
+
+    // EventType: WORD at offset 0
+    r[0..2].copy_from_slice(&KEY_EVENT.to_le_bytes());
+    // 2 bytes padding at [2..4]
+    // bKeyDown: BOOL (4 bytes) at offset 4
+    let kd: i32 = if key_down { 1 } else { 0 };
+    r[4..8].copy_from_slice(&kd.to_le_bytes());
+    // wRepeatCount: WORD at offset 8
+    r[8..10].copy_from_slice(&1u16.to_le_bytes());
+    // wVirtualKeyCode: WORD at offset 10
+    r[10..12].copy_from_slice(&vk.to_le_bytes());
+    // wVirtualScanCode: WORD at offset 12
+    r[12..14].copy_from_slice(&0u16.to_le_bytes());
+    // uChar.UnicodeChar: WCHAR at offset 14
+    r[14..16].copy_from_slice(&ch.to_le_bytes());
+    // dwControlKeyState: DWORD at offset 16
+    r[16..20].copy_from_slice(&0u32.to_le_bytes());
+}
+
+/// Join paths into the byte string that is shipped to the backend.
+///
+/// Contract: each path on its own line (newline-separated), with a
+/// **trailing space** so a subsequent backend prompt doesn't fuse with
+/// the last path. Empty input yields an empty string.
+pub fn join_paths_for_injection(paths: &[String]) -> String {
+    if paths.is_empty() {
+        return String::new();
+    }
+    let mut s = paths.join("\n");
+    s.push(' ');
+    s
+}
+
+/// Build a PTY-mode injector: writes the joined paths into the supplied
+/// PTY master. The master must be `Send` so the OLE callback (which
+/// runs on the GUI thread that owns the console window) can invoke it.
+pub fn pty_master_injector(master: Arc<Mutex<Box<dyn Write + Send>>>) -> DropInjector {
+    Box::new(move |paths: &[String]| {
+        if paths.is_empty() {
+            return;
+        }
+        let payload = join_paths_for_injection(paths);
+        if let Ok(mut guard) = master.lock() {
+            // Best-effort: a failed write here can't be surfaced to the
+            // user from inside the OLE callback. Drop silently.
+            let _ = guard.write_all(payload.as_bytes());
+            let _ = guard.flush();
+        }
+    })
+}
+
+/// Build a subprocess-mode injector that writes the joined paths into
+/// the *console input buffer* via `WriteConsoleInputW`. The backend's
+/// `ReadFile`/`ReadConsole` then sees them as if typed.
+#[cfg(windows)]
+pub fn subprocess_console_injector() -> DropInjector {
+    Box::new(move |paths: &[String]| {
+        if paths.is_empty() {
+            return;
+        }
+        let payload = join_paths_for_injection(paths);
+        let records = build_input_records(&payload);
+        // Best-effort — like the PTY path, we can't surface failures
+        // from inside the OLE callback.
+        let _ = write_to_console_input(&records);
+    })
+}
+
+/// Windows-only: write a pre-built `INPUT_RECORD` byte buffer to the
+/// console input buffer attached to the current process.
+///
+/// `records_bytes` must be a multiple of [`INPUT_RECORD_SIZE`]; partial
+/// records are an error.
+#[cfg(windows)]
+pub fn write_to_console_input(records_bytes: &[u8]) -> std::io::Result<()> {
+    use windows::Win32::System::Console::{
+        GetStdHandle, WriteConsoleInputW, INPUT_RECORD, STD_INPUT_HANDLE,
+    };
+
+    if records_bytes.is_empty() {
+        return Ok(());
+    }
+    if records_bytes.len() % INPUT_RECORD_SIZE != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "records buffer length {} is not a multiple of {}",
+                records_bytes.len(),
+                INPUT_RECORD_SIZE
+            ),
+        ));
+    }
+
+    // SAFETY: INPUT_RECORD is repr(C) and our byte layout matches its
+    // wire format exactly (verified by build_input_records tests).
+    // Reinterpret the slice for the FFI call.
+    let count = records_bytes.len() / INPUT_RECORD_SIZE;
+    let records: &[INPUT_RECORD] =
+        unsafe { std::slice::from_raw_parts(records_bytes.as_ptr() as *const INPUT_RECORD, count) };
+
+    let stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) }.map_err(|e| {
+        std::io::Error::other(format!("GetStdHandle(STD_INPUT_HANDLE) failed: {e}"))
+    })?;
+
+    let mut written: u32 = 0;
+    unsafe {
+        WriteConsoleInputW(stdin, records, &mut written)
+            .map_err(|e| std::io::Error::other(format!("WriteConsoleInputW failed: {e}")))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_input_records_for_simple_ascii() {
+        // "hi" → 4 records: h-down, h-up, i-down, i-up.
+        let records = build_input_records("hi");
+        assert_eq!(records.len(), 4 * INPUT_RECORD_SIZE);
+
+        // Record 0: 'h' down
+        assert_eq!(&records[0..2], &KEY_EVENT.to_le_bytes());
+        assert_eq!(&records[4..8], &1i32.to_le_bytes()); // bKeyDown = TRUE
+        assert_eq!(&records[10..12], &0u16.to_le_bytes()); // VK = 0
+        assert_eq!(&records[14..16], &(b'h' as u16).to_le_bytes());
+
+        // Record 1: 'h' up
+        let r1 = &records[INPUT_RECORD_SIZE..2 * INPUT_RECORD_SIZE];
+        assert_eq!(&r1[0..2], &KEY_EVENT.to_le_bytes());
+        assert_eq!(&r1[4..8], &0i32.to_le_bytes()); // bKeyDown = FALSE
+        assert_eq!(&r1[14..16], &(b'h' as u16).to_le_bytes());
+
+        // Record 3: 'i' up
+        let r3 = &records[3 * INPUT_RECORD_SIZE..4 * INPUT_RECORD_SIZE];
+        assert_eq!(&r3[4..8], &0i32.to_le_bytes());
+        assert_eq!(&r3[14..16], &(b'i' as u16).to_le_bytes());
+    }
+
+    #[test]
+    fn build_input_records_handles_unicode() {
+        // BMP non-ASCII char — single UTF-16 unit.
+        let records = build_input_records("é");
+        assert_eq!(records.len(), 2 * INPUT_RECORD_SIZE);
+        let down = &records[0..INPUT_RECORD_SIZE];
+        let expected_unit: u16 = 0x00E9; // 'é'
+        assert_eq!(&down[14..16], &expected_unit.to_le_bytes());
+        assert_eq!(&down[10..12], &0u16.to_le_bytes()); // VK = 0 for unicode-char path
+    }
+
+    #[test]
+    fn build_input_records_handles_supplementary_plane_emoji() {
+        // 🚀 (U+1F680) encodes to a surrogate pair in UTF-16. We emit
+        // four records — down/up for each surrogate code unit.
+        let records = build_input_records("🚀");
+        assert_eq!(records.len(), 4 * INPUT_RECORD_SIZE);
+        // High surrogate first
+        let high = u16::from_le_bytes([records[14], records[15]]);
+        assert!((0xD800..=0xDBFF).contains(&high));
+        let low = u16::from_le_bytes([
+            records[2 * INPUT_RECORD_SIZE + 14],
+            records[2 * INPUT_RECORD_SIZE + 15],
+        ]);
+        assert!((0xDC00..=0xDFFF).contains(&low));
+    }
+
+    #[test]
+    fn build_input_records_handles_newline() {
+        // "a\nb" produces a-down, a-up, RETURN-down, RETURN-up, b-down, b-up.
+        let records = build_input_records("a\nb");
+        assert_eq!(records.len(), 6 * INPUT_RECORD_SIZE);
+
+        // Record 2 should be VK_RETURN down with UnicodeChar = 0.
+        let r2 = &records[2 * INPUT_RECORD_SIZE..3 * INPUT_RECORD_SIZE];
+        assert_eq!(&r2[4..8], &1i32.to_le_bytes()); // key down
+        assert_eq!(&r2[10..12], &VK_RETURN.to_le_bytes());
+        assert_eq!(&r2[14..16], &0u16.to_le_bytes());
+    }
+
+    #[test]
+    fn build_input_records_skips_bare_cr() {
+        // CRLF — we should emit ONE VK_RETURN sequence (for the LF),
+        // not two and not a bare-CR no-op.
+        let crlf = build_input_records("\r\n");
+        assert_eq!(crlf.len(), 2 * INPUT_RECORD_SIZE); // just RETURN-down + RETURN-up
+        let r0 = &crlf[0..INPUT_RECORD_SIZE];
+        assert_eq!(&r0[10..12], &VK_RETURN.to_le_bytes());
+    }
+
+    #[test]
+    fn build_input_records_empty_string() {
+        assert!(build_input_records("").is_empty());
+    }
+
+    #[test]
+    fn join_paths_for_injection_single_path_has_trailing_space() {
+        let s = join_paths_for_injection(&[r"C:\a.txt".to_string()]);
+        assert_eq!(s, "C:\\a.txt ");
+    }
+
+    #[test]
+    fn join_paths_for_injection_multi_path_uses_newlines_with_trailing_space() {
+        let s = join_paths_for_injection(&[r"C:\a.txt".to_string(), r"C:\b.txt".to_string()]);
+        assert_eq!(s, "C:\\a.txt\nC:\\b.txt ");
+    }
+
+    #[test]
+    fn join_paths_for_injection_empty_returns_empty() {
+        assert!(join_paths_for_injection(&[]).is_empty());
+    }
+
+    #[test]
+    fn pty_master_injector_writes_normalized_path_with_trailing_space() {
+        // Fake PTY master: an in-memory Vec<u8> behind Arc<Mutex<Box<dyn Write + Send>>>.
+        struct VecWriter(Arc<Mutex<Vec<u8>>>);
+        impl Write for VecWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let writer: Box<dyn Write + Send> = Box::new(VecWriter(Arc::clone(&captured)));
+        let master = Arc::new(Mutex::new(writer));
+
+        let injector = pty_master_injector(master);
+        injector(&[r"C:\a.txt".to_string(), r"C:\b.txt".to_string()]);
+
+        let got = captured.lock().unwrap().clone();
+        assert_eq!(got, b"C:\\a.txt\nC:\\b.txt ");
+    }
+
+    #[test]
+    fn pty_master_injector_empty_paths_writes_nothing() {
+        struct VecWriter(Arc<Mutex<Vec<u8>>>);
+        impl Write for VecWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let captured: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let writer: Box<dyn Write + Send> = Box::new(VecWriter(Arc::clone(&captured)));
+        let master = Arc::new(Mutex::new(writer));
+
+        let injector = pty_master_injector(master);
+        injector(&[]);
+
+        assert!(captured.lock().unwrap().is_empty());
+    }
+}

--- a/crates/clud-bin/src/dnd/mod.rs
+++ b/crates/clud-bin/src/dnd/mod.rs
@@ -30,11 +30,14 @@
 //!   structure. Used by the (Windows-only) `IDropTarget` adapter that
 //!   intercepts drops before conhost can refuse them. See issue #66.
 //! - [`console_drop_target`] — Windows-only `IDropTarget` registration
-//!   skeleton + platform-agnostic dispatch glue. Addresses issue #65
-//!   (OS-level drop refusal); see issue #66 for the design.
+//!   plus the platform-agnostic dispatch glue. See issues #65, #66, #79.
+//! - [`injectors`] — per-launch-mode byte injectors that the
+//!   `IDropTarget` callback hands the dropped paths to (subprocess via
+//!   `WriteConsoleInputW`, PTY via the master writer).
 
 pub mod console_drop_target;
 pub mod dropfiles;
+pub mod injectors;
 
 /// Normalize a single dragged-path payload emitted by a terminal into a
 /// plain filesystem path.

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,6 +1,6 @@
 use clud::{
-    args, backend, command, daemon, loop_spec, session, session_registry, subprocess, trampoline,
-    voice, wasm,
+    args, backend, command, daemon, dnd, loop_spec, session, session_registry, subprocess,
+    trampoline, voice, wasm,
 };
 
 use std::io::{self, Read};
@@ -100,6 +100,26 @@ fn main() {
         std::process::exit(0);
     }
 
+    // Issue #79 / #65 / #66: register `clud` as the IDropTarget for
+    // the console window so dropped files reach the backend. Held for
+    // the lifetime of the launch; dropped on graceful exit so the
+    // refresh worker thread joins and `RevokeDragDrop` runs. POSIX
+    // skips this — terminals there already deliver drops as stdin
+    // bytes that the #63 normalizer handles. `--no-dnd` opts out.
+    //
+    // PTY mode wires the registration *inside* `run_plan_pty` so the
+    // injector can write into the live PTY via a channel. Subprocess
+    // mode registers up-front because the `subprocess_console_injector`
+    // operates on the shared console input buffer, no per-iteration
+    // state required.
+    let _dnd_subprocess_guard = if should_register_drop_target(&args)
+        && plan.launch_mode == backend::LaunchMode::Subprocess
+    {
+        try_register_console_drop_target_subprocess()
+    } else {
+        None
+    };
+
     // Issue #73: open the SQLite session registry, GC dead siblings,
     // refuse to launch if we're at the cap, otherwise insert our own row.
     // Held until end-of-`main` so `Drop` removes the row on graceful exit.
@@ -121,11 +141,98 @@ fn main() {
             backend::LaunchMode::Subprocess => {
                 run_plan_subprocess(&plan, args.verbose, interrupted.as_ref())
             }
-            backend::LaunchMode::Pty => run_plan_pty(&plan, args.verbose, interrupted.as_ref()),
+            backend::LaunchMode::Pty => run_plan_pty(
+                &plan,
+                args.verbose,
+                interrupted.as_ref(),
+                should_register_drop_target(&args),
+            ),
         }
     };
     drop(_registry_guard);
+    drop(_dnd_subprocess_guard);
     std::process::exit(exit_code);
+}
+
+/// Issue #79: a launch should register the console IDropTarget unless
+/// the user opted out (`--no-dnd`) or the run can't possibly need a
+/// drop target (`--dry-run` returns before this is consulted, but the
+/// helper still rejects it for symmetry / explicit testability).
+///
+/// Factored out so `main.rs`'s logic can be unit-tested without
+/// touching OLE or spawning processes.
+fn should_register_drop_target(args: &args::Args) -> bool {
+    if args.no_dnd {
+        return false;
+    }
+    if args.dry_run {
+        return false;
+    }
+    cfg!(windows)
+}
+
+/// Subprocess-mode IDropTarget registration. Returns `None` on any
+/// failure (logging a one-line warning to stderr), so a registration
+/// hiccup never aborts the launch path.
+fn try_register_console_drop_target_subprocess(
+) -> Option<dnd::console_drop_target::ConsoleDropTargetGuard> {
+    #[cfg(not(windows))]
+    {
+        None
+    }
+    #[cfg(windows)]
+    {
+        use dnd::console_drop_target::{register_console_drop_target, RefreshConfig};
+        let injector = dnd::injectors::subprocess_console_injector();
+        match register_console_drop_target(injector, RefreshConfig::default_displacement()) {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                eprintln!("[clud] note: console drag-drop unavailable: {}", e);
+                None
+            }
+        }
+    }
+}
+
+/// PTY-mode IDropTarget registration. The injector writes into a
+/// channel; the pump drains it each iteration and forwards into the
+/// PTY master.
+#[cfg(windows)]
+fn try_register_console_drop_target_pty() -> (
+    Option<dnd::console_drop_target::ConsoleDropTargetGuard>,
+    Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+) {
+    use dnd::console_drop_target::{register_console_drop_target, RefreshConfig};
+    use std::sync::{mpsc, Arc, Mutex};
+
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+
+    // Adapter `Write` impl: each `write_all` from the OLE callback
+    // becomes a `Vec<u8>` chunk in the channel. Send failure means the
+    // pump exited (receiver dropped) — silently drop the bytes.
+    struct ChannelWriter(mpsc::Sender<Vec<u8>>);
+    impl std::io::Write for ChannelWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let n = buf.len();
+            let _ = self.0.send(buf.to_vec());
+            Ok(n)
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let writer: Box<dyn std::io::Write + Send> = Box::new(ChannelWriter(tx));
+    let master = Arc::new(Mutex::new(writer));
+    let injector = dnd::injectors::pty_master_injector(master);
+
+    match register_console_drop_target(injector, RefreshConfig::default_displacement()) {
+        Ok(guard) => (Some(guard), Some(rx)),
+        Err(e) => {
+            eprintln!("[clud] note: console drag-drop unavailable: {}", e);
+            (None, None)
+        }
+    }
 }
 
 /// Issue #73: enforce the live-session cap. On `Refuse` this calls
@@ -323,7 +430,12 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
     last_exit
 }
 
-fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicBool) -> i32 {
+fn run_plan_pty(
+    plan: &command::LaunchPlan,
+    verbose: bool,
+    interrupted: &AtomicBool,
+    dnd_enabled: bool,
+) -> i32 {
     use running_process_core::pty::NativePtyProcess;
 
     // Enable VT input on the Windows console for the whole PTY session.
@@ -332,6 +444,23 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
     // inherits the console directly and must be allowed to configure input
     // modes itself.
     let _console_guard = enable_console_vt_input();
+
+    // Issue #79 / #65 / #66: register the console IDropTarget for PTY
+    // launches. The injector writes into `dnd_rx` which the pump drains
+    // and forwards to the PTY master. Held for the full launch — the
+    // refresh worker thread needs to keep displacing Claude Code's
+    // own IDropTarget across iterations.
+    #[cfg(windows)]
+    let (_dnd_pty_guard, mut dnd_rx) = if dnd_enabled {
+        try_register_console_drop_target_pty()
+    } else {
+        (None, None)
+    };
+    #[cfg(not(windows))]
+    let (_dnd_pty_guard, mut dnd_rx): (Option<()>, Option<std::sync::mpsc::Receiver<Vec<u8>>>) = {
+        let _ = dnd_enabled;
+        (None, None)
+    };
 
     let env = child_env();
     let mut last_exit = 0i32;
@@ -370,7 +499,19 @@ fn run_plan_pty(plan: &command::LaunchPlan, verbose: bool, interrupted: &AtomicB
 
         let mut hooks = voice::VoiceMode::from_env();
         let _raw_guard = session::enter_raw_mode_if_tty();
-        let exit_code = session::run_raw_pty_pump(&process, interrupted, &mut hooks, io::stdin());
+        // First iteration takes ownership of the dnd_rx (if any);
+        // subsequent iterations get None. We can't clone the receiver
+        // and the OLE registration is a one-shot for the whole
+        // process anyway (see RefreshConfig — the worker thread is
+        // shared across iterations).
+        let extra_rx = if iteration == 0 { dnd_rx.take() } else { None };
+        let exit_code = session::run_raw_pty_pump_with_extra_rx(
+            &process,
+            interrupted,
+            &mut hooks,
+            io::stdin(),
+            extra_rx,
+        );
         drop(_raw_guard);
         last_exit = normalize_exit_code(exit_code);
 
@@ -533,12 +674,77 @@ fn atty_is_terminal() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_terminal_size;
+    use super::{resolve_terminal_size, should_register_drop_target};
+    use clud::args::Args;
+
+    fn args_from(argv: &[&str]) -> Args {
+        let raw: Vec<String> = argv.iter().map(|s| s.to_string()).collect();
+        Args::parse_from_raw(raw)
+    }
 
     #[test]
     fn launch_mode_defaults_to_subprocess() {
         let launch_mode = crate::backend::LaunchMode::Subprocess;
         assert_eq!(launch_mode.as_str(), "subprocess");
+    }
+
+    /// Issue #79 B3: a `--dry-run` invocation must NOT trigger any
+    /// `RegisterDragDrop` side effect. We can't observe the OLE call
+    /// directly from a unit test (it would require a console window),
+    /// so we test the gating helper that `main()` consults.
+    #[test]
+    fn main_dry_run_does_not_register_drop_target() {
+        let args = args_from(&["clud", "--dry-run", "-p", "hi"]);
+        assert!(args.dry_run);
+        assert!(
+            !should_register_drop_target(&args),
+            "--dry-run must short-circuit the drop-target registration"
+        );
+    }
+
+    #[test]
+    fn main_no_dnd_flag_disables_registration() {
+        let args = args_from(&["clud", "--no-dnd"]);
+        assert!(args.no_dnd);
+        assert!(
+            !should_register_drop_target(&args),
+            "--no-dnd must opt out of drop-target registration"
+        );
+    }
+
+    #[test]
+    fn main_no_drag_drop_alias_disables_registration() {
+        let args = args_from(&["clud", "--no-drag-drop"]);
+        assert!(args.no_dnd);
+        assert!(!should_register_drop_target(&args));
+    }
+
+    /// Default invocation: registration is requested on Windows, skipped
+    /// on POSIX. The actual COM call is downstream of this gate.
+    #[test]
+    fn main_default_invocation_requests_registration_on_windows() {
+        let args = args_from(&["clud", "-p", "hi"]);
+        let want = cfg!(windows);
+        assert_eq!(should_register_drop_target(&args), want);
+    }
+
+    /// Issue #79 B3: registration failure (any `RegisterError` variant)
+    /// must NOT abort the launch path. The `try_register_console_drop_target_*`
+    /// helpers swallow errors and return `None` so the launch proceeds.
+    ///
+    /// On Windows we exercise this against the real
+    /// `register_console_drop_target` — in a unit-test process there is
+    /// typically no console window, so the registration returns
+    /// `ConsoleWindowUnavailable`, exactly the failure variant we want
+    /// to confirm is non-fatal.
+    #[cfg(windows)]
+    #[test]
+    fn main_registration_failure_does_not_abort_launch() {
+        // Subprocess injector — does no work synchronously; the OLE
+        // failure on the worker thread is what we care about. Whether
+        // it succeeds or fails, the function must return Option<Guard>
+        // (never panic, never abort the process).
+        let _result = super::try_register_console_drop_target_subprocess();
     }
 
     #[test]

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -8,6 +8,8 @@ use crossterm::execute;
 use running_process_core::pty::reexports::portable_pty::PtySize;
 use running_process_core::pty::NativePtyProcess;
 
+use crate::dnd::{looks_like_dropped_path, normalize_dropped_path};
+
 /// Resize the PTY. On Windows, `running_process_core::pty::NativePtyProcess::resize_impl`
 /// is a deliberate no-op (see that crate's `pty/mod.rs:730-737`), so reaching
 /// the underlying master's `resize()` directly is the only way to honor a
@@ -216,9 +218,38 @@ where
     H: InteractiveHooks,
     R: std::io::Read + Send + 'static,
 {
+    run_raw_pty_pump_with_extra_rx(process, interrupted, hooks, stdin_source, None)
+}
+
+/// Production pump entry that wires a side channel for IDropTarget
+/// callbacks (issue #79). Constructs the platform-native resize watcher
+/// internally and passes through to `run_raw_pty_pump_full`.
+///
+/// `extra_rx` chunks are interleaved with stdin chunks and forwarded to
+/// the PTY exactly like real stdin, EXCEPT they bypass the
+/// bracketed-paste normalizer (the OLE/IDropTarget callback already
+/// hands us a normalized, newline-joined path).
+pub fn run_raw_pty_pump_with_extra_rx<H, R>(
+    process: &NativePtyProcess,
+    interrupted: &AtomicBool,
+    hooks: &mut H,
+    stdin_source: R,
+    extra_rx: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+) -> i32
+where
+    H: InteractiveHooks,
+    R: std::io::Read + Send + 'static,
+{
     let (resize_tx, resize_rx) = std::sync::mpsc::channel::<(u16, u16)>();
     spawn_os_resize_watcher(resize_tx);
-    run_raw_pty_pump_with_resize_rx(process, interrupted, hooks, stdin_source, resize_rx)
+    run_raw_pty_pump_full(
+        process,
+        interrupted,
+        hooks,
+        stdin_source,
+        resize_rx,
+        extra_rx,
+    )
 }
 
 /// Spawn the platform-native resize-watcher thread that feeds
@@ -289,6 +320,23 @@ where
     H: InteractiveHooks,
     R: std::io::Read + Send + 'static,
 {
+    run_raw_pty_pump_full(process, interrupted, hooks, stdin_source, resize_rx, None)
+}
+
+/// Most-general pump entry. See `run_raw_pty_pump_with_extra_rx` for
+/// the public-facing version that constructs the resize receiver.
+pub fn run_raw_pty_pump_full<H, R>(
+    process: &NativePtyProcess,
+    interrupted: &AtomicBool,
+    hooks: &mut H,
+    stdin_source: R,
+    resize_rx: std::sync::mpsc::Receiver<(u16, u16)>,
+    extra_rx: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+) -> i32
+where
+    H: InteractiveHooks,
+    R: std::io::Read + Send + 'static,
+{
     use std::sync::mpsc;
 
     let (stdin_tx, stdin_rx) = mpsc::channel::<Vec<u8>>();
@@ -322,6 +370,12 @@ where
     });
 
     let mut observer = F3Observer::new();
+    // Issue #63 / #79: bracketed-paste passes through the PTY pump as
+    // raw bytes. When the user drags a file onto the terminal, the
+    // terminal emits `\x1b[200~ <path-shaped string> \x1b[201~`. We
+    // normalize that path BEFORE forwarding so all backends see a
+    // canonical form, regardless of which terminal produced the drop.
+    let mut paste = BracketedPasteNormalizer::new();
 
     loop {
         // Child output → our stdout is handled by the library's PTY plumbing;
@@ -345,12 +399,35 @@ where
         // `poll_pty_process` and blocks on a full PTY input buffer, so
         // a large pending stdin backlog stops us from noticing that the
         // child has exited. One chunk per loop keeps the cadence even.
+        // Drain one chunk from the side channel (drag-drop OLE
+        // callback) — these are pre-normalized path bytes that should
+        // bypass the bracketed-paste detector and go straight to the
+        // PTY.
+        if let Some(ref rx) = extra_rx {
+            if let Ok(chunk) = rx.try_recv() {
+                if let Err(err) = process.write_impl(&chunk, false) {
+                    eprintln!(
+                        "[clud] warning: failed to forward dropped paths to pty: {}",
+                        err
+                    );
+                }
+            }
+        }
+
         if let Ok(chunk) = stdin_rx.try_recv() {
             let requested_interrupt =
                 interrupt_on_ctrl_c_byte && stdin_chunk_requests_interrupt(&chunk);
-            if let Err(err) = process.write_impl(&chunk, false) {
+            // Run the bracketed-paste normalizer over the chunk BEFORE
+            // forwarding to the PTY. Non-paste bytes pass through with
+            // O(1) state cost (just a 6-byte prefix matcher); paste
+            // bodies are buffered and rewritten in place.
+            let outgoing = paste.process(&chunk);
+            if let Err(err) = process.write_impl(&outgoing, false) {
                 eprintln!("[clud] warning: failed to forward stdin to pty: {}", err);
             } else if hooks.intercept_f3() {
+                // F3 detection still runs over the ORIGINAL chunk: a
+                // press inside a paste body is unusual but we want
+                // detection symmetry with raw byte forwarding.
                 let presses = observer.observe(&chunk);
                 for _ in 0..presses {
                     if let Err(err) = hooks.on_f3_press(process) {
@@ -401,6 +478,142 @@ fn normalize_interactive_console_stdin_chunk(chunk: &mut [u8]) {
 
 fn stdin_chunk_requests_interrupt(chunk: &[u8]) -> bool {
     chunk.contains(&0x03)
+}
+
+/// Bracketed-paste byte sequence emitted by xterm-class terminals when
+/// the user pastes (or drags-and-drops) text.
+const PASTE_START: &[u8] = b"\x1b[200~";
+const PASTE_END: &[u8] = b"\x1b[201~";
+
+/// Stream-resumable bracketed-paste detector that, on each completed
+/// paste, runs the buffered inner content through
+/// [`looks_like_dropped_path`] / [`normalize_dropped_path`] to canonicalize
+/// terminal-specific drop encodings (issue #63 / #79).
+///
+/// Behavior:
+/// - Bytes outside any paste pass through unchanged.
+/// - Bytes inside a bracketed paste are buffered. On `\x1b[201~`:
+///     - If `looks_like_dropped_path(inner)` returns true, emit
+///       `\x1b[200~` + `normalize_dropped_path(inner)` + `\x1b[201~`.
+///     - Otherwise, emit the original `\x1b[200~ inner \x1b[201~` verbatim.
+/// - The detector survives across chunks: a paste split across reads is
+///   reassembled correctly.
+///
+/// The PASS-IT-VERBATIM rule on non-path content is essential — a
+/// multi-line code paste must not be mutated, even if its first line
+/// happens to start with `/`.
+pub struct BracketedPasteNormalizer {
+    /// How many bytes of `PASTE_START` we've matched while outside a
+    /// paste. 0..PASTE_START.len().
+    start_match: usize,
+    /// `Some(buf)` while we are inside a paste body. The buffer holds
+    /// the *inner* paste content (no `\x1b[200~` prefix and no terminal
+    /// `\x1b[201~`).
+    inside: Option<Vec<u8>>,
+    /// How many bytes of `PASTE_END` we've matched while inside a paste.
+    end_match: usize,
+}
+
+impl BracketedPasteNormalizer {
+    pub fn new() -> Self {
+        Self {
+            start_match: 0,
+            inside: None,
+            end_match: 0,
+        }
+    }
+
+    /// Process a chunk, returning the byte stream that should be
+    /// forwarded downstream (PTY master, in production).
+    pub fn process(&mut self, chunk: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(chunk.len());
+        for &b in chunk {
+            if let Some(buf) = self.inside.as_mut() {
+                // We are inside a paste body. Look for PASTE_END.
+                if b == PASTE_END[self.end_match] {
+                    self.end_match += 1;
+                    if self.end_match == PASTE_END.len() {
+                        // Complete: emit normalized form and reset.
+                        let inner = std::mem::take(buf);
+                        self.inside = None;
+                        self.end_match = 0;
+                        emit_paste_block(&mut out, &inner);
+                    }
+                    continue;
+                }
+
+                // PASTE_END prefix broke. Flush any partial-end bytes
+                // back into the inner buffer, then this byte too.
+                if self.end_match > 0 {
+                    buf.extend_from_slice(&PASTE_END[..self.end_match]);
+                    // The byte that broke the prefix may itself start a
+                    // new PASTE_END match.
+                    self.end_match = if b == PASTE_END[0] { 1 } else { 0 };
+                    if self.end_match == 0 {
+                        buf.push(b);
+                    }
+                } else {
+                    buf.push(b);
+                }
+            } else {
+                // We are outside a paste. Look for PASTE_START.
+                if b == PASTE_START[self.start_match] {
+                    self.start_match += 1;
+                    if self.start_match == PASTE_START.len() {
+                        // Complete: enter paste body.
+                        self.start_match = 0;
+                        self.end_match = 0;
+                        self.inside = Some(Vec::new());
+                    }
+                    continue;
+                }
+
+                // PASTE_START prefix broke. Flush partial bytes verbatim.
+                if self.start_match > 0 {
+                    out.extend_from_slice(&PASTE_START[..self.start_match]);
+                    self.start_match = if b == PASTE_START[0] { 1 } else { 0 };
+                    if self.start_match == 0 {
+                        out.push(b);
+                    }
+                } else {
+                    out.push(b);
+                }
+            }
+        }
+        out
+    }
+}
+
+impl Default for BracketedPasteNormalizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Helper for `BracketedPasteNormalizer::process` — given a captured
+/// inner paste body, emit the wrapped (and possibly path-normalized)
+/// bracketed-paste block to `out`.
+fn emit_paste_block(out: &mut Vec<u8>, inner: &[u8]) {
+    out.extend_from_slice(PASTE_START);
+    // Decide path-rewrite on the WHOLE buffer, not per-line: a
+    // multi-line code paste with a path-shaped first line must remain
+    // verbatim. `looks_like_dropped_path` is conservative — it requires
+    // the entire trimmed string to look like a single path token.
+    let s = match std::str::from_utf8(inner) {
+        Ok(s) => s,
+        Err(_) => {
+            out.extend_from_slice(inner);
+            out.extend_from_slice(PASTE_END);
+            return;
+        }
+    };
+    if looks_like_dropped_path(s) {
+        let normalized = normalize_dropped_path(s);
+        out.extend_from_slice(normalized.as_bytes());
+    } else {
+        out.extend_from_slice(inner);
+    }
+    out.extend_from_slice(PASTE_END);
 }
 
 fn reap_pty_exit(process: &NativePtyProcess) -> i32 {
@@ -599,5 +812,95 @@ mod tests {
     fn only_real_stdin_gets_interactive_console_policy() {
         assert!(stdin_source_is_real_stdin::<std::io::Stdin>());
         assert!(!stdin_source_is_real_stdin::<std::io::Cursor<Vec<u8>>>());
+    }
+
+    // ─── BracketedPasteNormalizer (issue #63 / #79) ────────────────────
+
+    #[test]
+    fn paste_normalizer_passthrough_bytes_outside_paste() {
+        let mut p = BracketedPasteNormalizer::new();
+        // Plain typing — no PASTE_START seen — passes through verbatim.
+        let out = p.process(b"hello world\n");
+        assert_eq!(out, b"hello world\n");
+    }
+
+    /// session_paste_normalizes_path_on_drop — when a bracketed paste
+    /// arrives whose body looks like a dragged path, the body must be
+    /// rewritten through `normalize_dropped_path` before forwarding.
+    #[test]
+    fn session_paste_normalizes_path_on_drop() {
+        let mut p = BracketedPasteNormalizer::new();
+        // GNOME-Terminal-style file URI drop. Should canonicalize to
+        // the platform-appropriate path form.
+        let chunk = b"\x1b[200~file:///home/me/my%20file.txt\x1b[201~";
+        let out = p.process(chunk);
+        // Both POSIX and Windows must wrap output in bracketed-paste
+        // markers and percent-decode the URI.
+        assert!(out.starts_with(PASTE_START), "must keep PASTE_START");
+        assert!(out.ends_with(PASTE_END), "must keep PASTE_END");
+        let inner_start = PASTE_START.len();
+        let inner_end = out.len() - PASTE_END.len();
+        let inner = std::str::from_utf8(&out[inner_start..inner_end]).expect("utf8");
+        assert!(
+            inner.contains("my file.txt"),
+            "inner must be percent-decoded; got {inner:?}"
+        );
+        // The original URI scheme is gone (normalized form is a path,
+        // not a URI).
+        assert!(!inner.contains("file://"), "URI must be stripped");
+    }
+
+    /// session_paste_passthrough_for_non_path_text — a paste of plain
+    /// text (e.g. a code snippet) must be forwarded VERBATIM with the
+    /// PASTE_START / PASTE_END markers preserved.
+    #[test]
+    fn session_paste_passthrough_for_non_path_text() {
+        let mut p = BracketedPasteNormalizer::new();
+        let chunk = b"\x1b[200~hello world\x1b[201~";
+        let out = p.process(chunk);
+        // No path → exact passthrough.
+        assert_eq!(out, b"\x1b[200~hello world\x1b[201~");
+    }
+
+    #[test]
+    fn paste_normalizer_multiline_paste_with_path_first_line_is_passthrough() {
+        // A multi-line paste whose first line happens to look like a
+        // path must not have the path-rewrite applied. The whole-buffer
+        // `looks_like_dropped_path` check handles this — multi-line
+        // strings don't match the heuristic.
+        let mut p = BracketedPasteNormalizer::new();
+        let chunk = b"\x1b[200~/Users/me/x.txt\nlet x = 1;\x1b[201~";
+        let out = p.process(chunk);
+        assert_eq!(out, chunk);
+    }
+
+    #[test]
+    fn paste_normalizer_handles_split_chunks() {
+        // PASTE_START split across two chunks, body in a third, end in a
+        // fourth. The detector must reassemble correctly.
+        let mut p = BracketedPasteNormalizer::new();
+        let mut all = Vec::new();
+        all.extend_from_slice(&p.process(b"abc\x1b[2"));
+        all.extend_from_slice(&p.process(b"00~"));
+        all.extend_from_slice(&p.process(b"hello"));
+        all.extend_from_slice(&p.process(b"\x1b[201~tail"));
+        assert_eq!(all, b"abc\x1b[200~hello\x1b[201~tail");
+    }
+
+    #[test]
+    fn paste_normalizer_broken_start_prefix_is_flushed() {
+        // \x1b[2 then a non-matching byte — the partial prefix should
+        // be forwarded verbatim, not swallowed.
+        let mut p = BracketedPasteNormalizer::new();
+        let out = p.process(b"\x1b[2X");
+        assert_eq!(out, b"\x1b[2X");
+    }
+
+    #[test]
+    fn paste_normalizer_two_pastes_back_to_back() {
+        // Two pastes, neither path-shaped, should pass through cleanly.
+        let mut p = BracketedPasteNormalizer::new();
+        let out = p.process(b"\x1b[200~foo\x1b[201~bar\x1b[200~baz\x1b[201~");
+        assert_eq!(out, b"\x1b[200~foo\x1b[201~bar\x1b[200~baz\x1b[201~");
     }
 }


### PR DESCRIPTION
## Summary

Implements meta issue #79, which rolls up:

- #22 (closed) — original DnD subprocess vs PTY analysis
- #63 — path normalization wiring
- #65 — OS-level drop refusal investigation
- #66 — `IDropTarget` registration on `GetConsoleWindow()`

## What's in this PR

### Part A — Windows OLE/COM `IDropTarget` (commit `8982a53`)

- `crates/clud-bin/Cargo.toml` — `windows = "0.61"` + `windows-core = "0.61"` with the Win32 COM/Ole/Console/DataExchange/Memory/Shell features.
- `crates/clud-bin/src/dnd/console_drop_target.rs` — replaced the `NotImplemented` stub with a full `OleInitialize` + `IDropTarget` (via `windows::core::implement`) + `RegisterDragDrop(GetConsoleWindow(), …)` registration. `Drop` callback decodes `CF_HDROP` via `parse_dropfiles_buffer`, normalizes paths via `normalize_dropped_path`, and forwards to the caller-supplied injector. Includes a refresh worker that re-asserts the registration if Claude Code (or another sibling) displaces it. RAII `ConsoleDropTargetGuard` revokes + uninits on drop.
- `crates/clud-bin/src/dnd/injectors.rs` (new) — `pty_master_injector` (writes normalized path bytes into the PTY master) and `subprocess_console_injector` (`WriteConsoleInputW`-based; synthesizes `KEY_EVENT` records for the shared console input buffer) plus `build_input_records` / `join_paths_for_injection` helpers.

### Part B — Wiring + paste normalization (commit `612c93b`)

- `crates/clud-bin/src/main.rs` — anchored DnD registration. Subprocess mode registers in `main()` just before session-cap enforcement; PTY mode registers inside `run_plan_pty` after `enable_console_vt_input`. Failures print a one-line stderr warning and continue. `--dry-run` skips registration entirely. Helpers `should_register_drop_target`, `try_register_console_drop_target_subprocess`, `try_register_console_drop_target_pty`.
- `crates/clud-bin/src/session.rs` — `BracketedPasteNormalizer` runs incoming paste chunks through `normalize_dropped_path` only when `looks_like_dropped_path` returns true. Hook is at line 415 (`let outgoing = paste.process(&chunk);`). New PTY-pump variants `run_raw_pty_pump_full` / `run_raw_pty_pump_with_extra_rx` accept a drop-channel `mpsc::Receiver<Vec<u8>>` so OLE callbacks (on the GUI thread) can post bytes that the pump drains into the PTY master without sharing the master handle across threads.
- `crates/clud-bin/src/args.rs` — new `--no-dnd` (alias `--no-drag-drop`) flag, default off.

## Tests

- 51 dnd-module tests (parser + dispatch + COM registration smoke + worker loop + refresh-config + injector layout).
- 7 new `session::` tests for `BracketedPasteNormalizer` (path normalize, non-path passthrough, multi-line paste handling, empty/partial chunks).
- 5 new `main::` tests for `should_register_drop_target` + dry-run/`--no-dnd` short-circuits + failure-soft semantics.
- 3 new `args::` tests for `--no-dnd` parsing.

## Test plan

- [x] `bash lint` — clean
- [ ] `bash test` — to be verified by CI on this push
- [ ] Manual Windows: drag from Explorer onto console — cursor shows copy indicator (not ⊘), release inserts the normalized path into the prompt
- [ ] Manual Windows: same under `clud --pty`
- [ ] Manual cross-platform: clud still launches when console is unavailable / on POSIX

🤖 Generated with [Claude Code](https://claude.com/claude-code)