### PR TITLE
test(dnd): poll for register-loop ticks instead of fixed-sleep wait

### DIFF
--- a/crates/clud-bin/src/dnd/console_drop_target.rs
+++ b/crates/clud-bin/src/dnd/console_drop_target.rs
@@ -1179,18 +1179,22 @@ mod tests {
             run_registration_loop(&*worker_registrar, cfg, &worker_shutdown)
         });
 
-        // Let the loop tick a few times.
-        std::thread::sleep(Duration::from_millis(220));
+        // Poll for the loop to tick 1 initial + ≥2 refreshes. A fixed sleep
+        // was flaky on slow runners (e.g. macOS ARM under load only managed
+        // 2 calls in 220 ms, see run 25886391903). Polling with a generous
+        // deadline keeps the test deterministic on any platform.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while calls.load(Ordering::SeqCst) < 3 && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
         shutdown.signal();
         let result = handle.join().expect("worker panicked");
         result.expect("loop ok");
 
-        // 1 initial + at least 2 refreshes within ~220ms.
         let n = calls.load(Ordering::SeqCst);
         assert!(
             n >= 3,
-            "expected at least 3 register calls, got {} (initial + ≥2 refreshes)",
-            n
+            "expected at least 3 register calls, got {n} (initial + ≥2 refreshes) within 5s budget",
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the macOS ARM Integration Test flake observed in [run 25886391903 / job 76079033050](https://github.com/zackees/clud/actions/runs/25886391903/job/76079033050) where `dnd::console_drop_target::tests::registration_loop_refreshes_periodically` panicked:

```
expected at least 3 register calls, got 2 (initial + ≥2 refreshes)
```

The test slept 220 ms expecting the 50 ms-interval registration loop to fire 1 initial + ≥2 refresh calls. Under load on the macOS ARM runner the loop only managed 2 calls in 220 ms — a classic timing-flake.

## Fix

Replaced the fixed 220 ms sleep with a polling loop that waits exactly until `calls.load() >= 3` (the test's actual success condition), with a generous 5 s deadline. The test now:

- Returns as fast as possible on healthy hardware (~120 ms in practice).
- Tolerates arbitrary slowness on overloaded CI nodes.
- Asserts the same invariant as before.

No production code change. 14/14 tests in `dnd::console_drop_target` pass locally on windows-msvc.