### PR TITLE
feat(loop): render claude stream-json events as live progress (Windows)

### DIFF
--- a/crates/clud-bin/assets/skills/clud-issue-triage/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-issue-triage/SKILL.md
@@ -1,0 +1,83 @@
+<!-- managed-by: clud -->
+---
+name: clud-issue-triage
+description: Triage GitHub issues — close ones that are absolutely resolved, and silently file follow-up issues for un-addressed CodeRabbit comments. Single issue, last week, or all (parallel sub-agents in worktrees).
+triggers:
+  - When the user types "/clud-issue-triage" with or without an issue number/URL
+  - When the user types "/clud-issue-triage all"
+  - When the user asks to "triage issues", "sweep stale issues", or "clean up the issue tracker"
+---
+
+# /clud-issue-triage
+
+Triage GitHub issues for closeable resolution and un-addressed CodeRabbit follow-ups. Four hard rules:
+
+1. **Bias toward caution on closing.** Default action is *leave open*. Only close when the resolution is unambiguous: a merged PR landed code on the default branch and that code clearly satisfies the issue's acceptance criteria. When in doubt, don't close.
+2. **File follow-ups without asking.** Un-addressed CodeRabbit comments → file a new follow-up issue immediately, no user prompt. At the end, hand the user the list of follow-ups you filed.
+3. **Bulk mode = main scans, sub-agents triage in parallel git worktrees.** The main agent never does per-issue triage in bulk mode. It enumerates and filters the candidate set, then dispatches one sub-agent per issue in a single tool-use block. Each sub-agent runs in its own `.claude/worktrees/triage-<num>/`.
+4. **Nothing left in the repo when done.** Every worktree gets `git worktree remove`'d after its sub-agent finishes. Same `.gitignore` gate and stale-worktree rules as `/clud-pr`.
+
+## Argument modes
+
+- **`/clud-issue-triage <num>` or `<url>`** → single-issue mode. Main agent does the work directly (no sub-agent — overkill for one issue).
+- **`/clud-issue-triage`** (no arg) → bulk mode, scoped to issues created in the **last 7 days**.
+- **`/clud-issue-triage all`** → bulk mode, scoped to **all OPEN issues** in the repo.
+
+## Single-issue workflow
+
+1. **Resolve the input.** Accept a bare number, a `#NNN`, or a full GitHub URL. `gh issue view <num> --json number,state,title,body,url,labels,closedByPullRequestsReferences,timelineItems`. If the call fails, say so and stop.
+2. **If already CLOSED** → don't re-close. But still run step 5 (CodeRabbit follow-ups) against any linked PRs, then report.
+3. **Find resolving PRs.** Scan `closedByPullRequestsReferences`, the timeline `cross-referenced` events, and `gh search prs "Closes #<num>" OR "Fixes #<num>" OR "Resolves #<num>" --repo <owner>/<repo>`. For each candidate:
+   - `gh pr view <pr> --json state,merged,mergeCommit,baseRefName,files`.
+   - Confirm `merged == true` AND `baseRefName == <default-branch>` (else the code didn't reach main — see `/clud-pr` step 3).
+   - Read the diff (`gh pr diff <pr>`) and confirm it actually implements the issue's acceptance criteria. Don't trust the PR title or "Closes #" mention alone.
+4. **Decide closure.** Bias toward caution:
+   - Resolved unambiguously (merged + on default branch + diff matches criteria) → `gh issue close <num> --comment "Resolved by #<pr>. Verified: <one-line evidence>."`
+   - Anything ambiguous (partial implementation, stack-base merge, criteria not fully met, no clear PR) → leave open. Don't comment unless the user asked you to triage-comment.
+5. **Scan for un-addressed CodeRabbit comments.** For every PR linked to this issue (resolving or merely referencing):
+   - `gh api repos/<owner>/<repo>/pulls/<pr>/comments` (review-thread comments) and `gh pr view <pr> --json reviews,comments`.
+   - Filter authors matching `coderabbitai*` (`coderabbitai`, `coderabbitai[bot]`).
+   - Drop nits, praise, "consider", and threads marked `outdated` or `resolved: true`.
+   - Group remaining comments by file/topic.
+6. **File follow-up issues silently.** For each cluster of substantive un-addressed CodeRabbit comments, `gh issue create --title "follow-up: <topic> from #<pr>" --body ...`. The body must include: source PR link, source comment permalinks, the CodeRabbit suggestion verbatim, and a one-line "why this matters" framing. Label `coderabbit-followup` if the repo has it; otherwise skip the label.
+7. **Report.** Output exactly:
+   - One line: closed (yes/no) + one-line evidence or one-line reason left open.
+   - One line per follow-up issue filed: `#<num> — <title> — <url>`.
+   - Nothing else.
+
+## Bulk workflow (no arg or `all`)
+
+1. **Enumerate candidates (main agent).**
+   - No arg → `gh issue list --state open --limit 200 --search "created:>=$(date -d '7 days ago' --iso-8601 2>/dev/null || date -v-7d +%Y-%m-%d)" --json number,title,labels,createdAt,updatedAt`.
+   - `all` → `gh issue list --state open --limit 1000 --json number,title,labels,createdAt,updatedAt`.
+2. **Filter (main agent, fast pass).** Drop issues that are obviously not triage candidates: anything labeled `discussion`, `meta`, `roadmap`, `wontfix`, `duplicate`, `question`; anything updated in the last 24h (active conversation); anything with zero linked PRs/cross-references. The remainder is the work set.
+3. **Stale-worktree prompt + .gitignore gate.** Same as `/clud-pr`'s **Worktree workspace** section. Confirm `.gitignore` covers `.claude/`. Ask the user about deleting any stale `.claude/worktrees/triage-*` older than 24h before starting.
+4. **Plan worktrees.** One worktree per issue: `.claude/worktrees/triage-<num>/`. Branch off `origin/<default>` (read-only — these worktrees only inspect, they don't commit code). `git fetch origin && git worktree add --detach .claude/worktrees/triage-<num> origin/<default>` for each.
+5. **Dispatch sub-agents in parallel.** Single tool-use block, one Agent call per issue. Each sub-agent gets:
+   - The issue number and URL
+   - The repo `<owner>/<repo>`
+   - Its dedicated worktree path
+   - Instruction: run the **Single-issue workflow** (steps 1–6 above) for this issue, in this worktree, and return a structured report (closed: bool, reason, follow-ups: list of {num, title, url})
+   - Hard constraint: do not touch any path outside the assigned worktree; do not modify code in the main checkout
+6. **Aggregate.** Collect every sub-agent's report. Tear down every worktree (`git worktree remove .claude/worktrees/triage-<num>` per issue). Confirm `git worktree list` shows none of them and `.claude/worktrees/` is empty (or holds only unrelated entries).
+7. **Report (main agent).** Two sections:
+   - **Closed (N):** one line per closed issue: `#<num> — <title> — resolved by #<pr>`.
+   - **Follow-ups filed (M):** one line per filed follow-up: `#<num> — <title> — <url>`.
+   - If both sections are empty, say so in one line. Nothing else.
+
+## Failure modes to avoid
+
+- **Closing on weak evidence.** A PR that merely *mentions* the issue isn't resolution. Read the diff, match it to the criteria, or leave the issue open.
+- **Closing on a stack-base merge.** A merged PR with `baseRefName != <default-branch>` did NOT land on main. Treat as not-resolved.
+- **Asking before filing follow-ups.** The skill's job is to file silently. Asking defeats the point.
+- **Counting CodeRabbit nits as un-addressed.** Praise, "nit:", and "consider" suggestions don't get follow-ups. Substantive threads only.
+- **Filing duplicate follow-ups.** Before `gh issue create`, search: `gh issue list --search "from #<pr> coderabbit-followup" --state all`. Skip if a matching follow-up already exists.
+- **Doing per-issue triage on the main agent in bulk mode.** Bulk mode = scan + dispatch + aggregate. Triage is sub-agent work, in worktrees, in parallel.
+- **Letting worktrees leak.** Every dispatched worktree gets removed at the end, even on partial failure. Verify with `git worktree list`.
+- **Touching the main checkout from a sub-agent.** Sub-agents only read/inspect inside their assigned `.claude/worktrees/triage-<num>/`. They do not commit, edit, or `cd` outside.
+
+## When NOT to use this
+
+- The user wants to file a brand-new issue → `/clud-issue` instead.
+- The user wants to implement an issue → `/clud-pr` instead.
+- The repo's issue tracker is mostly used for discussion (not work tracking) — closing rules don't apply cleanly.

--- a/crates/clud-bin/assets/skills/clud-issue/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-issue/SKILL.md
@@ -1,0 +1,42 @@
+<!-- managed-by: clud -->
+---
+name: clud-issue
+description: File a deeply-researched GitHub issue via investigate → interview → investigate → post, returning a summary plus the issue URL.
+triggers:
+  - When the user types "/clud-issue" with a topic or problem statement
+  - When the user asks to "file an issue with research" or "open an issue after investigating"
+  - When the user wants to draft an issue but needs the agent to clarify scope first
+---
+
+# /clud-issue
+
+File a GitHub issue informed by real research and a real conversation. Four hard rules:
+
+1. **Two investigation rounds, one interview in between** — never skip the interview, never post after a single pass.
+2. **Post the issue** — finish with `gh issue create`. The deliverable is an issue URL, not a draft in chat.
+3. **Surface strong duplicates only** — search existing issues; mention related issues *only* when similarity is strong (same component + overlapping intent). Don't pad the report with weak matches.
+4. **Summary + URL last.** End with a short summary of what was filed and the URL — nothing else.
+
+## Workflow
+
+1. **Round 1 investigation (silent prep).** Read the topic. Skim the relevant code paths, existing docs, and recent git history to form a working model: what the user likely means, what's already in place, what's missing, what the obvious unknowns are. One round — don't spiral.
+2. **Interview mode.** Ask the user clarifying questions to nail scope, constraints, and acceptance criteria. For each question you can answer well from the code or from public knowledge, *offer your best-judgement answer* alongside the question and ask the user to confirm or override. Batch related questions; don't drip-feed. Keep going until ambiguity is resolved — don't post a vague issue.
+3. **Round 2 investigation.** With the user's answers in hand, do the deeper dig: confirm file paths, identify touch points, note prior art, list risks/edge cases. This round informs the actual issue body.
+4. **Search for duplicates.** `gh issue list --search "<keywords>" --state all` (open + closed). Only flag issues with strong similarity — same component *and* overlapping intent. Weak keyword matches don't count.
+5. **Draft the issue.** Title in conventional style (`feat:`, `fix:`, `chore:`, etc.). Body sections: **Context**, **Proposal**, **Acceptance criteria**, **Open questions** (if any remain), **Related issues** (only if strong matches found). No filler.
+6. **Post.** `gh issue create --title "..." --body "$(cat <<'EOF' ... EOF)"`. Use a heredoc so formatting survives.
+7. **Report.** Give the user: a 2-3 sentence summary of what was filed, then the issue URL. If strong related issues exist, mention them in one line above the URL. Nothing else.
+
+## Failure modes to avoid
+
+- **Skipping the interview.** Even "obvious" topics have hidden constraints. The interview is mandatory.
+- **Posting before round 2.** Round 1 is for forming questions. Round 2 is for forming the issue. Don't conflate them.
+- **Padding "Related issues" with weak matches.** A keyword overlap isn't a related issue. Only flag genuine overlap.
+- **Vague acceptance criteria.** If the issue can't be closed objectively, the criteria are wrong. Rewrite them.
+- **Posting without confirming.** Show the user the drafted title + body before `gh issue create` and let them adjust.
+
+## When NOT to use this
+
+- The user already has a clear, well-scoped issue draft — just file it directly.
+- The work is trivial enough to implement immediately (skip the issue, do `/clud-pr` style work).
+- The topic is a question, not a request for tracked work — answer it instead of filing.

--- a/crates/clud-bin/assets/skills/clud-pr/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-pr/SKILL.md
@@ -1,0 +1,112 @@
+<!-- managed-by: clud -->
+---
+name: clud-pr
+description: Implement a GitHub issue (or triage a PR link) inside a .claude/ worktree and ship as a single PR with no files left in the repo.
+triggers:
+  - When the user asks to implement a GitHub issue
+  - When the user passes a PR URL/number to "/clud-pr" (triage mode)
+  - When the user says "ship", "do-pr", "/clud-pr", or references an issue URL/number with intent to deliver
+---
+
+# /clud-pr
+
+Implement a GitHub issue end-to-end using parallel sub-agents inside a disposable `.claude/` worktree, then push as a single PR. Three hard rules:
+
+1. **Parallel sub-agents** — decompose work into independent file-scoped subtasks and dispatch sub-agents concurrently (single message, multiple Agent tool calls). Sequential implementation defeats the skill.
+2. **Push the PR** — finish with `gh pr create`. Local commits don't count; the deliverable is a PR URL.
+3. **Nothing left in the repo after push** — the worktree itself, untracked files, scratch files, build artifacts: all gone. After `gh pr create` succeeds, the main checkout's `git status` AND the worktree directory must both be clean (worktree removed). Never leave anything behind.
+
+## Worktree workspace (do all PR work here)
+
+Do not commit on the main checkout. Create a git worktree under `.claude/worktrees/<branch-name>/` and work there.
+
+1. **`.gitignore` gate.** The worktree path must be ignored by git so the parent checkout never sees it as untracked. Check `.gitignore` for an entry that covers `.claude/` (e.g. `.claude/`, `.claude/**`, or `/.claude/`).
+   - If present → fine, continue.
+   - If missing → **delete any existing `.claude/worktrees/`** to keep the repo clean, then either (a) ask the user for permission to add `.claude/` to `.gitignore`, or (b) fall back to a sibling path outside the repo (`../<repo>-wt-<branch>/`). Do NOT silently create a worktree at an un-ignored path.
+2. **Stale-worktree prompt.** Before creating the new worktree, scan `.claude/worktrees/*` for subdirectories whose mtime is older than 24 hours. If any exist, list them and ask the user:
+   > "Found N stale worktree(s) in `.claude/worktrees/` (older than 1 day): <list>. Delete them before I start?"
+   On "yes" → `git worktree remove --force <path>` for each (falling back to `rm -rf` if `git worktree remove` rejects it because the worktree is corrupt). On "no" → leave them alone and continue.
+3. **Create the worktree.** `git fetch origin main && git worktree add -b feat/<short-name> .claude/worktrees/<branch> origin/main`. All subsequent edits, commits, lint, and test runs happen inside that path. Never `cd` back to the main checkout for this PR's work.
+4. **Tear down after push.** After `gh pr create` returns successfully, run `git worktree remove .claude/worktrees/<branch>` (use `--force` only if needed). Confirm with `git worktree list` that the entry is gone and `ls .claude/worktrees/` no longer contains the directory. The user's repo state should look identical to before `/clud-pr` ran.
+
+## Mode selection
+
+Look at the input first:
+
+- **Issue URL / number / freeform task** → run the **issue → PR workflow** below.
+- **PR URL / number** → run **PR triage mode** instead. Don't start branching or coding until triage decides what (if anything) to do.
+
+## PR triage mode (when `/clud-pr` is given a PR link)
+
+1. **Verify the PR exists.** `gh pr view <url-or-num> --json number,state,title,url,headRefName,mergedAt,closedAt,author`. If the call fails (404, wrong repo, malformed URL), say so and stop — don't guess.
+2. **Branch on state.**
+   - **OPEN** → report the PR's current state (CI status, review status, mergeability) and ask the user what they want done. Don't implement anything unprompted.
+   - **MERGED** → say so and stop. Follow-up work belongs in a new PR/issue, not this one.
+   - **CLOSED (not merged)** → continue with the checks below.
+3. **Check for CodeRabbit review comments.** `gh pr view <num> --json reviews,comments` and `gh api repos/<owner>/<repo>/pulls/<num>/comments` (review-thread comments live there, not on the issue). Filter for author logins matching `coderabbitai*` (bot accounts: `coderabbitai`, `coderabbitai[bot]`). Count actionable comments — skip "LGTM" / praise / nit-only threads.
+4. **Check for failing GH Actions.** `gh pr checks <num>` (or `gh run list --branch <headRefName> --limit 5`). Note which workflows failed and on which commit.
+5. **Check for an existing follow-up PR.** `gh pr list --state all --search "<headRefName> OR #<num>"` and scan the closed PR's timeline (`gh api repos/<owner>/<repo>/issues/<num>/timeline`) for `cross-referenced` events linking to a later PR by the same author or touching the same files. If one exists and looks like it addresses the comments / fixes the CI, surface it — the user may not need to redo the work.
+6. **Report findings and ask, one question per finding.** Examples:
+   - "I see N actionable CodeRabbit comments on this closed PR (summary: ...). Want me to address them in a new PR?"
+   - "CI failed on the `<workflow>` job (last failure: <one-line summary>). Want me to fix it in a new PR?"
+   - "I found a follow-up PR #<num> that looks like it already addresses the CodeRabbit feedback. Want me to confirm and stop, or continue regardless?"
+   Wait for the user's answer before doing anything destructive or branch-creating.
+7. **On user "yes" → switch to issue → PR workflow,** but: branch off `origin/main` inside a fresh `.claude/worktrees/<branch>` (per the worktree section above), and reference the closed PR in the new PR body (`Refs #<num>` and a short note: "Addresses CodeRabbit feedback from #<num>" or "Fixes CI failure from #<num>"). Cherry-pick only the closed PR's commits the user explicitly asks to keep.
+
+## Workflow (issue → PR)
+
+1. **Read the issue.** `gh issue view <num>` (or fetch the URL). Extract acceptance criteria, in-scope vs out-of-scope, touch points.
+2. **Verify the issue is OPEN.** Check status and recent git log. If it was already implemented, surface that and stop — don't redo closed work.
+3. **Check if a PR already resolves it.** Even an OPEN issue may already be done — the issue just wasn't closed. Look for resolving PRs:
+   - `gh issue view <num> --json closedByPullRequestsReferences,timelineItems` and scan the timeline for `cross-referenced` PRs.
+   - `gh pr list --state all --search "<num> in:title,body"` and `gh search prs "Closes #<num>" OR "Fixes #<num>" OR "Resolves #<num>" --repo <owner>/<repo>`.
+   - For any candidate PR found: confirm it actually addresses the issue's acceptance criteria (read its diff/description), not just mentions the number.
+   - **Verify the code reached main.** `gh pr view <pr> --json state,merged,mergeCommit,baseRefName`. If `baseRefName` isn't the repo's default branch, the merge only landed on a stack base — the code does NOT yet reach main. Treat the issue as **not resolved** and continue to step 4 (dependency walk).
+   If a PR genuinely resolves the issue *and* its merge landed on main, tell the user: "Issue #<num> looks resolved by PR #<pr> (merged to <branch>). Want me to close issue #<num> with a comment linking the PR?" On "yes" → `gh issue close <num> --comment "Resolved by #<pr>."` Either way, stop here — don't start a redundant new PR.
+4. **Dependency walk (only when the resolving PR is blocked by upstream work).** If step 3 found a PR that addresses the issue but the code hasn't reached main (stack base, linked dependent PR, "blocked by #X" reference, etc.), enumerate the blockers before doing anything else:
+   - Read the resolving PR's `baseRefName` and look up the PR/issue that owns that branch. Recurse until you hit `main`.
+   - Pull `gh issue view <num> --json closedByPullRequestsReferences,timelineItems` and parse the issue body for `Depends on #<n>`, `Blocked by #<n>`, `Part of #<n>`, and explicit `<owner>/<repo>#<n>` cross-repo references.
+   - Group findings by repo:
+     - **Same repo** → these are the priority. List them to the user in dependency order and default to taking them on first. Phrase as a confirmation, not an open question: "To land #<num>, these must merge first: #A, #B (same repo). I'll take them in that order — confirm or override."
+     - **Other repos** → never auto-tackle. Ask explicitly, one prompt per repo: "Issue #<num> also depends on work in `<owner>/<repo>` (issues: #X, #Y). Want me to take those on too?"
+   - Dispatch:
+     - Same-repo dependencies → run them through the workflow sequentially (each lands on main before the next starts), unless they touch fully independent files (then parallel — same rule as step 6).
+     - **Cross-repo dependencies → always parallel.** One sub-agent per repo, all dispatched in a single tool-use block. Each sub-agent runs the full `/clud-pr` workflow scoped to its repo, with its own worktree under that repo's `.claude/worktrees/<branch>/`. Sub-agents must not cross repo boundaries.
+   - Only after the upstream work is done (or explicitly deferred by the user) come back to the originally-requested issue.
+5. **Set up the worktree.** Run the `.gitignore` gate, the stale-worktree prompt, and `git worktree add` from the **Worktree workspace** section above. All work from here on is inside `.claude/worktrees/<branch>/`.
+6. **Plan decomposition.** Identify file-scoped chunks that can run in parallel without merge conflicts. If everything must touch the same file, parallel agents won't help — say so and run sequentially.
+7. **Dispatch parallel agents.** One Agent tool call per independent chunk, all in a single tool-use block so they run concurrently. Each agent gets: the issue text, its specific scope, the files it owns, the worktree path it must operate in, and an explicit constraint not to touch files outside that scope.
+8. **Lint + test.** Run the repo's lint and test commands (e.g. `bash lint`, `bash test`) inside the worktree. Both green before push. Never `--no-verify`; if a hook fails, fix the underlying cause.
+9. **Clean tree gate.** Run `git status` inside the worktree. For every untracked or modified file:
+   - Belongs in source → `git add` and commit
+   - Tmp / scratch / build artifact → delete (`rm`) before commit
+   No exceptions. The worktree must be clean before push.
+10. **Commit.** Conventional commit format. Reference the issue (`Closes #<num>` in commit body or PR body).
+11. **Push + PR.** `git push -u origin <branch>`, then `gh pr create` with a body that links the issue, summarizes what each parallel agent did, and includes a test plan checklist.
+12. **Tear down the worktree.** `git worktree remove .claude/worktrees/<branch>`. Confirm `git worktree list` no longer shows it and `.claude/worktrees/` doesn't contain it. Then verify the *main checkout's* `git status` is clean — nothing the worktree did should have leaked there.
+
+## Failure modes to avoid
+
+- **Sequential masquerading as parallel.** If your "parallel agents" depend on each other's output, they aren't parallel. Restructure or admit it's sequential.
+- **Pushing with a dirty tree.** Never `git stash` away stray files to fake a clean status. Each file gets a commit-or-delete decision.
+- **Skipping lint/test.** Mandatory after code changes. Don't push red.
+- **Implementing closed issues.** Verify state before starting.
+- **Implementing an issue that already has a resolving PR.** Even open issues can be already-done. Search for resolving PRs and offer to close the issue instead of starting parallel work.
+- **Calling an issue "resolved" when the PR didn't reach main.** A merged PR whose `baseRefName` isn't main only landed on a stack base — the code isn't on main yet. Walk the dependency chain instead.
+- **Auto-tackling cross-repo dependencies.** Same-repo prerequisites are taken on by default; cross-repo ones require an explicit user "yes" — one prompt per repo. Never silently spawn work in a repo the user didn't sign off on.
+- **Sequential cross-repo work.** When the user approves multiple cross-repo dependencies, dispatch one sub-agent per repo in a single tool-use block. Doing them serially defeats the parallelism rule.
+- **Multiple PRs for one issue.** The deliverable is a single PR. If the work is too large for one PR, raise that with the user before splitting.
+- **Acting on a PR link without triage.** Never branch / code / push when the input is a PR URL until triage has run and the user has answered the findings.
+- **Pattern-matching CodeRabbit nits as actionable.** Praise, "nit:", and "consider" suggestions don't count as findings unless the user asks. Count only substantive review comments.
+- **Reopening already-fixed work.** If a follow-up PR exists that addresses the comments / CI, surface it before offering to redo the work.
+- **Committing on the main checkout.** All commits happen inside `.claude/worktrees/<branch>/`. The main checkout stays untouched.
+- **Creating a worktree at an un-ignored path.** If `.gitignore` doesn't cover `.claude/`, delete the worktree dir and resolve the gitignore situation before continuing — never let worktree internals show up as untracked files in the parent repo.
+- **Skipping `git worktree remove` after push.** The deliverable is "PR pushed AND repo state restored." A leftover worktree is a leftover file.
+- **Auto-deleting stale worktrees without asking.** Even old worktrees may hold the user's in-progress work. Always prompt before removing.
+
+## When NOT to use this
+
+- Single-file changes where parallelism gives no benefit
+- Issues that need design discussion before implementation
+- Work crossing major architectural boundaries (do design first)
+- A PR link whose triage shows no actionable findings (nothing to do — say so and stop)

--- a/crates/clud-bin/assets/skills/clud-tag-release/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-tag-release/SKILL.md
@@ -1,0 +1,72 @@
+<!-- managed-by: clud -->
+---
+name: clud-tag-release
+description: Tag a release and let the auto-release workflow build it. Validates version match, clean main, no duplicate tag — then pushes the tag and surfaces the workflow URL.
+triggers:
+  - When the user types "/clud-tag-release" with or without a version arg
+  - When the user says "cut a release", "tag a release", "ship a version"
+  - When the user wants to publish a new version of a Rust/Python crate
+---
+
+# /clud-tag-release
+
+Tag a release the way `zackees/zccache` does it: the tag is the trigger, the workflow does the rest. Five hard rules:
+
+1. **Tag must equal workspace version.** Read the version from `Cargo.toml [workspace.package].version` (workspace) or `Cargo.toml [package].version` (single crate) or `pyproject.toml [project].version`. The tag pushed must match — `1.2.3` and `v1.2.3` are both fine, but `1.2.3` ≠ `1.2.4`. If they don't match, stop and tell the user to bump first; do not silently retag.
+2. **Tag from clean default branch only.** Working tree clean, on `main`/`master`, in sync with `origin`. Never tag from a feature branch or a dirty tree.
+3. **No duplicates.** Tag must not exist locally or on origin; no GitHub release record for that tag yet. If it does, stop — re-tagging a published release is destructive.
+4. **Push the tag — don't `gh release create`.** `gh release create` creates the release record directly and bypasses the auto-release workflow's preflight (version validation, idempotency check, registry skip-existing). The deliverable is an annotated tag pushed to origin; the workflow does everything else.
+5. **Verify the workflow kicked off.** After push, find the run, surface its URL, and confirm it transitioned to `in_progress` (or queued). A push that doesn't trigger a run means the workflow isn't wired up — surface that.
+
+## Workflow
+
+1. **Detect the version source.** In repo root, in this order:
+   - `Cargo.toml` with `[workspace.package].version` → that's the version.
+   - `Cargo.toml` with `[package].version` (no workspace) → that's the version.
+   - `pyproject.toml` with `[project].version` → that's the version.
+   - None of the above → stop with a message; this skill is for Rust/Python projects with a tag-driven release flow.
+2. **Detect the auto-release workflow.** Look for `.github/workflows/release-auto.yml` or any workflow whose `on.push.tags` pattern matches version-style tags (`v*`, `[0-9]*`). If none exists, stop and tell the user — point them at `zackees/zccache` (`.github/workflows/release-auto.yml`) for the canonical pattern. Don't try to push a tag with no workflow waiting.
+3. **Resolve the tag to push.**
+   - No arg → use the detected version verbatim. Tell the user: "I'll tag `<version>` (or `v<version>` if your existing tags use that prefix)." Pick the prefix that matches the most recent existing release tag; default to bare (no `v`) if there are no prior releases.
+   - Arg `<version>` or `v<version>` → use as given, but validate it matches the workspace version. On mismatch: stop and tell the user to bump (`crates/.../Cargo.toml` or `pyproject.toml`) first.
+4. **Pre-flight gates.** Every gate is blocking. Run them in parallel where possible (`git fetch` and `gh api` calls). Report the first failure and stop:
+   - `git rev-parse --abbrev-ref HEAD` is `main` (or the repo's default — `gh api repos/<owner>/<repo> --jq .default_branch`).
+   - `git status --porcelain` is empty.
+   - `git fetch origin && git rev-list HEAD...origin/<default>` is empty (in sync, no diverging commits).
+   - `git tag -l <tag>` and `git tag -l v<tag>` are both empty (no local tag).
+   - `git ls-remote --tags origin <tag>` and same with `v<tag>` are empty (no remote tag).
+   - `gh api repos/<owner>/<repo>/releases/tags/<tag>` returns 404 (no published release).
+   - Last CI run on `<default>` is green: `gh run list --branch <default> --limit 1 --json conclusion,headSha`. If red or in progress, surface and ask before proceeding — don't silently ship a broken main.
+5. **Confirm with the user.** Show:
+   - Tag to push: `<tag>`
+   - HEAD SHA: `<sha>` (and one-line commit subject)
+   - Workflow that will fire: `<release-workflow-path>`
+   - Last CI status on `<default>`: green/red/in-progress
+   Wait for explicit confirmation. Don't proceed on silence.
+6. **Tag and push.**
+   - `git tag -a <tag> -m "Release <version>"` — **annotated**, not lightweight, so `git describe` works downstream.
+   - `git push origin <tag>` — push *just the tag*, not `--tags` (which would push every local tag).
+7. **Locate the triggered run.** Poll `gh run list --workflow=<release-workflow-file> --event=push --limit 5 --json databaseId,headSha,status,url` for up to 30 seconds, looking for a run whose `headSha` matches the tagged commit's SHA. The workflow can take a few seconds to register. If none appears after 30s, surface that — the workflow may not be configured to trigger on this tag pattern.
+8. **Report.** Output exactly:
+   - Tag pushed: `<tag>` → `<sha>`
+   - Workflow run: `<url>` (status: `<queued|in_progress>`)
+   - One line on what the workflow will do (build, publish to PyPI/crates.io, attach release artifacts) — pulled from the workflow file's job names, not invented.
+   - Nothing else. Don't `gh run watch` unless the user asked.
+
+## Failure modes to avoid
+
+- **Mismatched tag and workspace version.** Re-tagging to a version that doesn't exist in `Cargo.toml`/`pyproject.toml` will fail in the workflow's preflight anyway — better to catch it locally and tell the user to bump.
+- **`gh release create v1.2.3`.** This creates the release record directly; the auto-release workflow won't fire (or will see the release already exists and skip steps). Always use `git tag` + `git push origin <tag>`.
+- **`git push --tags`.** Pushes every local tag, including stale ones from old branches. Push exactly the one you just created.
+- **Lightweight tag.** `git tag <tag>` (no `-a`/`-m`) creates a lightweight ref with no metadata. Use annotated tags so `git describe` and release notes have something to anchor on.
+- **Tagging from a feature branch.** Even if the commit is identical to main's HEAD, the branch context muddies the audit trail. Switch to main first.
+- **Tagging on a red main.** The auto-release workflow may publish artifacts before realizing tests are failing. Confirm the last CI on main is green; if red, ask the user before tagging.
+- **Re-pushing a deleted tag.** If a tag was previously published and then deleted, the GitHub release may still exist (just untagged). The skill checks `releases/tags/<tag>`; respect the result.
+- **Skipping the workflow detection step.** Pushing a tag with no auto-release workflow is a silent no-op — the user will think they shipped, nothing happens. Always confirm a workflow is wired up to the tag pattern.
+
+## When NOT to use this
+
+- The repo has no auto-release workflow → set one up first (model on `zackees/zccache` `.github/workflows/release-auto.yml`).
+- The user wants to publish a hotfix from a branch other than main → that's a different flow; do a backport PR or use the workflow's `workflow_dispatch` input directly.
+- The user wants to bump the version → that's `/clud-bump` (or a manual edit + commit + this skill). This skill assumes the version is already bumped and committed.
+- The release publishes via a non-tag-driven path (e.g. `cargo publish` from CI on every main push) — the skill's pre-flight checks don't apply.

--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -90,6 +90,11 @@ pub struct LaunchPlan {
     /// after each iteration and terminate accordingly.
     #[serde(default)]
     pub loop_markers: Option<LoopMarkers>,
+    /// When set, claude is being invoked with `--output-format stream-json
+    /// --verbose` and the subprocess runner should route its captured stdout
+    /// through `stream_json::render_line` so the user sees live progress.
+    #[serde(default)]
+    pub stream_json_progress: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -267,6 +272,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
 
     cmd.extend(args.passthrough.iter().cloned());
 
+    let is_loop_cmd = matches!(&args.command, Some(Command::Loop { .. }));
     let is_loop = loop_markers.is_some() && repeat_schedule.is_none();
     let parent_has_tty = crate::session::terminals_are_interactive();
     let launch_mode = crate::backend::resolve_launch_mode(
@@ -277,6 +283,20 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         is_loop,
         parent_has_tty,
     );
+
+    // Issue: subprocess-mode loops on claude went silent until the iteration
+    // finished, because `claude -p` buffers its single final response. Inject
+    // `--output-format stream-json --verbose` so claude emits one JSON event
+    // per turn step, and let the runtime render those into progress lines.
+    // PTY-mode loops already stream the live TUI; codex doesn't expose this
+    // flag at all.
+    let stream_json_progress =
+        matches!(backend, Backend::Claude) && is_loop_cmd && launch_mode == LaunchMode::Subprocess;
+    if stream_json_progress {
+        cmd.push("--output-format".to_string());
+        cmd.push("stream-json".to_string());
+        cmd.push("--verbose".to_string());
+    }
 
     LaunchPlan {
         command: cmd,
@@ -289,6 +309,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         repeat_schedule,
         task_summary,
         loop_markers,
+        stream_json_progress,
     }
 }
 
@@ -971,6 +992,105 @@ mod tests {
         // it does for the claude path.
         let p = plan(&["clud", "--codex", "loop", "task", "--", "--verbose"]);
         assert!(p.command.contains(&"--verbose".to_string()));
+    }
+
+    // ---- Stream-JSON progress injection ----
+    //
+    // `clud loop` against claude in *subprocess* launch mode (Windows default,
+    // or anywhere `--subprocess` is forced) used to go silent for the whole
+    // iteration because `claude -p` buffers its final response. The fix is to
+    // append `--output-format stream-json --verbose` so claude streams its
+    // turn events live, and let the runtime render each event as a one-line
+    // progress update. PTY-mode loops already show the live TUI, so no
+    // injection is needed there.
+
+    /// Helper: locate the index of `needle` in `cmd`, panicking with a
+    /// readable message if missing.
+    fn expect_arg(cmd: &[String], needle: &str) -> usize {
+        cmd.iter().position(|a| a == needle).unwrap_or_else(|| {
+            panic!("expected `{needle}` in command; got {cmd:?}");
+        })
+    }
+
+    #[test]
+    fn test_claude_loop_subprocess_injects_stream_json() {
+        let p = plan(&["clud", "--subprocess", "loop", "task"]);
+        assert_eq!(p.launch_mode, LaunchMode::Subprocess);
+        let idx = expect_arg(&p.command, "stream-json");
+        assert_eq!(
+            p.command[idx - 1],
+            "--output-format",
+            "stream-json must follow --output-format; cmd={:?}",
+            p.command
+        );
+        assert!(
+            p.command.iter().any(|a| a == "--verbose"),
+            "stream-json requires --verbose per claude's CLI contract; cmd={:?}",
+            p.command
+        );
+        assert!(
+            p.stream_json_progress,
+            "LaunchPlan must signal the runtime to parse stream-json"
+        );
+    }
+
+    #[test]
+    fn test_claude_loop_pty_does_not_inject_stream_json() {
+        // PTY mode runs the live claude TUI; switching it into the
+        // non-interactive stream-json wire format would *remove* the
+        // streaming UX we already have.
+        let p = plan(&["clud", "--pty", "loop", "task"]);
+        assert_eq!(p.launch_mode, LaunchMode::Pty);
+        assert!(
+            !p.command.iter().any(|a| a == "stream-json"),
+            "pty-mode loop must NOT inject stream-json; cmd={:?}",
+            p.command
+        );
+        assert!(
+            !p.stream_json_progress,
+            "pty mode does not need the stream-json renderer"
+        );
+    }
+
+    #[test]
+    fn test_codex_loop_does_not_inject_stream_json() {
+        // codex does not accept `--output-format stream-json` — the flag is
+        // claude-only. Forcing subprocess to be explicit so the test is
+        // platform-independent.
+        let p = plan(&["clud", "--codex", "--subprocess", "loop", "task"]);
+        assert!(
+            !p.command.iter().any(|a| a == "stream-json"),
+            "codex must NOT receive --output-format stream-json; cmd={:?}",
+            p.command
+        );
+        assert!(!p.stream_json_progress);
+    }
+
+    #[test]
+    fn test_claude_plain_prompt_does_not_inject_stream_json() {
+        // Single-shot `clud -p` is short-lived and not a loop, so we keep
+        // the existing UX untouched. Stream-json injection is loop-only.
+        let p = plan(&["clud", "--subprocess", "-p", "hello"]);
+        assert!(
+            !p.command.iter().any(|a| a == "stream-json"),
+            "plain -p must NOT receive stream-json injection; cmd={:?}",
+            p.command
+        );
+        assert!(!p.stream_json_progress);
+    }
+
+    #[test]
+    fn test_claude_loop_safe_mode_still_injects_stream_json() {
+        // `--safe` only drops the YOLO permissions flag; it must not also
+        // suppress progress streaming, which is orthogonal.
+        let p = plan(&["clud", "--subprocess", "--safe", "loop", "task"]);
+        assert!(p.command.iter().any(|a| a == "stream-json"));
+        assert!(p.stream_json_progress);
+        // Sanity: --safe removed the permissions bypass.
+        assert!(!p
+            .command
+            .iter()
+            .any(|a| a == "--dangerously-skip-permissions"));
     }
 
     #[test]

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -15,6 +15,7 @@ pub mod loop_spec;
 pub mod session;
 pub mod session_registry;
 pub mod skills;
+pub mod stream_json;
 pub mod subprocess;
 pub mod trampoline;
 pub mod voice;

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -14,6 +14,7 @@ pub mod dnd;
 pub mod loop_spec;
 pub mod session;
 pub mod session_registry;
+pub mod skills;
 pub mod subprocess;
 pub mod trampoline;
 pub mod voice;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,6 +1,6 @@
 use clud::{
     args, backend, command, console_title, daemon, dnd, loop_spec, session, session_registry,
-    subprocess, trampoline, voice, wasm,
+    skills, subprocess, trampoline, voice, wasm,
 };
 
 use std::io::{self, Read};
@@ -27,6 +27,16 @@ fn main() {
     // only way to defend the title.
     console_title::set_for_current_cwd();
     console_title::keep_setting_in_background();
+
+    // Expand bundled slash-command skills (clud-issue, clud-pr) into every
+    // backend's global skills directory that already exists
+    // (~/.claude/skills/ for Claude Code, ~/.codex/skills/ for Codex).
+    // Existing files are left alone so user edits survive. Failures are
+    // non-fatal — we log and continue, since a skills hiccup must never
+    // block a launch.
+    if let Err(e) = skills::ensure_installed() {
+        eprintln!("[clud] note: could not install bundled skills: {e}");
+    }
 
     let mut args = args::Args::parse_with_passthrough();
 

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,6 +1,6 @@
 use clud::{
     args, backend, command, console_title, daemon, dnd, loop_spec, session, session_registry,
-    skills, subprocess, trampoline, voice, wasm,
+    skills, stream_json, subprocess, trampoline, voice, wasm,
 };
 
 use std::io::{self, Read};
@@ -387,7 +387,11 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
             command: subprocess::command_spec_for_subprocess(plan.command.clone()),
             cwd: plan.cwd.as_ref().map(PathBuf::from),
             env: Some(env.clone()),
-            capture: false,
+            // When stream-json progress is on, we capture stdout so we can
+            // drain it line-by-line and route each event through the
+            // renderer. Otherwise stdio is inherited and the child writes
+            // directly to our console (preserving any TUI behavior).
+            capture: plan.stream_json_progress,
             stderr_mode: StderrMode::Stdout,
             creationflags: None,
             create_process_group: false,
@@ -409,37 +413,29 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
             return 1;
         }
 
-        loop {
-            match process.poll() {
-                Ok(Some(code)) => {
-                    if interrupted.load(Ordering::SeqCst) {
-                        eprintln!("[clud] interrupted via Ctrl+C");
-                        return 130;
-                    }
-                    last_exit = code;
-                    if last_exit != 0 && plan.iterations > 1 {
-                        eprintln!(
-                            "[clud] iteration {} failed with exit code {}",
-                            iteration + 1,
-                            last_exit
-                        );
-                        return last_exit;
-                    }
-                    break;
+        let exit_code = if plan.stream_json_progress {
+            run_with_stream_json_renderer(&process, interrupted)
+        } else {
+            run_with_inherited_stdio(&process, interrupted)
+        };
+        match exit_code {
+            ProcessOutcome::Exited(code) => {
+                last_exit = code;
+                if last_exit != 0 && plan.iterations > 1 {
+                    eprintln!(
+                        "[clud] iteration {} failed with exit code {}",
+                        iteration + 1,
+                        last_exit
+                    );
+                    return last_exit;
                 }
-                Ok(None) => {
-                    if interrupted.load(Ordering::SeqCst) {
-                        let _ = process.kill();
-                        let _ = process.wait(Some(std::time::Duration::from_secs(2)));
-                        eprintln!("[clud] interrupted via Ctrl+C");
-                        return 130;
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(50));
-                }
-                Err(e) => {
-                    eprintln!("[clud] error waiting for process: {}", e);
-                    return 1;
-                }
+            }
+            ProcessOutcome::Interrupted => {
+                eprintln!("[clud] interrupted via Ctrl+C");
+                return 130;
+            }
+            ProcessOutcome::Error => {
+                return 1;
             }
         }
 
@@ -453,6 +449,110 @@ fn run_plan_subprocess(plan: &command::LaunchPlan, verbose: bool, interrupted: &
     }
 
     last_exit
+}
+
+/// Outcome of one subprocess-mode iteration. Threaded through both the
+/// inherited-stdio path and the stream-json renderer path so the outer loop
+/// in `run_plan_subprocess` can stay uniform.
+enum ProcessOutcome {
+    Exited(i32),
+    Interrupted,
+    Error,
+}
+
+/// Inherited-stdio path: poll the child until it exits, kill on Ctrl+C.
+/// This is the original `run_plan_subprocess` body, extracted unchanged so
+/// the stream-json path can sit alongside it without duplicating the
+/// non-streaming control flow.
+fn run_with_inherited_stdio(
+    process: &running_process_core::NativeProcess,
+    interrupted: &AtomicBool,
+) -> ProcessOutcome {
+    loop {
+        match process.poll() {
+            Ok(Some(code)) => {
+                if interrupted.load(Ordering::SeqCst) {
+                    return ProcessOutcome::Interrupted;
+                }
+                return ProcessOutcome::Exited(code);
+            }
+            Ok(None) => {
+                if interrupted.load(Ordering::SeqCst) {
+                    let _ = process.kill();
+                    let _ = process.wait(Some(std::time::Duration::from_secs(2)));
+                    return ProcessOutcome::Interrupted;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => {
+                eprintln!("[clud] error waiting for process: {}", e);
+                return ProcessOutcome::Error;
+            }
+        }
+    }
+}
+
+/// Stream-JSON path: drain captured stdout line-by-line, pipe each line
+/// through `stream_json::render_line`, and print the rendered progress
+/// line to our own stderr (so it shows alongside the existing
+/// `[clud] iteration X/Y` banner and is easily distinguished from any
+/// real claude stdout payload).
+fn run_with_stream_json_renderer(
+    process: &running_process_core::NativeProcess,
+    interrupted: &AtomicBool,
+) -> ProcessOutcome {
+    use running_process_core::{ReadStatus, StreamKind};
+    use std::time::Duration;
+
+    let timeout = Duration::from_millis(100);
+    loop {
+        if interrupted.load(Ordering::SeqCst) {
+            let _ = process.kill();
+            let _ = process.wait(Some(Duration::from_secs(2)));
+            return ProcessOutcome::Interrupted;
+        }
+        match process.read_stream(StreamKind::Stdout, Some(timeout)) {
+            ReadStatus::Line(bytes) => {
+                emit_rendered_line(&bytes);
+            }
+            ReadStatus::Timeout => {
+                // No new data within the window; check if the child has
+                // exited so we don't spin forever after a slow turn.
+                if let Ok(Some(_)) = process.poll() {
+                    // Drain anything still queued before declaring done.
+                    drain_remaining_stdout(process);
+                    break;
+                }
+            }
+            ReadStatus::Eof => {
+                break;
+            }
+        }
+    }
+
+    match process.wait(Some(Duration::from_secs(2))) {
+        Ok(code) => ProcessOutcome::Exited(code),
+        Err(_) => match process.returncode() {
+            // EOF on the pipe doesn't imply the OS-level wait succeeded;
+            // fall back to whatever the shared returncode tracker has.
+            Some(code) => ProcessOutcome::Exited(code),
+            None => ProcessOutcome::Exited(0),
+        },
+    }
+}
+
+fn drain_remaining_stdout(process: &running_process_core::NativeProcess) {
+    use running_process_core::StreamKind;
+    for chunk in process.drain_stream(StreamKind::Stdout) {
+        emit_rendered_line(&chunk);
+    }
+}
+
+fn emit_rendered_line(bytes: &[u8]) {
+    let line = String::from_utf8_lossy(bytes);
+    if let Some(rendered) = stream_json::render_line(line.trim_end_matches(['\r', '\n'])) {
+        eprintln!("{rendered}");
+    }
 }
 
 fn run_plan_pty(

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -1,0 +1,343 @@
+//! Bundle slash-command "skills" inside the `clud` binary and install them
+//! into every supported backend's global skills directory on launch.
+//!
+//! Backends are listed in [`SKILL_BACKENDS`] — adding support for a new CLI
+//! (OpenRouter, OpenCode, etc.) is one line: append a new [`SkillBackend`].
+//! Each backend declares the home subdir it lives under (`.claude`,
+//! `.codex`, …) and the path under that where its skills live.
+//!
+//! We install only into a backend whose home subdir already exists — that
+//! way users who only run one CLI don't get the other CLIs' directories
+//! created in their home. Existing skill files are never overwritten, so
+//! user edits survive.
+//!
+//! The asset files live under `crates/clud-bin/assets/skills/` and are
+//! embedded at compile time via `include_str!`, so the runtime needs no
+//! filesystem access to read the source content.
+//!
+//! Errors are non-fatal: `main()` calls [`ensure_installed`], logs any
+//! failure to stderr, and proceeds with launch.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// One bundled skill: the directory name and the literal `SKILL.md` body.
+pub struct BundledSkill {
+    pub name: &'static str,
+    pub skill_md: &'static str,
+}
+
+/// All skills the binary ships with. Add new entries here when you bundle
+/// another `assets/skills/<name>/SKILL.md`.
+pub const BUNDLED_SKILLS: &[BundledSkill] = &[
+    BundledSkill {
+        name: "clud-issue",
+        skill_md: include_str!("../assets/skills/clud-issue/SKILL.md"),
+    },
+    BundledSkill {
+        name: "clud-issue-triage",
+        skill_md: include_str!("../assets/skills/clud-issue-triage/SKILL.md"),
+    },
+    BundledSkill {
+        name: "clud-pr",
+        skill_md: include_str!("../assets/skills/clud-pr/SKILL.md"),
+    },
+    BundledSkill {
+        name: "clud-tag-release",
+        skill_md: include_str!("../assets/skills/clud-tag-release/SKILL.md"),
+    },
+];
+
+/// One CLI backend that consumes `SKILL.md` files. Adding support for a
+/// new tool is a one-line append to [`SKILL_BACKENDS`] — the on-disk layout
+/// is the same as Claude Code's, just rooted under the tool's home subdir.
+pub struct SkillBackend {
+    /// Display name for log messages.
+    pub name: &'static str,
+    /// Path under the user's home dir where this backend stores config
+    /// (e.g. `.claude`, `.codex`).
+    pub home_subdir: &'static str,
+    /// Path under `home_subdir` where skill packages live (almost always
+    /// `skills`, parameterized in case a future tool uses a different
+    /// name).
+    pub skills_subdir: &'static str,
+}
+
+impl SkillBackend {
+    /// Resolved skills dir for this backend, given a home dir.
+    pub fn skills_dir(&self, home: &Path) -> PathBuf {
+        home.join(self.home_subdir).join(self.skills_subdir)
+    }
+
+    /// True when this backend's home subdir exists as a directory under
+    /// `home` — used to gate installs so we don't auto-create a backend
+    /// root the user hasn't installed.
+    pub fn root_exists(&self, home: &Path) -> bool {
+        home.join(self.home_subdir).is_dir()
+    }
+}
+
+/// Backends we install bundled skills into. To support a new CLI: confirm
+/// it loads `SKILL.md`-format playbooks from a per-tool skills dir, then
+/// append a `SkillBackend { ... }` entry here.
+pub const SKILL_BACKENDS: &[SkillBackend] = &[
+    SkillBackend {
+        name: "Claude Code",
+        home_subdir: ".claude",
+        skills_subdir: "skills",
+    },
+    SkillBackend {
+        name: "Codex",
+        home_subdir: ".codex",
+        skills_subdir: "skills",
+    },
+    // To add a new backend (e.g. OpenRouter CLI):
+    // SkillBackend {
+    //     name: "OpenRouter",
+    //     home_subdir: ".openrouter",
+    //     skills_subdir: "skills",
+    // },
+];
+
+#[derive(Debug)]
+pub enum InstallError {
+    NoHomeDir,
+    Io(io::Error),
+}
+
+impl std::fmt::Display for InstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InstallError::NoHomeDir => write!(f, "could not resolve user home directory"),
+            InstallError::Io(e) => write!(f, "io error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for InstallError {}
+
+impl From<io::Error> for InstallError {
+    fn from(e: io::Error) -> Self {
+        InstallError::Io(e)
+    }
+}
+
+/// Result of an install pass into a single backend's skills dir.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct InstallReport {
+    pub installed: Vec<&'static str>,
+    pub skipped_existing: Vec<&'static str>,
+}
+
+/// Install bundled skills into every backend whose home subdir exists.
+/// Returns one `(backend, report)` per backend actually written to.
+/// Returns [`InstallError::NoHomeDir`] only when the home dir itself
+/// cannot be resolved.
+pub fn ensure_installed() -> Result<Vec<(&'static SkillBackend, InstallReport)>, InstallError> {
+    let home = home_dir().ok_or(InstallError::NoHomeDir)?;
+    let mut results = Vec::new();
+    for backend in active_backends(&home) {
+        let report = install_to(&backend.skills_dir(&home), BUNDLED_SKILLS)?;
+        results.push((backend, report));
+    }
+    Ok(results)
+}
+
+/// All `SkillBackend`s whose home subdir currently exists under `home` —
+/// i.e. the backends the user has installed.
+pub fn active_backends(home: &Path) -> Vec<&'static SkillBackend> {
+    SKILL_BACKENDS
+        .iter()
+        .filter(|b| b.root_exists(home))
+        .collect()
+}
+
+/// Install the given skills into `base/<name>/SKILL.md`. Writes only when
+/// the target file is missing.
+pub fn install_to(base: &Path, skills: &[BundledSkill]) -> Result<InstallReport, InstallError> {
+    let mut report = InstallReport::default();
+    for skill in skills {
+        let skill_dir = base.join(skill.name);
+        let skill_md = skill_dir.join("SKILL.md");
+        if skill_md.exists() {
+            report.skipped_existing.push(skill.name);
+            continue;
+        }
+        std::fs::create_dir_all(&skill_dir)?;
+        std::fs::write(&skill_md, skill.skill_md)?;
+        report.installed.push(skill.name);
+    }
+    Ok(report)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(p) = std::env::var_os("USERPROFILE") {
+            if !p.is_empty() {
+                return Some(PathBuf::from(p));
+            }
+        }
+    }
+    if let Some(p) = std::env::var_os("HOME") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn fake_skills() -> Vec<BundledSkill> {
+        vec![
+            BundledSkill {
+                name: "alpha",
+                skill_md: "alpha body\n",
+            },
+            BundledSkill {
+                name: "beta",
+                skill_md: "beta body\n",
+            },
+        ]
+    }
+
+    #[test]
+    fn installs_when_missing() {
+        let dir = tempdir().unwrap();
+        let report = install_to(dir.path(), &fake_skills()).unwrap();
+        assert_eq!(report.installed, vec!["alpha", "beta"]);
+        assert!(report.skipped_existing.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("alpha/SKILL.md")).unwrap(),
+            "alpha body\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("beta/SKILL.md")).unwrap(),
+            "beta body\n"
+        );
+    }
+
+    #[test]
+    fn skips_existing_and_preserves_user_edits() {
+        let dir = tempdir().unwrap();
+        let alpha_dir = dir.path().join("alpha");
+        std::fs::create_dir_all(&alpha_dir).unwrap();
+        std::fs::write(alpha_dir.join("SKILL.md"), "USER EDIT").unwrap();
+
+        let report = install_to(dir.path(), &fake_skills()).unwrap();
+        assert_eq!(report.installed, vec!["beta"]);
+        assert_eq!(report.skipped_existing, vec!["alpha"]);
+        assert_eq!(
+            std::fs::read_to_string(alpha_dir.join("SKILL.md")).unwrap(),
+            "USER EDIT",
+            "existing user content must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn idempotent_second_pass_is_a_noop() {
+        let dir = tempdir().unwrap();
+        let first = install_to(dir.path(), &fake_skills()).unwrap();
+        assert_eq!(first.installed.len(), 2);
+        let second = install_to(dir.path(), &fake_skills()).unwrap();
+        assert!(second.installed.is_empty());
+        assert_eq!(second.skipped_existing, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn creates_missing_parent_dirs() {
+        let dir = tempdir().unwrap();
+        let nested = dir.path().join("a/b/c");
+        let report = install_to(&nested, &fake_skills()).unwrap();
+        assert_eq!(report.installed, vec!["alpha", "beta"]);
+        assert!(nested.join("alpha/SKILL.md").exists());
+    }
+
+    /// The bundled assets must be non-empty — `include_str!` would fail at
+    /// build time on a missing file, but a 0-byte file would silently ship.
+    #[test]
+    fn bundled_skills_are_non_empty() {
+        assert!(!BUNDLED_SKILLS.is_empty());
+        for s in BUNDLED_SKILLS {
+            assert!(!s.skill_md.trim().is_empty(), "skill {} is empty", s.name);
+            assert!(
+                s.skill_md.contains("managed-by: clud"),
+                "skill {} missing managed-by marker",
+                s.name
+            );
+        }
+    }
+
+    #[test]
+    fn bundled_includes_all_known_skills() {
+        let names: Vec<&str> = BUNDLED_SKILLS.iter().map(|s| s.name).collect();
+        assert!(names.contains(&"clud-issue"));
+        assert!(names.contains(&"clud-issue-triage"));
+        assert!(names.contains(&"clud-pr"));
+        assert!(names.contains(&"clud-tag-release"));
+    }
+
+    #[test]
+    fn skill_backends_include_claude_and_codex() {
+        let names: Vec<&str> = SKILL_BACKENDS.iter().map(|b| b.home_subdir).collect();
+        assert!(names.contains(&".claude"));
+        assert!(names.contains(&".codex"));
+    }
+
+    #[test]
+    fn active_backends_returns_all_when_all_roots_exist() {
+        let home = tempdir().unwrap();
+        for b in SKILL_BACKENDS {
+            std::fs::create_dir_all(home.path().join(b.home_subdir)).unwrap();
+        }
+        let active = active_backends(home.path());
+        assert_eq!(active.len(), SKILL_BACKENDS.len());
+    }
+
+    #[test]
+    fn active_backends_filters_to_existing_roots() {
+        let home = tempdir().unwrap();
+        // Only the first backend is installed.
+        std::fs::create_dir_all(home.path().join(SKILL_BACKENDS[0].home_subdir)).unwrap();
+        let active = active_backends(home.path());
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].home_subdir, SKILL_BACKENDS[0].home_subdir);
+    }
+
+    #[test]
+    fn active_backends_empty_when_nothing_installed() {
+        let home = tempdir().unwrap();
+        assert!(active_backends(home.path()).is_empty());
+    }
+
+    /// A file (not a directory) at a backend's home path must not register
+    /// as installed — `is_dir()` filters it out.
+    #[test]
+    fn active_backends_ignores_non_directory_at_root() {
+        let home = tempdir().unwrap();
+        std::fs::write(
+            home.path().join(SKILL_BACKENDS[0].home_subdir),
+            b"not a dir",
+        )
+        .unwrap();
+        assert!(active_backends(home.path()).is_empty());
+    }
+
+    #[test]
+    fn skills_dir_resolves_under_backend_root() {
+        let home = tempdir().unwrap();
+        let backend = SkillBackend {
+            name: "Test",
+            home_subdir: ".testtool",
+            skills_subdir: "skills",
+        };
+        assert_eq!(
+            backend.skills_dir(home.path()),
+            home.path().join(".testtool").join("skills")
+        );
+    }
+}

--- a/crates/clud-bin/src/stream_json.rs
+++ b/crates/clud-bin/src/stream_json.rs
@@ -1,0 +1,358 @@
+//! Renderer for claude's `--output-format stream-json` events.
+//!
+//! When `clud loop` runs claude in subprocess launch mode (Windows default,
+//! or any explicit `--subprocess`), claude is invoked with
+//! `--output-format stream-json --verbose`, which makes it emit one JSON
+//! object per line as the turn progresses. This module turns each line into a
+//! single human-readable progress line so the operator can see what claude is
+//! doing in real time instead of staring at silence until the iteration
+//! finishes.
+//!
+//! Design goals:
+//!
+//! * **Pure & cheap to test.** `render_line` takes a `&str`, returns
+//!   `Option<String>`, and has no side effects. Tests feed canned event
+//!   strings — no subscription key or real claude invocation needed.
+//! * **Conservative.** Unknown event types are skipped silently; non-JSON
+//!   input is passed through verbatim so error messages still surface.
+//! * **One line per event.** Multi-line assistant text collapses to its
+//!   first non-empty line plus an ellipsis; tool arguments are truncated.
+
+use serde_json::Value;
+
+/// Maximum characters of free-form text (assistant prose, tool command
+/// strings) we'll show on a single progress line before truncating.
+const MAX_TEXT_CHARS: usize = 160;
+
+/// Render a single stream-json line into a human-readable progress line.
+///
+/// Returns:
+/// * `Some(rendered)` — print this line to stderr (one line of progress).
+/// * `None` — drop the event (uninteresting / noise).
+pub fn render_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Non-JSON lines pass through verbatim. claude's stream-json mode emits
+    // only JSON, but stderr is merged into the same stream by the runner, so
+    // a panic backtrace or `npm WARN ...` line shouldn't be silently dropped.
+    let value: Value = match serde_json::from_str(trimmed) {
+        Ok(v) => v,
+        Err(_) => return Some(trimmed.to_string()),
+    };
+
+    let msg_type = value.get("type").and_then(Value::as_str)?;
+    match msg_type {
+        "system" => render_system(&value),
+        "assistant" => render_assistant(&value),
+        "result" => render_result(&value),
+        // `user` events carry tool_result payloads — usually long, often
+        // duplicating what the tool_use line already conveyed. Skipped.
+        _ => None,
+    }
+}
+
+fn render_system(value: &Value) -> Option<String> {
+    let subtype = value.get("subtype").and_then(Value::as_str).unwrap_or("");
+    if subtype != "init" {
+        return None;
+    }
+    let model = value
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    Some(format!("[claude] session start · model={model}"))
+}
+
+fn render_assistant(value: &Value) -> Option<String> {
+    let content = value
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)?;
+    let mut lines: Vec<String> = Vec::new();
+    for item in content {
+        let item_type = item.get("type").and_then(Value::as_str).unwrap_or("");
+        match item_type {
+            "text" => {
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    if let Some(first_line) = first_nonempty_line(text) {
+                        lines.push(format!(
+                            "[claude] {}",
+                            truncate(&first_line, MAX_TEXT_CHARS)
+                        ));
+                    }
+                }
+            }
+            "tool_use" => {
+                let name = item.get("name").and_then(Value::as_str).unwrap_or("(tool)");
+                let input = item.get("input");
+                let summary = summarize_tool_input(name, input);
+                if summary.is_empty() {
+                    lines.push(format!("[tool] {name}"));
+                } else {
+                    lines.push(format!(
+                        "[tool] {name}: {}",
+                        truncate(&summary, MAX_TEXT_CHARS)
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+fn render_result(value: &Value) -> Option<String> {
+    let duration_ms = value.get("duration_ms").and_then(Value::as_u64);
+    let cost = value.get("total_cost_usd").and_then(Value::as_f64);
+    let turns = value.get("num_turns").and_then(Value::as_u64);
+    let is_error = value
+        .get("is_error")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(
+        (if is_error {
+            "[claude] error"
+        } else {
+            "[claude] done"
+        })
+        .to_string(),
+    );
+    if let Some(ms) = duration_ms {
+        parts.push(format!("{:.1}s", ms as f64 / 1000.0));
+    }
+    if let Some(c) = cost {
+        parts.push(format!("${c:.2}"));
+    }
+    if let Some(t) = turns {
+        parts.push(format!("{t} turns"));
+    }
+    Some(parts.join(" · "))
+}
+
+/// Build a short summary string from a tool's `input` object. Empty string
+/// means "no informative argument" — the caller falls back to printing just
+/// the tool name.
+fn summarize_tool_input(name: &str, input: Option<&Value>) -> String {
+    let Some(input) = input else {
+        return String::new();
+    };
+    let lookup = |key: &str| input.get(key).and_then(Value::as_str).unwrap_or("");
+
+    // A `description` field, when present, is the most human-readable
+    // summary the agent can provide. Honor it before tool-specific logic.
+    let description = lookup("description");
+
+    let body = match name {
+        "Bash" => {
+            let cmd = lookup("command");
+            if !cmd.is_empty() {
+                cmd.to_string()
+            } else {
+                description.to_string()
+            }
+        }
+        "Read" | "Edit" | "Write" | "NotebookEdit" => lookup("file_path").to_string(),
+        "Grep" | "Glob" => lookup("pattern").to_string(),
+        "WebFetch" | "WebSearch" => lookup("url").to_string(),
+        _ => description.to_string(),
+    };
+
+    // Collapse newlines/whitespace so the progress line stays single-line.
+    body.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn first_nonempty_line(text: &str) -> Option<String> {
+    for line in text.lines() {
+        let t = line.trim();
+        if !t.is_empty() {
+            return Some(t.to_string());
+        }
+    }
+    None
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    let count = s.chars().count();
+    if count <= max_chars {
+        return s.to_string();
+    }
+    let keep = max_chars.saturating_sub(1);
+    let mut out: String = s.chars().take(keep).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_line_returns_none() {
+        assert!(render_line("").is_none());
+        assert!(render_line("   \t\n").is_none());
+    }
+
+    #[test]
+    fn non_json_line_passes_through_verbatim() {
+        // stderr (npm warnings, panics) is merged into the same stream by
+        // the subprocess runner. We must not swallow it.
+        let line = "npm WARN deprecated foo@1.0";
+        assert_eq!(render_line(line).as_deref(), Some(line));
+    }
+
+    #[test]
+    fn json_array_at_root_passes_through() {
+        // serde_json parses `[1,2,3]` successfully but it has no "type"
+        // field. The renderer must drop it (it's not a turn event) rather
+        // than panic.
+        assert!(render_line("[1, 2, 3]").is_none());
+    }
+
+    #[test]
+    fn assistant_text_renders_as_claude_line() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Looking at the issue, I'll start by reading the file."}]}}"#;
+        assert_eq!(
+            render_line(line).as_deref(),
+            Some("[claude] Looking at the issue, I'll start by reading the file.")
+        );
+    }
+
+    #[test]
+    fn assistant_text_collapses_to_first_nonempty_line() {
+        // Multi-line assistant text would blow up a one-line progress
+        // display. We keep only the first non-empty line.
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"\n\nStep 1: read file\n\nStep 2: edit"}]}}"#;
+        assert_eq!(
+            render_line(line).as_deref(),
+            Some("[claude] Step 1: read file")
+        );
+    }
+
+    #[test]
+    fn assistant_text_is_truncated_when_too_long() {
+        let long = "x".repeat(500);
+        let line = format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"text","text":"{long}"}}]}}}}"#
+        );
+        let rendered = render_line(&line).expect("text event must render");
+        // Format prefix + ellipsis + bounded chars; assert we didn't dump
+        // all 500 chars.
+        assert!(rendered.chars().count() < 200, "got {}", rendered.len());
+        assert!(
+            rendered.ends_with('…'),
+            "must end with ellipsis: {rendered}"
+        );
+        assert!(rendered.starts_with("[claude] "));
+    }
+
+    #[test]
+    fn tool_use_bash_renders_command_snippet() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"cargo test --release","description":"run tests"}}]}}"#;
+        assert_eq!(
+            render_line(line).as_deref(),
+            Some("[tool] Bash: cargo test --release"),
+            "Bash should prefer command over description"
+        );
+    }
+
+    #[test]
+    fn tool_use_read_renders_file_path() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"x","name":"Read","input":{"file_path":"/tmp/foo.rs"}}]}}"#;
+        assert_eq!(
+            render_line(line).as_deref(),
+            Some("[tool] Read: /tmp/foo.rs")
+        );
+    }
+
+    #[test]
+    fn tool_use_grep_renders_pattern() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"x","name":"Grep","input":{"pattern":"fn main","path":"src/"}}]}}"#;
+        assert_eq!(render_line(line).as_deref(), Some("[tool] Grep: fn main"));
+    }
+
+    #[test]
+    fn tool_use_unknown_tool_with_description() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"x","name":"SomeCustom","input":{"description":"do a thing"}}]}}"#;
+        assert_eq!(
+            render_line(line).as_deref(),
+            Some("[tool] SomeCustom: do a thing")
+        );
+    }
+
+    #[test]
+    fn tool_use_unknown_tool_without_useful_input() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"x","name":"SomeCustom","input":{}}]}}"#;
+        assert_eq!(render_line(line).as_deref(), Some("[tool] SomeCustom"));
+    }
+
+    #[test]
+    fn assistant_with_both_text_and_tool_use_emits_both_lines() {
+        // Real claude turns often pack a text thought + a tool call into
+        // one assistant event. Both should surface so the operator sees
+        // the chain of reasoning.
+        let line = r#"{"type":"assistant","message":{"content":[
+            {"type":"text","text":"I'll run the tests."},
+            {"type":"tool_use","id":"x","name":"Bash","input":{"command":"cargo test"}}
+        ]}}"#;
+        let rendered = render_line(line).expect("must render combined event");
+        assert!(
+            rendered.contains("[claude] I'll run the tests."),
+            "{rendered}"
+        );
+        assert!(rendered.contains("[tool] Bash: cargo test"), "{rendered}");
+    }
+
+    #[test]
+    fn result_event_renders_summary() {
+        let line = r#"{"type":"result","subtype":"success","is_error":false,"duration_ms":12500,"num_turns":7,"total_cost_usd":0.1234}"#;
+        let rendered = render_line(line).expect("result event must render");
+        assert!(rendered.starts_with("[claude] done"), "{rendered}");
+        assert!(rendered.contains("12.5s"), "{rendered}");
+        assert!(rendered.contains("$0.12"), "{rendered}");
+        assert!(rendered.contains("7 turns"), "{rendered}");
+    }
+
+    #[test]
+    fn result_event_with_is_error_renders_error_summary() {
+        let line = r#"{"type":"result","subtype":"error_max_turns","is_error":true,"duration_ms":4000,"num_turns":3}"#;
+        let rendered = render_line(line).expect("error result must render");
+        assert!(rendered.starts_with("[claude] error"), "{rendered}");
+    }
+
+    #[test]
+    fn system_init_event_renders_model() {
+        let line = r#"{"type":"system","subtype":"init","session_id":"abc","tools":["Bash"],"model":"claude-opus-4-7","permissionMode":"default"}"#;
+        let rendered = render_line(line).expect("system init must render");
+        assert!(rendered.contains("session start"), "{rendered}");
+        assert!(rendered.contains("claude-opus-4-7"), "{rendered}");
+    }
+
+    #[test]
+    fn user_tool_result_event_is_skipped() {
+        // claude-stream-json's "user" events carry the bytes the tool
+        // returned. They're typically large and redundant with the
+        // tool_use line that already printed. Skipped.
+        let line = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"x","content":"file contents..."}]}}"#;
+        assert!(render_line(line).is_none());
+    }
+
+    #[test]
+    fn unknown_event_type_is_skipped() {
+        let line = r#"{"type":"some_future_event","payload":42}"#;
+        assert!(render_line(line).is_none());
+    }
+
+    #[test]
+    fn assistant_event_with_no_content_is_skipped() {
+        let line = r#"{"type":"assistant","message":{"content":[]}}"#;
+        assert!(render_line(line).is_none());
+    }
+}

