### PR TITLE
refactor(toolchain): drop _cargo/_rustc/_rustfmt trampolines for soldr-direct

### DIFF
--- a/.claude/hooks/check-soldr.py
+++ b/.claude/hooks/check-soldr.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: route Rust toolchain calls through soldr.
+
+Blocks bare ``cargo``/``rustc``/``rustfmt`` Bash invocations and tells the
+agent to prefix them with ``soldr`` (so they resolve through the rustup-
+managed toolchain via ``rustup which`` — see CLAUDE.md). If soldr itself is
+not on PATH, the denial points the user at ``./install``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+
+GUARDED = ("cargo", "rustc", "rustfmt")
+INSTALL_HINT = (
+    "Install it with: ./install   "
+    "(or ./install --global for a system-wide install)."
+)
+
+
+def first_command(cmd: str) -> str | None:
+    """Return the first executable token in a shell command line.
+
+    Skips leading env-var assignments (``FOO=bar BAR=baz cargo ...``) so we
+    still see ``cargo`` as the head.
+    """
+    cmd = cmd.lstrip()
+    while True:
+        m = re.match(r"\s*[A-Za-z_][A-Za-z0-9_]*=\S*\s+", cmd)
+        if not m:
+            break
+        cmd = cmd[m.end() :]
+    m = re.match(r"\s*([^\s|;&<>()`]+)", cmd)
+    return m.group(1) if m else None
+
+
+def normalize(token: str) -> str:
+    base = token.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    return base.split(".", 1)[0]
+
+
+def deny(reason: str) -> None:
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        },
+        sys.stdout,
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    head = first_command(command)
+    if head is None:
+        return 0
+    base = normalize(head)
+
+    soldr_present = shutil.which("soldr") is not None
+
+    if base == "soldr":
+        if not soldr_present:
+            deny(
+                "soldr is not installed but the command requires it.\n"
+                + INSTALL_HINT
+            )
+        return 0
+
+    if base not in GUARDED:
+        return 0
+
+    if not soldr_present:
+        deny(
+            f"`{base}` is blocked: this repo requires Rust toolchain calls to "
+            "go through soldr (https://github.com/zackees/soldr), but soldr "
+            "is not on PATH.\n" + INSTALL_HINT
+        )
+        return 0
+
+    deny(
+        f"`{base}` is blocked: prefix Rust toolchain calls with `soldr` so "
+        "they resolve through the rustup-managed toolchain. "
+        f"Re-run as: soldr {base} ... (preserves remaining args)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/check-soldr.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,12 @@ coverage-*.xml
 # clud loop state (GH issue cache, DONE/BLOCKED markers)
 .clud/
 
-# Claude Code session state
-.claude/
+# Claude Code: ignore ephemeral session/cache state, keep project config
+# (settings + hooks + commands + agents + skills are checked in).
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/commands/
+!.claude/agents/
+!.claude/skills/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ This file provides guidance to Claude Code when working with this repository.
 - **Lint**: `bash lint` - Run cargo fmt, clippy, and ruff (**MANDATORY** after code changes)
 - **Test**: `bash test` - Run Rust unit tests + Python unit tests
 - **Test (Full)**: `bash test --integration` - Include integration tests with mock agents
-- **Wrong toolchain?**: use `./_cargo`, `./_rustc`, `./_rustfmt` — these route through [soldr](https://github.com/zackees/soldr) (pulled via dev deps) which resolves the rustup-managed toolchain via `rustup which`. Handy on Windows where chocolatey cargo or other stale shims can take precedence on PATH. `soldr cargo ...` works directly too.
+- **Rust toolchain calls** (`cargo`, `rustc`, `rustfmt`) **must go through [soldr](https://github.com/zackees/soldr)**: `soldr cargo build`, `soldr rustc ...`, etc. soldr resolves the rustup-managed toolchain via `rustup which`, sidestepping chocolatey cargo on Windows and other stale PATH shims. A `.claude/hooks/check-soldr.py` PreToolUse hook enforces this and tells you to install soldr if it's missing.
+- **Install soldr**: run `./install` (places it in this repo's `.venv`) or `./install --global` (places it in `~/.cargo/bin` or `~/.local/bin`). soldr is intentionally **not** a Python dep — it is installed as a standalone binary from GitHub Releases. CI uses `zackees/setup-soldr@v0`.
 
 ### Architecture
 

--- a/_cargo
+++ b/_cargo
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Optional trampoline for developers who hit wrong-toolchain issues
-# (chocolatey cargo on Windows, stale system rust on Linux, etc.).
-# Routes through soldr so `rustup which` picks the rustup-managed
-# toolchain. `--no-cache` keeps soldr's RUSTC_WRAPPER / zccache path
-# off so this matches bare-cargo semantics.
-exec uv run soldr --no-cache cargo "$@"

--- a/_rustc
+++ b/_rustc
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Optional trampoline — routes rustc through soldr so the
-# rustup-managed toolchain is always used.
-exec uv run soldr rustc "$@"

--- a/_rustfmt
+++ b/_rustfmt
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Optional trampoline — routes rustfmt through soldr so the
-# rustup-managed toolchain is always used.
-exec uv run soldr rustfmt "$@"

--- a/install
+++ b/install
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Install the soldr binary used by build/lint/test to route Rust toolchain
+# calls through `rustup which`. soldr is intentionally NOT a Python dep —
+# it ships as a standalone binary published to GitHub Releases.
+#
+# Default: install into this repo's .venv ({Scripts,bin}/soldr[.exe]).
+# With --global: install into ~/.cargo/bin (or ~/.local/bin if absent).
+
+set -euo pipefail
+
+VERSION="${SOLDR_VERSION:-0.7.11}"
+GLOBAL=0
+
+usage() {
+    cat <<EOF
+Usage: ./install [--global] [--version=VERSION]
+
+Installs soldr (https://github.com/zackees/soldr) — a thin wrapper around
+the rustup-managed cargo/rustc/rustfmt that this repo's build scripts
+expect on PATH.
+
+Options:
+  --global              Install to ~/.cargo/bin (or ~/.local/bin) instead
+                        of the local .venv. Useful if you work across
+                        multiple Rust repos.
+  --version=VERSION     Pin a specific soldr version (default: ${VERSION}).
+  -h, --help            Show this message.
+
+Environment:
+  SOLDR_VERSION         Same as --version.
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --global) GLOBAL=1 ;;
+        --version=*) VERSION="${arg#--version=}" ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown arg: $arg" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+uname_s=$(uname -s)
+uname_m=$(uname -m)
+
+case "$uname_m" in
+    x86_64|amd64) arch=x86_64 ;;
+    aarch64|arm64) arch=aarch64 ;;
+    *) echo "unsupported architecture: $uname_m" >&2; exit 1 ;;
+esac
+
+case "$uname_s" in
+    Linux*)   triple="${arch}-unknown-linux-gnu"; ext=tar.gz ;;
+    Darwin*)  triple="${arch}-apple-darwin";      ext=tar.gz ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+              triple="${arch}-pc-windows-msvc";   ext=zip ;;
+    *) echo "unsupported OS: $uname_s" >&2; exit 1 ;;
+esac
+
+asset="soldr-v${VERSION}-${triple}.${ext}"
+url="https://github.com/zackees/soldr/releases/download/v${VERSION}/${asset}"
+binary="soldr"
+[[ "$ext" == "zip" ]] && binary="soldr.exe"
+
+repo_root="$(cd "$(dirname "$0")" && pwd)"
+
+if (( GLOBAL )); then
+    if [[ -d "${HOME}/.cargo/bin" ]]; then
+        target_dir="${HOME}/.cargo/bin"
+    else
+        target_dir="${HOME}/.local/bin"
+        mkdir -p "$target_dir"
+    fi
+else
+    if [[ -d "${repo_root}/.venv/Scripts" ]]; then
+        target_dir="${repo_root}/.venv/Scripts"
+    elif [[ -d "${repo_root}/.venv/bin" ]]; then
+        target_dir="${repo_root}/.venv/bin"
+    else
+        echo "no .venv at ${repo_root}/.venv — run 'uv sync --group dev' first, or pass --global" >&2
+        exit 1
+    fi
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading $url"
+curl -fSL "$url" -o "$tmp/$asset"
+
+if [[ "$ext" == "zip" ]]; then
+    if command -v unzip >/dev/null 2>&1; then
+        unzip -q "$tmp/$asset" -d "$tmp"
+    else
+        python -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
+            "$tmp/$asset" "$tmp"
+    fi
+else
+    tar -xzf "$tmp/$asset" -C "$tmp"
+fi
+
+src=$(find "$tmp" -type f -name "$binary" | head -n1)
+if [[ -z "$src" ]]; then
+    echo "binary $binary not found in $asset" >&2
+    exit 1
+fi
+
+cp "$src" "$target_dir/$binary"
+chmod +x "$target_dir/$binary"
+echo "Installed soldr ${VERSION} -> $target_dir/$binary"
+"$target_dir/$binary" --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,11 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest-timeout>=2.3.0",
     "ruff>=0.8.0",
