### PR TITLE
test(daemon): close remaining test gaps for daemon session system (#25)

### DIFF
--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -937,6 +937,179 @@ class TestDaemonCentralizedPersistence:
         finally:
             _kill_daemon_for_session(state_dir, session_id)
 
+    def test_daemon_reboot_purges_orphaned_session_state(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        # Issue #25: when both the daemon and worker die uncleanly (e.g. host
+        # reboot, OOM kill), the on-disk session snapshot is left with
+        # `exit_code = None`, which would make `clud list` report a phantom
+        # "running" session. The next daemon boot's `cleanup_stale_state()`
+        # must mark such sessions exited so the world is consistent again.
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "orphan-test",
+            "--",
+            "--mock-sleep-ms",
+            "30000",
+        )
+        _wait_for_exit(proc, timeout=10)
+
+        # Snapshot is populated; capture all relevant pids while they're alive.
+        metadata = _session_metadata(state_dir, session_id)
+        daemon_pid = metadata["daemon_pid"]
+        worker_pid = metadata["worker_pid"]
+        root_pid = metadata["root_pid"]
+        assert metadata["exit_code"] is None
+
+        # Sanity: orphan session shows up as "running" in `clud list` before reboot.
+        listed_before = subprocess.run(
+            [str(clud_binary), "list"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert listed_before.returncode == 0
+        assert session_id in listed_before.stdout
+
+        # Kill daemon FIRST, so we shrink the window in which its
+        # liveness-monitor would self-clean the worker. We then race to kill
+        # the worker before its 200ms-tick monitor notices.
+        _kill_process_only(daemon_pid)
+        _kill_process_only(worker_pid)
+        if root_pid is not None:
+            _kill_process_only(root_pid)
+        _wait_for_pids_to_exit([worker_pid] + ([root_pid] if root_pid else []))
+
+        # Snapshot file should still exist on disk (nothing removed it; we
+        # killed the worker before its `fs::remove_file(spec_path)` line).
+        snapshot_path = state_dir / "sessions" / f"{session_id}.json"
+        assert snapshot_path.is_file(), "snapshot must persist across reboot"
+
+        # Now boot a fresh daemon by spawning a brand-new session. The new
+        # parent process calls `ensure_daemon()` -> `cleanup_stale_state()`
+        # before the new daemon child starts.
+        proc2, session_id_2 = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "post-reboot",
+            "--",
+            "--mock-sleep-ms",
+            "3000",
+        )
+        try:
+            _wait_for_exit(proc2, timeout=10)
+
+            # The orphan's snapshot must now have an exit_code recorded
+            # (cleanup_stale_state sets 137 for sessions with dead workers).
+            orphan_meta = json.loads(
+                snapshot_path.read_text(encoding="utf-8")
+            )
+            assert orphan_meta["exit_code"] is not None, (
+                f"orphan still has exit_code=None after daemon reboot: {orphan_meta}"
+            )
+
+            # And `clud list` must no longer show the orphan as running.
+            listed_after = subprocess.run(
+                [str(clud_binary), "list"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert listed_after.returncode == 0
+            assert session_id not in listed_after.stdout, (
+                f"orphan session still listed after reboot: {listed_after.stdout!r}"
+            )
+        finally:
+            _kill_daemon_for_session(state_dir, session_id_2)
+
+    def test_stale_attached_client_evicted_by_heartbeat(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        # Issue #25: a half-closed TCP attach client (terminal crash, SSH
+        # drop, kill -9) used to permanently block reattach with "session
+        # already has an attached client". The daemon's 2s heartbeat thread
+        # now probes the attach socket and evicts dead peers. A fresh
+        # attach must succeed within ~heartbeat-interval seconds.
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        # Use a backend that lives long enough to outlive the eviction
+        # heartbeat (2s) plus our buffer — but short enough that the
+        # second attach can wait it out and exit cleanly within timeout.
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "stale-attach",
+            "--",
+            "--mock-sleep-ms",
+            "8000",
+        )
+        first_attach: subprocess.Popen[str] | None = None
+        try:
+            _wait_for_exit(proc, timeout=10)
+
+            first_attach = subprocess.Popen(
+                [str(clud_binary), "attach", session_id],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            # Give the attach a beat to handshake with the worker before we
+            # forcibly kill it. Without this we might kill the client process
+            # before the worker has registered it, so eviction wouldn't be
+            # the path under test.
+            time.sleep(1.0)
+            assert first_attach.poll() is None, (
+                f"attach client died before we could kill it: "
+                f"stderr={first_attach.stderr.read() if first_attach.stderr else ''!r}"
+            )
+
+            # Force-kill (no graceful shutdown) — leaves a half-closed TCP
+            # socket on the daemon's side until the heartbeat probes it.
+            _kill_process_only(first_attach.pid)
+            first_attach.wait(timeout=5)
+
+            # Heartbeat fires every 2s (see daemon.rs:1627). Wait long
+            # enough for at least one probe to detect the dead peer and
+            # call `evict_dead_client`. We also rely on `attach_client`
+            # itself calling `evict_dead_client` first (daemon.rs:399), so
+            # this is a belt-and-suspenders timeout.
+            time.sleep(3.0)
+
+            # Second attach: must NOT be rejected as occupied. The mock
+            # backend has ~4s of sleep remaining, after which it exits 0
+            # and the attach drains and returns.
+            second_attach = subprocess.run(
+                [str(clud_binary), "attach", session_id],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env=env,
+            )
+            assert "session already has an attached client" not in second_attach.stderr, (
+                f"stale client was not evicted; stderr={second_attach.stderr!r}"
+            )
+            assert second_attach.returncode == 0, (
+                f"reattach failed: rc={second_attach.returncode} "
+                f"stdout={second_attach.stdout!r} stderr={second_attach.stderr!r}"
+            )
+        finally:
+            if first_attach is not None and first_attach.poll() is None:
+                first_attach.kill()
+                first_attach.wait(timeout=5)
+            _kill_daemon_for_session(state_dir, session_id)
+
 
 class TestDaemonCentralizedCleanup:
     def test_subprocess_tree_dies_when_daemon_dies(
@@ -1337,3 +1510,73 @@ class TestDaemonSessionHardening:
             assert "second-session" in report["args"]
         finally:
             _kill_daemon_for_session(state_dir, session_id_1)
+
+    def test_worker_crash_on_startup_records_failure(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        # Issue #25: when the backend exits immediately with a non-zero code
+        # (simulates a worker startup-time crash), the daemon must still
+        # record the actual exit_code in the session snapshot, the worker
+        # process must terminate cleanly, the daemon must survive, and the
+        # session must NOT show up as "running" in `clud list`.
+        state_dir = tmp_path / "daemon-state"
+        env = _managed_env(mock_env, state_dir)
+        proc, session_id = _launch_detached(
+            clud_binary,
+            env,
+            "--codex",
+            "-p",
+            "crash-startup",
+            "--",
+            "--mock-exit-code",
+            "17",
+            "--mock-sleep-ms",
+            "0",
+        )
+        try:
+            assert _wait_for_exit(proc, timeout=10) == 0
+
+            # Wait specifically until the worker has BOTH observed the
+            # backend exit AND persisted the actual exit_code. We can't use
+            # `_wait_for_session_exit` here because that helper returns
+            # early when root_pid dies but exit_code hasn't been written
+            # yet — and that's exactly the race we need to wait through.
+            deadline = time.time() + 15.0
+            metadata: dict | None = None
+            while time.time() < deadline:
+                metadata = _session_metadata(state_dir, session_id)
+                if metadata["exit_code"] is not None:
+                    break
+                time.sleep(0.1)
+            assert metadata is not None
+            assert metadata["exit_code"] == 17, (
+                f"expected exit_code=17 from --mock-exit-code 17; got {metadata!r}"
+            )
+
+            # Worker should self-terminate after broadcast_exit (its main
+            # accept-loop bails when stop_accepting && !has_client).
+            worker_pid = metadata["worker_pid"]
+            _wait_for_pids_to_exit([worker_pid], timeout=10)
+
+            # Daemon must survive — its stale-state cleanup may mark sessions
+            # exited, but the daemon process itself must still be alive and
+            # serving (otherwise we'd be looking at a much worse bug).
+            daemon_pid = metadata["daemon_pid"]
+            assert _pid_is_alive(daemon_pid), (
+                f"daemon process {daemon_pid} died on backend crash"
+            )
+
+            # `clud list` must not show this dead session as running.
+            listed = subprocess.run(
+                [str(clud_binary), "list"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=env,
+            )
+            assert listed.returncode == 0
+            assert session_id not in listed.stdout, (
+                f"crashed session still listed as running: {listed.stdout!r}"
+            )
+        finally:
+            _kill_daemon_for_session(state_dir, session_id)


### PR DESCRIPTION
## Summary

Closes the three remaining unchecked test gaps from tracking issue #25, finishing the daemon-session feature:

- **`test_worker_crash_on_startup_records_failure`** — verifies that when the backend exits non-zero immediately on startup, the daemon records `exit_code` and the session does not appear as `running` in `clud list`.
- **`test_daemon_reboot_purges_orphaned_session_state`** — kills the daemon and child processes, then boots a new daemon and asserts that `cleanup_stale_state()` marks the orphaned session with a non-null `exit_code` and that it disappears from `clud list`.
- **`test_stale_attached_client_evicted_by_heartbeat`** — kills an attach client mid-session, waits past the daemon's 2s heartbeat (`crates/clud-bin/src/daemon.rs:1627`), and verifies a fresh `clud attach` is no longer rejected with \"session already has an attached client\".

## Background

Per audit of #25, 8 of 10 unchecked items were already implemented in earlier merged PRs (#26, #44, #54, #56, #93). Only the three test gaps above remained. No production code is touched in this PR — only `tests/integration/test_daemon_centralized.py` (+243 lines).

## Test plan

- [x] `uv run ruff check tests/integration/test_daemon_centralized.py` → clean
- [x] All 3 new tests pass on Windows local: 3 passed in 32.10s (worker-crash 1.4s, daemon-reboot 4.3s, stale-client 8.5s)
- [ ] Full integration matrix passes on this PR

Pre-existing failures observed locally (NOT introduced here, verified by stashing this diff):
- `test_detachable_ctrl_c_yes_backgrounds_session`, `test_detachable_noninteractive_ctrl_c_*`, `test_attach_last`, `test_ctrl_c_reports_pty_mode_when_forced` — Windows Ctrl+Break / PTY pipe-EOF, tracked under #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)