--- a/testbins/mock-agent/src/main.rs
+++ b/testbins/mock-agent/src/main.rs
@@ -38,6 +38,12 @@ fn main() {
     let mut pty_size_samples: u32 = 0;
     let mut pty_size_interval_ms: u64 = 100;
     let mut ansi_script: Option<PathBuf> = None;
+    // Emit canned `--output-format stream-json` lines from a file (one line
+    // each, separated by `--mock-stream-delay-ms`). Used by integration tests
+    // that exercise clud's stream-json renderer without needing a real
+    // claude subscription key.
+    let mut stream_json_script: Option<PathBuf> = None;
+    let mut stream_delay_ms: u64 = 0;
     let mut filtered_args: Vec<String> = Vec::new();
     let mut skip_next = false;
     for (i, arg) in args.iter().enumerate().skip(1) {
@@ -157,6 +163,20 @@ fn main() {
             skip_next = true;
             continue;
         }
+        if arg == "--mock-stream-json" {
+            if let Some(path) = args.get(i + 1) {
+                stream_json_script = Some(PathBuf::from(path));
+            }
+            skip_next = true;
+            continue;
+        }
+        if arg == "--mock-stream-delay-ms" {
+            if let Some(ms) = args.get(i + 1) {
+                stream_delay_ms = ms.parse().unwrap_or(0);
+            }
+            skip_next = true;
+            continue;
+        }
         filtered_args.push(arg.clone());
     }
 
@@ -169,6 +189,26 @@ fn main() {
             let _ = io::stdout().write_all(&bytes);
             let _ = io::stdout().flush();
         }
+    }
+
+    // Emit canned stream-json events line-by-line. When the integration
+    // test wants to exercise clud's renderer, it points this at a file
+    // containing one JSON event per line; we write them with a flush
+    // between each so the parent's drain loop sees them incrementally,
+    // exactly like real claude would emit them. Then exit immediately
+    // so the test's wait completes without the usual JSON-report tail.
+    if let Some(path) = stream_json_script.as_ref() {
+        if let Ok(text) = std::fs::read_to_string(path) {
+            for line in text.lines() {
+                let _ = io::stdout().write_all(line.as_bytes());
+                let _ = io::stdout().write_all(b"\n");
+                let _ = io::stdout().flush();
+                if stream_delay_ms > 0 {
+                    std::thread::sleep(Duration::from_millis(stream_delay_ms));
+                }
+            }
+        }
+        std::process::exit(exit_code);
     }
 
     if let Some(path) = pty_size_report_to.as_ref() {

--- a/tests/integration/test_loop_stream_json.py
+++ b/tests/integration/test_loop_stream_json.py
@@ -1,0 +1,203 @@
+"""Integration test: `clud loop` renders claude's stream-json events as
+human-readable progress lines instead of dumping raw JSON.
+
+This test does NOT call real claude — it uses the mock-agent's
+``--mock-stream-json <path>`` flag to emit a canned sequence of stream-json
+events, exactly the way real claude would when invoked with
+``--output-format stream-json --verbose``. The renderer under test then has
+to turn those JSON lines into ``[claude] ...`` / ``[tool] ...`` progress
+lines.
+
+Why this matters: on Windows, ``clud loop`` runs claude in subprocess launch
+mode (PTY mode hangs under loops, see #38). Without the renderer the user
+sees ``[clud] iteration 1/50`` and then silence until the whole iteration
+finishes, because ``claude -p`` buffers its final response. The renderer
+restores the live-progress UX the old Python loop had.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_TIMEOUT = 30
+
+
+def _run(
+    clud: Path,
+    *args: str,
+    env: dict[str, str],
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    # Copy clud into the test's tmpdir so the Windows trampoline rename
+    # dance never targets a file outside the temp scope. Matches the
+    # pattern in test_mock_agents.py.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        launch = Path(temp_dir) / clud.name
+        shutil.copy2(clud, launch)
+        return subprocess.run(
+            [str(launch), *args],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT,
+            env=env,
+            cwd=cwd,
+        )
+
+
+def _write_canned_events(path: Path) -> None:
+    """Write a small but representative sequence of stream-json events."""
+    events = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "abc123",
+            "tools": ["Bash", "Read", "Edit"],
+            "model": "claude-opus-4-7",
+            "permissionMode": "default",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "I'll start by reading the file."}
+                ]
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "Bash",
+                        "input": {"command": "cargo test --lib"},
+                    }
+                ]
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "duration_ms": 4321,
+            "num_turns": 2,
+            "total_cost_usd": 0.0456,
+        },
+    ]
+    path.write_text("\n".join(json.dumps(e) for e in events), encoding="utf-8")
+
+
+_WIN_ONLY_SKIP = (
+    "POSIX clud loop runs in PTY mode where streaming already works; "
+    "the subprocess-mode stream-json renderer is the Windows-only path."
+)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason=_WIN_ONLY_SKIP)
+def test_loop_renders_stream_json_as_progress_lines(
+    clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+) -> None:
+    """`clud loop` (subprocess mode) must render stream-json events as
+    `[claude] ...` / `[tool] ...` lines instead of leaking raw JSON.
+    """
+    script = tmp_path / "events.jsonl"
+    _write_canned_events(script)
+
+    # `--no-done` so we don't wait for a DONE marker. `--loop-count 1` so the
+    # loop terminates after the single canned run. We force `--subprocess`
+    # so the test is platform-independent (the renderer is subprocess-only).
+    result = _run(
+        clud_binary,
+        "--subprocess",
+        "loop",
+        "--no-done",
+        "--loop-count",
+        "1",
+        "make progress",
+        "--",
+        "--mock-stream-json",
+        str(script),
+        env=mock_env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, (
+        f"clud exited {result.returncode}\nstderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+    )
+
+    # The renderer emits one progress line per event. We collect output from
+    # both streams because the runtime is free to print progress on stderr
+    # (alongside the existing `[clud] iteration X/Y` line) or stdout.
+    combined = result.stdout + "\n" + result.stderr
+
+    # Assistant text event → `[claude] I'll start by reading the file.`
+    assert "[claude] I'll start by reading the file." in combined, (
+        f"missing assistant text render in:\n{combined}"
+    )
+
+    # Tool-use event for Bash → `[tool] Bash: cargo test --lib`
+    assert "[tool] Bash: cargo test --lib" in combined, (
+        f"missing tool_use render in:\n{combined}"
+    )
+
+    # Result event → `[claude] done · 4.3s · $0.05 · 2 turns`
+    assert "[claude] done" in combined, f"missing result render in:\n{combined}"
+    assert "4.3s" in combined, f"missing duration in result render:\n{combined}"
+
+    # The raw JSON event must NOT have been passed through verbatim — that's
+    # the whole point of the renderer. If we see the literal `"type":` keys
+    # for the assistant event, the renderer didn't run.
+    assert '"type":"assistant"' not in combined, (
+        f"raw assistant JSON leaked into output:\n{combined}"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason=_WIN_ONLY_SKIP)
+def test_loop_passes_through_non_json_stderr_lines(
+    clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+) -> None:
+    """Lines that are not valid JSON (e.g. a stray panic line that claude or
+    a wrapper printed to stderr) must NOT be silently dropped — the
+    renderer passes them through verbatim so the operator still sees
+    diagnostic messages.
+    """
+    script = tmp_path / "events.jsonl"
+    script.write_text(
+        # An assistant event, plus a non-JSON line, plus a result event.
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}\n'
+        "npm WARN deprecated foo@1.0\n"
+        '{"type":"result","subtype":"success","is_error":false,"duration_ms":100,"num_turns":1}\n',
+        encoding="utf-8",
+    )
+
+    result = _run(
+        clud_binary,
+        "--subprocess",
+        "loop",
+        "--no-done",
+        "--loop-count",
+        "1",
+        "task",
+        "--",
+        "--mock-stream-json",
+        str(script),
+        env=mock_env,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    combined = result.stdout + "\n" + result.stderr
+    assert "[claude] hello" in combined
+    assert "npm WARN deprecated foo@1.0" in combined, (
+        f"non-JSON stderr line was dropped:\n{combined}"
+    )

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -350,12 +350,28 @@ class TestLoopMode:
             env=mock_env,
         )
         assert result.returncode == 0
-        cleaned = _strip_ansi(result.stdout)
-        json_lines = [line.strip() for line in cleaned.splitlines() if line.strip().startswith("{")]
-        assert len(json_lines) == 3
-        for line in json_lines:
-            report = json.loads(line)
-            assert "do stuff" in report["args"]
+        # `clud loop` against the claude backend now injects
+        # `--output-format stream-json --verbose` in subprocess mode and
+        # routes the child's stdout through the renderer, so the
+        # mock-agent's own JSON report no longer arrives on the parent's
+        # stdout verbatim. Count iterations via the `[clud] iteration N/3`
+        # banner clud itself prints on stderr, which the renderer doesn't
+        # touch.
+        cleaned_stderr = _strip_ansi(result.stderr)
+        iter_lines = [
+            line
+            for line in cleaned_stderr.splitlines()
+            # Match the start-of-iteration banner specifically (it has the
+            # form `[clud] iteration N/M`), not the per-iteration failure
+            # diagnostic (`[clud] iteration N failed with exit code X`).
+            if re.match(r"\[clud\] iteration \d+/\d+", line.strip())
+        ]
+        assert len(iter_lines) == 3, (
+            f"expected 3 iteration banners, got {len(iter_lines)}: {iter_lines!r}"
+        )
+        assert "[clud] iteration 1/3" in cleaned_stderr
+        assert "[clud] iteration 2/3" in cleaned_stderr
+        assert "[clud] iteration 3/3" in cleaned_stderr
 
     def test_loop_stops_on_failure(
         self, clud_binary: Path, mock_env: dict[str, str]
@@ -372,9 +388,22 @@ class TestLoopMode:
             env=mock_env,
         )
         assert result.returncode == 1
-        cleaned = _strip_ansi(result.stdout)
-        json_lines = [line.strip() for line in cleaned.splitlines() if line.strip().startswith("{")]
-        assert len(json_lines) == 1
+        # Same rationale as `test_loop_iterations`: iteration banners on
+        # stderr are the post-renderer way to count iterations. We expect
+        # exactly one because the failure aborts the loop.
+        cleaned_stderr = _strip_ansi(result.stderr)
+        iter_lines = [
+            line
+            for line in cleaned_stderr.splitlines()
+            # Match the start-of-iteration banner specifically (it has the
+            # form `[clud] iteration N/M`), not the per-iteration failure
+            # diagnostic (`[clud] iteration N failed with exit code X`).
+            if re.match(r"\[clud\] iteration \d+/\d+", line.strip())
+        ]
+        assert len(iter_lines) == 1, (
+            f"expected loop to stop after iteration 1, got banners: {iter_lines!r}"
+        )
+        assert "[clud] iteration 1/5" in cleaned_stderr
 
     # ---- Issue #48: `clud --codex loop "..."` must work against codex ----
 


### PR DESCRIPTION
## Summary

- On Windows, `clud loop` against claude went silent between
  `[clud] iteration N/M` banners because `claude -p` buffers its whole
  response in non-streaming mode. The Python predecessor solved this by
  injecting `--output-format stream-json --verbose` and rendering events
  into one-line progress updates. The Rust port had dropped both pieces.
- This PR restores live progress when claude runs in subprocess launch
  mode. Linux/macOS PTY-mode loops and the codex backend are untouched.
- Also bundles a pre-existing, unrelated commit that installs
  clud-issue / clud-pr / clud-issue-triage / clud-tag-release SKILL.md
  into each backend's skills directory on launch — that work was
  already staged locally and is included for cleanliness.

## What changed (stream-json piece)

1. **Command builder** (`crates/clud-bin/src/command.rs`) — when
   `backend=Claude AND command=Loop AND launch_mode=Subprocess`, append
   `--output-format stream-json --verbose` and set the new
   `LaunchPlan.stream_json_progress` flag.
2. **Renderer** (`crates/clud-bin/src/stream_json.rs`, new) — pure
   `render_line(&str) -> Option<String>` that turns each JSON event
   into `[claude] <text>` / `[tool] <name>: <summary>` /
   `[claude] done · 12.3s · $0.12 · 5 turns`. Non-JSON lines pass
   through verbatim; unknown JSON event types drop silently.
3. **Runtime** (`crates/clud-bin/src/main.rs`) —
   `run_plan_subprocess` now branches on `stream_json_progress`. When
   true it captures stdout (with stderr merged in) and drains it line
   by line through the renderer to stderr. The inherited-stdio path
   stays unchanged for single-shot prompts, codex, and PTY.

## TDD approach (red → green, no real claude needed)

All tests use mocks — there is **no dependency on a Claude subscription
key** at any point in the test pipeline.

- **23 new Rust unit tests** (5 command-builder injection cases + 18
  renderer cases covering text/tool_use/result/system-init/malformed/
  truncation/multi-content events). Total Rust suite: **341 → 364
  tests passing**.
- **2 new Python integration tests** in
  `tests/integration/test_loop_stream_json.py` driving an
  end-to-end Windows subprocess run. A new `--mock-stream-json <path>`
  flag on `testbins/mock-agent` emits canned JSON events line by line
  through the real subprocess pipe.
- **2 existing loop tests** in `test_mock_agents.py` were updated to
  count `[clud] iteration N/M` stderr banners instead of mock-agent
  JSON reports — those reports now correctly get filtered by the
  renderer and the new counting method is more faithful to user intent.

## Test plan

- [x] `soldr cargo test -p clud --lib` (364 passing)
- [x] `bash lint` clean
- [x] `CLUD_INTEGRATION_TESTS=1 pytest tests/integration/test_loop_stream_json.py` (2 passing on Windows)
- [x] `pytest tests/integration/test_mock_agents.py tests/integration/test_loop_markers.py` (47 passing, 1 pre-existing PTY Ctrl+C flake deselected — unrelated to this PR)
- [ ] CI matrix (6 platforms × 4 job types) once pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)