### PR TITLE
chore(lint): ban tokio::process in banned_imports

### DIFF
--- a/ci/banned_imports.py
+++ b/ci/banned_imports.py
@@ -22,6 +22,10 @@ BANNED_PATTERNS: list[tuple[str, str]] = [
     (r"\bstd::process::Child\b", "use running_process_core::NativeProcess instead"),
     (r"\bstd::process::Output\b", "use running_process_core::NativeProcess instead"),
     (r"\buse std::process::\{", "use running_process_core instead of std::process"),
+    # Tokio's async process API is also banned — running-process-core is the
+    # single chokepoint. If async is needed, extend running-process-core.
+    (r"\btokio::process\b", "use running_process_core::NativeProcess instead"),
+    (r"\buse tokio::process\b", "use running_process_core instead of tokio::process"),
 ]
 
 # Only std::process::exit is allowed (it's not subprocess spawning)


### PR DESCRIPTION
## Summary
- Adds explicit `tokio::process` and `use tokio::process` patterns to `ci/banned_imports.py`.
- Forward guard: tokio isn't a dependency today, but if it gets pulled in later (directly or transitively wired into a crate), all subprocess execution must still funnel through `running-process-core`.
- The existing `\bprocess::Command\b` rule already catches `tokio::process::Command` via substring match, but the error message pointed at std. The new rules give the right hint ("use running_process_core::NativeProcess instead").

## Test plan
- [x] `uv run python -m ci.banned_imports` passes (no false positives in current tree)
- [x] Regex sanity-checked against `use tokio::process::Command;`, `tokio::process::Command::new(...)`, `use tokio::process;` — all match. `std::process::exit` and unrelated lines do not match.
- [ ] CI matrix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)