### PR TITLE
feat(loop): harden completion detection — absolute path contract + token fallback + exhaustion diagnostics (#95)

### DIFF
--- a/crates/clud-bin/src/command.rs
+++ b/crates/clud-bin/src/command.rs
@@ -195,20 +195,21 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
             if let Some(ref t) = task {
                 let prompt_text = resolve_loop_task(t, &git_root, *refresh);
                 task_summary = Some(summarize_task_name(&prompt_text, 50));
-                let final_prompt =
-                    if let Some((markers, display_done, display_blocked)) = marker_paths.as_ref() {
-                        let _ = markers;
-                        format!(
-                            "{}{}",
-                            prompt_text,
-                            done_marker_contract(display_done, display_blocked)
-                        )
-                    } else {
-                        prompt_text
-                    };
+                let final_prompt = if let Some(markers) = marker_paths.as_ref() {
+                    // Issue #95: feed absolute paths into the contract so the
+                    // model writes to the exact path clud is polling, not
+                    // some invented alternative like `~/.loop/LOOP.md`.
+                    format!(
+                        "{}{}",
+                        prompt_text,
+                        done_marker_contract(&markers.done, &markers.blocked)
+                    )
+                } else {
+                    prompt_text
+                };
                 push_prompt(&mut cmd, backend, final_prompt);
             }
-            if let Some((markers, _, _)) = marker_paths {
+            if let Some(markers) = marker_paths {
                 loop_markers = Some(LoopMarkers {
                     done_path: markers.done.to_string_lossy().to_string(),
                     blocked_path: markers.blocked.to_string_lossy().to_string(),
@@ -328,29 +329,14 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
     }
 }
 
-fn resolve_marker_paths(
-    cwd: &Path,
-    git_root: &Path,
-    done_override: Option<&str>,
-) -> (MarkerPaths, String, String) {
+fn resolve_marker_paths(cwd: &Path, git_root: &Path, done_override: Option<&str>) -> MarkerPaths {
     match done_override {
         Some(raw) => {
-            let display_done = raw.to_string();
-            let display_blocked = blocked_path_from_done(Path::new(raw))
-                .to_string_lossy()
-                .to_string();
             let done = cwd.join(raw);
             let blocked = blocked_path_from_done(&done);
-            (MarkerPaths { done, blocked }, display_done, display_blocked)
+            MarkerPaths { done, blocked }
         }
-        None => {
-            let markers = loop_spec::default_marker_paths(git_root);
-            (
-                markers,
-                ".clud/loop/DONE".to_string(),
-                ".clud/loop/BLOCKED".to_string(),
-            )
-        }
+        None => loop_spec::default_marker_paths(git_root),
     }
 }
 
@@ -881,8 +867,16 @@ mod tests {
         assert!(p.command.contains(&"-p".to_string()));
         let prompt = prompt_from_plan(&p);
         assert!(prompt.starts_with("do stuff"));
-        assert!(prompt.contains(".clud/loop/DONE"));
-        assert!(prompt.contains(".clud/loop/BLOCKED"));
+        // Issue #95: contract now embeds absolute paths; the relative
+        // suffix is still present, but the separator is platform-native.
+        assert!(
+            prompt.contains(".clud/loop/DONE") || prompt.contains(".clud\\loop\\DONE"),
+            "prompt missing DONE marker path: {prompt}"
+        );
+        assert!(
+            prompt.contains(".clud/loop/BLOCKED") || prompt.contains(".clud\\loop\\BLOCKED"),
+            "prompt missing BLOCKED marker path: {prompt}"
+        );
         assert!(p.loop_markers.is_some());
     }
 
@@ -963,8 +957,16 @@ mod tests {
     fn test_codex_loop_appends_done_marker_contract() {
         let p = plan(&["clud", "--codex", "loop", "do stuff"]);
         let prompt = last_arg(&p);
-        assert!(prompt.contains(".clud/loop/DONE"));
-        assert!(prompt.contains(".clud/loop/BLOCKED"));
+        // Issue #95: absolute paths in contract; assert on the relative
+        // suffix using platform-native separators.
+        assert!(
+            prompt.contains(".clud/loop/DONE") || prompt.contains(".clud\\loop\\DONE"),
+            "prompt missing DONE marker path: {prompt}"
+        );
+        assert!(
+            prompt.contains(".clud/loop/BLOCKED") || prompt.contains(".clud\\loop\\BLOCKED"),
+            "prompt missing BLOCKED marker path: {prompt}"
+        );
         assert!(p.loop_markers.is_some());
     }
 
@@ -1407,14 +1409,16 @@ mod tests {
     #[test]
     fn test_loop_done_path_uses_supplied_path_in_prompt() {
         // --done <path> must thread the *supplied* path into the prompt
-        // contract, not the default `.clud/loop/DONE`.
+        // contract, not the default `.clud/loop/DONE`. Issue #95: the
+        // contract now uses absolute paths, but the user-supplied filename
+        // is still visible in the absolute form.
         let p = plan(&["clud", "loop", "--done", "custom/DONE.txt", "task"]);
         let prompt = prompt_from_plan(&p);
-        // The DONE side is the raw user-supplied string, untouched, so the
-        // forward slash survives on every platform.
+        // The DONE filename must appear; the directory segment may use
+        // either separator depending on platform.
         assert!(
-            prompt.contains("custom/DONE.txt"),
-            "prompt missing custom DONE path: {prompt}"
+            prompt.contains("DONE.txt"),
+            "prompt missing custom DONE filename: {prompt}"
         );
         // BLOCKED is derived from the DONE *filename's extension* via
         // `blocked_path_from_done`, which uses platform-native path joining.

--- a/crates/clud-bin/src/loop_spec.rs
+++ b/crates/clud-bin/src/loop_spec.rs
@@ -19,7 +19,14 @@ use running_process_core::{NativeProcess, ProcessConfig, ReadStatus, StderrMode,
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;
 
+/// Display string for the marker directory (forward slashes for the
+/// user-facing prompt). Always join the segments via `Path::join` when
+/// constructing on-disk paths so the separators stay platform-native —
+/// otherwise mixed separators (`.clud/loop\DONE` on Windows) leak into
+/// the prompt text and confuse the agent.
 pub const LOOP_DIR: &str = ".clud/loop";
+const LOOP_DIR_PARENT: &str = ".clud";
+const LOOP_DIR_LEAF: &str = "loop";
 pub const DONE_MARKER: &str = "DONE";
 pub const BLOCKED_MARKER: &str = "BLOCKED";
 
@@ -135,8 +142,12 @@ pub fn git_root_from(start: &Path) -> PathBuf {
 }
 
 /// Resolve the `<git-root>/.clud/loop/` directory.
+///
+/// Joins segment-by-segment so the separators stay platform-native
+/// (`\` on Windows, `/` elsewhere). Using `git_root.join(".clud/loop")`
+/// would leak a stray `/` into the middle of an otherwise-Windows path.
 pub fn loop_dir(git_root: &Path) -> PathBuf {
-    git_root.join(LOOP_DIR)
+    git_root.join(LOOP_DIR_PARENT).join(LOOP_DIR_LEAF)
 }
 
 /// Path to the DONE marker.
@@ -475,22 +486,122 @@ pub fn render_cache(doc: &IssueDoc, fetched_at: &str) -> String {
 
 /// Default prompt instructions appended to every loop-driven task when the
 /// DONE/BLOCKED marker contract is active.
-pub fn done_marker_contract(done_path: &str, blocked_path: &str) -> String {
+///
+/// `done_abs` and `blocked_abs` are passed as absolute paths so the model
+/// cannot reinterpret a display-relative form (e.g. `.clud/loop/DONE`) as a
+/// generic "write a completion file somewhere" instruction. See issue #95
+/// for the original failure mode (agent writing to `~/.loop/LOOP.md`).
+///
+/// The contract also documents the `<<<CLUD_LOOP_DONE: ...>>>` /
+/// `<<<CLUD_LOOP_BLOCKED: ...>>>` token fallback (see
+/// `scan_completion_token`) for the case where the agent cannot write a
+/// file — the loop runner scans its captured output for those tokens.
+pub fn done_marker_contract(done_abs: &Path, blocked_abs: &Path) -> String {
+    let done_display = done_abs.display();
+    let blocked_display = blocked_abs.display();
     format!(
         "\n\n---\n\
 You are running in a ralph loop. The loop will re-invoke you up to N times \
 with the same task until you complete it.\n\
 \n\
 When the task is fully resolved and verified (tests pass, lint clean where \
-applicable), write `{done_path}` with a one-line summary of what you \
-did. Do not write DONE prematurely — only after you are confident the work \
-is complete.\n\
+applicable), write the file at this EXACT absolute path with a one-line \
+summary of what you did:\n\
+\n\
+    {done_display}\n\
 \n\
 If you cannot make progress (missing info, external dependency, needs \
-human input), write `{blocked_path}` with a one-line reason and stop.\n\
+human input), write the file at this EXACT absolute path with a one-line \
+reason and stop:\n\
 \n\
-Otherwise, continue working — you will be re-invoked.\n"
+    {blocked_display}\n\
+\n\
+Do not create any other completion files. Only writing to the exact \
+absolute path above terminates the loop. Do not write to ~/.loop/, \
+./loop.md, LOOP.md, or any other location.\n\
+\n\
+If you cannot write the marker file for any reason, you may instead emit \
+the literal token `<<<CLUD_LOOP_DONE: <one-line summary>>>>` on a line by \
+itself as the very last thing you output, and clud will treat that as a \
+DONE signal. Use `<<<CLUD_LOOP_BLOCKED: <reason>>>>` for the BLOCKED \
+equivalent. Writing the marker file is still strongly preferred.\n\
+\n\
+Do not write DONE prematurely — only after you are confident the work is \
+complete. Otherwise, continue working — you will be re-invoked.\n"
     )
+}
+
+/// Result of scanning captured output for a `<<<CLUD_LOOP_...>>>` token.
+///
+/// Mirrors `MarkerState` but is produced by parsing stdout/stderr text
+/// rather than by reading marker files. This is a fallback for agents that
+/// summarize "task complete" without writing the marker file (issue #95).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenState {
+    Done(String),
+    Blocked(String),
+    None,
+}
+
+/// Scan captured output for completion tokens.
+///
+/// Recognizes lines that START with `<<<CLUD_LOOP_DONE:` or
+/// `<<<CLUD_LOOP_BLOCKED:` and end with `>>>`. Tokens embedded mid-line are
+/// ignored — the contract documents that the token must be on a line by
+/// itself. If multiple tokens appear, the LAST one wins (the agent's
+/// final word).
+///
+/// Used only in subprocess launch mode where we capture stdout. In PTY
+/// mode the child writes directly to the user's terminal and we never see
+/// the bytes — for now, only the marker-file path is supported there.
+pub fn scan_completion_token(captured: &str) -> TokenState {
+    const DONE_PREFIX: &str = "<<<CLUD_LOOP_DONE:";
+    const BLOCKED_PREFIX: &str = "<<<CLUD_LOOP_BLOCKED:";
+    const SUFFIX: &str = ">>>";
+
+    let mut last: TokenState = TokenState::None;
+    for raw_line in captured.lines() {
+        let line = raw_line.trim();
+        let (state, payload) = if let Some(rest) = line.strip_prefix(DONE_PREFIX) {
+            let Some(inner) = rest.strip_suffix(SUFFIX) else {
+                continue;
+            };
+            (
+                TokenState::Done(String::new()),
+                inner.trim().trim_end_matches('>').trim().to_string(),
+            )
+        } else if let Some(rest) = line.strip_prefix(BLOCKED_PREFIX) {
+            let Some(inner) = rest.strip_suffix(SUFFIX) else {
+                continue;
+            };
+            (
+                TokenState::Blocked(String::new()),
+                inner.trim().trim_end_matches('>').trim().to_string(),
+            )
+        } else {
+            continue;
+        };
+        last = match state {
+            TokenState::Done(_) => TokenState::Done(payload),
+            TokenState::Blocked(_) => TokenState::Blocked(payload),
+            TokenState::None => TokenState::None,
+        };
+    }
+    last
+}
+
+/// Read marker state from disk OR from a token in `captured` output, with
+/// the marker file taking precedence. This is the loop-runner entry point
+/// for subprocess mode where stdout is captured into a buffer.
+pub fn read_markers_or_token(paths: &MarkerPaths, captured: &str) -> MarkerState {
+    match read_markers_at(paths) {
+        MarkerState::None => match scan_completion_token(captured) {
+            TokenState::Done(s) => MarkerState::Done(s),
+            TokenState::Blocked(s) => MarkerState::Blocked(s),
+            TokenState::None => MarkerState::None,
+        },
+        state => state,
+    }
 }
 
 #[cfg(test)]
@@ -643,6 +754,136 @@ mod tests {
         assert_eq!(doc.labels, vec!["bug", "prio-high"]);
         assert_eq!(doc.comments.len(), 1);
         assert_eq!(doc.comments[0].author, "bob");
+    }
+
+    // ---- Issue #95: tightened DONE marker contract ----
+
+    #[test]
+    fn done_marker_contract_uses_absolute_paths() {
+        let done = Path::new("/tmp/proj/.clud/loop/DONE");
+        let blocked = Path::new("/tmp/proj/.clud/loop/BLOCKED");
+        let text = done_marker_contract(done, blocked);
+        // Absolute paths must appear verbatim in the contract.
+        assert!(
+            text.contains(&done.display().to_string()),
+            "contract must reference absolute DONE path: {text}"
+        );
+        assert!(
+            text.contains(&blocked.display().to_string()),
+            "contract must reference absolute BLOCKED path: {text}"
+        );
+        // Explicit "do not write elsewhere" rule must be present.
+        assert!(
+            text.contains("Do not create any other completion files"),
+            "contract must forbid other completion file locations"
+        );
+        // Token fallback must be documented.
+        assert!(
+            text.contains("<<<CLUD_LOOP_DONE:"),
+            "contract must document the DONE token fallback"
+        );
+        assert!(
+            text.contains("<<<CLUD_LOOP_BLOCKED:"),
+            "contract must document the BLOCKED token fallback"
+        );
+    }
+
+    // ---- Issue #95: token-based completion fallback ----
+
+    #[test]
+    fn scan_token_matches_done() {
+        let s = "work work work\n<<<CLUD_LOOP_DONE: fixed the bug>>>\n";
+        assert_eq!(
+            scan_completion_token(s),
+            TokenState::Done("fixed the bug".to_string())
+        );
+    }
+
+    #[test]
+    fn scan_token_matches_blocked() {
+        let s = "<<<CLUD_LOOP_BLOCKED: missing API key>>>";
+        assert_eq!(
+            scan_completion_token(s),
+            TokenState::Blocked("missing API key".to_string())
+        );
+    }
+
+    #[test]
+    fn scan_token_ignores_unclosed() {
+        let s = "<<<CLUD_LOOP_DONE: oops no terminator\nnext line";
+        assert_eq!(scan_completion_token(s), TokenState::None);
+    }
+
+    #[test]
+    fn scan_token_ignores_midline_occurrence() {
+        // Token must START the line (after trimming whitespace).
+        let s = "blah blah <<<CLUD_LOOP_DONE: nope>>> trailing";
+        assert_eq!(scan_completion_token(s), TokenState::None);
+    }
+
+    #[test]
+    fn scan_token_prefers_later_token() {
+        let s =
+            "<<<CLUD_LOOP_DONE: first attempt>>>\nmore work\n<<<CLUD_LOOP_DONE: actually done>>>";
+        assert_eq!(
+            scan_completion_token(s),
+            TokenState::Done("actually done".to_string())
+        );
+    }
+
+    #[test]
+    fn scan_token_none_for_empty() {
+        assert_eq!(scan_completion_token(""), TokenState::None);
+        assert_eq!(
+            scan_completion_token("just some output\n"),
+            TokenState::None
+        );
+    }
+
+    #[test]
+    fn scan_token_strips_extra_trailing_angle_brackets() {
+        // The contract template uses `>>>>` at the end (matched template
+        // syntax `<<<...>>>>`). We accept stray trailing `>` in the payload
+        // so the model isn't punished for the visually-confusing example.
+        let s = "<<<CLUD_LOOP_DONE: payload>>>>";
+        assert_eq!(
+            scan_completion_token(s),
+            TokenState::Done("payload".to_string())
+        );
+    }
+
+    #[test]
+    fn read_markers_or_token_prefers_marker_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        ensure_loop_dir(tmp.path()).unwrap();
+        std::fs::write(done_path(tmp.path()), "via file\n").unwrap();
+        let paths = default_marker_paths(tmp.path());
+        let captured = "<<<CLUD_LOOP_BLOCKED: via token>>>\n";
+        assert_eq!(
+            read_markers_or_token(&paths, captured),
+            MarkerState::Done("via file".to_string())
+        );
+    }
+
+    #[test]
+    fn read_markers_or_token_falls_back_to_token() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = default_marker_paths(tmp.path());
+        let captured = "<<<CLUD_LOOP_DONE: token-only completion>>>\n";
+        assert_eq!(
+            read_markers_or_token(&paths, captured),
+            MarkerState::Done("token-only completion".to_string())
+        );
+    }
+
+    #[test]
+    fn read_markers_or_token_none_when_neither() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = default_marker_paths(tmp.path());
+        assert_eq!(
+            read_markers_or_token(&paths, "nothing relevant\n"),
+            MarkerState::None
+        );
     }
 
     #[test]

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -502,8 +502,15 @@ fn run_plan_subprocess(
             return 1;
         }
 
+        // Issue #95: in stream-json mode we also accumulate the rendered
+        // output so we can fall back to scanning for the
+        // `<<<CLUD_LOOP_DONE: ...>>>` token if the agent skipped the
+        // marker file. In inherited-stdio mode the child writes directly
+        // to the user's terminal and we never see the bytes — the token
+        // fallback is unavailable there.
+        let mut captured_output = String::new();
         let exit_code = if plan.stream_json_progress {
-            run_with_stream_json_renderer(&process, interrupted)
+            run_with_stream_json_renderer(&process, interrupted, &mut captured_output)
         } else {
             run_with_inherited_stdio(&process, interrupted)
         };
@@ -536,7 +543,7 @@ fn run_plan_subprocess(
             }
         }
 
-        if let Some(code) = check_loop_markers(plan, iter_num) {
+        if let Some(code) = check_loop_markers_with_output(plan, iter_num, &captured_output) {
             return code;
         }
     }
@@ -594,9 +601,16 @@ fn run_with_inherited_stdio(
 /// line to our own stderr (so it shows alongside the existing
 /// `[clud] iteration X/Y` banner and is easily distinguished from any
 /// real claude stdout payload).
+///
+/// `captured_output` accumulates the **raw** lines (before stream-json
+/// rendering) so the loop runner can scan for the
+/// `<<<CLUD_LOOP_DONE: ...>>>` token fallback (issue #95). The raw form
+/// is what the agent emits in a non-JSON-wrapped chunk; we keep the
+/// payload as-is so token recognition isn't confused by event framing.
 fn run_with_stream_json_renderer(
     process: &running_process_core::NativeProcess,
     interrupted: &AtomicBool,
+    captured_output: &mut String,
 ) -> ProcessOutcome {
     use running_process_core::{ReadStatus, StreamKind};
     use std::time::Duration;
@@ -610,14 +624,14 @@ fn run_with_stream_json_renderer(
         }
         match process.read_stream(StreamKind::Stdout, Some(timeout)) {
             ReadStatus::Line(bytes) => {
-                emit_rendered_line(&bytes);
+                emit_rendered_line(&bytes, captured_output);
             }
             ReadStatus::Timeout => {
                 // No new data within the window; check if the child has
                 // exited so we don't spin forever after a slow turn.
                 if let Ok(Some(_)) = process.poll() {
                     // Drain anything still queued before declaring done.
-                    drain_remaining_stdout(process);
+                    drain_remaining_stdout(process, captured_output);
                     break;
                 }
             }
@@ -638,16 +652,24 @@ fn run_with_stream_json_renderer(
     }
 }
 
-fn drain_remaining_stdout(process: &running_process_core::NativeProcess) {
+fn drain_remaining_stdout(
+    process: &running_process_core::NativeProcess,
+    captured_output: &mut String,
+) {
     use running_process_core::StreamKind;
     for chunk in process.drain_stream(StreamKind::Stdout) {
-        emit_rendered_line(&chunk);
+        emit_rendered_line(&chunk, captured_output);
     }
 }
 
-fn emit_rendered_line(bytes: &[u8]) {
+fn emit_rendered_line(bytes: &[u8], captured_output: &mut String) {
     let line = String::from_utf8_lossy(bytes);
-    if let Some(rendered) = stream_json::render_line(line.trim_end_matches(['\r', '\n'])) {
+    let trimmed = line.trim_end_matches(['\r', '\n']);
+    // Issue #95: keep the raw text around so we can scan for the
+    // `<<<CLUD_LOOP_DONE: ...>>>` token fallback after the iteration ends.
+    captured_output.push_str(trimmed);
+    captured_output.push('\n');
+    if let Some(rendered) = stream_json::render_line(trimmed) {
         eprintln!("{rendered}");
     }
 }
@@ -784,12 +806,31 @@ fn run_plan_pty(
 
 /// Check for DONE/BLOCKED markers after an iteration finishes. Returns a
 /// terminal exit code to return from the runner, or `None` to continue.
+///
+/// File-only variant — used by the PTY launch path, where the child writes
+/// directly to the user's terminal and stdout never flows through clud.
 fn check_loop_markers(plan: &command::LaunchPlan, iteration: u32) -> Option<i32> {
+    check_loop_markers_with_output(plan, iteration, "")
+}
+
+/// Same as [`check_loop_markers`] but also scans `captured_output` for the
+/// `<<<CLUD_LOOP_DONE: ...>>>` / `<<<CLUD_LOOP_BLOCKED: ...>>>` token
+/// fallback (issue #95).
+///
+/// Marker files take precedence over tokens — if both are present, the
+/// file wins. Pass an empty `captured_output` to opt out of token scanning
+/// (PTY mode).
+fn check_loop_markers_with_output(
+    plan: &command::LaunchPlan,
+    iteration: u32,
+    captured_output: &str,
+) -> Option<i32> {
     let markers = plan.loop_markers.as_ref()?;
-    match loop_spec::read_markers_at(&loop_spec::MarkerPaths {
+    let paths = loop_spec::MarkerPaths {
         done: std::path::PathBuf::from(&markers.done_path),
         blocked: std::path::PathBuf::from(&markers.blocked_path),
-    }) {
+    };
+    match loop_spec::read_markers_or_token(&paths, captured_output) {
         loop_spec::MarkerState::Done(summary) => {
             if summary.is_empty() {
                 eprintln!(
@@ -814,14 +855,73 @@ fn check_loop_markers(plan: &command::LaunchPlan, iteration: u32) -> Option<i32>
 
 /// Called after the iteration count is exhausted without a DONE/BLOCKED
 /// marker. Only returns an override exit code when loop markers are active.
+///
+/// Issue #95: also print a diagnostic block listing the expected absolute
+/// paths and the actual contents of `.clud/loop/`, so users can see when
+/// the agent invented its own completion filename (e.g. `LOOP.md`,
+/// `ITERATION_1.md`) instead of writing `DONE`.
 fn loop_unconverged_exit(plan: &command::LaunchPlan) -> Option<i32> {
-    plan.loop_markers.as_ref().map(|_| {
-        eprintln!(
-            "[clud loop] iteration count ({}) exhausted without a DONE marker; task did not converge.",
-            plan.iterations
-        );
-        2
-    })
+    let markers = plan.loop_markers.as_ref()?;
+    eprintln!(
+        "[clud loop] iteration count ({}) exhausted without a DONE marker; task did not converge.",
+        plan.iterations
+    );
+    print_exhaustion_diagnostics(&markers.done_path, &markers.blocked_path);
+    Some(2)
+}
+
+/// Print a short hint block when the loop exhausts without converging.
+/// See [`loop_unconverged_exit`] for context.
+fn print_exhaustion_diagnostics(done_path: &str, blocked_path: &str) {
+    eprintln!("[clud loop] expected DONE marker at: {done_path}");
+    eprintln!("[clud loop] expected BLOCKED marker at: {blocked_path}");
+
+    let done_pathbuf = std::path::PathBuf::from(done_path);
+    let dir = done_pathbuf
+        .parent()
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    match std::fs::read_dir(&dir) {
+        Ok(entries) => {
+            let names: Vec<String> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .collect();
+            let listing = if names.is_empty() {
+                "<empty>".to_string()
+            } else {
+                names.join(", ")
+            };
+            eprintln!("[clud loop] {} contents: {}", dir.display(), listing);
+
+            // Issue #95: call out *.md stragglers that look like agent
+            // invention (LOOP.md, ITERATION_*.md) so the user immediately
+            // sees why convergence failed.
+            let strays: Vec<&String> = names
+                .iter()
+                .filter(|n| {
+                    let lower = n.to_ascii_lowercase();
+                    lower.ends_with(".md") && lower != "done.md" && lower != "blocked.md"
+                })
+                .collect();
+            if !strays.is_empty() {
+                let stray_list = strays
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                eprintln!(
+                    "[clud loop] found *.md files NOT recognized as completion markers: {stray_list}"
+                );
+            }
+        }
+        Err(_) => {
+            eprintln!("[clud loop] {} contents: <dir missing>", dir.display());
+        }
+    }
+    eprintln!(
+        "[clud loop] tip: ensure the agent writes to the exact path above. ~/.loop/ and ./LOOP.md are NOT detected."
+    );
 }
 
 /// RAII guard that restores the original console input mode on drop.

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -230,8 +230,11 @@ def test_dry_run_loop() -> None:
     # contract appended. Original task is preserved at the start.
     prompt = data["command"][-1]
     assert prompt.startswith("do stuff")
-    assert ".clud/loop/DONE" in prompt
-    assert ".clud/loop/BLOCKED" in prompt
+    # Issue #95: contract now embeds the absolute marker path; the relative
+    # suffix is still present with platform-native separators.
+    normalized_prompt = prompt.replace("\\", "/")
+    assert ".clud/loop/DONE" in normalized_prompt
+    assert ".clud/loop/BLOCKED" in normalized_prompt
     assert data["loop_markers"] is not None
     assert data["loop_markers"]["done_path"].replace("\\", "/").endswith(".clud/loop/DONE")
     assert data["loop_markers"]["blocked_path"].replace("\\", "/").endswith(


### PR DESCRIPTION
Closes #95.

## Summary

`clud loop` was iterating to `--loop-count` even when the agent considered the task complete, because the contract showed a *display-relative* path (`.clud/loop/DONE`) which the model reinterpreted as a generic "write a completion file somewhere" instruction — landing on `~/.loop/LOOP.md` and friends. There were also no diagnostics when the loop exhausted, so the failure was undebuggable.

This PR implements three of the four suggested fixes from the issue. Fix #2 (`.clud/loop/log.txt` mirror) is intentionally left for pending PR #97 (`feat(loop): port .clud/loop artifacts from python-legacy`).

### Fix 1 — Tighten the DONE marker contract

- `done_marker_contract` now takes absolute `&Path` values for DONE/BLOCKED and emits them verbatim into the prompt.
- Added explicit rule: *"Do not create any other completion files. Only writing to the exact absolute path above terminates the loop. Do not write to `~/.loop/`, `./loop.md`, `LOOP.md`, or any other location."*
- Normalized `loop_dir` to use segment-by-segment `Path::join` so the absolute path never mixes `\` and `/` on Windows (a regression that surfaced while updating the tests).

### Fix 3 — Token-based completion fallback

- New `scan_completion_token` recognizes `<<<CLUD_LOOP_DONE: ...>>>` / `<<<CLUD_LOOP_BLOCKED: ...>>>` lines in captured output.
- New `read_markers_or_token` composes file detection with token scanning. The marker file wins if both are present.
- The subprocess stream-json renderer now also accumulates raw output into a buffer; `check_loop_markers_with_output` consumes it. PTY mode stays file-only (the child writes directly to the user's terminal and clud never sees the bytes — documented in code).
- The contract paragraph documents the token fallback as a backup path.

### Fix 4 — Diagnostics on exhaustion

When `loop_unconverged_exit` fires, we now also print:

```
[clud loop] expected DONE marker at: <abs_done>
[clud loop] expected BLOCKED marker at: <abs_blocked>
[clud loop] <dir> contents: <listing | <dir missing>>
[clud loop] found *.md files NOT recognized as completion markers: LOOP.md, ITERATION_1.md
[clud loop] tip: ensure the agent writes to the exact path above. ~/.loop/ and ./LOOP.md are NOT detected.
```

The `*.md` stray-file callout fires when there are `*.md` files in the marker dir other than `DONE.md` / `BLOCKED.md` — exactly the failure mode reported in the issue.

## Out of scope

- Fix #2 (`.clud/loop/log.txt` mirror) is covered by pending PR #97.

## Test plan

- [x] `soldr cargo fmt --all --check`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo test --workspace` (472 unit tests pass, including new ones for token parsing and the absolute-path contract)
- [x] `python -m pytest tests/test_hello.py -x` (29 tests pass; `test_dry_run_loop` updated to accept the new absolute-path contract via cross-platform substring match)
- [x] `ruff check src tests ci`

New unit tests added:
- `done_marker_contract_uses_absolute_paths` — contract embeds absolute paths and forbids other completion files; token fallback is documented.
- `scan_token_matches_done` / `scan_token_matches_blocked` — happy paths.
- `scan_token_ignores_unclosed` — rejects tokens missing the `>>>` closer.
- `scan_token_ignores_midline_occurrence` — token must START the line.
- `scan_token_prefers_later_token` — last token wins when multiple match.
- `scan_token_none_for_empty` — empty input.
- `scan_token_strips_extra_trailing_angle_brackets` — tolerant of the visually-confusing `>>>>` form from the contract template.
- `read_markers_or_token_prefers_marker_file` / `_falls_back_to_token` / `_none_when_neither` — composition with the file-based detector.