### PR TITLE
Use NativeProcess for Linux audio capture

### DIFF
--- a/crates/clud-bin/src/voice.rs
+++ b/crates/clud-bin/src/voice.rs
@@ -22,22 +22,29 @@
 
 mod enabled {
     use std::env;
+    #[cfg(target_os = "linux")]
+    use std::fs;
     use std::io::{self, Write};
     use std::path::PathBuf;
     use std::sync::{mpsc, Arc, Mutex};
-    #[cfg(not(target_os = "linux"))]
     use std::time::Duration;
 
     #[cfg(target_os = "linux")]
     use std::io::Read;
     #[cfg(target_os = "linux")]
-    use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    #[cfg(target_os = "linux")]
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[cfg(not(target_os = "linux"))]
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
     #[cfg(not(target_os = "linux"))]
     use rodio::{OutputStreamBuilder, Sink, Source};
     use running_process_core::pty::NativePtyProcess;
+    #[cfg(target_os = "linux")]
+    use running_process_core::{
+        CommandSpec, Containment, NativeProcess, ProcessConfig, ProcessError, StderrMode, StdinMode,
+    };
     // Issue #13 follow-up: whisper-rs-sys does not build on aarch64-pc-windows-msvc.
     // The dep is target-gated in Cargo.toml; voice transcription is stubbed
     // on that one platform via `WhisperContextHandle = ()` plus an error
@@ -593,61 +600,82 @@ mod enabled {
 
     #[cfg(target_os = "linux")]
     struct LinuxCapture {
-        child: Child,
-        stderr: Option<ChildStderr>,
+        process: NativeProcess,
+        capture_dir: PathBuf,
+        reader_done: Arc<AtomicBool>,
         reader: Option<std::thread::JoinHandle<Result<(), String>>>,
     }
 
     #[cfg(target_os = "linux")]
     impl LinuxCapture {
         fn start(samples: Arc<Mutex<Vec<f32>>>) -> Result<Self, String> {
-            let mut child = Command::new("arecord")
-                .args(["-q", "-t", "raw", "-f", "S16_LE", "-c", "1", "-r", "16000"])
-                .stdin(Stdio::null())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .map_err(|err| {
-                    if err.kind() == io::ErrorKind::NotFound {
-                        "Linux voice capture requires `arecord` (install alsa-utils)".to_string()
-                    } else {
-                        format!("failed to start Linux voice capture (`arecord`): {err}")
-                    }
-                })?;
+            let (capture_dir, sample_path) = create_arecord_output_path()?;
+            let process = NativeProcess::new(ProcessConfig {
+                command: CommandSpec::Argv(vec![
+                    "arecord".to_string(),
+                    "-q".to_string(),
+                    "-t".to_string(),
+                    "raw".to_string(),
+                    "-f".to_string(),
+                    "S16_LE".to_string(),
+                    "-c".to_string(),
+                    "1".to_string(),
+                    "-r".to_string(),
+                    "16000".to_string(),
+                    sample_path.to_string_lossy().into_owned(),
+                ]),
+                cwd: None,
+                env: None,
+                capture: true,
+                stderr_mode: StderrMode::Pipe,
+                creationflags: None,
+                create_process_group: false,
+                stdin_mode: StdinMode::Null,
+                nice: None,
+                containment: Some(Containment::Contained),
+            });
 
-            let Some(stdout) = child.stdout.take() else {
-                let _ = child.kill();
-                return Err("failed to capture arecord stdout".to_string());
+            if let Err(err) = process.start() {
+                let _ = fs::remove_dir_all(&capture_dir);
+                return Err(match err {
+                    ProcessError::Spawn(err) if err.kind() == io::ErrorKind::NotFound => {
+                        "Linux voice capture requires `arecord` (install alsa-utils)".to_string()
+                    }
+                    other => format!("failed to start Linux voice capture (`arecord`): {other}"),
+                });
             };
-            let stderr = child.stderr.take();
-            let reader = std::thread::spawn(move || read_arecord_stdout(stdout, samples));
+
+            let reader_done = Arc::new(AtomicBool::new(false));
+            let reader = {
+                let reader_done = Arc::clone(&reader_done);
+                std::thread::spawn(move || read_arecord_file(sample_path, reader_done, samples))
+            };
 
             Ok(Self {
-                child,
-                stderr,
+                process,
+                capture_dir,
+                reader_done,
                 reader: Some(reader),
             })
         }
 
         fn stop(mut self) -> Result<(), String> {
-            let status = match self
-                .child
-                .try_wait()
+            if self
+                .process
+                .poll()
                 .map_err(|err| format!("failed to inspect arecord process: {err}"))?
+                .is_none()
             {
-                Some(status) => status,
-                None => {
-                    if let Err(err) = self.child.kill() {
-                        if err.kind() != io::ErrorKind::InvalidInput {
-                            return Err(format!("failed to stop arecord process: {err}"));
-                        }
-                    }
-                    self.child
-                        .wait()
-                        .map_err(|err| format!("failed to wait for arecord process: {err}"))?
-                }
-            };
+                self.process
+                    .kill()
+                    .map_err(|err| format!("failed to stop arecord process: {err}"))?;
+            }
+            let exit_code = self
+                .process
+                .wait(Some(Duration::from_secs(2)))
+                .map_err(|err| format!("failed to wait for arecord process: {err}"))?;
 
+            self.reader_done.store(true, Ordering::Release);
             let reader_result = self
                 .reader
                 .take()
@@ -655,20 +683,20 @@ mod enabled {
                 .join()
                 .map_err(|_| "arecord reader thread panicked".to_string())?;
 
-            let mut stderr_text = String::new();
-            if let Some(mut stderr) = self.stderr.take() {
-                let _ = stderr.read_to_string(&mut stderr_text);
-            }
+            let stderr_text = captured_stderr_text(&self.process);
+            let _ = fs::remove_dir_all(&self.capture_dir);
 
             reader_result?;
 
-            if status.success() || exit_status_was_signal(&status) {
+            if exit_code == 0 || exit_code < 0 {
                 return Ok(());
             }
 
             let detail = stderr_text.trim();
             if detail.is_empty() {
-                Err(format!("microphone capture command failed with {status}"))
+                Err(format!(
+                    "microphone capture command failed with exit code {exit_code}"
+                ))
             } else {
                 Err(format!("microphone capture command failed: {detail}"))
             }
@@ -676,55 +704,125 @@ mod enabled {
     }
 
     #[cfg(target_os = "linux")]
-    fn read_arecord_stdout(
-        mut stdout: ChildStdout,
+    fn create_arecord_output_path() -> Result<(PathBuf, PathBuf), String> {
+        let base = env::temp_dir();
+        let pid = std::process::id();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        for attempt in 0..32_u8 {
+            let dir = base.join(format!("clud-arecord-{pid}-{nonce}-{attempt}"));
+            match fs::create_dir(&dir) {
+                Ok(()) => {
+                    let sample_path = dir.join("capture.raw");
+                    return Ok((dir, sample_path));
+                }
+                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(err) => {
+                    return Err(format!(
+                        "failed to create temporary audio capture directory: {err}"
+                    ));
+                }
+            }
+        }
+
+        Err("failed to allocate temporary audio capture path".to_string())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn read_arecord_file(
+        path: PathBuf,
+        done: Arc<AtomicBool>,
         samples: Arc<Mutex<Vec<f32>>>,
     ) -> Result<(), String> {
+        let mut file = loop {
+            match fs::File::open(&path) {
+                Ok(file) => break file,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    if done.load(Ordering::Acquire) {
+                        return Ok(());
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(err) => {
+                    return Err(format!(
+                        "failed to open arecord sample file {}: {err}",
+                        path.display()
+                    ));
+                }
+            }
+        };
+
         let mut buffer = [0u8; 8192];
         let mut carry: Option<u8> = None;
 
         loop {
-            let n = stdout
+            let n = file
                 .read(&mut buffer)
                 .map_err(|err| format!("failed to read microphone samples: {err}"))?;
             if n == 0 {
-                break;
+                if done.load(Ordering::Acquire) {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+                continue;
             }
 
-            let mut start = 0usize;
-            let mut converted: Vec<f32> = Vec::with_capacity((n + 1) / 2);
-            if let Some(lo) = carry.take() {
-                let sample = i16::from_le_bytes([lo, buffer[0]]);
-                converted.push(sample as f32 / i16::MAX as f32);
-                start = 1;
-            }
-
-            let chunk = &buffer[start..n];
-            let even_len = chunk.len() & !1usize;
-            for bytes in chunk[..even_len].chunks_exact(2) {
-                let sample = i16::from_le_bytes([bytes[0], bytes[1]]);
-                converted.push(sample as f32 / i16::MAX as f32);
-            }
-            if even_len < chunk.len() {
-                carry = Some(chunk[even_len]);
-            }
-
-            if !converted.is_empty() {
-                samples
-                    .lock()
-                    .map_err(|_| "microphone sample buffer lock poisoned".to_string())?
-                    .extend(converted);
-            }
+            append_pcm16le_samples(&buffer[..n], &mut carry, &samples)?;
         }
 
         Ok(())
     }
 
     #[cfg(target_os = "linux")]
-    fn exit_status_was_signal(status: &std::process::ExitStatus) -> bool {
-        use std::os::unix::process::ExitStatusExt;
+    fn append_pcm16le_samples(
+        data: &[u8],
+        carry: &mut Option<u8>,
+        samples: &Arc<Mutex<Vec<f32>>>,
+    ) -> Result<(), String> {
+        let mut start = 0usize;
+        let mut converted: Vec<f32> = Vec::with_capacity(data.len().div_ceil(2));
+        if let Some(lo) = carry.take() {
+            if let Some(&hi) = data.first() {
+                let sample = i16::from_le_bytes([lo, hi]);
+                converted.push(sample as f32 / i16::MAX as f32);
+                start = 1;
+            } else {
+                *carry = Some(lo);
+                return Ok(());
+            }
+        }
 
-        status.signal().is_some()
+        let chunk = &data[start..];
+        let even_len = chunk.len() & !1usize;
+        for bytes in chunk[..even_len].chunks_exact(2) {
+            let sample = i16::from_le_bytes([bytes[0], bytes[1]]);
+            converted.push(sample as f32 / i16::MAX as f32);
+        }
+        if even_len < chunk.len() {
+            *carry = Some(chunk[even_len]);
+        }
+
+        if !converted.is_empty() {
+            samples
+                .lock()
+                .map_err(|_| "microphone sample buffer lock poisoned".to_string())?
+                .extend(converted);
+        }
+
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn captured_stderr_text(process: &NativeProcess) -> String {
+        process
+            .captured_stderr()
+            .into_iter()
+            .map(|line| String::from_utf8_lossy(&line).into_owned())
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     fn downmix_and_resample(samples: Vec<f32>, channels: u16, sample_rate: u32) -> Vec<f32> {


### PR DESCRIPTION
## Summary
- replace Linux voice capture's direct std::process arecord spawn with running_process_core::NativeProcess
- keep raw PCM out of NativeProcess's line-oriented stdout capture by having arecord write to a private temp raw file
- poll that raw file while recording so Linux VAD still receives live samples, and preserve graceful arecord error handling

## Verification
- uv run --no-editable python ci/banned_imports.py
- cargo fmt --check
- uv run --no-editable -m ci.lint
- cargo check -p clud
- git diff --check

Note: local Linux target check could not run before installing targets because rustc reported x86_64-unknown-linux-gnu was not installed on this Windows host.
