### PR TITLE
Fix CI failures after PR 114

### DIFF
--- a/ci/check_windows_wheel.py
+++ b/ci/check_windows_wheel.py
@@ -1,8 +1,8 @@
 """Assert that a Windows wheel's clud.exe was built against MSVC, not MinGW.
 
 Issue #27: the test harness and dev workflow pin the MSVC toolchain via
-`ci/env.py::build_env()` and `soldr`, but nothing at the CI layer asserts
-the resulting binary actually has only MSVC runtime imports. If the pin
+`ci/env.py::build_env()`, but nothing at the CI layer asserts the
+resulting binary actually has only MSVC runtime imports. If the pin
 ever slipped, we'd ship a wheel depending on `libstdc++-6.dll` /
 `libgcc_s_seh-1.dll` / `libwinpthread-1.dll` — none of which ship with
 Windows, so the binary would fail to start for any user who doesn't

--- a/ci/env.py
+++ b/ci/env.py
@@ -241,14 +241,10 @@ def build_env() -> dict[str, str]:
 def soldr_path(env: dict[str, str] | None = None) -> str | None:
     """Return the path to the soldr binary, or None if not available.
 
-    soldr (https://github.com/zackees/soldr) is pulled in as a dev dependency
-    and proxies cargo/rustc/maturin invocations through the rustup-managed
-    toolchain (via `rustup which`). On Windows, developer machines that have
-    a chocolatey-installed GNU-host cargo first on PATH produce binaries
-    that link MinGW runtime DLLs (libstdc++-6.dll etc.), which fail to load
-    on stock Windows. CI runners today happen to have the MSVC rustup
-    toolchain first on PATH, but that's luck — this helper pins the
-    behavior by making every cargo/maturin CI call go through soldr.
+    This remains for legacy callers and tests that need to discover the
+    optional soldr helper. CI cargo/maturin invocations use the explicit
+    tool paths and environment from this module rather than routing through
+    soldr by default.
     """
     path = None if env is None else env.get("PATH")
     return shutil.which("soldr", path=path)
@@ -257,21 +253,17 @@ def soldr_path(env: dict[str, str] | None = None) -> str | None:
 def cargo_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list[str]:
     """Return the cargo argv for CI and local helper scripts.
 
-    Issue #27 pinned this on Windows; issue #68 extends it to all platforms
-    so that local dev and CI (via `zackees/setup-soldr@v0`) go through the
-    same rustup-resolved toolchain. Falls back to bare `cargo` when soldr
-    isn't on PATH — matches `tests/integration/conftest.py::_cargo_argv`.
     Explicit `CARGO` wins because Windows build_env() pins it to the MSVC
-    rustup toolchain, while `soldr cargo` on Windows x64 can split rustc
-    check-cfg arguments at spaces and pass `values(...))` as a filename.
+    rustup toolchain. Otherwise use bare `cargo`: setup-soldr still installs
+    the requested toolchain and restores the target cache, while routing
+    through `soldr cargo` starts zccache. In PR #114 CI, that zccache layer
+    exited early on Linux x86 integration and was killed with 137 on Linux ARM
+    lint, so cargo itself is the stable execution path.
     """
     cargo = None if env is None else env.get("CARGO")
     if cargo:
         return [cargo, *subcommand]
 
-    soldr = soldr_path(env)
-    if soldr:
-        return [soldr, "cargo", *subcommand]
     return ["cargo", *subcommand]
 
 

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -16,7 +16,7 @@ def run(cmd: list[str]) -> int:
 
 
 def _cargo(subcommand: list[str]) -> list[str]:
-    """Return the cargo argv, preferring `soldr cargo` on Windows (issue #27)."""
+    """Return the cargo argv for the configured CI environment."""
     from ci.env import cargo_argv, clean_env
 
     return cargo_argv(subcommand, env=clean_env())

--- a/ci/test.py
+++ b/ci/test.py
@@ -24,7 +24,7 @@ def run(cmd: list[str]) -> int:
 
 
 def _cargo(subcommand: list[str]) -> list[str]:
-    """Return the cargo argv, preferring `soldr cargo` on Windows (issue #27)."""
+    """Return the cargo argv for the configured CI environment."""
     from ci.env import cargo_argv, clean_env
 
     return cargo_argv(subcommand, env=clean_env())

--- a/crates/clud-bin/src/daemon.rs
+++ b/crates/clud-bin/src/daemon.rs
@@ -1422,7 +1422,7 @@ fn daemon_create_session(
         .map_err(|err| io::Error::other(err.to_string()))?;
 
     let started = Instant::now();
-    let snapshot = loop {
+    let mut snapshot = loop {
         match read_json_file::<SessionSnapshot>(&session_snapshot_path(state_dir, &session_id)) {
             Ok(snapshot) => break snapshot,
             Err(err) if started.elapsed() < Duration::from_secs(5) => {
@@ -1434,12 +1434,25 @@ fn daemon_create_session(
     };
 
     // Verify the worker's TCP listener is actually accepting connections
-    // before reporting the session as ready. Repeat jobs intentionally don't
-    // expose an attach port, so `worker_port == 0` is valid there.
+    // before reporting the session as ready. If the backend exits immediately,
+    // the worker can persist the final snapshot and close its listener before
+    // this readiness loop observes it; that is still a valid created session
+    // whose failure can be inspected later.
     if snapshot.attachable {
         loop {
+            if snapshot.exit_code.is_some() {
+                break;
+            }
             if TcpStream::connect(("127.0.0.1", snapshot.worker_port)).is_ok() {
                 break;
+            }
+            if let Ok(updated) =
+                read_json_file::<SessionSnapshot>(&session_snapshot_path(state_dir, &session_id))
+            {
+                snapshot = updated;
+                if snapshot.exit_code.is_some() {
+                    break;
+                }
             }
             if started.elapsed() >= Duration::from_secs(5) {
                 return Err(io::Error::new(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(ROOT))
 
 
 def _cargo_argv(subcommand: list[str]) -> list[str]:
-    """Return the cargo argv, preferring `soldr cargo` on Windows.
+    """Return the cargo argv, pinning the MSVC toolchain on Windows.
 
     Windows rustc installations from chocolatey ship a GNU-host rustc which
     links C++ deps (whisper-rs) against MinGW runtime DLLs
@@ -26,8 +26,9 @@ def _cargo_argv(subcommand: list[str]) -> list[str]:
     aren't present on stock Windows, so the resulting debug binary fails
     with STATUS_ENTRYPOINT_NOT_FOUND when launched as a subprocess.
 
-    `soldr cargo ...` forces the MSVC target, which links against
-    VCRUNTIME140.dll / MSVCP140.dll — both ship with Windows 10+.
+    `ci.env.build_env()` exports the rustup-managed MSVC cargo/rustc paths,
+    which link against VCRUNTIME140.dll / MSVCP140.dll. The `soldr` branch
+    below is only an emergency fallback if this file is run outside the repo.
     """
     if sys.platform == "win32":
         try:
@@ -46,8 +47,7 @@ def _cargo_build_env() -> dict[str, str]:
     """Return the env used for building clud/mock-agent in tests.
 
     On Windows, reuse ci.env.build_env() which pins RUSTUP_TOOLCHAIN and
-    CARGO_BUILD_TARGET to the MSVC variants — the same env the wheel build
-    uses. This is a fallback for systems without `soldr`.
+    CARGO_BUILD_TARGET to the MSVC variants, matching the wheel build.
     """
     if sys.platform != "win32":
         return os.environ.copy()
@@ -293,7 +293,7 @@ def _scan_for_clud_zombies() -> list[dict]:
     """Scan the system for orphaned CLUD-spawned processes."""
     ext = ".exe" if sys.platform == "win32" else ""
     candidates = [
-        # soldr / explicit --target put artifacts under target/<triple>/debug.
+        # MSVC-pinned builds put artifacts under target/<triple>/debug.
         ROOT
         / "target"
         / "x86_64-pc-windows-msvc"

--- a/tests/integration/test_daemon_centralized.py
+++ b/tests/integration/test_daemon_centralized.py
@@ -25,6 +25,7 @@ _ANSI_RE = re.compile(
     # restores full state; the test must strip them before parsing JSON.
     r"|[\x30-\x7e])"
 )
+_DETACH_EXIT_TIMEOUT = 10.0
 
 
 def _daemon_env(mock_env: dict[str, str], state_dir: Path) -> dict[str, str]:
@@ -245,7 +246,7 @@ class TestDaemonManagedSessionFlags:
             "3000",
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
 
             attached = subprocess.run(
                 [str(clud_binary), "attach", session_id],
@@ -290,7 +291,7 @@ class TestDaemonManagedSessionFlags:
             "5000",
         )
         try:
-            assert _wait_for_exit(proc1, timeout=2) == 0
+            assert _wait_for_exit(proc1, timeout=_DETACH_EXIT_TIMEOUT) == 0
 
             listed = subprocess.run(
                 [str(clud_binary), "attach"],
@@ -324,7 +325,7 @@ class TestDaemonManagedSessionFlags:
             cwd=launch_cwd,
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
             metadata = _session_metadata(state_dir, session_id)
 
             listed = subprocess.run(
@@ -1203,7 +1204,7 @@ class TestDaemonSessionHardening:
             "3000",
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
             # `_read_session_id` already consumed the "session ... running
             # in background" line. The "attach with: clud attach <id>" line
             # follows it, terminated by \n. `readline()` reads until \n so
@@ -1247,7 +1248,7 @@ class TestDaemonSessionHardening:
             "3000",
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
             attached = subprocess.run(
                 [str(clud_binary), "attach"],
                 capture_output=True,
@@ -1277,7 +1278,7 @@ class TestDaemonSessionHardening:
             "30000",
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
             result = subprocess.run(
                 [str(clud_binary), "kill", session_id],
                 capture_output=True,
@@ -1364,7 +1365,7 @@ class TestDaemonSessionHardening:
             "3000",
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
 
             # Attach by name instead of ID
             attached = subprocess.run(
@@ -1398,7 +1399,7 @@ class TestDaemonSessionHardening:
             "3000",
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
             listed = subprocess.run(
                 [str(clud_binary), "list"],
                 capture_output=True,
@@ -1428,7 +1429,7 @@ class TestDaemonSessionHardening:
             "3000",
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
             # Use first 10 chars of session_id as prefix
             prefix = session_id[:10]
             attached = subprocess.run(
@@ -1462,7 +1463,7 @@ class TestDaemonSessionHardening:
             "30000",
         )
         try:
-            assert _wait_for_exit(proc, timeout=2) == 0
+            assert _wait_for_exit(proc, timeout=_DETACH_EXIT_TIMEOUT) == 0
             result = subprocess.run(
                 [str(clud_binary), "kill", "kill-by-name"],
                 capture_output=True,
@@ -1491,7 +1492,7 @@ class TestDaemonSessionHardening:
             "--mock-sleep-ms",
             "5000",
         )
-        assert _wait_for_exit(proc1, timeout=2) == 0
+        assert _wait_for_exit(proc1, timeout=_DETACH_EXIT_TIMEOUT) == 0
         time.sleep(0.2)
         # Create second session (most recent)
         proc2, _session_id_2 = _launch_detached(
@@ -1504,7 +1505,7 @@ class TestDaemonSessionHardening:
             "--mock-sleep-ms",
             "3000",
         )
-        assert _wait_for_exit(proc2, timeout=2) == 0
+        assert _wait_for_exit(proc2, timeout=_DETACH_EXIT_TIMEOUT) == 0
         try:
             # attach --last should get the second session
             attached = subprocess.run(

--- a/tests/test_ci_env.py
+++ b/tests/test_ci_env.py
@@ -14,10 +14,10 @@ def test_cargo_argv_prefers_explicit_cargo(monkeypatch) -> None:
     ]
 
 
-def test_cargo_argv_uses_soldr_when_no_explicit_cargo(monkeypatch) -> None:
+def test_cargo_argv_uses_bare_cargo_when_no_explicit_cargo(monkeypatch) -> None:
     monkeypatch.setattr(ci_env, "soldr_path", lambda env=None: "soldr")
 
-    assert ci_env.cargo_argv(["check"], env={}) == ["soldr", "cargo", "check"]
+    assert ci_env.cargo_argv(["check"], env={}) == ["cargo", "check"]
 
 
 def test_cargo_argv_falls_back_to_bare_cargo(monkeypatch) -> None:

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -27,13 +27,13 @@ def _project_version() -> str:
 
 
 def _cargo_argv(subcommand: list[str]) -> list[str]:
-    """Return the cargo argv, preferring `soldr cargo` on Windows (issue #27).
+    """Return the cargo argv, pinning the MSVC toolchain on Windows.
 
     Windows rustc installations from chocolatey ship a GNU-host rustc which
     links C/C++ deps against MinGW runtime DLLs (libstdc++-6.dll,
     libgcc_s_seh-1.dll, libwinpthread-1.dll). Those DLLs aren't on stock
     Windows, so a test that launches the resulting binary fails with
-    STATUS_ENTRYPOINT_NOT_FOUND (0xC0000139). `soldr cargo ...` forces the
+    STATUS_ENTRYPOINT_NOT_FOUND (0xC0000139). `ci.env.build_env()` forces the
     MSVC target via the rustup-managed toolchain. Mirrors
     `tests/integration/conftest.py::_cargo_argv`.
     """
@@ -72,8 +72,8 @@ def _clud_binary() -> str:
             return msg["executable"]
 
     ext = ".exe" if sys.platform == "win32" else ""
-    # soldr / `--target x86_64-pc-windows-msvc` lands artifacts in a
-    # triple-qualified subdir; bare cargo lands in target/debug. Check both.
+    # The MSVC-pinned env lands artifacts in a triple-qualified subdir; bare
+    # cargo lands in target/debug. Check both.
     for fallback in (
         ROOT / "target" / "x86_64-pc-windows-msvc" / "debug" / f"clud{ext}",
         ROOT / "target" / "aarch64-pc-windows-msvc" / "debug" / f"clud{ext}",


### PR DESCRIPTION
## Summary
- Stop default CI cargo invocations from routing through `soldr cargo`; explicit `CARGO` from `ci.env.build_env()` still wins for the Windows MSVC pin.
- Let daemon session creation succeed when an attachable worker already persisted an exited snapshot before the TCP readiness probe observes the listener.
- Increase detach-parent exit assertions to a shared 10s timeout for slower runners and refresh stale MSVC/soldr helper docs.

## Context
Follow-up to #114. The failing runs showed `soldr cargo`/zccache instability on Linux x86/ARM, a too-tight 2s detach-parent wait on Linux ARM, and a Windows ARM race where an immediately crashing backend could exit before session creation completed readiness probing.

## Test plan
- [x] `uv run --no-editable -m ruff check ci\env.py ci\lint.py ci\test.py ci\check_windows_wheel.py tests\test_ci_env.py tests\integration\conftest.py tests\test_hello.py tests\integration\test_daemon_centralized.py`
- [x] `py -3.13t -m pytest tests\test_ci_env.py -q`
- [x] `py -3.13t -c "from ci.env import build_env, cargo_argv; ... cargo_argv([''test'', ''-p'', ''clud'', ''--lib'', ''daemon::'']) ..."`
- [x] `py -3.13t -m pytest tests\integration\test_daemon_centralized.py::TestDaemonManagedSessionFlags::test_detach_launch_returns_immediately_and_can_attach tests\integration\test_daemon_centralized.py::TestDaemonSessionHardening::test_worker_crash_on_startup_records_failure -q`
- [x] `uv run --no-editable -m ci.lint`
- [ ] `uv run --no-editable -m ci.test` passed all Rust suites but hit an existing local Windows console-title pytest where this interactive shell changed the title externally (`expected clud <tmpdir>`, got current shell title). The targeted and CI-relevant tests above passed.
