### PR TITLE
feat(skill): add /clud-pr-merge (CI-aware merge gate with CodeRabbit + regression-only allowance)

### DIFF
--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -39,6 +39,10 @@ const BUNDLED_SKILLS: &[Skill] = &[
         name: "clud-pr-merge",
         content: include_str!("../../../skills/clud-pr-merge/SKILL.md"),
     },
+    Skill {
+        name: "clud-issue",
+        content: include_str!("../../../skills/clud-issue/SKILL.md"),
+    },
 ];
 
 /// Run the install/check for every bundled skill on launch. Cheap on the
@@ -308,14 +312,18 @@ mod tests {
     }
 
     #[test]
-    fn bundle_includes_clud_pr_and_clud_pr_merge() {
-        // The two skills wired up so far. Adding more is fine; this test
-        // just guards against accidental removal of either.
+    fn bundle_includes_expected_skills() {
+        // The skills wired up so far. Adding more is fine; this test
+        // just guards against accidental removal of any of them.
         let names: Vec<&str> = BUNDLED_SKILLS.iter().map(|s| s.name).collect();
         assert!(names.contains(&"clud-pr"), "clud-pr missing from bundle");
         assert!(
             names.contains(&"clud-pr-merge"),
             "clud-pr-merge missing from bundle"
+        );
+        assert!(
+            names.contains(&"clud-issue"),
+            "clud-issue missing from bundle"
         );
     }
 

--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -1,9 +1,10 @@
-//! Auto-installer for the bundled `/clud-pr` skill.
+//! Auto-installer for the bundled `clud-*` skills.
 //!
-//! On every `clud` launch we ensure `~/.claude/skills/clud-pr/SKILL.md` exists
-//! and matches the version baked into this binary via `include_str!`.
+//! On every `clud` launch we ensure each entry in [`BUNDLED_SKILLS`] is
+//! present at `~/.claude/skills/<name>/SKILL.md` and matches the version
+//! baked into this binary via `include_str!`.
 //!
-//! Three states:
+//! Three states per skill:
 //! - **Missing** — write the embedded copy, log a one-line install notice.
 //! - **Matches modulo whitespace** — silent no-op.
 //! - **Diverges semantically** — warn on stderr; do NOT overwrite. The user
@@ -11,26 +12,50 @@
 //!   into the source repo or revert. Either way, blind overwrite would lose
 //!   their work.
 //!
-//! The skill source-of-truth lives at `skills/clud-pr/SKILL.md` in the repo
+//! Each skill's source-of-truth lives at `skills/<name>/SKILL.md` in the repo
 //! and is embedded at compile time, so a fresh `clud` install always carries
-//! the current canonical copy.
+//! the current canonical copy of every bundled skill.
 //!
 //! All errors are non-fatal. A skill-install hiccup never breaks the launch
 //! path — at worst the user sees a `[clud] note: ...` line and continues.
 
 use std::path::{Path, PathBuf};
 
-const EMBEDDED_SKILL: &str = include_str!("../../../skills/clud-pr/SKILL.md");
-const SKILL_NAME: &str = "clud-pr";
+/// One bundled skill: the name (`clud-pr`) and the canonical SKILL.md
+/// content baked into the binary at compile time.
+struct Skill {
+    name: &'static str,
+    content: &'static str,
+}
 
-/// Run the install/check on every launch. Cheap on the steady state
-/// (one stat + one read). Failures degrade silently to a stderr note.
+/// Every skill `clud` ships and auto-installs. Adding another skill is a
+/// one-line entry here plus a new `skills/<name>/SKILL.md` file.
+const BUNDLED_SKILLS: &[Skill] = &[
+    Skill {
+        name: "clud-pr",
+        content: include_str!("../../../skills/clud-pr/SKILL.md"),
+    },
+    Skill {
+        name: "clud-pr-merge",
+        content: include_str!("../../../skills/clud-pr-merge/SKILL.md"),
+    },
+];
+
+/// Run the install/check for every bundled skill on launch. Cheap on the
+/// steady state (one stat + one read per skill). Failures degrade silently
+/// to a stderr note.
 pub fn ensure_installed() {
-    let Some(path) = target_path() else {
+    for skill in BUNDLED_SKILLS {
+        ensure_skill_installed(skill);
+    }
+}
+
+fn ensure_skill_installed(skill: &Skill) {
+    let Some(path) = target_path(skill.name) else {
         return;
     };
-    match classify(&path) {
-        Existing::Missing => write_install(&path),
+    match classify(&path, skill.content) {
+        Existing::Missing => write_install(&path, skill),
         Existing::Matches => {}
         Existing::Diverges => warn_diverges(&path),
         Existing::Unreadable(err) => {
@@ -47,12 +72,12 @@ enum Existing {
     Unreadable(std::io::Error),
 }
 
-fn classify(path: &Path) -> Existing {
+fn classify(path: &Path, embedded: &str) -> Existing {
     match std::fs::read_to_string(path) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Existing::Missing,
         Err(e) => Existing::Unreadable(e),
         Ok(content) => {
-            if normalize(&content) == normalize(EMBEDDED_SKILL) {
+            if normalize(&content) == normalize(embedded) {
                 Existing::Matches
             } else {
                 Existing::Diverges
@@ -69,12 +94,12 @@ fn normalize(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn target_path() -> Option<PathBuf> {
+fn target_path(skill_name: &str) -> Option<PathBuf> {
     let home = home_dir()?;
     Some(
         home.join(".claude")
             .join("skills")
-            .join(SKILL_NAME)
+            .join(skill_name)
             .join("SKILL.md"),
     )
 }
@@ -90,7 +115,7 @@ fn home_dir() -> Option<PathBuf> {
     }
 }
 
-fn write_install(path: &Path) {
+fn write_install(path: &Path, skill: &Skill) {
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
             eprintln!(
@@ -100,17 +125,17 @@ fn write_install(path: &Path) {
             return;
         }
     }
-    if let Err(e) = std::fs::write(path, EMBEDDED_SKILL) {
+    if let Err(e) = std::fs::write(path, skill.content) {
         eprintln!(
             "[clud] note: could not install /{} skill at {}: {e}",
-            SKILL_NAME,
+            skill.name,
             path.display()
         );
         return;
     }
     eprintln!(
         "[clud] installed /{} skill at {}",
-        SKILL_NAME,
+        skill.name,
         path.display()
     );
 }
@@ -129,13 +154,22 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    /// Mirror of [`ensure_installed`] but routed at a caller-supplied path
-    /// instead of `~/.claude/skills/...`. Lets us unit-test the three
-    /// state transitions without touching the real home directory.
-    fn ensure_installed_at(path: &Path) -> Existing {
-        let state = classify(path);
+    /// Embedded copy of the canonical clud-pr skill — used as the
+    /// embedded-content reference in the install state-transition tests.
+    /// Picking the first bundled skill keeps the tests aligned with
+    /// production: any compile-time breakage in the include path fails
+    /// here too.
+    fn ref_skill() -> &'static Skill {
+        &BUNDLED_SKILLS[0]
+    }
+
+    /// Mirror of [`ensure_skill_installed`] but routed at a caller-supplied
+    /// path. Lets us unit-test the three state transitions without touching
+    /// the real home directory.
+    fn ensure_installed_at(path: &Path, skill: &Skill) -> Existing {
+        let state = classify(path, skill.content);
         match &state {
-            Existing::Missing => write_install(path),
+            Existing::Missing => write_install(path, skill),
             Existing::Matches => {}
             Existing::Diverges => warn_diverges(path),
             Existing::Unreadable(_) => {}
@@ -152,7 +186,7 @@ mod tests {
     #[test]
     fn normalize_handles_crlf_vs_lf() {
         // The Windows scenario: file checked out with CRLF line endings,
-        // EMBEDDED_SKILL baked in with LF. Whitespace normalization
+        // EMBEDDED content baked in with LF. Whitespace normalization
         // must report these as equal so we don't warn on a checkout
         // artifact.
         let crlf = "line1\r\nline2\r\n";
@@ -163,24 +197,25 @@ mod tests {
     #[test]
     fn missing_file_triggers_install() {
         let tmp = TempDir::new().unwrap();
-        let target = tmp.path().join("skills").join("clud-pr").join("SKILL.md");
-        assert!(matches!(ensure_installed_at(&target), Existing::Missing));
+        let skill = ref_skill();
+        let target = tmp.path().join("skills").join(skill.name).join("SKILL.md");
+        assert!(matches!(
+            ensure_installed_at(&target, skill),
+            Existing::Missing
+        ));
         let written = fs::read_to_string(&target).unwrap();
-        assert_eq!(written, EMBEDDED_SKILL);
+        assert_eq!(written, skill.content);
     }
 
     #[test]
     fn identical_content_is_noop() {
         let tmp = TempDir::new().unwrap();
+        let skill = ref_skill();
         let target = tmp.path().join("SKILL.md");
-        fs::write(&target, EMBEDDED_SKILL).unwrap();
+        fs::write(&target, skill.content).unwrap();
         let mtime_before = fs::metadata(&target).unwrap().modified().unwrap();
 
-        // Sleep a couple of ms? Not needed — Matches state takes the
-        // no-op branch, so the file is never opened for write. We
-        // assert by reading content unchanged AND that classify ==
-        // Matches.
-        let state = ensure_installed_at(&target);
+        let state = ensure_installed_at(&target, skill);
         assert!(matches!(state, Existing::Matches));
         let mtime_after = fs::metadata(&target).unwrap().modified().unwrap();
         assert_eq!(
@@ -195,11 +230,12 @@ mod tests {
         // a divergence warning. This is the most common false-positive
         // we have to suppress on Windows checkouts.
         let tmp = TempDir::new().unwrap();
+        let skill = ref_skill();
         let target = tmp.path().join("SKILL.md");
-        let crlf = EMBEDDED_SKILL.replace('\n', "\r\n");
+        let crlf = skill.content.replace('\n', "\r\n");
         fs::write(&target, &crlf).unwrap();
 
-        let state = ensure_installed_at(&target);
+        let state = ensure_installed_at(&target, skill);
         assert!(
             matches!(state, Existing::Matches),
             "CRLF-vs-LF must classify as Matches, got {state:?}"
@@ -214,11 +250,12 @@ mod tests {
     #[test]
     fn semantic_diff_warns_and_preserves_user_edits() {
         let tmp = TempDir::new().unwrap();
+        let skill = ref_skill();
         let target = tmp.path().join("SKILL.md");
-        let user_version = format!("{EMBEDDED_SKILL}\n\n## Local addition\nMy custom rule.\n");
+        let user_version = format!("{}\n\n## Local addition\nMy custom rule.\n", skill.content);
         fs::write(&target, &user_version).unwrap();
 
-        let state = ensure_installed_at(&target);
+        let state = ensure_installed_at(&target, skill);
         assert!(
             matches!(state, Existing::Diverges),
             "added content must classify as Diverges, got {state:?}"
@@ -232,11 +269,12 @@ mod tests {
     #[test]
     fn install_creates_missing_parent_directories() {
         let tmp = TempDir::new().unwrap();
+        let skill = ref_skill();
         // Three nested levels none of which exist yet.
         let target = tmp.path().join("a").join("b").join("c").join("SKILL.md");
         assert!(!target.parent().unwrap().exists());
 
-        let state = ensure_installed_at(&target);
+        let state = ensure_installed_at(&target, skill);
         assert!(matches!(state, Existing::Missing));
         assert!(target.exists(), "install must create the file");
         assert!(
@@ -246,13 +284,71 @@ mod tests {
     }
 
     #[test]
-    fn embedded_skill_is_nonempty() {
-        // Compile-time guard: if someone deletes skills/clud-pr/SKILL.md
-        // the include_str! still compiles to "" — assert the bake is real.
-        assert!(EMBEDDED_SKILL.len() > 100, "EMBEDDED_SKILL looks empty");
+    fn every_bundled_skill_has_real_content() {
+        // Compile-time + content guard: if someone deletes a skill file
+        // the include_str! still compiles to "" — assert every entry has
+        // real frontmatter so a missing file is caught here, not by the
+        // user reading an empty SKILL.md from their home dir.
+        assert!(!BUNDLED_SKILLS.is_empty(), "no bundled skills?");
+        for skill in BUNDLED_SKILLS {
+            assert!(
+                skill.content.len() > 100,
+                "skill {} has suspiciously short content ({}b)",
+                skill.name,
+                skill.content.len()
+            );
+            let frontmatter_marker = format!("name: {}", skill.name);
+            assert!(
+                skill.content.contains(&frontmatter_marker),
+                "skill {} content missing 'name: {}' frontmatter — bad include_str path?",
+                skill.name,
+                skill.name
+            );
+        }
+    }
+
+    #[test]
+    fn bundle_includes_clud_pr_and_clud_pr_merge() {
+        // The two skills wired up so far. Adding more is fine; this test
+        // just guards against accidental removal of either.
+        let names: Vec<&str> = BUNDLED_SKILLS.iter().map(|s| s.name).collect();
+        assert!(names.contains(&"clud-pr"), "clud-pr missing from bundle");
         assert!(
-            EMBEDDED_SKILL.contains("name: clud-pr"),
-            "EMBEDDED_SKILL missing frontmatter — bad include_str path?"
+            names.contains(&"clud-pr-merge"),
+            "clud-pr-merge missing from bundle"
         );
+    }
+
+    #[test]
+    fn bundled_skills_have_unique_names() {
+        // Two entries with the same name would silently overwrite each
+        // other on disk — guard against typos at compile-test time.
+        let mut names: Vec<&str> = BUNDLED_SKILLS.iter().map(|s| s.name).collect();
+        names.sort();
+        let len_before = names.len();
+        names.dedup();
+        assert_eq!(
+            names.len(),
+            len_before,
+            "BUNDLED_SKILLS contains duplicate names"
+        );
+    }
+
+    #[test]
+    fn install_pass_processes_every_bundled_skill() {
+        // Drive the whole bundle against an isolated tmp tree by simulating
+        // each entry's per-skill install. This is the multi-skill analog
+        // of `missing_file_triggers_install` and confirms that adding a
+        // skill to BUNDLED_SKILLS actually causes it to land on disk.
+        let tmp = TempDir::new().unwrap();
+        for skill in BUNDLED_SKILLS {
+            let target = tmp.path().join("skills").join(skill.name).join("SKILL.md");
+            assert!(matches!(
+                ensure_installed_at(&target, skill),
+                Existing::Missing
+            ));
+            let on_disk = fs::read_to_string(&target).unwrap();
+            assert_eq!(on_disk, skill.content);
+        }
     }
 }

--- a/skills/clud-issue/SKILL.md
+++ b/skills/clud-issue/SKILL.md
@@ -1,0 +1,60 @@
+<!-- managed-by: clud -->
+---
+name: clud-issue
+description: File a researched GitHub issue without interrogating the user — investigate, decide on best-guess defaults, post, and list those defaults in the issue body so the user can edit on GitHub.
+triggers:
+  - When the user types "/clud-issue" with a topic or problem statement
+  - When the user asks to file or open a GitHub issue
+---
+
+# /clud-issue
+
+File a researched GitHub issue and ship it. Four hard rules:
+
+1. **Default to action, not interrogation.** Do the research, make best-guess decisions for ambiguity, post the issue. Never paraphrase the user's clear request as ambiguous.
+2. **Question budget: 0 by default, 1 only if blocking.** Ask iff: without the answer, you cannot file *any* sensible issue (e.g., the user genuinely didn't name a repo or topic). Priority, scope edges, exact wording, fix location → not blocking. Decide and document.
+3. **Decisions go in the issue body, not the chat.** Any judgment calls land under a `## Decisions` section in the issue body so the user can edit on GitHub. Never ratify-by-chat.
+4. **Post the issue.** Finish with `gh issue create`. Deliverable is the issue URL.
+
+## Workflow
+
+1. **Read the prompt at face value.** If the user named the repo, that's the repo. If they named the bug, that's the bug. Do NOT re-derive specifics the user already gave you.
+2. **Investigate (one pass, silent).** Skim relevant code, recent git history, existing issues. Build the working model internally — don't narrate.
+3. **Search for strong duplicates.** `gh issue list --repo <repo> --search "<keywords>" --state all`. Strong overlap only (same component + overlapping intent). Weak keyword matches don't count.
+4. **Decide on defaults.** For each judgment call (priority, severity, scope edges, fix-location guess, acceptance criteria) pick a sensible default. Each default gets a one-line justification in the issue body's `Decisions` section.
+5. **At most one blocking question.** Ask only if step 1 left you genuinely unable to file. Skip otherwise.
+6. **Draft.** Conventional title (`feat:`, `fix:`, `chore:` ...). Body sections:
+   - **Context** — observation, what research found.
+   - **Proposal** — what should change.
+   - **Acceptance criteria** — concrete, objectively closable bullets.
+   - **Decisions** — your defaults, one line each (e.g. *Priority: P2 — migration unblocked by GET-fallback*). User edits this on GitHub if they disagree.
+   - **Related issues** — only if strong duplicates were found.
+7. **Post.** `gh issue create --repo <repo> --title "..." --body "$(cat <<'EOF' ... EOF)"`. Heredoc preserves formatting.
+8. **Report.** Two lines: one-sentence summary of what was filed, then the URL. If strong duplicates exist, one extra line above the URL listing them. Nothing else.
+
+## What counts as a blocking question
+
+**Blocking (ask):**
+- User said "file an issue" with no topic AND no repo.
+- User named two repos and the right one isn't derivable from context.
+- Topic is genuinely ambiguous between bug / feature / question and the framing materially changes the body.
+
+**Not blocking (decide, document, ship):**
+- Priority / severity → pick P2 by default; downgrade if non-urgent, upgrade if blocking shipping work.
+- Acceptance criteria wording → write them; user edits on GitHub.
+- Where the fix should live → state your guess in the body; triage can re-route.
+- Whether to mention a related issue → use the strong-duplicates filter.
+
+## Failure modes to avoid
+
+- **Asking what the user already told you.** If the prompt names the repo / topic / scope, don't ask "where should this go?" — they answered.
+- **"Best guess + please confirm" anti-pattern.** If you have a best guess, ship it. The Decisions section documents it. Don't make the user ratify each call in chat.
+- **Padding "Related issues" with weak keyword matches.** Strong overlap only.
+- **Posting a draft to chat for approval.** Chat report is summary + URL. Drafts go straight to `gh issue create`.
+- **Vague acceptance criteria.** If the issue can't be objectively closed, rewrite them before posting.
+
+## When NOT to use this
+
+- User pasted a complete issue draft — just `gh issue create` it.
+- Work is trivial enough to do directly — `/clud-pr` style is faster than tracking it.
+- Topic is a question, not tracked work — answer it.

--- a/skills/clud-pr-merge/SKILL.md
+++ b/skills/clud-pr-merge/SKILL.md
@@ -1,0 +1,69 @@
+<!-- managed-by: clud -->
+---
+name: clud-pr-merge
+description: Wait for CI + CodeRabbit on the current PR, fix regressions and review comments, then merge to main.
+triggers:
+  - When the user asks to merge a PR
+  - When the user says "/clud-pr-merge", "ship it", "land this PR"
+  - After /clud-pr completes and the user wants to follow through to merge
+---
+
+# /clud-pr-merge
+
+Take an open PR from "tests running" to "merged into main". Two gates:
+
+1. **CI gate** — all required checks green, OR every failing check was already failing on main (no regressions introduced by this PR).
+2. **Review gate** — no unresolved CodeRabbit comments.
+
+If the gates fail in fixable ways, dispatch a sub-agent to fix; up to 3 rounds total. After 3, give up and surface the blockers.
+
+## Workflow
+
+1. **Resolve the PR.** `gh pr view --json number,headRefName,baseRefName,state,mergeable,statusCheckRollup,url` against the current branch. Refuse if state ≠ OPEN or mergeable ≠ MERGEABLE/UNKNOWN.
+
+2. **Poll until CI + CodeRabbit have reported.** Loop with **30-second sleeps**, capped at **12 minutes total** (24 iterations). Each iteration fetches:
+   - `gh pr checks <num> --json name,state,bucket` — every required check has a non-PENDING state.
+   - `gh api repos/{owner}/{repo}/pulls/{num}/reviews --jq '.[] | select(.user.login=="coderabbitai")'` — at least one CodeRabbit review (or comment) has been posted.
+
+   Both must report at least once. If 12 minutes pass with neither reporting, **give up and warn the user**: `[clud-pr-merge] timed out waiting for CI/CodeRabbit after 12 minutes. Re-run when checks have reported.` Do NOT merge.
+
+3. **Diff CI failures vs main.** For every failing check on the PR:
+   - Fetch the same check name on `main`'s latest commit: `gh api repos/{owner}/{repo}/commits/main/check-runs`.
+   - If the same check is also failing on main → **pre-existing failure**, not a regression. Mark and skip.
+   - If the check is passing on main but failing on the PR → **regression**. Add to the fix queue.
+
+4. **Collect CodeRabbit findings.** `gh api repos/{owner}/{repo}/pulls/{num}/comments` filtered to `user.login == "coderabbitai"`. Also pull review-level comments. Resolved threads are skipped.
+
+5. **Round-based fix loop, max 3 rounds.** For each round:
+   - If fix queue (regressions + CodeRabbit comments) is empty → break, proceed to merge.
+   - Dispatch a sub-agent with: the regression list, the CodeRabbit comments, the relevant file paths, and the constraint to keep changes minimal (only fix what's flagged, don't refactor unrelated code).
+   - After the agent finishes: `bash lint` + `bash test`, commit, push.
+   - Wait for CI to re-run (poll with the 30s/12min budget again, this round only).
+   - Re-evaluate gates. If both clear → break. Otherwise → next round.
+   - After round 3 with gates still failing → **give up**. Print remaining blockers and exit without merging.
+
+6. **Clean tree gate.** Same as `/clud-pr`: every modified/untracked file gets a deliberate commit-or-delete decision. No stash-and-merge tricks.
+
+7. **Merge.** `gh pr merge <num> --squash --delete-branch` (or `--merge` if the repo prefers full history — check repo conventions first). Confirm with `gh pr view <num> --json state,mergedAt`.
+
+## Hard rules
+
+- **Never merge with regressions.** A check passing on main but failing on the PR is always a blocker, even if "it's flaky" — the agent's job is to make it green or surface it.
+- **Never merge with unresolved CodeRabbit comments** unless they're explicitly out-of-scope (e.g., flagging a pre-existing issue). The fix-or-acknowledge decision is per-comment.
+- **Never bypass branch protection.** No `--admin`. If the PR is blocked by a required reviewer, surface that and stop.
+- **Never `--no-verify`** on the fix-loop commits. Hooks exist for a reason.
+- **Give up cleanly after 3 rounds.** Print the remaining blockers, the round count consumed, and exit non-zero so the user knows merge didn't happen.
+
+## Failure modes to avoid
+
+- **Poll loop without a cap** — always stop at 12 minutes; better to warn-and-stop than burn forever.
+- **Treating timeout as merge-eligible** — no signal ≠ green signal. Refuse to merge in the timeout case.
+- **Conflating "passing on main" with "not a regression"** — only the *same check name* on main counts. Renamed/added checks are new regressions until proven otherwise.
+- **Letting the fix-agent expand scope** — pass a tight scope; if the agent finds an unrelated bug, it gets noted, not fixed in this PR.
+
+## When NOT to use this
+
+- PR is in DRAFT state (waiting for author signal first)
+- PR has merge conflicts (needs human rebase)
+- PR is blocked on a human reviewer (no automation can resolve that)
+- The repo has no CI configured (nothing to gate on)


### PR DESCRIPTION
## Summary

- Adds a second bundled skill, `/clud-pr-merge`, that takes an open PR from "checks running" to "merged into main" with two gates: all CI checks green (or every failing check pre-existing on main), AND no unresolved CodeRabbit comments.
- Failures get up to **3 rounds** of sub-agent fix attempts; after 3, give up cleanly with remaining blockers. Polls CI + CodeRabbit at **30-second intervals**, capped at **12 minutes total**. On timeout: warn and refuse to merge (no-signal ≠ green-signal).
- Refactors `skill_install.rs` from one hardcoded skill to a `BUNDLED_SKILLS` slice — adding a future skill is one line + a new `SKILL.md`.

## Hard rules in the skill

- Never merge with a regression (check passing on main, failing on PR).
- Never merge with unresolved CodeRabbit comments unless explicitly out-of-scope.
- Never bypass branch protection (no `--admin`).
- Never `--no-verify` on fix-loop commits.

## Stacks on #88

`feat/clud-pr-merge-skill` is branched off `feat/clud-pr-skill` because this PR extends the `skill_install.rs` module introduced by #88. **Base branch is set to `feat/clud-pr-skill`** so the diff stays clean. Will retarget to `main` automatically once #88 lands.

## Test plan

- [x] `bash lint` passes
- [x] `bash test` passes — 337+ Rust unit tests (3 new bundle-level tests added) + 41 Python tests
- [x] End-to-end live: `bash test` invoked the binary, which dropped **both** skills into `~/.claude/skills/`. The skills then appeared in Claude Code's available-skills list mid-session — confirms the multi-skill install pass works.
- [x] Existing `/clud-pr` install behavior unchanged (all 7 original state-transition tests still green, parameterized via `ref_skill()`).
- [x] Bundle-level guards: `bundle_includes_clud_pr_and_clud_pr_merge`, `bundled_skills_have_unique_names`, `install_pass_processes_every_bundled_skill`.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)