### PR TITLE
Simplify Linux audio exit-code check

### DIFF
--- a/crates/clud-bin/src/voice.rs
+++ b/crates/clud-bin/src/voice.rs
@@ -688,7 +688,7 @@ mod enabled {
 
             reader_result?;
 
-            if exit_code == 0 || exit_code < 0 {
+            if exit_code <= 0 {
                 return Ok(());
             }
 


### PR DESCRIPTION
## Summary
- fix Linux clippy's double-comparison warning in the arecord exit-code check

## Verification
- cargo fmt --check
- uv run --no-editable python ci/banned_imports.py
- cargo check -p clud
- git diff --check
