### PR TITLE
fix(ci): mock-agent raw-mode stdin unblocks voice-mode transcript capture

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -60,8 +60,11 @@ jobs:
       # Issue #68: replace dtolnay/rust-toolchain + mozilla-actions/sccache-action
       # + Swatinem/rust-cache with setup-soldr. soldr pins the MSVC toolchain on
       # Windows (issue #27) and owns build + target caching for every platform.
+      # Pinned SHA: floating `v0` regressed to a Node20 rewrite that fails
+      # to honor `components` from `rust-toolchain.toml`. See
+      # zackees/setup-soldr#76.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0
+        uses: zackees/setup-soldr@8bc6da394b8ad370654826a0b3d8f5e3615d10d6 # v0 (pre-Node20-rewrite)
         with:
           toolchain: "1.94.1"
           version: "0.7.11"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -50,8 +50,11 @@ jobs:
       # `build-cache-mode: thin` avoids the setup-soldr#53 pitfall where the
       # dev build + cargo test --no-run + cargo test pipeline shares one
       # target dir.
+      # Pinned SHA: floating `v0` regressed to a Node20 rewrite that fails
+      # to honor `components` from `rust-toolchain.toml`. See
+      # zackees/setup-soldr#76.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0
+        uses: zackees/setup-soldr@8bc6da394b8ad370654826a0b3d8f5e3615d10d6 # v0 (pre-Node20-rewrite)
         with:
           toolchain: "1.94.1"
           version: "0.7.11"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -46,8 +46,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
 
       # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
+      # Pinned to a specific SHA because the floating `v0` tag moved to a
+      # Node20 TypeScript port that fails to read `components` from
+      # `rust-toolchain.toml`, leaving the toolchain without rustfmt/clippy
+      # and causing `cargo fmt --check` to fail with "'cargo-fmt' is not
+      # installed for the toolchain". See zackees/setup-soldr#76.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0
+        uses: zackees/setup-soldr@8bc6da394b8ad370654826a0b3d8f5e3615d10d6 # v0 (pre-Node20-rewrite)
         with:
           toolchain: "1.94.1"
           version: "0.7.11"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -51,8 +51,11 @@ jobs:
       # `build-cache-mode: thin` avoids the setup-soldr#53 pitfall where
       # ci/test.py's back-to-back cargo build / cargo test --no-run / cargo
       # test invocations share a single target dir.
+      # Pinned SHA: floating `v0` regressed to a Node20 rewrite that fails
+      # to honor `components` from `rust-toolchain.toml`. See
+      # zackees/setup-soldr#76.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0
+        uses: zackees/setup-soldr@8bc6da394b8ad370654826a0b3d8f5e3615d10d6 # v0 (pre-Node20-rewrite)
         with:
           toolchain: "1.94.1"
           version: "0.7.11"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
 name = "mock-agent"
 version = "2.0.9"
 dependencies = [
+ "libc",
  "serde_json",
  "terminal_size",
 ]

--- a/testbins/mock-agent/Cargo.toml
+++ b/testbins/mock-agent/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 serde_json = "1"
 terminal_size = "0.4"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [[bin]]
 name = "mock-agent"
 path = "src/main.rs"

--- a/testbins/mock-agent/src/main.rs
+++ b/testbins/mock-agent/src/main.rs
@@ -318,9 +318,36 @@ fn main() {
     std::process::exit(exit_code);
 }
 
+/// Put stdin into raw mode (no canonical line buffering, no echo) when it is
+/// a terminal. No-op on non-Unix or when stdin is a pipe.
+#[cfg(unix)]
+fn set_stdin_raw_if_tty() {
+    use std::os::unix::io::AsRawFd;
+    let fd = io::stdin().as_raw_fd();
+    if unsafe { libc::isatty(fd) } == 0 {
+        return;
+    }
+    let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+    if unsafe { libc::tcgetattr(fd, &mut termios) } != 0 {
+        return;
+    }
+    unsafe { libc::cfmakeraw(&mut termios) };
+    let _ = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &termios) };
+}
+
+#[cfg(not(unix))]
+fn set_stdin_raw_if_tty() {}
+
 /// Read from stdin for up to `timeout_ms` milliseconds, collecting whatever arrives.
 /// Works regardless of whether stdin is a terminal or pipe.
 fn read_stdin_timed(timeout_ms: u64) -> Option<Vec<u8>> {
+    // Real TUI children (e.g., codex Ink) put their PTY slave into raw mode
+    // before reading. The mock-agent must do the same when its stdin is a PTY
+    // slave, otherwise the kernel's canonical line discipline holds non-
+    // newline-terminated bytes (like the F3 voice-mode transcript) forever
+    // and they never reach the test's stdin capture.
+    set_stdin_raw_if_tty();
+
     let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
     std::thread::spawn(move || {
         let mut buf = [0u8; 4096];


### PR DESCRIPTION
## Summary

Follow-up to #104. The synthetic-recording fix unblocked the Whisper short-circuit but the Linux integration matrix is still red because the **PTY's canonical line discipline buffers the transcript bytes forever** — the test capture only sees the F3 sequence + `\n` that the test piped in.

### Why mock-agent ends up holding the bag

In `test_voice_mode_transcript_injects_into_pty`:
1. Test pipes `\x1bOR\x1b[57346;1:3u\n` into clud's stdin.
2. clud's pump forwards to the PTY → mock-agent's canonical line read returns the line up to `\n`. ✓
3. F3 release fires → worker emits `"hello voice mode"` (no newline — auto-submit would be a UX bug).
4. clud writes those bytes to the PTY master → kernel holds them in the line buffer waiting for `\n`. ✗
5. mock-agent's `read()` is still blocked. 1500ms deadline expires. Captured stdin has only the F3 bytes.

Real TUI backends (codex Ink, claude) put their slave into raw mode before reading; the existing Rust test in `pty_behavior.rs` already documents this gap. The mock-agent is the only "TUI child" that didn't, and the Python test is the only one that asserts on post-newline bytes, so the seam shows.

## Changes

- `testbins/mock-agent/Cargo.toml` — add `libc` as a Unix-only dep.
- `testbins/mock-agent/src/main.rs` — `set_stdin_raw_if_tty()` calls `cfmakeraw` + `tcsetattr` on Unix when stdin is a terminal. Invoked at the top of `read_stdin_timed`. No-op on Windows (the voice test is skipped there anyway — ConPTY doesn't deliver kitty release sequences).

Subprocess-mode tests are unaffected: their stdin is a pipe, `isatty()` returns 0, the function exits early. PTY tests with newline-terminated payloads (e.g., `raw_pump_fires_voice_f3_release_when_kitty_sequence_present`) keep working because raw mode is a strict superset of \"deliver bytes as they arrive.\"

## Test plan

- [x] `bash lint` — clean
- [x] `bash test` — 43 Python + all Rust unit tests pass on Windows
- [ ] Full integration matrix passes on CI (the proof — particularly Linux x86/ARM Integration Test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)