### PR TITLE
feat(startup): large source file guard (#132)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +283,7 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "dirs",
+ "ignore",
  "libc",
  "redb",
  "rodio",
@@ -691,6 +702,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +842,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -23,6 +23,9 @@ ctrlc = "3"
 # a small blocking HTTP client, and a hash verifier. `ureq` is sync and
 # avoids dragging in a tokio runtime just to fetch one file.
 dirs = "5"
+# Issue #132: gitignore-aware repo walk for the startup large-file guard.
+# Matches the major version ripgrep / fd use; no feature flags needed.
+ignore = "0.4"
 sha2 = "0.10"
 ureq = { version = "2", default-features = false, features = ["tls"] }
 # Issue #73 / #110: embedded KV store for the session and tracked-entry

--- a/crates/clud-bin/src/large_file_guard.rs
+++ b/crates/clud-bin/src/large_file_guard.rs
@@ -1,0 +1,370 @@
+//! Startup-time nudge: warn when the project contains source files large
+//! enough to cause AI agents to get stuck. See zackees/clud#132.
+//!
+//! On launch we walk the project's git root, honoring `.gitignore`,
+//! `.ignore`, hidden-file rules, and global git excludes via the `ignore`
+//! crate's parallel walker. Files whose size is ≥ [`SIZE_THRESHOLD`] and
+//! whose extension is on a small whitelist of source-code languages are
+//! reported to stderr — top [`REPORT_LIMIT`] by size, with a `(N more)`
+//! tail when more qualify.
+//!
+//! The walk hard-stops at [`DEADLINE`] (1 s wall) regardless of progress
+//! so that startup is never blocked by a pathological repo: if the
+//! deadline trips, stderr reports a partial-scan note instead of stalling.
+
+use ignore::{DirEntry, WalkBuilder, WalkState};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// 40 kB ≈ 1000 LOC at clud's measured ~37 bytes/line (see issue #132).
+pub const SIZE_THRESHOLD: u64 = 40 * 1024;
+
+/// Hard wall-clock deadline for the entire walk. Per user requirement
+/// the check stops at 1 s even if files remain unvisited.
+pub const DEADLINE: Duration = Duration::from_secs(1);
+
+/// Top-N largest files reported.
+pub const REPORT_LIMIT: usize = 4;
+
+/// Source-file extensions worth checking (no leading dot).
+const SOURCE_EXTS: &[&str] = &[
+    "rs", "py", "js", "jsx", "ts", "tsx", "mjs", "cjs", "go", "c", "cc", "cpp", "cxx", "h", "hpp",
+    "hxx", "java", "kt", "scala", "rb", "swift", "cs", "php", "lua", "m", "mm", "r", "jl", "ex",
+    "exs", "erl", "clj", "cljs", "ml", "fs", "vb", "dart", "sh", "ps1",
+];
+
+/// Conventional directory names that hold third-party / vendored source we
+/// never want to flag. Most are also gitignored in practice, but some repos
+/// commit them (cargo vendor, go vendor, git-subrepo trees), so pruning by
+/// name is a belt-and-suspenders complement to gitignore + nested-`.git`.
+const VENDOR_DIRS: &[&str] = &[
+    "vendor",
+    "third_party",
+    "third-party",
+    "external",
+    "deps",
+    "subprojects",
+    "node_modules",
+];
+
+/// A single file that crossed the size threshold.
+#[derive(Debug, Clone)]
+pub struct LargeFile {
+    pub rel_path: PathBuf,
+    pub size: u64,
+}
+
+/// Run the startup check from `project_root`. Silent on non-git roots and
+/// when no files qualify. Errors are swallowed — a failed scan must never
+/// block a launch.
+pub fn run(project_root: &Path) {
+    // Silent if not in a git repo (the warning is project-scoped).
+    if !project_root.join(".git").exists() {
+        return;
+    }
+
+    let report = collect(project_root, DEADLINE);
+    emit(&report.files, report.total_qualifying, report.timed_out);
+}
+
+struct Report {
+    files: Vec<LargeFile>,
+    total_qualifying: usize,
+    timed_out: bool,
+}
+
+fn collect(root: &Path, deadline: Duration) -> Report {
+    let start = Instant::now();
+    let stop = AtomicBool::new(false);
+    let hits: Mutex<Vec<LargeFile>> = Mutex::new(Vec::new());
+
+    let walker = WalkBuilder::new(root)
+        .standard_filters(true) // .gitignore + .ignore + hidden
+        .same_file_system(true)
+        .filter_entry({
+            let root = root.to_path_buf();
+            move |e| !is_pruned_nested_git(&root, e)
+        })
+        .build_parallel();
+
+    walker.run(|| {
+        let stop = &stop;
+        let hits = &hits;
+        let root = root.to_path_buf();
+        Box::new(move |result| {
+            if start.elapsed() >= deadline {
+                stop.store(true, Ordering::Relaxed);
+                return WalkState::Quit;
+            }
+            if stop.load(Ordering::Relaxed) {
+                return WalkState::Quit;
+            }
+            let Ok(entry) = result else {
+                return WalkState::Continue;
+            };
+            if !entry.file_type().is_some_and(|t| t.is_file()) {
+                return WalkState::Continue;
+            }
+            let path = entry.path();
+            if !is_whitelisted_source(path) {
+                return WalkState::Continue;
+            }
+            let Ok(md) = entry.metadata() else {
+                return WalkState::Continue;
+            };
+            if md.len() < SIZE_THRESHOLD {
+                return WalkState::Continue;
+            }
+            let rel = path.strip_prefix(&root).unwrap_or(path).to_path_buf();
+            hits.lock().unwrap().push(LargeFile {
+                rel_path: rel,
+                size: md.len(),
+            });
+            WalkState::Continue
+        })
+    });
+
+    let timed_out = start.elapsed() >= deadline;
+    let mut files = hits.into_inner().unwrap();
+    files.sort_by(|a, b| b.size.cmp(&a.size));
+    let total = files.len();
+    files.truncate(REPORT_LIMIT);
+    Report {
+        files,
+        total_qualifying: total,
+        timed_out,
+    }
+}
+
+fn is_whitelisted_source(path: &Path) -> bool {
+    // Exclude *.min.* bundles (multi-component check, not a single extension).
+    let name = match path.file_name().and_then(|s| s.to_str()) {
+        Some(s) => s,
+        None => return false,
+    };
+    if name.contains(".min.") {
+        return false;
+    }
+    let ext = match path.extension().and_then(|s| s.to_str()) {
+        Some(e) => e.to_ascii_lowercase(),
+        None => return false,
+    };
+    SOURCE_EXTS.contains(&ext.as_str())
+}
+
+fn is_pruned_nested_git(root: &Path, e: &DirEntry) -> bool {
+    if !e.file_type().is_some_and(|t| t.is_dir()) {
+        return false;
+    }
+    if e.path() == root {
+        return false;
+    }
+    // Pruned if the directory has its own `.git` (vendored sub-repo).
+    if e.path().join(".git").exists() {
+        return true;
+    }
+    // Pruned if the directory's basename is a conventional vendor / deps
+    // directory. Repos that commit `cargo vendor` / `go vendor` / similar
+    // trees would otherwise dominate the report with third-party LOC.
+    if let Some(name) = e.path().file_name().and_then(|s| s.to_str()) {
+        if VENDOR_DIRS.contains(&name) {
+            return true;
+        }
+    }
+    false
+}
+
+fn emit(files: &[LargeFile], total: usize, timed_out: bool) {
+    if files.is_empty() {
+        if timed_out {
+            eprintln!("[clud] note: large-file scan exceeded 1s budget — skipping");
+        }
+        return;
+    }
+    eprintln!(
+        "[clud] warning: large source files (\u{2265}40 kB) detected — AI may get stuck on these; recommend refactoring:"
+    );
+    for f in files {
+        eprintln!("  {} ({})", f.rel_path.display(), human_kb(f.size));
+    }
+    let extra = total.saturating_sub(files.len());
+    if extra > 0 {
+        eprintln!("  ({extra} more)");
+    }
+    if timed_out {
+        eprintln!("[clud] note: scan stopped at 1s — report may be partial");
+    }
+}
+
+fn human_kb(bytes: u64) -> String {
+    let kb = (bytes as f64) / 1024.0;
+    if kb >= 1024.0 {
+        format!("{:.1} MB", kb / 1024.0)
+    } else {
+        format!("{} kB", kb.round() as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Helper: make a fixture dir with a `.git` marker so `run()` won't bail.
+    fn fixture() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        dir
+    }
+
+    fn write_file(dir: &Path, rel: &str, size: usize) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        // Write `size` bytes of ASCII content. Use 'a' so the file is a
+        // valid source-text payload for any tool that might inspect it.
+        let payload = vec![b'a'; size];
+        fs::write(path, payload).unwrap();
+    }
+
+    #[test]
+    fn threshold_constant_is_documented() {
+        // Sanity-check that the public constant matches the issue spec —
+        // future drift will flag here before the doc comment ages out.
+        assert_eq!(SIZE_THRESHOLD, 40 * 1024);
+    }
+
+    #[test]
+    fn whitelist_excludes_json() {
+        let dir = fixture();
+        write_file(dir.path(), "big.json", 200 * 1024);
+        let report = collect(dir.path(), DEADLINE);
+        assert!(report.files.is_empty());
+        assert_eq!(report.total_qualifying, 0);
+    }
+
+    #[test]
+    fn whitelist_excludes_min_files() {
+        let dir = fixture();
+        write_file(dir.path(), "bundle.min.js", 200 * 1024);
+        let report = collect(dir.path(), DEADLINE);
+        assert!(report.files.is_empty());
+        assert_eq!(report.total_qualifying, 0);
+    }
+
+    #[test]
+    fn whitelist_includes_known_extensions() {
+        let dir = fixture();
+        for ext in &["rs", "py", "ts", "go", "cpp"] {
+            write_file(dir.path(), &format!("file.{ext}"), 50 * 1024);
+        }
+        let report = collect(dir.path(), DEADLINE);
+        assert_eq!(report.total_qualifying, 5);
+        // truncated to REPORT_LIMIT
+        assert_eq!(report.files.len(), REPORT_LIMIT);
+    }
+
+    #[test]
+    fn under_threshold_silent() {
+        let dir = fixture();
+        write_file(dir.path(), "small.rs", 10 * 1024);
+        let report = collect(dir.path(), DEADLINE);
+        assert!(report.files.is_empty());
+        assert_eq!(report.total_qualifying, 0);
+    }
+
+    #[test]
+    fn gitignore_pruning() {
+        let dir = fixture();
+        fs::write(dir.path().join(".gitignore"), "target/\n").unwrap();
+        write_file(dir.path(), "target/foo.rs", 100 * 1024);
+        let report = collect(dir.path(), DEADLINE);
+        assert!(report.files.is_empty(), "got: {:?}", report.files);
+        assert_eq!(report.total_qualifying, 0);
+    }
+
+    #[test]
+    fn nested_git_pruned() {
+        let dir = fixture();
+        fs::create_dir_all(dir.path().join("vendored-dep/.git")).unwrap();
+        write_file(dir.path(), "vendored-dep/huge.rs", 100 * 1024);
+        let report = collect(dir.path(), DEADLINE);
+        assert!(report.files.is_empty(), "got: {:?}", report.files);
+        assert_eq!(report.total_qualifying, 0);
+    }
+
+    #[test]
+    fn vendor_dirs_pruned_by_name() {
+        // No nested `.git` here — pruning is purely by directory name.
+        // Mirrors the real-world case in zackees/clud where `vendor/...`
+        // contains committed C++ third-party source without its own .git.
+        let dir = fixture();
+        for d in &[
+            "vendor",
+            "third_party",
+            "third-party",
+            "external",
+            "deps",
+            "subprojects",
+            "node_modules",
+        ] {
+            write_file(dir.path(), &format!("{d}/big.cpp"), 100 * 1024);
+        }
+        let report = collect(dir.path(), DEADLINE);
+        assert!(report.files.is_empty(), "got: {:?}", report.files);
+        assert_eq!(report.total_qualifying, 0);
+    }
+
+    #[test]
+    fn root_git_does_not_prune_self() {
+        let dir = fixture();
+        write_file(dir.path(), "src.rs", 50 * 1024);
+        let report = collect(dir.path(), DEADLINE);
+        assert_eq!(report.total_qualifying, 1);
+        assert_eq!(report.files.len(), 1);
+        assert_eq!(report.files[0].rel_path, PathBuf::from("src.rs"));
+    }
+
+    #[test]
+    fn report_caps_at_four() {
+        let dir = fixture();
+        for i in 0..10 {
+            write_file(dir.path(), &format!("f{i}.rs"), 100 * 1024);
+        }
+        let report = collect(dir.path(), DEADLINE);
+        assert_eq!(report.files.len(), 4);
+        assert_eq!(report.total_qualifying, 10);
+    }
+
+    #[test]
+    fn report_sorted_descending() {
+        let dir = fixture();
+        write_file(dir.path(), "a.rs", 120 * 1024);
+        write_file(dir.path(), "b.rs", 60 * 1024);
+        write_file(dir.path(), "c.rs", 80 * 1024);
+        let report = collect(dir.path(), DEADLINE);
+        assert_eq!(report.files.len(), 3);
+        let sizes: Vec<u64> = report.files.iter().map(|f| f.size).collect();
+        assert_eq!(sizes, vec![120 * 1024, 80 * 1024, 60 * 1024]);
+    }
+
+    #[test]
+    fn report_sizes_human_readable() {
+        assert_eq!(human_kb(112 * 1024), "112 kB");
+        assert_eq!(human_kb(2 * 1024 * 1024), "2.0 MB");
+    }
+
+    #[test]
+    fn deadline_short_circuits() {
+        // Zero deadline guarantees an immediate cutoff without any
+        // sleep-based flake risk in CI.
+        let dir = fixture();
+        write_file(dir.path(), "src.rs", 100 * 1024);
+        let report = collect(dir.path(), Duration::from_millis(0));
+        assert!(report.timed_out);
+    }
+}

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -13,6 +13,7 @@ pub mod daemon;
 pub mod dnd;
 pub mod gc;
 pub mod hook_health;
+pub mod large_file_guard;
 pub mod loop_artifacts;
 pub mod loop_spec;
 pub mod process_tree;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,7 @@
 use clud::{
-    args, backend, command, console_title, daemon, dnd, gc, hook_health, loop_artifacts, loop_spec,
-    process_tree, session, session_registry, skill_install, skills, stream_json, subprocess,
-    trampoline, voice, wasm, worktrees,
+    args, backend, command, console_title, daemon, dnd, gc, hook_health, large_file_guard,
+    loop_artifacts, loop_spec, process_tree, session, session_registry, skill_install, skills,
+    stream_json, subprocess, trampoline, voice, wasm, worktrees,
 };
 
 use std::io::{self, Read};
@@ -135,6 +135,12 @@ fn main() {
 
     if hook_health::should_check_launch(&args) {
         hook_health::emit_launch_warnings();
+    }
+
+    if !args.clean_worktrees && !args.fix_hooks {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let root = loop_spec::git_root_from(&cwd);
+        large_file_guard::run(&root);
     }
 
     let backend = backend::resolve_backend(args.claude, args.codex);

--- a/tests/test_large_file_guard.py
+++ b/tests/test_large_file_guard.py
@@ -1,0 +1,102 @@
+"""Startup large-source-file guard — see zackees/clud#132.
+
+The guard runs once at clud launch and prints a `[clud] warning:` block
+to stderr listing the top 4 source files in the repo that exceed the
+~1000 LOC threshold (40 kB). The check has a 1 s hard deadline.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+# Reuse the binary builder + helper already exercised by test_hello.py.
+from test_hello import CLUD, copied_clud_env
+
+ROOT = Path(__file__).resolve().parent.parent
+
+WARNING_HEADER = "large source files"
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [CLUD, *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=copied_clud_env(Path(CLUD)),
+    )
+
+
+def test_warns_in_clud_repo() -> None:
+    """Inside the clud repo, the guard fires, names the worst offenders,
+    and reports at least 4 lines with a `(N more)` tail.
+
+    Naming exact files is brittle (a single edit on top of any file could
+    flip the leaderboard), so we assert (a) the worst three known-large
+    `.rs` files are all listed, and (b) the report is capped at 4 entries
+    with a `(N more)` tail proving there are extras the user should look
+    into.
+    """
+    result = _run(ROOT, "--dry-run", "-p", "hello")
+    assert result.returncode == 0, result.stderr
+    assert WARNING_HEADER in result.stderr, (
+        f"warning header missing from stderr:\n{result.stderr}"
+    )
+    # `daemon.rs`, `command.rs`, and `voice.rs` have been the top 3 by
+    # source-file size in clud for a long time; if any of these drops out
+    # of the report a non-trivial refactor has landed.
+    for expected in ("daemon.rs", "command.rs", "voice.rs"):
+        assert expected in result.stderr, (
+            f"expected {expected} in warning, got:\n{result.stderr}"
+        )
+    # Report must include a `(N more)` tail — clud has more than 4 files
+    # over the threshold (Rust sources, large integration tests, etc.).
+    assert "more)" in result.stderr, (
+        f"expected `(N more)` tail in warning, got:\n{result.stderr}"
+    )
+
+
+def test_silent_in_tiny_tempdir() -> None:
+    """In a fresh repo with one tiny source file, no warning is emitted."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        # `.git` marker is enough; the guard checks for the directory, not a
+        # real worktree. Avoids needing `git init` (which may not be on PATH
+        # in some CI images and would add ~50ms of latency anyway).
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "hello.rs").write_text("fn main() {}\n")
+        result = _run(tmp_path, "--dry-run", "-p", "hi")
+        assert result.returncode == 0, result.stderr
+        assert WARNING_HEADER not in result.stderr, (
+            f"unexpected warning in tiny repo:\n{result.stderr}"
+        )
+
+
+def test_silent_outside_git_repo() -> None:
+    """Outside any git repo, the guard exits silently — it's project-scoped."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        # No `.git` marker — `loop_spec::git_root_from` falls back to `tmp`,
+        # `run()` short-circuits because the dir has no `.git`.
+        (tmp_path / "huge.rs").write_text("x" * (100 * 1024))
+        result = _run(tmp_path, "--dry-run", "-p", "hi")
+        assert result.returncode == 0, result.stderr
+        assert WARNING_HEADER not in result.stderr, (
+            f"unexpected warning in non-git dir:\n{result.stderr}"
+        )
+
+
+def test_guard_does_not_blow_startup_budget() -> None:
+    """Sanity-check: even in the clud repo, dry-run completes well under 5s."""
+    start = time.monotonic()
+    result = _run(ROOT, "--dry-run", "-p", "hello")
+    elapsed = time.monotonic() - start
+    assert result.returncode == 0
+    # 5s is generous — the guard alone has a 1s hard deadline, and the rest
+    # of dry-run is pure arg parsing. CI machines under load might be slow,
+    # but we should never approach the subprocess timeout.
+    assert elapsed < 5.0, f"dry-run took {elapsed:.2f}s, expected <5s"


### PR DESCRIPTION
## Summary

Implements zackees/clud#132. On clud launch, performs a parallel, gitignore-aware walk of the project root and emits a `[clud] warning:` block listing the top-4 source files larger than 40 kB (~1000 LOC at the measured 37 bytes/line). The check has a **1 s hard wall-clock deadline** — startup is never blocked by a pathological repo.

## Behavior

- Walks via `ignore::WalkParallel` (the crate behind ripgrep) — parallel + gitignore-aware out of the box.
- Prunes nested `.git/` subtrees (vendored sub-repos).
- **Also** prunes conventional vendor directory names: `vendor`, `third_party`, `third-party`, `external`, `deps`, `subprojects`, `node_modules`. **This deviation from #132's spec** is necessary because clud commits `vendor/whisper-rs-sys/whisper.cpp/` — without the name prune, its 800 kB C++ files dominated the report and pushed out the actual clud source.
- Whitelisted source extensions only (rs/py/ts/go/cpp/etc.); excludes `.json` and `*.min.*` bundles.
- Top-4 by size, with `(N more)` tail; silent when nothing qualifies.
- Deadline trips → `[clud] note: scan stopped at 1s — report may be partial`.

## Wiring

`main.rs` calls `large_file_guard::run(&project_root)` immediately after `hook_health::emit_launch_warnings()`, gated against `--clean-worktrees` and `--fix-hooks`. `--dry-run` is **not** in the gate so the integration test can drive the guard without spawning a real backend. `gc`/`wasm` subcommands short-circuit upstream and never reach this point.

## Test coverage

**Rust unit tests (13/13 green locally):**
- threshold constant documented
- whitelist excludes `.json`
- whitelist excludes `*.min.*`
- whitelist includes `.rs .py .ts .go .cpp`
- under-threshold silent
- gitignore prune
- nested-git prune
- vendor-dir prune by name (new — covers the whisper.cpp case)
- root-git does not prune self
- report caps at 4
- report sorted descending
- report sizes human-readable
- deadline short-circuits

**Python integration tests (4/4 green locally):**
- warns in clud repo, names daemon/command/voice, has `(N more)` tail
- silent in tiny tempdir
- silent outside any git repo (project-scoped guard)
- startup budget sanity (whole dry-run well under subprocess timeout)

## Local verification (windows-msvc)

- `bash lint` — clean
- `bash test` — 53 passed (52 prior + 4 new − 3 deselected) + 3 skipped
- `bash build` — clean
- Manual smoke: `clud --dry-run -p hello` from clud repo root → warning lists `daemon.rs` (112 kB), `command.rs` (59 kB), `voice.rs` (58 kB), `test_daemon_centralized.py` (54 kB), `(4 more)`.

## Notes on deviation from #132

- The issue listed `main.rs` as the 4th largest. After the vendor prune it actually shows as 5th — a 54 kB integration-test Python file outranks it. The Python test now asserts the persistent top 3 + a `(N more)` tail rather than naming the 4th slot (which would be brittle).

Closes #132