### PR TITLE
fix(skills): move managed-by marker after frontmatter so codex can load SKILL.md

### DIFF
--- a/crates/clud-bin/assets/skills/clud-issue-triage/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-issue-triage/SKILL.md
@@ -1,4 +1,3 @@
-<!-- managed-by: clud -->
 ---
 name: clud-issue-triage
 description: Triage GitHub issues — close ones that are absolutely resolved, and silently file follow-up issues for un-addressed CodeRabbit comments. Single issue, last week, or all (parallel sub-agents in worktrees).
@@ -7,6 +6,7 @@ triggers:
   - When the user types "/clud-issue-triage all"
   - When the user asks to "triage issues", "sweep stale issues", or "clean up the issue tracker"
 ---
+<!-- managed-by: clud -->
 
 # /clud-issue-triage
 

--- a/crates/clud-bin/assets/skills/clud-issue/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-issue/SKILL.md
@@ -1,4 +1,3 @@
-<!-- managed-by: clud -->
 ---
 name: clud-issue
 description: File a deeply-researched GitHub issue via investigate → interview → investigate → post, returning a summary plus the issue URL.
@@ -7,6 +6,7 @@ triggers:
   - When the user asks to "file an issue with research" or "open an issue after investigating"
   - When the user wants to draft an issue but needs the agent to clarify scope first
 ---
+<!-- managed-by: clud -->
 
 # /clud-issue
 

--- a/crates/clud-bin/assets/skills/clud-pr/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-pr/SKILL.md
@@ -1,4 +1,3 @@
-<!-- managed-by: clud -->
 ---
 name: clud-pr
 description: Implement a GitHub issue (or triage a PR link) inside a .claude/ worktree and ship as a single PR with no files left in the repo.
@@ -7,6 +6,7 @@ triggers:
   - When the user passes a PR URL/number to "/clud-pr" (triage mode)
   - When the user says "ship", "do-pr", "/clud-pr", or references an issue URL/number with intent to deliver
 ---
+<!-- managed-by: clud -->
 
 # /clud-pr
 

--- a/crates/clud-bin/assets/skills/clud-tag-release/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-tag-release/SKILL.md
@@ -1,4 +1,3 @@
-<!-- managed-by: clud -->
 ---
 name: clud-tag-release
 description: Tag a release and let the auto-release workflow build it. Validates version match, clean main, no duplicate tag — then pushes the tag and surfaces the workflow URL.
@@ -7,6 +6,7 @@ triggers:
   - When the user says "cut a release", "tag a release", "ship a version"
   - When the user wants to publish a new version of a Rust/Python crate
 ---
+<!-- managed-by: clud -->
 
 # /clud-tag-release
 

--- a/skills/clud-issue/SKILL.md
+++ b/skills/clud-issue/SKILL.md
@@ -1,4 +1,3 @@
-<!-- managed-by: clud -->
 ---
 name: clud-issue
 description: File a researched GitHub issue without interrogating the user — investigate, decide on best-guess defaults, post, and list those defaults in the issue body so the user can edit on GitHub.
@@ -6,6 +5,7 @@ triggers:
   - When the user types "/clud-issue" with a topic or problem statement
   - When the user asks to file or open a GitHub issue
 ---
+<!-- managed-by: clud -->
 
 # /clud-issue
 

--- a/skills/clud-pr-merge/SKILL.md
+++ b/skills/clud-pr-merge/SKILL.md
@@ -1,4 +1,3 @@
-<!-- managed-by: clud -->
 ---
 name: clud-pr-merge
 description: Wait for CI + CodeRabbit on the current PR, fix regressions and review comments, then merge to main.
@@ -7,6 +6,7 @@ triggers:
   - When the user says "/clud-pr-merge", "ship it", "land this PR"
   - After /clud-pr completes and the user wants to follow through to merge
 ---
+<!-- managed-by: clud -->
 
 # /clud-pr-merge
 

--- a/skills/clud-pr/SKILL.md
+++ b/skills/clud-pr/SKILL.md
@@ -1,4 +1,3 @@
-<!-- managed-by: clud -->
 ---
 name: clud-pr
 description: Implement a GitHub issue via parallel sub-agents and ship as a single PR with a clean working tree.
@@ -6,6 +5,7 @@ triggers:
   - When the user asks to implement a GitHub issue
   - When the user says "ship", "do-pr", "/clud-pr", or references an issue URL/number with intent to deliver
 ---
+<!-- managed-by: clud -->
 
 # /clud-pr
 


### PR DESCRIPTION
## Summary

Codex's skill loader requires `---` YAML frontmatter as the very first bytes of `SKILL.md`. Our bundled skills start with `<!-- managed-by: clud -->` instead, so codex logs on every launch:

```
ERROR codex_core::session: failed to load skill C:\Users\<user>\.codex\skills\clud-issue\SKILL.md: missing YAML frontmatter delimited by ---
ERROR codex_core::session: failed to load skill C:\Users\<user>\.codex\skills\clud-issue-triage\SKILL.md: missing YAML frontmatter delimited by ---
ERROR codex_core::session: failed to load skill C:\Users\<user>\.codex\skills\clud-pr\SKILL.md: missing YAML frontmatter delimited by ---
ERROR codex_core::session: failed to load skill C:\Users\<user>\.codex\skills\clud-tag-release\SKILL.md: missing YAML frontmatter delimited by ---
```

Claude Code accepts the comment-first ordering, so this only manifested on Codex.

## Fix

Move the `<!-- managed-by: clud -->` line to immediately after the closing `---` of the frontmatter. The marker stays visible to humans and to the substring check in `skills::tests` (already `.contains("managed-by: clud")`), and codex now finds `---` at byte 0.

## Files

Both bundle sets in the repo:
- `crates/clud-bin/assets/skills/{clud-issue,clud-issue-triage,clud-pr,clud-tag-release}/SKILL.md`
- `skills/{clud-issue,clud-pr,clud-pr-merge}/SKILL.md`

## On user-installed copies

Existing files in `~/.claude/skills/` and `~/.codex/skills/` will report `Existing::Diverges` from the install flow's whitespace-tolerant classifier (the comment _moved_, not just trailing whitespace), so users will see a one-time \"diverges from the version embedded in clud\" note when they next run clud. That note is the correct signal: delete the file and it gets reinstalled with the codex-friendly ordering. The install flow deliberately never overwrites user-edited skills.

## Test plan

- [x] `bash lint` — clean
- [x] `skills::tests::bundled_skills_have_unique_names` etc still pass (substring marker check)
- [ ] CI matrix passes (the actual proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)