### PR TITLE
Run CI workflows on push only

### DIFF
--- a/.github/workflows/linux-arm-build.yml
+++ b/.github/workflows/linux-arm-build.yml
@@ -1,8 +1,7 @@
 name: Linux ARM Build
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/linux-arm-integration-test.yml
+++ b/.github/workflows/linux-arm-integration-test.yml
@@ -1,8 +1,7 @@
 name: Linux ARM Integration Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml

--- a/.github/workflows/linux-arm-lint.yml
+++ b/.github/workflows/linux-arm-lint.yml
@@ -1,8 +1,7 @@
 name: Linux ARM Lint
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/linux-arm-unit-test.yml
+++ b/.github/workflows/linux-arm-unit-test.yml
@@ -1,8 +1,6 @@
 name: Linux ARM Unit Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/linux-x86-build.yml
+++ b/.github/workflows/linux-x86-build.yml
@@ -1,8 +1,7 @@
 name: Linux x86 Build
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/linux-x86-integration-test.yml
+++ b/.github/workflows/linux-x86-integration-test.yml
@@ -1,8 +1,7 @@
 name: Linux x86 Integration Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml

--- a/.github/workflows/linux-x86-lint.yml
+++ b/.github/workflows/linux-x86-lint.yml
@@ -1,8 +1,7 @@
 name: Linux x86 Lint
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/linux-x86-unit-test.yml
+++ b/.github/workflows/linux-x86-unit-test.yml
@@ -1,8 +1,6 @@
 name: Linux x86 Unit Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/macos-arm-build.yml
+++ b/.github/workflows/macos-arm-build.yml
@@ -1,8 +1,7 @@
 name: macOS ARM Build
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/macos-arm-integration-test.yml
+++ b/.github/workflows/macos-arm-integration-test.yml
@@ -1,8 +1,7 @@
 name: macOS ARM Integration Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml

--- a/.github/workflows/macos-arm-lint.yml
+++ b/.github/workflows/macos-arm-lint.yml
@@ -1,8 +1,7 @@
 name: macOS ARM Lint
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/macos-arm-unit-test.yml
+++ b/.github/workflows/macos-arm-unit-test.yml
@@ -1,8 +1,6 @@
 name: macOS ARM Unit Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/macos-x86-build.yml
+++ b/.github/workflows/macos-x86-build.yml
@@ -1,8 +1,7 @@
 name: macOS x86 Build
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/macos-x86-integration-test.yml
+++ b/.github/workflows/macos-x86-integration-test.yml
@@ -1,8 +1,7 @@
 name: macOS x86 Integration Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml

--- a/.github/workflows/macos-x86-lint.yml
+++ b/.github/workflows/macos-x86-lint.yml
@@ -1,8 +1,7 @@
 name: macOS x86 Lint
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/macos-x86-unit-test.yml
+++ b/.github/workflows/macos-x86-unit-test.yml
@@ -1,8 +1,6 @@
 name: macOS x86 Unit Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/windows-arm-build.yml
+++ b/.github/workflows/windows-arm-build.yml
@@ -1,8 +1,7 @@
 name: Windows ARM Build
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/windows-arm-integration-test.yml
+++ b/.github/workflows/windows-arm-integration-test.yml
@@ -1,8 +1,7 @@
 name: Windows ARM Integration Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml

--- a/.github/workflows/windows-arm-lint.yml
+++ b/.github/workflows/windows-arm-lint.yml
@@ -1,8 +1,7 @@
 name: Windows ARM Lint
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/windows-arm-unit-test.yml
+++ b/.github/workflows/windows-arm-unit-test.yml
@@ -1,8 +1,6 @@
 name: Windows ARM Unit Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/windows-x86-build.yml
+++ b/.github/workflows/windows-x86-build.yml
@@ -1,8 +1,7 @@
 name: Windows x86 Build
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/windows-x86-integration-test.yml
+++ b/.github/workflows/windows-x86-integration-test.yml
@@ -1,8 +1,7 @@
 name: Windows x86 Integration Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml

--- a/.github/workflows/windows-x86-lint.yml
+++ b/.github/workflows/windows-x86-lint.yml
@@ -1,8 +1,7 @@
 name: Windows x86 Lint
 on:
   push:
-    branches: [rust, main]
-  pull_request:
+    branches: [main]
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/windows-x86-unit-test.yml
+++ b/.github/workflows/windows-x86-unit-test.yml
@@ -1,8 +1,6 @@
 name: Windows x86 Unit Test
 on:
   push:
-    branches: [rust, main]
-  pull_request:
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml


### PR DESCRIPTION
## Summary
- remove pull_request triggers from top-level CI workflows
- run build, lint, and integration workflows only on pushes to main
- keep platform unit-test workflows on all branch pushes

## Verification
- rg -n "pull_request|branches: \[rust, main\]" .github/workflows (no matches)
- git diff --check
- inspected trigger matrix: build/lint/integration = main, unit-test = all
