### PR TITLE
fix(ci): session-scope clud_binary fixture to unbreak Windows integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -274,9 +274,18 @@ def mock_env_codex_cmd(mock_agent_binary: Path, tmp_path: Path) -> dict[str, str
     return env
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def clud_binary() -> Path:
-    """Return the path to the current repo's clud binary."""
+    """Return the path to the current repo's clud binary.
+
+    Session-scoped so the build runs once per pytest session rather than
+    once per test. Function scope caused every test (88 of them) to invoke
+    `cargo build -p clud` for an incremental fingerprint check; on Windows
+    that occasionally raced with a still-shutting-down clud.exe child from
+    the previous test and failed with file-lock errors, cascading the rest
+    of the suite into "cargo build -p clud exited with code 1" ERROR setups.
+    On slow runners (Windows ARM) the cumulative cargo overhead also
+    pushed the integration job past its 30-minute budget."""
     return _find_clud()
 
 


### PR DESCRIPTION
## Summary

Fixes both Windows integration-test breakages:
- [run 25813247537 (Windows x86)](https://github.com/zackees/clud/actions/runs/25813247537/job/75834898724): 72 tests ERROR'd with \"cargo build -p clud exited with code 1\" cascading from the fixture.
- [run 25813505761 (Windows ARM)](https://github.com/zackees/clud/actions/runs/25813505761): cancelled at 36 min on the Integration Tests step.

## Root cause

`tests/integration/conftest.py::clud_binary` was function-scoped:

\`\`\`python
@pytest.fixture
def clud_binary() -> Path:
    return _find_clud()
\`\`\`

…so every one of the 88 integration tests re-invoked \`cargo build -p clud\` for a fingerprint check. On Windows that occasionally raced with a still-shutting-down \`clud.exe\` from the prior test and failed with a file-lock error, cascading the rest of the suite into ERROR setups. On Windows ARM the cumulative cargo overhead also pushed the integration job past its 30-min budget.

\`mock_agent_binary\` was already \`scope=\"session\"\` — \`clud_binary\` just missed it.

## Fix

\`\`\`python
@pytest.fixture(scope=\"session\")
def clud_binary() -> Path:
    return _find_clud()
\`\`\`

Plus a docstring explaining the trap so it doesn't regress.

## Test plan

- [x] \`uv run ruff check tests/integration/conftest.py\` → clean
- [x] Local smoke test: 3 tests across two files (so the fixture is shared) pass in 19s (previously each would trigger its own incremental cargo invocation)
- [ ] Windows x86 + Windows ARM Integration Test jobs go green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)