### PR TITLE
Load Linux audio dependencies on demand

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -51,12 +51,6 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      # Issue #13: cpal links against ALSA on Linux. See _unit-test.yml for
-      # the full rationale.
-      - name: Install Linux audio deps
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-
       # Issue #68: replace dtolnay/rust-toolchain + mozilla-actions/sccache-action
       # + Swatinem/rust-cache with setup-soldr. soldr pins the MSVC toolchain on
       # Windows (issue #27) and owns build + target caching for every platform.

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -40,12 +40,6 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      # Issue #13: cpal links against ALSA on Linux. See _unit-test.yml for
-      # the full rationale.
-      - name: Install Linux audio deps
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-
       # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
       # `build-cache-mode: thin` avoids the setup-soldr#53 pitfall where the
       # dev build + cargo test --no-run + cargo test pipeline shares one

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -39,12 +39,6 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      # Issue #13: cargo clippy compiles the same code path as the build
-      # job, so it also needs ALSA dev headers on Linux for cpal to link.
-      - name: Install Linux audio deps
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-
       # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
       # Pinned to a specific SHA because the floating `v0` tag moved to a
       # Node20 TypeScript port that fails to read `components` from

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -39,14 +39,6 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      # Issue #13: cpal links against ALSA on Linux. The runner image ships
-      # the runtime lib (libasound2) but not the dev headers / static archive
-      # that whisper-rs-sys's CMake build also needs. Install before Rust
-      # setup so any cached toolchain is unaffected.
-      - name: Install Linux audio deps
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-
       # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
       # `build-cache-mode: thin` avoids the setup-soldr#53 pitfall where
       # ci/test.py's back-to-back cargo build / cargo test --no-run / cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,12 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,15 +573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,12 +593,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "extended"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fallible-iterator"
@@ -1557,7 +1536,6 @@ dependencies = [
  "cpal",
  "dasp_sample",
  "num-rational",
- "symphonia",
 ]
 
 [[package]]
