### PR TITLE
feat(daemon): add clud logs subcommand for read-only session tailing (#25)

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -134,14 +134,21 @@ pub enum Command {
     /// With no session id, lists all sessions that have log files and prints
     /// the last line of each. With an id, prints the log (last `--lines` or
     /// all) and optionally keeps following new output via `--follow`.
+    /// `--last` resolves to the most-recently-created session (live or
+    /// exited), mirroring `clud attach --last`. Read-only: never takes
+    /// exclusive ownership of the session and never evicts attached clients.
     Logs {
         session_id: Option<String>,
-        /// Keep watching the file and print new output as it arrives.
+        /// Keep watching the file and print new output as it arrives. Exits
+        /// once the session has terminated (after printing a status line).
         #[arg(long = "follow", short = 'f')]
         follow: bool,
         /// Print only the last N lines from the file. Default: all.
         #[arg(long = "lines", short = 'n')]
         lines: Option<usize>,
+        /// Operate on the most recently created session (live or exited).
+        #[arg(long = "last", short = 'l', conflicts_with = "session_id")]
+        last: bool,
     },
     #[command(name = "__daemon", hide = true)]
     InternalDaemon {
@@ -728,6 +735,104 @@ mod tests {
     fn test_list_subcommand() {
         let args = parse(&["clud", "list"]);
         assert!(matches!(args.command, Some(Command::List)));
+    }
+
+    #[test]
+    fn test_logs_with_session_id() {
+        let args = parse(&["clud", "logs", "sess-abc"]);
+        match args.command {
+            Some(Command::Logs {
+                session_id,
+                follow,
+                lines,
+                last,
+            }) => {
+                assert_eq!(session_id.as_deref(), Some("sess-abc"));
+                assert!(!follow);
+                assert!(lines.is_none());
+                assert!(!last);
+            }
+            _ => panic!("expected Logs subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_logs_follow_flag() {
+        let args = parse(&["clud", "logs", "-f", "sess-abc"]);
+        match args.command {
+            Some(Command::Logs {
+                session_id,
+                follow,
+                last,
+                ..
+            }) => {
+                assert_eq!(session_id.as_deref(), Some("sess-abc"));
+                assert!(follow);
+                assert!(!last);
+            }
+            _ => panic!("expected Logs subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_logs_lines_flag() {
+        let args = parse(&["clud", "logs", "-n", "100", "sess-abc"]);
+        match args.command {
+            Some(Command::Logs {
+                session_id,
+                lines,
+                last,
+                ..
+            }) => {
+                assert_eq!(session_id.as_deref(), Some("sess-abc"));
+                assert_eq!(lines, Some(100));
+                assert!(!last);
+            }
+            _ => panic!("expected Logs subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_logs_last_flag() {
+        let args = parse(&["clud", "logs", "--last"]);
+        match args.command {
+            Some(Command::Logs {
+                session_id,
+                follow,
+                last,
+                ..
+            }) => {
+                assert!(session_id.is_none());
+                assert!(!follow);
+                assert!(last);
+            }
+            _ => panic!("expected Logs subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_logs_last_short_flag() {
+        let args = parse(&["clud", "logs", "-l"]);
+        match args.command {
+            Some(Command::Logs { last, .. }) => {
+                assert!(last);
+            }
+            _ => panic!("expected Logs subcommand"),
+        }
+    }
+
+    /// `--last` conflicts with positional session id (mirrors `clud attach`).
+    #[test]
+    fn test_logs_last_with_session_id_conflicts() {
+        let argv: Vec<String> = ["clud", "logs", "--last", "sess-abc"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let result = Args::try_parse_from(argv);
+        assert!(
+            result.is_err(),
+            "clap should reject --last combined with a session id"
+        );
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -667,11 +667,31 @@ pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i
             session_id,
             follow,
             lines,
+            last,
         }) => {
             let state_dir = state_dir(args);
+            // `--last` resolves to the most recently created session,
+            // including exited ones — logs are valuable post-mortem.
+            let resolved_id: Option<String> = if *last {
+                match most_recent_session_any(&state_dir) {
+                    Some(session) => {
+                        eprintln!(
+                            "[clud] showing logs for most recent session: {}",
+                            session.id
+                        );
+                        Some(session.id)
+                    }
+                    None => {
+                        eprintln!("[clud] no sessions found");
+                        return Some(1);
+                    }
+                }
+            } else {
+                session_id.clone()
+            };
             Some(run_logs(
                 &state_dir,
-                session_id.as_deref(),
+                resolved_id.as_deref(),
                 *follow,
                 *lines,
                 interrupted,
@@ -2206,6 +2226,19 @@ fn most_recent_session(state_dir: &Path) -> Option<SessionSnapshot> {
         .max_by_key(|s| s.created_at.unwrap_or(0))
 }
 
+/// Return the most recently created session, *including exited ones*.
+/// Used by `clud logs --last`: a session's log is valuable after it dies,
+/// so we look at every snapshot on disk rather than only attachable ones.
+fn most_recent_session_any(state_dir: &Path) -> Option<SessionSnapshot> {
+    let entries = fs::read_dir(sessions_dir(state_dir)).ok()?;
+    entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .filter_map(|p| read_json_file::<SessionSnapshot>(&p).ok())
+        .max_by_key(|s| s.created_at.unwrap_or(0))
+}
+
 fn run_kill(state_dir: &Path, session_id: Option<&str>, all: bool) -> i32 {
     if let Err(err) = ensure_daemon(state_dir) {
         eprintln!("[clud] failed to reach daemon: {}", err);
@@ -2393,11 +2426,17 @@ fn run_logs(
         }
     };
     if !follow {
+        // If the session is already dead, print a status line so the user
+        // knows they're looking at a post-mortem rather than a live tail.
+        if let Some(code) = session_exit_code(state_dir, &resolved) {
+            eprintln!("[clud] session {} exited with status {}", resolved, code);
+        }
         return 0;
     }
     // pm2-style follow: poll for new bytes at the last known offset. A
     // short sleep on "no new data" keeps CPU low without requiring a file-
-    // watch API that differs per OS.
+    // watch API that differs per OS. Exits cleanly once the session has
+    // terminated (and any final bytes have been drained).
     loop {
         if interrupted.load(Ordering::SeqCst) {
             return 130;
@@ -2419,8 +2458,29 @@ fn run_logs(
                 return 1;
             }
         }
+        if let Some(code) = session_exit_code(state_dir, &resolved) {
+            // Drain any final bytes the worker flushed between our last
+            // follow_read and snapshot update before announcing the exit.
+            if let Ok((_, chunk)) = follow_read(&path, offset) {
+                if !chunk.is_empty() {
+                    let _ = io::stdout().write_all(&chunk);
+                    let _ = io::stdout().flush();
+                }
+            }
+            eprintln!("[clud] session {} exited with status {}", resolved, code);
+            return 0;
+        }
         thread::sleep(Duration::from_millis(200));
     }
+}
+
+/// Read the on-disk snapshot for `session_id` and return its `exit_code`
+/// if present. Returns `None` when the snapshot is missing, malformed,
+/// or the session is still running.
+fn session_exit_code(state_dir: &Path, session_id: &str) -> Option<i32> {
+    let path = session_snapshot_path(state_dir, session_id);
+    let session = read_json_file::<SessionSnapshot>(&path).ok()?;
+    session.exit_code
 }
 
 fn run_logs_summary(state_dir: &Path) -> i32 {
@@ -3194,5 +3254,70 @@ mod backlog_size_tests {
                 None => std::env::remove_var(self.key),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod logs_tests {
+    //! Issue #25: read-only session tailing via `clud logs`. These tests
+    //! poke at the on-disk-snapshot helpers that back `--last` and the
+    //! "session exited" status line so we can verify the contract without
+    //! spinning up a real daemon. End-to-end behavior is covered by the
+    //! Python integration test in `tests/integration/test_daemon_centralized.py`.
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_snapshot(state_dir: &Path, id: &str, created_at: u64, exit_code: Option<i32>) {
+        let snap = SessionSnapshot {
+            id: id.into(),
+            kind: SessionKind::Subprocess,
+            cwd: None,
+            name: None,
+            created_at: Some(created_at),
+            detachable: false,
+            background: true,
+            attachable: true,
+            repeat_interval_secs: None,
+            repeat_next_run_at: None,
+            repeat_running: false,
+            daemon_pid: 0,
+            worker_pid: 0,
+            worker_port: 0,
+            root_pid: None,
+            exit_code,
+        };
+        write_json_file(&session_snapshot_path(state_dir, id), &snap).unwrap();
+    }
+
+    #[test]
+    fn most_recent_session_any_returns_newest_including_exited() {
+        // `--last` must surface the most-recently-created session even if
+        // it has already exited. `most_recent_session` (the attach helper)
+        // filters exited sessions; `most_recent_session_any` does not.
+        let tmp = TempDir::new().unwrap();
+        write_snapshot(tmp.path(), "sess-old", 100, Some(0));
+        write_snapshot(tmp.path(), "sess-new", 200, Some(1));
+        let found = most_recent_session_any(tmp.path()).expect("should find a session");
+        assert_eq!(found.id, "sess-new");
+        assert_eq!(found.exit_code, Some(1));
+    }
+
+    #[test]
+    fn most_recent_session_any_none_when_dir_missing() {
+        let tmp = TempDir::new().unwrap();
+        let nonexistent = tmp.path().join("does-not-exist");
+        assert!(most_recent_session_any(&nonexistent).is_none());
+    }
+
+    #[test]
+    fn session_exit_code_reads_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        write_snapshot(tmp.path(), "sess-live", 1, None);
+        write_snapshot(tmp.path(), "sess-dead", 2, Some(42));
+        assert_eq!(session_exit_code(tmp.path(), "sess-live"), None);
+        assert_eq!(session_exit_code(tmp.path(), "sess-dead"), Some(42));
+        // Missing snapshot is treated as "still running" (None) rather than
+        // an error — the follow loop polls cheaply and re-checks.
+        assert_eq!(session_exit_code(tmp.path(), "sess-missing"), None);
     }
 }

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -843,6 +843,67 @@ class TestDaemonCentralizedPersistence:
         finally:
             _kill_daemon_for_session(state_dir, session_id)
 
+    def test_clud_logs_last_and_follow(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        # Issue #25: `clud logs --last` must resolve to the most recent
+        # session (including exited ones) and `-f` must tail without
+        # crashing, then exit cleanly once the session is dead.
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "tail-me-tag",
+            "--",
+            "--mock-sleep-ms",
+            "400",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=5) == 0
+            time.sleep(0.6)
+
+            # `--last` should pick the session we just ran (the only one).
+            last_result = subprocess.run(
+                [str(clud_binary), "logs", "--last"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert last_result.returncode == 0, last_result.stderr
+            assert "tail-me-tag" in last_result.stdout, (
+                f"prompt tag missing from --last output: {last_result.stdout!r}"
+            )
+            assert session_id in last_result.stderr, (
+                f"--last hint should mention resolved session id: {last_result.stderr!r}"
+            )
+            # Since the session is already dead, the status line should fire.
+            assert "exited with status" in last_result.stderr, (
+                f"expected exit-status line on dead session: {last_result.stderr!r}"
+            )
+
+            # Follow mode on a dead session: prints backlog, drains, then
+            # exits 0 once it spots the recorded exit_code in the snapshot.
+            follow_result = subprocess.run(
+                [str(clud_binary), "logs", "-f", session_id],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                env=env,
+            )
+            assert follow_result.returncode == 0, follow_result.stderr
+            assert "tail-me-tag" in follow_result.stdout, (
+                f"prompt tag missing from -f output: {follow_result.stdout!r}"
+            )
+            assert "exited with status" in follow_result.stderr, (
+                f"follow mode must announce exit: {follow_result.stderr!r}"
+            )
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)
+
     def test_clud_logs_with_no_id_lists_sessions(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Implements one unchecked item from tracking issue #25: read-only tailing of a background session's log via `clud logs <session_id>`. The pm2-style `clud logs` subcommand already existed; this PR adds the `--last` flag and the exit-status behavior the issue spells out, plus tests.

## Flags

- `clud logs <session_id>` — print the captured backlog and exit.
- `clud logs <session_id> -f` (`--follow`) — print backlog and keep streaming until the session ends or `Ctrl+C`. Now exits cleanly once the worker records an `exit_code` in the snapshot, after draining any final bytes.
- `clud logs --last` (`-l`) — operate on the most-recently-created session, **including exited ones** (logs are most useful post-mortem). Mirrors `clud attach --last`. Conflicts with a positional `session_id`.
- `clud logs -n 100 <session_id>` — already supported via `--lines`.
- On a dead session, all forms print an `[clud] session <id> exited with status N` line on stderr.

## Read-only contract

`logs` reads the on-disk `.log` file directly, **not** through the daemon's worker RPC. That means it:

- never takes exclusive ownership of the session (`attach` does)
- never forwards stdin
- never evicts a currently-attached client
- works whether the session is alive or dead

No new TCP/RPC surface or protocol changes were required.

## Files touched

- `crates/clud-bin/src/args.rs` — adds `last: bool` to `Command::Logs`, plus arg-parsing unit tests.
- `crates/clud-bin/src/daemon.rs` — adds `most_recent_session_any` (sees exited sessions, unlike `most_recent_session`), `session_exit_code`, the `--last` resolution in `handle_special_command`, and follow-loop exit on session termination. New `logs_tests` module covers the helpers.
- `tests/integration/test_daemon_centralized.py` — new `test_clud_logs_last_and_follow` integration test.

## Test plan

- [ ] `bash lint` — `cargo fmt --check`, `cargo clippy -D warnings`, `ruff check` all clean.
- [ ] `bash test` — Rust unit tests (incl. new `logs_tests` module and `args.rs` log tests) plus Python unit tests pass.
- [ ] `bash test --integration` — `test_clud_logs_last_and_follow` and existing `test_clud_logs_*` tests pass under the mock-agent harness.
- [ ] Manual: `clud --detach -p hi`, then `clud logs --last`, `clud logs <id> -f`, `clud logs -n 20 <id>` all behave as documented.

Refs #25 (tracking issue — not closing, only this one checkbox is done).