### PR TITLE
ci: bound memory, strip debuginfo, force mold on Linux

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -31,6 +31,15 @@ jobs:
       # vendored C++ build sees the modern SDK target on every macOS
       # job (no-op on Linux/Windows).
       MACOSX_DEPLOYMENT_TARGET: "10.15"
+      # Strip DWARF from C/C++ deps (whisper.cpp, bundled sqlite, bindgen
+      # targets) to lower per-process RSS during compile. Rust debuginfo is
+      # killed in Cargo.toml [profile.dev]/[profile.release].
+      CFLAGS: "-g0"
+      CXXFLAGS: "-g0"
+      # Future-proof: when cargo is routed through soldr (issue #285) this
+      # picks mold on Linux / lld elsewhere. No-op for the current direct-
+      # cargo path; mold is also forced via RUSTFLAGS below on Linux.
+      SOLDR_LINKER: "fast"
     steps:
       - uses: actions/checkout@v4
 
@@ -65,11 +74,32 @@ jobs:
           cache: true
           build-cache-mode: thin
 
+      - name: Install mold linker (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mold
+          # Force mold even when cargo isn't routed through soldr. Halves
+          # peak linker RSS vs. BFD/gold on clud's release link.
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS:-}" >> "$GITHUB_ENV"
+
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Build wheel (${{ inputs.build-mode || 'dev' }})
-        run: uv run --no-editable -m ci.build_wheel --${{ inputs.build-mode || 'dev' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Defensive RLIMIT_AS cap (~13 GB of 14-16 GB runner). When the
+          # build genuinely runs out of memory, exceeding this kills the
+          # offending process with a clean mmap/alloc failure instead of
+          # an unexplained `137` from the kernel OOM killer.
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            ulimit -v 13000000
+          fi
+          uv run --no-editable -m ci.build_wheel --${{ inputs.build-mode || 'dev' }}
 
       - name: Build sdist
         if: ${{ inputs.include-sdist }}
@@ -86,6 +116,25 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: dist/*
           if-no-files-found: error
+
+      - name: Diagnose Linux build failure
+        if: ${{ failure() && runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          set +e
+          echo "::group::OOM / killed-process scan"
+          (sudo dmesg 2>/dev/null || dmesg 2>/dev/null) | grep -iE 'killed|oom|out of memory|signal 9' | tail -50
+          [ $? -ne 0 ] && echo "(no OOM/kill messages found)"
+          echo "::endgroup::"
+          echo "::group::Last 100 dmesg lines"
+          (sudo dmesg 2>/dev/null || dmesg 2>/dev/null) | tail -100
+          echo "::endgroup::"
+          echo "::group::Memory snapshot"
+          free -h
+          echo "::endgroup::"
+          echo "::group::Disk snapshot"
+          df -h
+          echo "::endgroup::"
 
       - name: Upload failure logs
         if: ${{ failure() }}

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -20,6 +20,9 @@ jobs:
       # vendored C++ build sees the modern SDK target on every macOS
       # job (no-op on Linux/Windows).
       MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CFLAGS: "-g0"
+      CXXFLAGS: "-g0"
+      SOLDR_LINKER: "fast"
     steps:
       - uses: actions/checkout@v4
 
@@ -55,14 +58,54 @@ jobs:
           cache: true
           build-cache-mode: thin
 
+      - name: Install mold linker (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mold
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS:-}" >> "$GITHUB_ENV"
+
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Dev build
-        run: uv run --no-editable -m ci.build_wheel --dev
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            ulimit -v 13000000
+          fi
+          uv run --no-editable -m ci.build_wheel --dev
 
       - name: Integration Tests
-        run: uv run --no-editable -m ci.test --integration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            ulimit -v 13000000
+          fi
+          uv run --no-editable -m ci.test --integration
+
+      - name: Diagnose Linux build failure
+        if: ${{ failure() && runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          set +e
+          echo "::group::OOM / killed-process scan"
+          (sudo dmesg 2>/dev/null || dmesg 2>/dev/null) | grep -iE 'killed|oom|out of memory|signal 9' | tail -50
+          [ $? -ne 0 ] && echo "(no OOM/kill messages found)"
+          echo "::endgroup::"
+          echo "::group::Last 100 dmesg lines"
+          (sudo dmesg 2>/dev/null || dmesg 2>/dev/null) | tail -100
+          echo "::endgroup::"
+          echo "::group::Memory snapshot"
+          free -h
+          echo "::endgroup::"
+          echo "::group::Disk snapshot"
+          df -h
+          echo "::endgroup::"
 
       - name: Upload failure logs
         if: ${{ failure() }}

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -19,6 +19,9 @@ jobs:
       # clippy compiles the same C++ source successfully (no-op on
       # Linux/Windows).
       MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CFLAGS: "-g0"
+      CXXFLAGS: "-g0"
+      SOLDR_LINKER: "fast"
     steps:
       - uses: actions/checkout@v4
 
@@ -53,11 +56,45 @@ jobs:
           cache: true
           build-cache-mode: thin
 
+      - name: Install mold linker (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mold
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS:-}" >> "$GITHUB_ENV"
+
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Lint
-        run: uv run --no-editable -m ci.lint
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            ulimit -v 13000000
+          fi
+          uv run --no-editable -m ci.lint
+
+      - name: Diagnose Linux build failure
+        if: ${{ failure() && runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          set +e
+          echo "::group::OOM / killed-process scan"
+          (sudo dmesg 2>/dev/null || dmesg 2>/dev/null) | grep -iE 'killed|oom|out of memory|signal 9' | tail -50
+          [ $? -ne 0 ] && echo "(no OOM/kill messages found)"
+          echo "::endgroup::"
+          echo "::group::Last 100 dmesg lines"
+          (sudo dmesg 2>/dev/null || dmesg 2>/dev/null) | tail -100
+          echo "::endgroup::"
+          echo "::group::Memory snapshot"
+          free -h
+          echo "::endgroup::"
+          echo "::group::Disk snapshot"
+          df -h
+          echo "::endgroup::"
 
       - name: Upload failure logs
         if: ${{ failure() }}

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -19,6 +19,9 @@ jobs:
       # vendored C++ build sees the modern SDK target on every macOS
       # job (no-op on Linux/Windows).
       MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CFLAGS: "-g0"
+      CXXFLAGS: "-g0"
+      SOLDR_LINKER: "fast"
     steps:
       - uses: actions/checkout@v4
 
@@ -54,14 +57,54 @@ jobs:
           cache: true
           build-cache-mode: thin
 
+      - name: Install mold linker (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends mold
+          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS:-}" >> "$GITHUB_ENV"
+
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Dev build
-        run: uv run --no-editable -m ci.build_wheel --dev
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            ulimit -v 13000000
+          fi
+          uv run --no-editable -m ci.build_wheel --dev
 
       - name: Unit Tests
-        run: uv run --no-editable -m ci.test
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            ulimit -v 13000000
+          fi
+          uv run --no-editable -m ci.test
+
+      - name: Diagnose Linux build failure
+        if: ${{ failure() && runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          set +e
+          echo "::group::OOM / killed-process scan"
+          (sudo dmesg 2>/dev/null || dmesg 2>/dev/null) | grep -iE 'killed|oom|out of memory|signal 9' | tail -50
+          [ $? -ne 0 ] && echo "(no OOM/kill messages found)"
+          echo "::endgroup::"
+          echo "::group::Last 100 dmesg lines"
+          (sudo dmesg 2>/dev/null || dmesg 2>/dev/null) | tail -100
+          echo "::endgroup::"
+          echo "::group::Memory snapshot"
+          free -h
+          echo "::endgroup::"
+          echo "::group::Disk snapshot"
+          df -h
+          echo "::endgroup::"
 
       - name: Upload failure logs
         if: ${{ failure() }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ license = "BSD-3-Clause"
 repository = "https://github.com/zackees/clud"
 homepage = "https://github.com/zackees/clud"
 
+[profile.dev]
+debug = 0
+
 [profile.release]
-debug = "line-tables-only"
-split-debuginfo = "packed"
-strip = "none"
+debug = 0
 
 [patch.crates-io]
 whisper-rs = { path = "vendor/whisper-rs" }


### PR DESCRIPTION
## Summary

Two PR #114-era CI failures motivated this:
- Linux ARM lint exited with `137` (SIGKILL) only 3 seconds into cargo, immediately after `soldr: zccache start reported an unresponsive daemon`. Could be OOM, could be zccache daemon misbehavior — but the bare `137` gives nothing to debug.
- Linux x86 integration exited `1` with no further output after the same zccache message.

This PR doesn't fix soldr/zccache — that work is upstream — but it (a) lowers peak memory so the failures are less likely in the first place and (b) makes whatever does fail diagnosable.

## What changes

**Workflow templates** (`_build`, `_lint`, `_unit-test`, `_integration-test` — fans out to all 24 platform jobs):
- `CFLAGS=-g0` / `CXXFLAGS=-g0` workflow env — the `cc` crate stops emitting DWARF for whisper-rs-sys / bundled C. Cuts per-process RSS on the heaviest C++ TUs.
- `SOLDR_LINKER=fast` — no-op for the current direct-cargo path (`ci/env.py`'s explicit `cargo_argv`), picks mold/lld when soldr is reintroduced. Tracks soldr #285.
- New Linux-only step installs mold and exports `RUSTFLAGS=-C link-arg=-fuse-ld=mold`. Forces mold even when cargo bypasses soldr. Cuts peak linker RSS ~30–50% vs BFD on clud's release link.
- Each cargo-driving step now runs under `shell: bash` with `ulimit -v 13000000` on Linux (~13 GB of the 14–16 GB runner). Exceeding the cap surfaces as a clean mmap/alloc failure with stderr context instead of an opaque kernel kill.
- New `Diagnose Linux build failure` step (before the existing artifact upload) — dumps `dmesg` OOM/kill markers, `free -h`, and `df -h` inside collapsible `::group::` blocks. Runs only on Linux failures.

**`Cargo.toml`**:
- `[profile.dev] debug = 0` (new) and `[profile.release] debug = 0` (was `line-tables-only`) — no DWARF anywhere. Drops the now-irrelevant `split-debuginfo` / `strip` keys.

## Trade-offs

Panic backtraces lose inline `file:line` for inlined frames. Function names still resolve from the symbol table / unwind tables. Explicit `panic!` / `assert!` sites keep their own `file:line` (baked in at the call site by the macro). Net effect: backtraces still readable, just less detail inside inlined functions.

## Test plan

- [x] `bash lint` passes locally (only Cargo.toml is touched on the local-cargo path; workflow YAML parses validated)
- [ ] First CI run will exercise the new memory bounds + mold install + diagnostics step. Failure mode of interest: if the `ulimit -v 13G` cap fires, we'll see clean allocation-failure stderr from `clang++` / `ld` / `rustc` plus the dmesg/free/df dump — not a bare `137`.
- [ ] Separate PR #124 (redb replaces SQLite) further reduces compile/link memory; this PR is independent and intentionally not blocked on it.