### PR TITLE
Fix Windows CI after CMake build dependency

### DIFF
--- a/ci/env.py
+++ b/ci/env.py
@@ -255,13 +255,20 @@ def soldr_path(env: dict[str, str] | None = None) -> str | None:
 
 
 def cargo_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list[str]:
-    """Return the cargo argv, preferring `soldr cargo` on every platform.
+    """Return the cargo argv for CI and local helper scripts.
 
     Issue #27 pinned this on Windows; issue #68 extends it to all platforms
     so that local dev and CI (via `zackees/setup-soldr@v0`) go through the
     same rustup-resolved toolchain. Falls back to bare `cargo` when soldr
     isn't on PATH — matches `tests/integration/conftest.py::_cargo_argv`.
+    Explicit `CARGO` wins because Windows build_env() pins it to the MSVC
+    rustup toolchain, while `soldr cargo` on Windows x64 can split rustc
+    check-cfg arguments at spaces and pass `values(...))` as a filename.
     """
+    cargo = None if env is None else env.get("CARGO")
+    if cargo:
+        return [cargo, *subcommand]
+
     soldr = soldr_path(env)
     if soldr:
         return [soldr, "cargo", *subcommand]

--- a/tests/_subprocess_helpers.py
+++ b/tests/_subprocess_helpers.py
@@ -20,6 +20,7 @@ import sys
 # so the unit test can assert the *exact* bit pattern even when the test is
 # running off-Windows where the attribute does not exist.
 CREATE_NO_WINDOW: int = 0x0800_0000
+CREATE_NEW_PROCESS_GROUP: int = 0x0000_0200
 
 
 def windows_no_window_flags() -> dict[str, int]:
@@ -48,12 +49,11 @@ def windows_no_window_flags() -> dict[str, int]:
 
 
 def add_windows_create_no_window(kwargs: dict) -> None:
-    """OR ``CREATE_NO_WINDOW`` into ``kwargs["creationflags"]`` on Windows.
+    """Add ``CREATE_NO_WINDOW`` to ordinary Windows subprocess launches.
 
-    The OR is deliberate: callers may already have set
-    ``CREATE_NEW_PROCESS_GROUP`` (e.g. tests that send ``CTRL_BREAK_EVENT``
-    to a child). The two flags are independent bits and compose without
-    affecting Ctrl+Break delivery or process-group semantics.
+    Leave ``CREATE_NEW_PROCESS_GROUP`` launches alone: those tests send
+    ``CTRL_BREAK_EVENT`` to the child process group, and hidden-window
+    process groups have proven unreliable for that on Windows runners.
 
     No-op on non-Windows platforms.
     """
@@ -62,6 +62,9 @@ def add_windows_create_no_window(kwargs: dict) -> None:
     creationflags = kwargs.get("creationflags", 0)
     if not isinstance(creationflags, int):
         creationflags = 0
