### PR TITLE
fix(hooks): gate parity warnings on codex mode

### DIFF
--- a/crates/clud-bin/src/hook_health.rs
+++ b/crates/clud-bin/src/hook_health.rs
@@ -168,6 +168,9 @@ pub fn should_check_launch(args: &Args) -> bool {
     if args.fix_hooks || args.clean_worktrees {
         return false;
     }
+    if !args.codex {
+        return false;
+    }
     matches!(
         args.command,
         None | Some(CliCommand::Loop { .. })


### PR DESCRIPTION
## Summary
- Only emit Claude/Codex `PreToolUse` hook parity warnings when `--codex` is active
- Default Claude launches (and explicit `--claude`) no longer surface codex-specific config issues

## Why
The launch-time hook parity check fires for any user whose `.claude/` and `.codex/` hook configs differ — but users running the default Claude backend don't care about codex hook drift. Gating on `args.codex` keeps the warning useful for codex users without spamming everyone else. `--fix-hooks` still inspects both frontends.

## Test plan
- [x] `soldr cargo test -p clud --lib hook_health` (8 passed)
- [x] `soldr cargo clippy -p clud --lib -- -D warnings`
- [ ] Manual: `clud --dry-run` in a repo with mismatched hooks — no warning
- [ ] Manual: `clud --codex --dry-run` in the same repo — warning emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)