### PR TITLE
fix(dnd): gate Windows-only helpers behind cfg(windows) (#84)

### DIFF
--- a/crates/clud-bin/src/dnd/console_drop_target.rs
+++ b/crates/clud-bin/src/dnd/console_drop_target.rs
@@ -180,14 +180,20 @@ impl Default for RefreshConfig {
 /// COM.
 ///
 /// Production code uses the Windows-only `OleRegistrar`; tests use a
-/// `MockRegistrar` that just counts calls.
+/// `MockRegistrar` that just counts calls. Gated to Windows + tests
+/// because non-Windows targets never wire up an `IDropTarget` and
+/// would otherwise see this trait as dead code.
+#[cfg(any(windows, test))]
 trait DragDropRegistrar: Send + Sync {
     /// Register `clud` as the drop target. Returns the raw HRESULT on
     /// failure (so the worker loop can surface it via
     /// [`RegisterError::RegisterDragDropFailed`]).
     fn register(&self) -> Result<(), i32>;
     /// Revoke our registration. Best-effort — errors are logged but
-    /// can't be surfaced from `Drop`.
+    /// can't be surfaced from `Drop`. Only invoked from the
+    /// Windows-only `OleKeepAlive::drop`; non-Windows test builds
+    /// never call this so silence the dead-code lint there.
+    #[cfg_attr(not(windows), allow(dead_code))]
     fn revoke(&self) -> Result<(), i32>;
 }
 
@@ -197,6 +203,10 @@ struct RefreshShutdown {
 }
 
 impl RefreshShutdown {
+    /// Used only when constructing a live registration on Windows or
+    /// in unit tests; non-Windows builds never construct a
+    /// `RefreshShutdown`.
+    #[cfg(any(windows, test))]
     fn new() -> Self {
         Self {
             flag: AtomicBool::new(false),
@@ -205,6 +215,9 @@ impl RefreshShutdown {
     fn signal(&self) {
         self.flag.store(true, Ordering::SeqCst);
     }
+    /// Read by `responsive_sleep` and `run_registration_loop`, both of
+    /// which are themselves Windows-or-test only.
+    #[cfg(any(windows, test))]
     fn is_signaled(&self) -> bool {
         self.flag.load(Ordering::SeqCst)
     }
@@ -213,6 +226,7 @@ impl RefreshShutdown {
 /// Sleep `total` in slices of at most `chunk`, exiting early if
 /// `shutdown` is signaled. Returns `true` if the sleep completed
 /// without a shutdown signal, `false` if interrupted.
+#[cfg(any(windows, test))]
 fn responsive_sleep(total: Duration, shutdown: &RefreshShutdown) -> bool {
     if shutdown.is_signaled() {
         return false;
@@ -241,6 +255,7 @@ fn responsive_sleep(total: Duration, shutdown: &RefreshShutdown) -> bool {
 /// Returns `Ok(())` after the loop exits cleanly via the shutdown
 /// signal, or `Err(hr)` if the *initial* registration failed (so the
 /// caller can surface `RegisterDragDropFailed(hr)`).
+#[cfg(any(windows, test))]
 fn run_registration_loop<R: DragDropRegistrar + ?Sized>(
     registrar: &R,
     config: RefreshConfig,
@@ -829,7 +844,6 @@ mod tests {
 
     struct MockRegistrar {
         register_calls: Arc<AtomicUsize>,
-        revoke_calls: Arc<AtomicUsize>,
         fail_initial: bool,
     }
 
@@ -842,7 +856,6 @@ mod tests {
             Ok(())
         }
         fn revoke(&self) -> Result<(), i32> {
-            self.revoke_calls.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
     }
@@ -851,7 +864,6 @@ mod tests {
     fn registration_loop_calls_register_once_when_refresh_disabled() {
         let registrar = MockRegistrar {
             register_calls: Arc::new(AtomicUsize::new(0)),
-            revoke_calls: Arc::new(AtomicUsize::new(0)),
             fail_initial: false,
         };
         let calls = Arc::clone(&registrar.register_calls);
@@ -865,7 +877,6 @@ mod tests {
     fn registration_loop_surfaces_initial_failure() {
         let registrar = MockRegistrar {
             register_calls: Arc::new(AtomicUsize::new(0)),
-            revoke_calls: Arc::new(AtomicUsize::new(0)),
             fail_initial: true,
         };
         let shutdown = RefreshShutdown::new();
@@ -879,7 +890,6 @@ mod tests {
     fn registration_loop_refreshes_periodically() {
         let registrar = Arc::new(MockRegistrar {
             register_calls: Arc::new(AtomicUsize::new(0)),
-            revoke_calls: Arc::new(AtomicUsize::new(0)),
             fail_initial: false,
         });
         let calls = Arc::clone(&registrar.register_calls);
@@ -914,7 +924,6 @@ mod tests {
     fn registration_loop_exits_promptly_on_shutdown_during_initial_delay() {
         let registrar = Arc::new(MockRegistrar {
             register_calls: Arc::new(AtomicUsize::new(0)),
-            revoke_calls: Arc::new(AtomicUsize::new(0)),
             fail_initial: false,
         });
         let calls = Arc::clone(&registrar.register_calls);


### PR DESCRIPTION
## Summary

Closes #84.

PR #80's CI failed on Linux ARM Lint and Linux x86 Lint with several dead-code errors — `DragDropRegistrar` trait, `responsive_sleep`, `run_registration_loop`, and the `MockRegistrar` fields are only exercised by the Windows `IDropTarget` COM path.

Gate them with `#[cfg(any(windows, test))]` (or `#[cfg(windows)]` where appropriate) so non-Windows targets compile clean under `-D warnings`.

## Items gated

| Item | Gate | Why |
|---|---|---|
| `DragDropRegistrar` trait | `#[cfg(any(windows, test))]` | Only impls are `OleRegistrar` (Windows COM) and `MockRegistrar` (test). |
| `DragDropRegistrar::revoke` | `#[cfg_attr(not(windows), allow(dead_code))]` | Required for `OleKeepAlive::drop` on Windows; no test exercises the mock's revoke. |
| `RefreshShutdown::new` and `is_signaled` | `#[cfg(any(windows, test))]` | Only called from Windows worker spawn or `run_registration_loop` / `responsive_sleep` (themselves gated). `signal()` stays unconditional — `Drop for ConsoleDropTargetGuard` calls it on every platform. |
| `responsive_sleep` | `#[cfg(any(windows, test))]` | Only called from `run_registration_loop` and tests. |
| `run_registration_loop` | `#[cfg(any(windows, test))]` | Only called from the Windows worker thread and tests. |
| `MockRegistrar::revoke_calls` field | deleted | Genuinely never read; the test struct's `revoke` method now just returns `Ok(())`. |

## Test plan

- [x] `bash lint` clean on Windows (clippy `--workspace --all-targets -D warnings`)
- [x] `cargo test --lib -p clud dnd::` — 51 tests pass, including all 14 `console_drop_target` tests
- [ ] Linux x86 / ARM CI — to be verified by CI on this push

## Verification limits

The Linux target couldn't be exercised locally on this Windows host — `cargo clippy --target x86_64-unknown-linux-gnu` fails inside `libsqlite3-sys`'s build script because no Linux GCC cross-toolchain is installed. The fix relies on careful cfg-gate review: every flagged item is now invisible to a `not(windows)` non-test build, and items still in scope on Linux non-test (`signal`, the struct shells referenced via field types) read at least one field, so dead-code should not fire. CI on this PR is the final verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)