-    "soldr>=0.7.0",
     "ziglang>=0.15.2,<0.16",
 ]
+# soldr is intentionally NOT a Python dev dep — install it via ./install
+# (or `./install --global`) which fetches the binary from
+# https://github.com/zackees/soldr/releases. CI uses zackees/setup-soldr@v0.
 
 [tool.maturin]
 manifest-path = "crates/clud-bin/Cargo.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
     { name = "ruff" },
-    { name = "soldr" },
     { name = "ziglang" },
 ]
 
@@ -27,7 +26,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-timeout", specifier = ">=2.3.0" },
     { name = "ruff", specifier = ">=0.8.0" },
-    { name = "soldr", specifier = ">=0.7.0" },
     { name = "ziglang", specifier = ">=0.15.2,<0.16" },
 ]
 
@@ -302,19 +300,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
-]
-
-[[package]]
-name = "soldr"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/3b/c03ade86970c66712753986377ba1adfa9693cf73acbfabf9dcc70482c3b/soldr-0.7.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:009f08913325f807cb48bd58525a664102c63a1838cc7ed25d7dc053dfdbb380", size = 2775435, upload-time = "2026-04-16T23:08:58.003Z" },
-    { url = "https://files.pythonhosted.org/packages/57/2c/38b0366677e5a7b1f3e8a612f7787a07e04b81177bb2c9e034308eef39e7/soldr-0.7.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:27e5ad1933c213c37da1c0354ebe961d5a443c0d3cc30a458ba25b8bbcddf644", size = 2651596, upload-time = "2026-04-16T23:09:00.01Z" },
-    { url = "https://files.pythonhosted.org/packages/29/d6/827acd12fc8d4c291cfd6c71daf59e73a23282584db7aa1ec135f0a51311/soldr-0.7.0-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:0804c5e12bffe1219f573d66e666de15f2b032175cae83b8f75e56c8a7a1d2ce", size = 2888157, upload-time = "2026-04-16T23:09:01.854Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/e3/468ac6e5f86f5b5f966a5de8dd605f00efcd5c7a05f47844d6c5966b338a/soldr-0.7.0-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:003b75cf684c1be78ede590690283a646fead8ca287b03c63671dca833ad29d0", size = 2961724, upload-time = "2026-04-16T23:09:03.617Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bc/bc4182dfde721d8042fffd9b80bd6322e0961dc58bfbae04da7e4b72f857/soldr-0.7.0-py3-none-win_amd64.whl", hash = "sha256:1b749e51595abca5b325f37b6217104f19cbabbf73b895558a75b9f2522d9bef", size = 2557703, upload-time = "2026-04-16T23:09:05.158Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/76/e3a348a05251b5a80df0ece4e9c2c830b1ce1adb9418d288060618b71e14/soldr-0.7.0-py3-none-win_arm64.whl", hash = "sha256:9e297c34296ebbac3036f9011fbd0b0c7409a5765b9770626280f4600f1ebdb3", size = 2439090, upload-time = "2026-04-16T23:09:06.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Delete the `_cargo`, `_rustc`, `_rustfmt` shell trampolines; agents and humans now call soldr directly (`soldr cargo build`, etc.).
- Add a `.claude/hooks/check-soldr.py` PreToolUse hook (wired up in `.claude/settings.json`) that blocks bare `cargo`/`rustc`/`rustfmt` Bash calls — and points the user at `./install` when soldr is missing from PATH.
- New `./install` script downloads the matching soldr binary from GitHub Releases. Default lands in `.venv/{Scripts,bin}`; `--global` lands in `~/.cargo/bin` (fallback `~/.local/bin`). Pin via `--version=` or `SOLDR_VERSION=`.
- Remove `soldr` from pyproject dev deps so it never ships in the wheel and isn't pulled by `uv sync`. uv.lock relocked accordingly.
- `.gitignore`: stop ignoring all of `.claude/` — keep checked-in project config (settings/hooks/commands/agents/skills), still ignore session state + `settings.local.json`.
- `CLAUDE.md` updated with the new install + invocation flow.

CI is unaffected — workflows already use `zackees/setup-soldr@v0` to put soldr on PATH.

## Test plan
- [x] `bash lint` (cargo fmt + clippy + ruff) passes locally
- [x] `bash test` (104 Rust unit tests + 40 Python tests) passes locally
- [x] Hook smoke-tested with `cargo build`, `soldr cargo build`, `ls -la`, `FOO=bar rustc --version` payloads — blocks bare cargo/rustc/rustfmt, allows soldr-prefixed and unrelated commands
- [x] `./install --help` runs cleanly
- [ ] CI matrix passes (Linux/Windows/macOS x86 + ARM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)