+    if creationflags & CREATE_NEW_PROCESS_GROUP:
+        kwargs["creationflags"] = creationflags
+        return
     kwargs["creationflags"] = creationflags | getattr(
         subprocess, "CREATE_NO_WINDOW", CREATE_NO_WINDOW
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,6 +30,12 @@ def _cargo_argv(subcommand: list[str]) -> list[str]:
     VCRUNTIME140.dll / MSVCP140.dll — both ship with Windows 10+.
     """
     if sys.platform == "win32":
+        try:
+            from ci.env import build_env, cargo_argv  # type: ignore[import-not-found]
+
+            return cargo_argv(subcommand, env=build_env())
+        except Exception:
+            pass
         soldr = shutil.which("soldr")
         if soldr:
             return [soldr, "cargo", *subcommand]
@@ -95,12 +101,10 @@ def _suppress_windows_console_windows():
     """Hide console windows for integration-test subprocesses on Windows.
 
     The fixture is session-scoped so it applies to the build-time helpers as
-    well as the actual tests. Issue #55: OR's CREATE_NO_WINDOW into every
-    ``subprocess.run`` / ``subprocess.Popen`` call regardless of any
-    explicit ``creationflags`` the caller passed (e.g. Ctrl+Break tests
-    that need ``CREATE_NEW_PROCESS_GROUP``). The two flags are independent
-    bits and compose; suppressing the window does not affect signal
-    delivery or process-group semantics.
+    well as the actual tests. Issue #55: add CREATE_NO_WINDOW to ordinary
+    ``subprocess.run`` / ``subprocess.Popen`` calls. Ctrl+Break tests that
+    request ``CREATE_NEW_PROCESS_GROUP`` are left visible because hidden
+    process groups do not reliably receive Ctrl+Break on Windows runners.
     """
     if sys.platform != "win32":
         yield
@@ -112,18 +116,14 @@ def _suppress_windows_console_windows():
 
     def run(*args, **kwargs):
         kwargs = dict(kwargs)
-        # Issue #55: always add CREATE_NO_WINDOW (OR'd with any caller-set
-        # creationflags) — the previous version skipped this when
-        # creationflags was explicit, leaving Ctrl+Break test launches
-        # popping windows.
+        # Issue #55: hide ordinary child processes on Windows. Ctrl+Break
+        # tests keep their process-group creation flags unchanged.
         _add_windows_create_no_window(kwargs)
         return original_run(*args, **kwargs)
 
     def popen(*args, **kwargs):
         kwargs = dict(kwargs)
-        # Issue #55: same fix as `run` above. CREATE_NEW_PROCESS_GROUP and
-        # CREATE_NO_WINDOW are independent bits and may be OR'd together
-        # without affecting Ctrl+Break delivery.
+        # Issue #55: same fix as `run` above.
         _add_windows_create_no_window(kwargs)
         return original_popen(*args, **kwargs)
 

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -108,10 +108,19 @@ def _wait_for_tree_pids(path: Path, minimum: int, timeout: float = 10.0) -> list
     raise AssertionError(f"timed out waiting for {minimum} tree pids in {path}")
 
 
-def _session_metadata(state_dir: Path, session_id: str) -> dict:
+def _session_metadata(
+    state_dir: Path, session_id: str, timeout: float = 5.0
+) -> dict:
     path = state_dir / "sessions" / f"{session_id}.json"
     _wait_for_file(path)
-    return json.loads(path.read_text(encoding="utf-8"))
+    deadline = time.time() + timeout
+    while True:
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (PermissionError, json.JSONDecodeError):
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.05)
 
 
 def _wait_for_session_exit(state_dir: Path, session_id: str, timeout: float = 15.0) -> dict:

--- a/tests/test_ci_env.py
+++ b/tests/test_ci_env.py
@@ -1,0 +1,26 @@
+"""Tests for CI environment command selection."""
+
+from __future__ import annotations
+
+from ci import env as ci_env
+
+
+def test_cargo_argv_prefers_explicit_cargo(monkeypatch) -> None:
+    monkeypatch.setattr(ci_env, "soldr_path", lambda env=None: "soldr")
+
+    assert ci_env.cargo_argv(["check"], env={"CARGO": r"C:\rust\bin\cargo.exe"}) == [
+        r"C:\rust\bin\cargo.exe",
+        "check",
+    ]
+
+
+def test_cargo_argv_uses_soldr_when_no_explicit_cargo(monkeypatch) -> None:
+    monkeypatch.setattr(ci_env, "soldr_path", lambda env=None: "soldr")
+
+    assert ci_env.cargo_argv(["check"], env={}) == ["soldr", "cargo", "check"]
+
+
+def test_cargo_argv_falls_back_to_bare_cargo(monkeypatch) -> None:
+    monkeypatch.setattr(ci_env, "soldr_path", lambda env=None: None)
+
+    assert ci_env.cargo_argv(["check"], env={}) == ["cargo", "check"]

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -38,6 +38,12 @@ def _cargo_argv(subcommand: list[str]) -> list[str]:
     `tests/integration/conftest.py::_cargo_argv`.
     """
     if sys.platform == "win32":
+        try:
+            from ci.env import build_env, cargo_argv
+
+            return cargo_argv(subcommand, env=build_env())
+        except Exception:
+            pass
         soldr = shutil.which("soldr")
         if soldr:
             return [soldr, "cargo", *subcommand]

--- a/tests/test_windows_no_window_flags.py
+++ b/tests/test_windows_no_window_flags.py
@@ -27,6 +27,7 @@ if str(_TESTS_DIR) not in sys.path:
     sys.path.insert(0, str(_TESTS_DIR))
 
 from _subprocess_helpers import (  # type: ignore[import-not-found]  # noqa: E402
+    CREATE_NEW_PROCESS_GROUP,
     CREATE_NO_WINDOW,
     add_windows_create_no_window,
     windows_no_window_flags,
@@ -123,29 +124,24 @@ def test_add_windows_create_no_window_sets_flag_on_windows() -> None:
     assert kwargs == {"creationflags": 0x0800_0000}
 
 
-def test_add_windows_create_no_window_ors_with_existing_flag() -> None:
-    """Composing with CREATE_NEW_PROCESS_GROUP is a hard requirement.
+def test_add_windows_create_no_window_leaves_process_group_visible() -> None:
+    """CREATE_NEW_PROCESS_GROUP launches must stay signal-addressable.
 
-    Some integration tests deliver Ctrl+Break to children and need
-    ``CREATE_NEW_PROCESS_GROUP`` (0x0000_0200) on the spawn. The two
-    flags are independent bits and must compose — if the helper
-    overwrote ``creationflags`` instead of OR'ing, those tests would
-    silently lose their process-group semantics and the Ctrl+Break
-    delivery would land on the test runner instead.
+    Some integration tests deliver Ctrl+Break to children and need a real
+    process group. On Windows runners, adding CREATE_NO_WINDOW to those
+    launches prevents reliable Ctrl+Break delivery, so the popup-suppression
+    helper must leave the flags alone.
     """
     if sys.platform != "win32":
         import pytest
 
         pytest.skip("Windows-only behavior")
-    create_new_process_group = 0x0000_0200
-    kwargs: dict = {"creationflags": create_new_process_group}
+    kwargs: dict = {"creationflags": CREATE_NEW_PROCESS_GROUP}
     add_windows_create_no_window(kwargs)
-    expected = create_new_process_group | 0x0800_0000
-    assert kwargs["creationflags"] == expected
-    # Re-running the helper is idempotent — OR'ing the same bit twice is
-    # the same bit pattern.
+    assert kwargs["creationflags"] == CREATE_NEW_PROCESS_GROUP
+    # Re-running the helper is idempotent.
     add_windows_create_no_window(kwargs)
-    assert kwargs["creationflags"] == expected
+    assert kwargs["creationflags"] == CREATE_NEW_PROCESS_GROUP
 
 
 def test_add_windows_create_no_window_recovers_from_non_int_creationflags() -> None:


### PR DESCRIPTION
## Summary
- Follow-up to #111 for the Windows CI failures after adding the CMake build dependency.
- Prefer the explicit `CARGO` exported by `ci.env.build_env()` before falling back to `soldr cargo`, avoiding Windows x64 `rustc --check-cfg` argument splitting.
- Reuse the same cargo selection in Python build helpers used by unit and integration tests.
- Leave `CREATE_NEW_PROCESS_GROUP` subprocess launches visible so Ctrl+Break delivery remains reliable, and retry daemon metadata reads across transient Windows file locks.

## Test plan
- [x] `ruff check ci\env.py tests\_subprocess_helpers.py tests\test_windows_no_window_flags.py tests\test_ci_env.py tests\test_hello.py tests\integration\conftest.py tests\integration\test_daemon_centralized.py`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3.13t -m pytest tests\test_windows_no_window_flags.py tests\test_ci_env.py tests\test_packaging_metadata.py -q`
- [x] `CLUD_INTEGRATION_TESTS=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3.13t -m pytest <four PR #111 Windows Ctrl+Break failures> -q`
- [x] `py -3.13t -m ci.lint`

## Notes
- `py -3.13t -m ci.test` gets through the Rust unit suite locally, then fails before/inside Python collection because this machine has a broken global `pytest_playwright`/`greenlet` plugin and a pre-existing console-title E2E check has the terminal title overwritten by the host session. Focused pytest runs pass with plugin autoload disabled.
- `uv run --no-editable -m ci.test` now reaches CMake from the PR #111 dependency, but this nested `.claude/worktrees/...` path trips MSBuild FileTracker long-path `.tlog` creation locally. GitHub Actions checks out to a much shorter path.