### PR TITLE
fix(dnd): silence clippy::field-reassign-with-default on PROCESSENTRY32W init

### DIFF
--- a/crates/clud-bin/src/dnd/console_drop_target.rs
+++ b/crates/clud-bin/src/dnd/console_drop_target.rs
@@ -870,8 +870,10 @@ mod win {
         };
 
         let mut entries = Vec::new();
-        let mut entry = PROCESSENTRY32W::default();
-        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
 
         // SAFETY: `entry` has the required dwSize field initialized.
         if unsafe { Process32FirstW(snapshot, &mut entry) }.is_ok() {


### PR DESCRIPTION
## Summary
- CI lint job on `main` (run [25867970540](https://github.com/zackees/clud/actions/runs/25867970540/job/76015121872)) failed under Rust 1.94 with `-D warnings` because `PROCESSENTRY32W::default()` was followed by `entry.dwSize = ...` assignment.
- Use struct update syntax (`PROCESSENTRY32W { dwSize: ..., ..Default::default() }`) instead — same behavior, satisfies `clippy::field-reassign-with-default`.

## Test plan
- [x] `bash lint` passes locally on Windows