@@ -1840,153 +1818,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "symphonia"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
-dependencies = [
- "lazy_static",
- "symphonia-bundle-flac",
- "symphonia-bundle-mp3",
- "symphonia-codec-aac",
- "symphonia-codec-pcm",
- "symphonia-codec-vorbis",
- "symphonia-core",
- "symphonia-format-isomp4",
- "symphonia-format-ogg",
- "symphonia-format-riff",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-bundle-flac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-bundle-mp3"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-codec-aac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-pcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
-dependencies = [
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-vorbis"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-core"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "bytemuck",
- "lazy_static",
- "log",
-]
-
-[[package]]
-name = "symphonia-format-isomp4"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
-dependencies = [
- "encoding_rs",
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-ogg"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-riff"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
-dependencies = [
- "extended",
- "log",
- "symphonia-core",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-metadata"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
-dependencies = [
- "encoding_rs",
- "lazy_static",
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
-]
 
 [[package]]
 name = "syn"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ the same sessions with their root PID and current working directory.
 backend prompt using local `whisper.cpp`. Hold `F3`, speak, release `F3`, and
 the transcript appears at your cursor without auto-submitting — you can edit
 it before pressing Enter. Available on **all six** supported platforms
-(Linux x86/ARM, Windows x86/ARM, macOS x86/ARM).
+(Linux x86/ARM, Windows x86/ARM, macOS x86/ARM). On Linux, microphone capture
+uses `arecord` on demand so `libasound` is not required for normal startup.
 
 ### Enabling it
 
@@ -145,9 +146,11 @@ the auto-download is skipped.
 | Kitty-protocol terminals (kitty, Ghostty, modern iTerm2, WezTerm, Alacritty with kitty mode) | True press-and-hold: recording stops the instant you release `F3`. |
 | Everything else (Windows Terminal / ConPTY, older xterm, etc.) | Press `F3` to start; recording auto-stops after 1.5 seconds of silence (VAD) or 30 seconds maximum, whichever comes first. |
 
-Cues are short tones generated programmatically — `ding` on start
-(~880 Hz, 90 ms), `dong` on stop (~660 Hz, 120 ms). If the default audio
-output device is unavailable, `clud` falls back to a terminal bell.
+Cues are short tones generated programmatically on macOS/Windows — `ding`
+on start (~880 Hz, 90 ms), `dong` on stop (~660 Hz, 120 ms). Linux uses a
+terminal bell so `clud` does not link audio output libraries at startup. If
+the default audio output device is unavailable, `clud` falls back to a
+terminal bell.
 
 ### Environment variables
 
@@ -160,7 +163,7 @@ output device is unavailable, `clud` falls back to a terminal bell.
 
 ### Troubleshooting
 
-- **Nothing happens when I press F3.** Check that `CLUD_VOICE=1` is exported in the same shell. Then verify a default input device exists (`pamixer --get-default-source` on Linux, "Sound" preferences on macOS/Windows).
+- **Nothing happens when I press F3.** Check that `CLUD_VOICE=1` is exported in the same shell. On Linux, install `alsa-utils` so `arecord` is available, then verify a default input device exists (`arecord -l` on Linux, "Sound" preferences on macOS/Windows).
 - **"voice mode is enabled but the Whisper model is not yet available"** — the auto-download hasn't finished. Watch stderr for `[clud] voice: download N% (...)` lines, or pre-seed the cache path manually with `curl -L -o <cache-path> https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin`.
 - **Recording keeps stopping mid-sentence on non-kitty terminals.** The VAD silence window is 1.5 s — pause less, or switch to a kitty-protocol terminal for true hold-to-record.
 - **Transcript is empty / garbage.** Whisper struggles on very short utterances and noisy backgrounds. The `MIN_CAPTURE_MS` floor (150 ms) silently drops sub-150 ms blips; speak for at least half a second.

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -13,16 +13,12 @@ base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
 ctrlc = "3"
-# Issue #13: voice-mode stack. cpal owns mic capture, rodio plays the
-# ding/dong cues, whisper-rs runs local transcription via the vendored
-# `whisper.cpp` build (see `[patch.crates-io]` in the workspace Cargo.toml).
-# These used to be gated to (windows, x86_64) and (macos, aarch64) only;
-# moved unconditional so voice mode ships on all six supported platforms.
-# Linux CI must `apt-get install libasound2-dev` so cpal can link ALSA.
+# Issue #13: voice-mode stack. Linux capture shells out to `arecord` on
+# F3 press so libasound is loaded only by that on-demand helper process,
+# not by every `clud --help` / `clud --version` startup. Windows and macOS
+# keep the in-process cpal/rodio path below.
 # `whisper-rs` is gated below — see the target-specific stanza for the
 # aarch64-pc-windows-msvc carve-out.
-cpal = "0.16"
-rodio = "0.21"
 # Issue #13: model auto-downloader needs a per-OS cache dir resolver,
 # a small blocking HTTP client, and a hash verifier. `ureq` is sync and
 # avoids dragging in a tokio runtime just to fetch one file.
@@ -61,6 +57,10 @@ path = "tests/pty_behavior.rs"
 # (see `voice.rs`).
 [target.'cfg(not(all(target_arch = "aarch64", target_os = "windows")))'.dependencies]
 whisper-rs = "0.16"
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+cpal = "0.16"
+rodio = { version = "0.21", default-features = false, features = ["playback"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/clud-bin/src/voice.rs
+++ b/crates/clud-bin/src/voice.rs
@@ -3,8 +3,8 @@
 //! Flow:
 //!   1. `F3Observer` in [`crate::session`] watches the byte stream coming
 //!      from the user's terminal and reports F3 press/release events.
-//!   2. [`VoiceMode::on_f3_press`] starts a [`cpal`] mic stream and plays a
-//!      `ding` cue via [`rodio`].
+//!   2. [`VoiceMode::on_f3_press`] starts microphone capture and plays a
+//!      start cue.
 //!   3. Release (real kitty-protocol release, VAD-silence auto-stop, or the
 //!      30-second hard cap — whichever fires first) calls
 //!      [`VoiceMode::on_f3_release`], which plays a `dong` cue and hands
@@ -25,17 +25,25 @@ mod enabled {
     use std::io::{self, Write};
     use std::path::PathBuf;
     use std::sync::{mpsc, Arc, Mutex};
+    #[cfg(not(target_os = "linux"))]
     use std::time::Duration;
 
+    #[cfg(target_os = "linux")]
+    use std::io::Read;
+    #[cfg(target_os = "linux")]
+    use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
+
+    #[cfg(not(target_os = "linux"))]
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    #[cfg(not(target_os = "linux"))]
     use rodio::{OutputStreamBuilder, Sink, Source};
     use running_process_core::pty::NativePtyProcess;
     // Issue #13 follow-up: whisper-rs-sys does not build on aarch64-pc-windows-msvc.
     // The dep is target-gated in Cargo.toml; voice transcription is stubbed
     // on that one platform via `WhisperContextHandle = ()` plus an error
     // return from `transcribe_audio` (model loading + Whisper calls are
-    // bypassed there). All other surfaces (cpal mic capture, rodio cue
-    // playback, F3 state machine, downsampling) ship unchanged.
+    // bypassed there). All other surfaces (mic capture, cue playback,
+    // F3 state machine, downsampling) ship unchanged.
     #[cfg(not(all(target_arch = "aarch64", target_os = "windows")))]
     use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
@@ -307,7 +315,10 @@ mod enabled {
         /// [`ActiveRecording::synthetic`] for tests or for the
         /// `CLUD_VOICE_TEST_TRANSCRIPT` bypass — no mic is owned, so
         /// there is nothing to stop or drop. `Some` for real captures.
+        #[cfg(not(target_os = "linux"))]
         stream: Option<cpal::Stream>,
+        #[cfg(target_os = "linux")]
+        capture: Option<LinuxCapture>,
         /// Number of source-sample frames the recording had collected the
         /// last time the VAD checker ran. The tail-silence detector
         /// inspects only the new slice since the previous check.
@@ -318,6 +329,7 @@ mod enabled {
     }
 
     impl ActiveRecording {
+        #[cfg(not(target_os = "linux"))]
         fn start() -> Result<Self, String> {
             let host = cpal::default_host();
             let device = host
@@ -364,6 +376,22 @@ mod enabled {
             })
         }
 
+        #[cfg(target_os = "linux")]
+        fn start() -> Result<Self, String> {
+            let samples = Arc::new(Mutex::new(Vec::new()));
+            let capture = LinuxCapture::start(Arc::clone(&samples))?;
+
+            Ok(Self {
+                started_at: std::time::Instant::now(),
+                sample_rate: TARGET_SAMPLE_RATE,
+                channels: 1,
+                samples,
+                capture: Some(capture),
+                last_vad_offset: 0,
+                last_speech_at: None,
+            })
+        }
+
         /// Construct a recording with no real microphone stream. Used by
         /// the `CLUD_VOICE_TEST_TRANSCRIPT` bypass (so the integration
         /// test on CI runners with no audio device still exercises
@@ -397,7 +425,10 @@ mod enabled {
                 sample_rate,
                 channels: 1,
                 samples: Arc::new(Mutex::new(dummy)),
+                #[cfg(not(target_os = "linux"))]
                 stream: None,
+                #[cfg(target_os = "linux")]
+                capture: None,
                 last_vad_offset: 0,
                 last_speech_at: None,
             }
@@ -451,12 +482,12 @@ mod enabled {
             silence_ms >= VAD_SILENCE_TAIL_MS
         }
 
-        fn finish(self) -> Result<Vec<f32>, String> {
+        fn finish(mut self) -> Result<Vec<f32>, String> {
             let elapsed_ms = self.started_at.elapsed().as_millis();
-            // Drop the cpal stream first so its callbacks can't append
-            // more frames while we drain. For synthetic recordings the
-            // stream is `None`, so this is a no-op.
-            drop(self.stream);
+            // Stop the capture backend first so callbacks/readers can't
+            // append more frames while we drain. Synthetic recordings have
+            // no backend, so this is a no-op.
+            self.stop_capture_backend()?;
 
             let samples = match Arc::try_unwrap(self.samples) {
                 Ok(samples) => samples
@@ -478,8 +509,23 @@ mod enabled {
             }
             Ok(resampled)
         }
+
+        #[cfg(not(target_os = "linux"))]
+        fn stop_capture_backend(&mut self) -> Result<(), String> {
+            drop(self.stream.take());
+            Ok(())
+        }
+
+        #[cfg(target_os = "linux")]
+        fn stop_capture_backend(&mut self) -> Result<(), String> {
+            if let Some(capture) = self.capture.take() {
+                capture.stop()?;
+            }
+            Ok(())
+        }
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn build_input_stream_f32(
         device: &cpal::Device,
         config: &cpal::StreamConfig,
@@ -500,6 +546,7 @@ mod enabled {
             .map_err(|err| format!("failed to build microphone stream: {err}"))
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn build_input_stream_i16(
         device: &cpal::Device,
         config: &cpal::StreamConfig,
@@ -520,6 +567,7 @@ mod enabled {
             .map_err(|err| format!("failed to build microphone stream: {err}"))
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn build_input_stream_u16(
         device: &cpal::Device,
         config: &cpal::StreamConfig,
@@ -541,6 +589,142 @@ mod enabled {
                 None,
             )
             .map_err(|err| format!("failed to build microphone stream: {err}"))
+    }
+
+    #[cfg(target_os = "linux")]
+    struct LinuxCapture {
+        child: Child,
+        stderr: Option<ChildStderr>,
+        reader: Option<std::thread::JoinHandle<Result<(), String>>>,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl LinuxCapture {
+        fn start(samples: Arc<Mutex<Vec<f32>>>) -> Result<Self, String> {
+            let mut child = Command::new("arecord")
+                .args(["-q", "-t", "raw", "-f", "S16_LE", "-c", "1", "-r", "16000"])
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .map_err(|err| {
+                    if err.kind() == io::ErrorKind::NotFound {
+                        "Linux voice capture requires `arecord` (install alsa-utils)".to_string()
+                    } else {
+                        format!("failed to start Linux voice capture (`arecord`): {err}")
+                    }
+                })?;
+
+            let Some(stdout) = child.stdout.take() else {
+                let _ = child.kill();
+                return Err("failed to capture arecord stdout".to_string());
+            };
+            let stderr = child.stderr.take();
+            let reader = std::thread::spawn(move || read_arecord_stdout(stdout, samples));
+
+            Ok(Self {
+                child,
+                stderr,
+                reader: Some(reader),
+            })
+        }
+
+        fn stop(mut self) -> Result<(), String> {
+            let status = match self
+                .child
+                .try_wait()
+                .map_err(|err| format!("failed to inspect arecord process: {err}"))?
+            {
+                Some(status) => status,
+                None => {
+                    if let Err(err) = self.child.kill() {
+                        if err.kind() != io::ErrorKind::InvalidInput {
+                            return Err(format!("failed to stop arecord process: {err}"));
+                        }
+                    }
+                    self.child
+                        .wait()
+                        .map_err(|err| format!("failed to wait for arecord process: {err}"))?
+                }
+            };
+
+            let reader_result = self
+                .reader
+                .take()
+                .expect("arecord reader thread exists")
+                .join()
+                .map_err(|_| "arecord reader thread panicked".to_string())?;
+
+            let mut stderr_text = String::new();
+            if let Some(mut stderr) = self.stderr.take() {
+                let _ = stderr.read_to_string(&mut stderr_text);
+            }
+
+            reader_result?;
+
+            if status.success() || exit_status_was_signal(&status) {
+                return Ok(());
+            }
+
+            let detail = stderr_text.trim();
+            if detail.is_empty() {
+                Err(format!("microphone capture command failed with {status}"))
+            } else {
+                Err(format!("microphone capture command failed: {detail}"))
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn read_arecord_stdout(
+        mut stdout: ChildStdout,
+        samples: Arc<Mutex<Vec<f32>>>,
+    ) -> Result<(), String> {
+        let mut buffer = [0u8; 8192];
+        let mut carry: Option<u8> = None;
+
+        loop {
+            let n = stdout
+                .read(&mut buffer)
+                .map_err(|err| format!("failed to read microphone samples: {err}"))?;
+            if n == 0 {
+                break;
+            }
+
+            let mut start = 0usize;
+            let mut converted: Vec<f32> = Vec::with_capacity((n + 1) / 2);
+            if let Some(lo) = carry.take() {
+                let sample = i16::from_le_bytes([lo, buffer[0]]);
+                converted.push(sample as f32 / i16::MAX as f32);
+                start = 1;
+            }
+
+            let chunk = &buffer[start..n];
+            let even_len = chunk.len() & !1usize;
+            for bytes in chunk[..even_len].chunks_exact(2) {
+                let sample = i16::from_le_bytes([bytes[0], bytes[1]]);
+                converted.push(sample as f32 / i16::MAX as f32);
+            }
+            if even_len < chunk.len() {
+                carry = Some(chunk[even_len]);
+            }
+
+            if !converted.is_empty() {
+                samples
+                    .lock()
+                    .map_err(|_| "microphone sample buffer lock poisoned".to_string())?
+                    .extend(converted);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn exit_status_was_signal(status: &std::process::ExitStatus) -> bool {
+        use std::os::unix::process::ExitStatusExt;
+
+        status.signal().is_some()
     }
 
     fn downmix_and_resample(samples: Vec<f32>, channels: u16, sample_rate: u32) -> Vec<f32> {
@@ -751,6 +935,7 @@ mod enabled {
         Stop,
     }
 
+    #[cfg(not(target_os = "linux"))]
     fn play_cue(tone: CueTone) {
         std::thread::spawn(move || {
             let freq_hz = match tone {
@@ -778,6 +963,12 @@ mod enabled {
                 }
             }
         });
+    }
+
+    #[cfg(target_os = "linux")]
+    fn play_cue(_tone: CueTone) {
+        print!("\x07");
+        let _ = io::stdout().flush();
     }
 
     fn missing_model_message() -> String {

--- a/tests/integration/test_trampoline.py
+++ b/tests/integration/test_trampoline.py
@@ -14,27 +14,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [
-    pytest.mark.integration,
-    # The dev wheel maturin produces on Linux baked an auditwheel-style
-    # hashed SONAME (`libasound-a5b8423c.so.2`) into the clud binary's
-    # DT_NEEDED entries without bundling the renamed `.so` next to it.
-    # When pip installs the wheel into a fresh venv, ld.so cannot find
-    # the hashed name and every invocation aborts with exit code 127.
-    # The trampoline behaviour these tests verify (rename + copy-back
-    # to dodge the Windows file-lock on running executables) is itself
-    # Windows-only, so the Linux coverage here was always best-effort.
-    # Skip until the wheel-build pipeline either bundles the renamed
-    # ALSA lib or stops rewriting the SONAME for dev builds.
-    pytest.mark.skipif(
-        sys.platform.startswith("linux"),
-        reason=(
-            "dev wheel on Linux has unbundled hashed libasound SONAME — "
-            "clud exits 127 at load time inside a fresh venv (see PR "
-            "linked from this commit). Trampoline itself is Windows-only."
-        ),
-    ),
-]
+pytestmark = [pytest.mark.integration]
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -9,7 +9,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from functools import cache
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -90,40 +89,9 @@ CLUD = _clud_binary()
 PROJECT_VERSION = _project_version()
 
 
-@cache
-def _linux_runtime_library_dirs(source: Path) -> tuple[Path, ...]:
-    """Return Linux library dirs needed after copying the clud executable."""
-    dirs = [source.parent, source.parent / "deps", source.parent / "clud.libs"]
-    for root in (ROOT / ".venv", ROOT / "target"):
-        if root.exists():
-            dirs.extend(path.parent for path in root.rglob("libasound*.so*") if path.is_file())
-
-    seen: set[Path] = set()
-    existing_dirs: list[Path] = []
-    for path in dirs:
-        resolved = path.resolve()
-        if resolved.is_dir() and resolved not in seen:
-            seen.add(resolved)
-            existing_dirs.append(resolved)
-    return tuple(existing_dirs)
-
-
-def copied_clud_env(source: Path) -> dict[str, str]:
-    """Return an environment that can launch a copied clud binary.
-
-    Linux CI can build `clud` with a hashed ALSA SONAME such as
-    `libasound-a5b8423c.so.2` in a wheel `clud.libs` directory. The smoke tests
-    copy only the executable into a tempdir, so preserve the discovered runtime
-    library directories in `LD_LIBRARY_PATH` for the dynamic loader.
-    """
-    env = os.environ.copy()
-    if sys.platform.startswith("linux"):
-        existing = env.get("LD_LIBRARY_PATH")
-        parts = [str(path) for path in _linux_runtime_library_dirs(source)]
-        if existing:
-            parts.append(existing)
-        env["LD_LIBRARY_PATH"] = os.pathsep.join(parts)
-    return env
+def copied_clud_env(_source: Path) -> dict[str, str]:
+    """Return an environment that can launch a copied clud binary."""
+    return os.environ.copy()
 
 
 def _run(*args: str, input_data: str | None = None) -> subprocess.CompletedProcess[str]:
@@ -154,6 +122,23 @@ def test_version() -> None:
     result = _run("--version")
     assert result.returncode == 0
     assert result.stdout.strip() == f"clud {PROJECT_VERSION}"
+
+
+def test_linux_binary_does_not_require_libasound_at_startup() -> None:
+    if not sys.platform.startswith("linux"):
+        return
+    ldd = shutil.which("ldd")
+    if ldd is None:
+        return
+
+    result = subprocess.run(
+        [ldd, CLUD],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "libasound" not in (result.stdout + result.stderr).lower()
 
 
 def test_dry_run_prompt() -> None:


### PR DESCRIPTION
## Summary
- Move Linux voice capture to an on-demand `arecord` helper so `clud` no longer links `cpal`/`rodio`/ALSA at startup
- Remove Linux `libasound2-dev` CI setup and the old `LD_LIBRARY_PATH` test workaround
- Add a Linux startup regression test that checks the binary does not require `libasound`

## Verification
- `cargo fmt --check`
- `uv run --no-editable ruff check tests/test_hello.py tests/integration/test_trampoline.py`
- `cargo tree -p clud --target x86_64-unknown-linux-gnu -i alsa`
- `cargo tree -p clud --target x86_64-unknown-linux-gnu -i cpal`
- `cargo tree -p clud --target x86_64-unknown-linux-gnu -i rodio`

Note: Full local Windows `cargo check`/pytest smoke tests are blocked in this checkout by the existing vendored `whisper-rs` Windows build issue and one clean-target pytest build timeout; the Linux dependency-tree checks cover the libasound startup regression directly.