### PR TITLE
fix(build): trim whisper-rs-sys link-search emission to keep Windows rustc cmd under 32 KiB

### DIFF
--- a/vendor/whisper-rs-sys/build.rs
+++ b/vendor/whisper-rs-sys/build.rs
@@ -446,11 +446,55 @@ fn normalize_windows_gnu_bindings(path: &std::path::Path) {
 }
 
 fn add_link_search_path(dir: &std::path::Path) -> std::io::Result<()> {
-    if dir.is_dir() {
-        println!("cargo:rustc-link-search={}", dir.display());
-        for entry in std::fs::read_dir(dir)? {
-            add_link_search_path(&entry?.path())?;
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    // Only emit a `-L` entry for directories that actually contain link
+    // artifacts. Recursively walking every cmake scratch subdir
+    // (`CMakeFiles/<ver>/CompilerIdC/Debug/...tlog`, kept for incremental
+    // metadata) blows the rustc command line past Windows' 32 KiB
+    // CreateProcess limit once CMake 4.x is in play, garbling adjacent
+    // args like `--check-cfg cfg(feature, values(...))`. CMake 3.x was
+    // sparser and stayed under the limit. clud #114.
+    let mut has_artifact = false;
+    let mut subdirs: Vec<std::path::PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if file_type.is_dir() {
+            // Skip cmake's scratch trees — they never contain link
+            // artifacts and account for the vast majority of the
+            // recursion fan-out.
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            if name == "CMakeFiles" || name.ends_with(".dir") || name.ends_with(".tlog") {
+                continue;
+            }
+            subdirs.push(path);
+            continue;
         }
+        if !has_artifact {
+            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                if matches!(
+                    ext.to_ascii_lowercase().as_str(),
+                    "lib" | "a" | "so" | "dylib"
+                ) {
+                    has_artifact = true;
+                }
+            }
+        }
+    }
+    if has_artifact {
+        println!("cargo:rustc-link-search={}", dir.display());
+    }
+    for child in subdirs {
+        add_link_search_path(&child)?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes the Windows-only CI regression introduced by #111 (`cmake>=3.26` dev dep, which pulls in pip-cmake 4.x). Every Windows unit-test / integration-test / lint job since 37fc8c5 has failed with:

```
error: multiple input filenames provided (first two filenames are
       vendor\whisper-rs-sys\src\lib.rs and `values(coreml,`)
```

Root cause: `vendor/whisper-rs-sys/build.rs` recursively walks cmake's build tree and emits a `cargo:rustc-link-search` line for **every** subdirectory — including the hundreds of empty scratch dirs (`CMakeFiles/<ver>/CompilerIdC/Debug/...tlog`, `*.dir/Release/...tlog`). CMake 3.x produced a sparser tree and the resulting rustc command line stayed under Windows' 32 KiB CreateProcess limit. CMake 4.x's significantly deeper scratch layout pushes the cmd line past the limit, CreateProcess truncates the arg list, and adjacent flags like `--check-cfg cfg(feature, values("coreml","cuda",...))` get garbled — yielding the `values(coreml,` second-input-filename error.

Fix: only emit `-L` for directories that actually contain link artifacts (`.lib` / `.a` / `.so` / `.dylib`), and skip cmake's scratch trees (`CMakeFiles`, `*.dir`, `*.tlog`) entirely. Recursion is preserved for real artifact dirs so any nested library output still gets picked up.

## Repro + verification

Locally reproduced the failure:
```bash
rm -rf target/x86_64-pc-windows-msvc/debug/build/whisper-rs-sys-*
soldr cargo test --workspace --no-run
# error: multiple input filenames provided ... and `values(coreml,`
```

After the patch, the same command succeeds. `bash lint` and `bash test` both clean.

## Test plan

- [ ] CI matrix green on the previously-broken Windows lanes (x86 + ARM unit-test, integration-test, lint).
- [ ] Linux + macOS lanes still green (no behavior change on those platforms — they were never near the cmd-line limit and have different cmake/link-search patterns).
- [ ] Local: `bash lint` + `bash test` pass on Windows with a freshly-cleared `target/.../whisper-rs-sys-*` build cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)