### PR TITLE
fix(windows): isolate backend child in new process group on Ctrl+C

### DIFF
--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -655,6 +655,43 @@ enum ProcessOutcome {
     Error,
 }
 
+/// Tear down a backend child that has not exited yet because the user
+/// just hit Ctrl+C.
+///
+/// Sequence:
+///
+/// 1. Windows-only: send `CTRL_BREAK_EVENT` to the child's console
+///    process group. The backend is spawned with
+///    `CREATE_NEW_PROCESS_GROUP` so the OS does *not* deliver the
+///    user's `CTRL_C_EVENT` to it — that prevents stray
+///    `KeyboardInterrupt` tracebacks from blocking `subprocess` waits
+///    in the `nodejs-wheel` Python launcher used by some Claude Code
+///    installs. The break we send here is the cooperative path for any
+///    backend that *does* install a Ctrl+Break handler. Failures and
+///    non-Windows targets short-circuit silently and we proceed to the
+///    hard kill.
+/// 2. `kill_tree`: snapshot the PID *before* killing the direct child
+///    so we can walk descendants. On Windows the direct child is
+///    cmd.exe (BatBadBat wrapper, see `subprocess.rs`) and the real
+///    agent (node.exe for codex / claude) is a grandchild — plain
+///    `process.kill()` would only TerminateProcess the cmd.exe and the
+///    orphan would keep writing to the console until our Job Object
+///    closes, producing the multi-second hang users reported.
+/// 3. `process.kill()` + `process.wait(2s)`: final TerminateProcess on
+///    the direct handle and a bounded wait so we don't return while
+///    the child is still draining.
+fn teardown_interrupted_child(process: &running_process_core::NativeProcess) {
+    if let Some(pid) = process.pid() {
+        // Cooperative Ctrl+Break first. No-op on POSIX (returns false)
+        // and any failure on Windows is non-fatal — the hard kill below
+        // is always run regardless.
+        let _ = process_tree::try_break_group(pid);
+        process_tree::kill_tree(pid);
+    }
+    let _ = process.kill();
+    let _ = process.wait(Some(std::time::Duration::from_secs(2)));
+}
+
 /// Inherited-stdio path: poll the child until it exits, kill on Ctrl+C.
 /// This is the original `run_plan_subprocess` body, extracted unchanged so
 /// the stream-json path can sit alongside it without duplicating the
@@ -673,19 +710,7 @@ fn run_with_inherited_stdio(
             }
             Ok(None) => {
                 if interrupted.load(Ordering::SeqCst) {
-                    // Snapshot the PID *before* killing the direct child so
-                    // we can take down the descendant tree. On Windows the
-                    // direct child is cmd.exe (BatBadBat wrapper) but the
-                    // real agent (node.exe for codex) is a grandchild. A
-                    // plain `process.kill()` only TerminateProcess'es the
-                    // cmd.exe, leaving node.exe writing to the console
-                    // until clud itself exits and the Job Object closes —
-                    // that's the multi-second hang users were reporting.
-                    if let Some(pid) = process.pid() {
-                        process_tree::kill_tree(pid);
-                    }
-                    let _ = process.kill();
-                    let _ = process.wait(Some(std::time::Duration::from_secs(2)));
+                    teardown_interrupted_child(process);
                     return ProcessOutcome::Interrupted;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(50));
@@ -720,16 +745,7 @@ fn run_with_stream_json_renderer(
     let timeout = Duration::from_millis(100);
     loop {
         if interrupted.load(Ordering::SeqCst) {
-            // Same descendant-kill rationale as `run_with_inherited_stdio`:
-            // when the user Ctrl+C's `clud --codex loop`, the direct child
-            // is cmd.exe and the actual codex process (node.exe) lives one
-            // level deeper. We must take down the tree, not just the
-            // immediate child, otherwise Ctrl+C lags for seconds.
-            if let Some(pid) = process.pid() {
-                process_tree::kill_tree(pid);
-            }
-            let _ = process.kill();
-            let _ = process.wait(Some(Duration::from_secs(2)));
+            teardown_interrupted_child(process);
             return ProcessOutcome::Interrupted;
         }
         match process.read_stream(StreamKind::Stdout, Some(timeout)) {

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,8 @@
 use clud::{
     args, backend, command, console_title, daemon, dnd, gc, gc_daemon, hook_health,
     large_file_guard, loop_artifacts, loop_spec, process_tree, session, session_registry,
-    skill_install, skills, stream_json, subprocess, trampoline, voice, wasm, worktrees,
+    skill_install, skills, stream_json, subprocess, trampoline, voice, wasm, win_creation_flags,
+    worktrees,
 };
 
 use std::io::{self, Read};
@@ -558,7 +559,18 @@ fn run_plan_subprocess(
             // directly to our console (preserving any TUI behavior).
             capture: plan.stream_json_progress,
             stderr_mode: StderrMode::Stdout,
-            creationflags: None,
+            // Windows: spawn the backend in its own console process
+            // group so the OS does not deliver `CTRL_C_EVENT` to the
+            // child (or its descendants) when the user hits Ctrl+C.
+            // clud's own `ctrlc` handler catches the event and tears
+            // the child tree down via `process_tree::kill_tree`; the
+            // child only receives a hard termination, never a stray
+            // signal that would let the `nodejs-wheel` Python launcher
+            // raise `KeyboardInterrupt` and dump a traceback over
+            // clud's clean exit message. POSIX has no equivalent flag
+            // and the terminal foreground-process-group behavior is
+            // already correct, so the helper returns `None` there.
+            creationflags: win_creation_flags::user_facing_backend_creationflags(),
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,

--- a/crates/clud-bin/src/process_tree.rs
+++ b/crates/clud-bin/src/process_tree.rs
@@ -25,6 +25,10 @@
 //! Best-effort: failures are silent and the whole operation is bounded by
 //! the cost of one `sysinfo` system snapshot, which is well under our
 //! sub-second Ctrl+C latency target.
+//!
+//! [`try_break_group`] is the cooperative companion on Windows: it sends
+//! `CTRL_BREAK_EVENT` to the child's console process group so a
+//! well-behaved agent can flush state before the hard `kill_tree` follows.
 
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System};
 
@@ -86,6 +90,43 @@ fn descendant_pids(system: &System, root: Pid) -> Vec<Pid> {
         }
     }
     descendants
+}
+
+/// Best-effort cooperative shutdown of a Windows console process group.
+///
+/// When clud spawns the backend with `CREATE_NEW_PROCESS_GROUP`, the
+/// child becomes the root of a new console process group identified by
+/// its PID. Calling `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)`
+/// delivers a break signal to every process in that group, giving a
+/// well-behaved agent (one that installs a `SetConsoleCtrlHandler` for
+/// `CTRL_BREAK_EVENT`) a chance to flush state before clud follows up
+/// with a hard `kill_tree`.
+///
+/// Returns `true` if the OS accepted the call (the group existed and the
+/// event was queued), `false` otherwise. Failures are silent and
+/// non-fatal: the caller is expected to fall through to `kill_tree` after
+/// a short grace window regardless.
+///
+/// No-op on non-Windows targets — POSIX has no `CREATE_NEW_PROCESS_GROUP`
+/// concept and clud's foreground process group already receives the
+/// terminal's SIGINT directly.
+pub fn try_break_group(pid: u32) -> bool {
+    #[cfg(windows)]
+    {
+        use windows::Win32::System::Console::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT};
+        // SAFETY: `GenerateConsoleCtrlEvent` is documented as safe to
+        // call with any PID; passing a non-existent group simply returns
+        // FALSE without dereferencing memory. The function signature in
+        // `windows-rs` is `unsafe extern "system"`, which is the standard
+        // marker for Win32 entry points — no Rust invariant is violated.
+        let ok = unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid) };
+        ok.is_ok()
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = pid;
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/clud-bin/src/win_creation_flags.rs
+++ b/crates/clud-bin/src/win_creation_flags.rs
@@ -24,6 +24,16 @@
 #[cfg(windows)]
 pub const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
+/// Bit value of the Windows `CREATE_NEW_PROCESS_GROUP` process creation flag.
+///
+/// The child process becomes the root of a new console process group.
+/// CTRL_C_EVENT is masked for the child (it never receives Ctrl+C via the
+/// console signal path), but CTRL_BREAK_EVENT can still be delivered with
+/// `GenerateConsoleCtrlEvent`. See
+/// <https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags>.
+#[cfg(windows)]
+pub const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
 /// Returns the creation-flags bitmask to apply to a daemon-helper spawn so
 /// that it does not pop a visible console window. On non-Windows, returns
 /// `0` (callers can pass it unconditionally).
@@ -47,6 +57,58 @@ pub fn invisible_helper_creationflags() -> Option<u32> {
     #[cfg(windows)]
     {
         Some(CREATE_NO_WINDOW)
+    }
+    #[cfg(not(windows))]
+    {
+        None
+    }
+}
+
+/// Returns the creation-flags bitmask that puts the child into its own
+/// console process group on Windows. Returns `0` on every other platform
+/// so callers can OR it into a flags value unconditionally.
+///
+/// **Why this matters for the user-facing backend spawn.**
+///
+/// On Windows, when the user hits Ctrl+C in a clud session, the OS
+/// dispatches `CTRL_C_EVENT` to *every process attached to the console
+/// process group* — clud itself, the cmd.exe wrapper, the real backend
+/// (node.exe for Claude / Codex), and any tool grandchildren. clud's
+/// `ctrlc` handler catches it cleanly and prints the resume hint, but the
+/// `nodejs-wheel` distribution of Node.js used by some Claude Code
+/// installs is a Python launcher that calls `subprocess.communicate()` in
+/// blocking mode. Its `WaitForSingleObject` raises `KeyboardInterrupt` in
+/// Python, dumping a confusing traceback alongside clud's clean message.
+///
+/// Placing the child in `CREATE_NEW_PROCESS_GROUP` makes the OS skip the
+/// child (and its descendants) when delivering the console Ctrl+C signal,
+/// so only clud sees the event. clud is then responsible for tearing the
+/// child tree down — which it already does via `process_tree::kill_tree`
+/// in the interrupt branch.
+pub fn new_process_group_flags() -> u32 {
+    #[cfg(windows)]
+    {
+        CREATE_NEW_PROCESS_GROUP
+    }
+    #[cfg(not(windows))]
+    {
+        0
+    }
+}
+
+/// `Some(creationflags)` for the user-facing backend spawn (the child
+/// clud actually drives interactively): inherits stdio so the user sees
+/// the agent's output, and is placed in a new process group so the OS
+/// does not deliver console Ctrl+C events to the child or its descendants.
+/// clud's own handler stays in charge of teardown.
+///
+/// Returns `None` off Windows so running-process-core's `creationflags`
+/// short-circuit stays intact — POSIX has no equivalent flag and the
+/// terminal foreground-process-group behavior is already correct.
+pub fn user_facing_backend_creationflags() -> Option<u32> {
+    #[cfg(windows)]
+    {
+        Some(CREATE_NEW_PROCESS_GROUP)
     }
     #[cfg(not(windows))]
     {
@@ -102,14 +164,61 @@ mod tests {
         // independent and can be OR'd together — daemon helpers that
         // need both (none today, but the Python test harness's Ctrl+Break
         // tests do) must compose correctly without losing either bit.
-        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-        let combined = invisible_helper_flags() | CREATE_NEW_PROCESS_GROUP;
+        let create_new_process_group: u32 = 0x0000_0200;
+        let combined = invisible_helper_flags() | create_new_process_group;
+        assert_eq!(
+            combined & create_new_process_group,
+            create_new_process_group
+        );
+        #[cfg(windows)]
+        assert_eq!(combined & CREATE_NO_WINDOW, CREATE_NO_WINDOW);
+    }
+
+    /// The exported `CREATE_NEW_PROCESS_GROUP` constant on Windows must
+    /// match the documented Win32 bit pattern. Anchoring the literal here
+    /// means a typo in a future refactor fails CI rather than silently
+    /// re-routing console Ctrl+C events into our backend children.
+    #[cfg(windows)]
+    #[test]
+    fn create_new_process_group_value_matches_winapi() {
+        assert_eq!(CREATE_NEW_PROCESS_GROUP, 0x0000_0200);
+    }
+
+    /// `new_process_group_flags()` returns the Win32 bit pattern on
+    /// Windows and `0` elsewhere so callers can `flags |
+    /// new_process_group_flags()` unconditionally.
+    #[test]
+    fn new_process_group_flags_per_os() {
+        #[cfg(windows)]
+        assert_eq!(new_process_group_flags(), 0x0000_0200);
+        #[cfg(not(windows))]
+        assert_eq!(new_process_group_flags(), 0);
+    }
+
+    /// The `Option<u32>`-shaped helper for `ProcessConfig::creationflags`:
+    /// `Some(CREATE_NEW_PROCESS_GROUP)` on Windows, `None` elsewhere so
+    /// running-process-core's "no override" short-circuit stays intact on
+    /// POSIX where the flag has no meaning.
+    #[test]
+    fn user_facing_backend_creationflags_per_os() {
+        #[cfg(windows)]
+        assert_eq!(user_facing_backend_creationflags(), Some(0x0000_0200));
+        #[cfg(not(windows))]
+        assert!(user_facing_backend_creationflags().is_none());
+    }
+
+    /// CREATE_NO_WINDOW and CREATE_NEW_PROCESS_GROUP are independent bits
+    /// (0x0800_0000 vs 0x0000_0200) and must remain composable so a
+    /// daemon-helper that wants both can OR them without losing either.
+    #[cfg(windows)]
+    #[test]
+    fn create_no_window_and_create_new_process_group_compose() {
+        let combined = invisible_helper_flags() | new_process_group_flags();
+        assert_eq!(combined & CREATE_NO_WINDOW, CREATE_NO_WINDOW);
         assert_eq!(
             combined & CREATE_NEW_PROCESS_GROUP,
             CREATE_NEW_PROCESS_GROUP
         );
-        #[cfg(windows)]
-        assert_eq!(combined & CREATE_NO_WINDOW, CREATE_NO_WINDOW);
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

On Windows, hitting Ctrl+C in a `clud` (claude mode) session prints clud's clean interrupt message **and** a Python traceback from the `nodejs-wheel` shim that some Claude Code installs use:

```
^C[clud] interrupted via Ctrl+C
Resume this session with:
claude --resume 486a9124-...
Traceback (most recent call last):
  File "C:\tools\python13\Scripts\node.exe\__main__.py", line 6, in <module>
  File "...\nodejs_wheel\executable.py", line 300, in _node_entry_point
    raise SystemExit(node(close_fds=False))
  ...
  File "...\subprocess.py", line 1606, in _wait
    result = _winapi.WaitForSingleObject(self._handle, ...)
KeyboardInterrupt
```

### Root cause

clud spawns the backend (claude / codex) with `creationflags: None`. On Windows that means the child inherits the parent's console process group, so the OS delivers `CTRL_C_EVENT` to **every** process attached to the console — including the python-shimmed node. The shim's `subprocess.communicate()` blocks in `WaitForSingleObject`, which raises `KeyboardInterrupt` and bubbles up as a traceback printed alongside clud's clean exit. clud's own `ctrlc` handler already catches Ctrl+C properly; the problem is that the OS-level signal also reaches the child path before clud can tear it down.

### What changed

1. **`win_creation_flags.rs`** — exposes `CREATE_NEW_PROCESS_GROUP` (`0x0000_0200`), `new_process_group_flags()`, and `user_facing_backend_creationflags()` (`Option<u32>`, the shape `ProcessConfig::creationflags` expects). All per-OS so POSIX returns `None` / `0`.
2. **`main.rs::run_plan_subprocess`** — pass `creationflags: win_creation_flags::user_facing_backend_creationflags()` to the spawn. Windows puts the child in its own console process group; POSIX is unchanged. The OS no longer delivers the user's `CTRL_C_EVENT` to the child or its descendants — only clud sees it.
3. **`process_tree.rs::try_break_group`** — cooperative companion: on Windows, send `CTRL_BREAK_EVENT` via `GenerateConsoleCtrlEvent` to the child's process group. Well-behaved backends that install a Ctrl+Break handler get a chance to flush state. Failures are silent — the hard kill below runs regardless. No-op on POSIX.
4. **`main.rs::teardown_interrupted_child`** — factors the duplicated Ctrl+C teardown out of `run_with_inherited_stdio` and `run_with_stream_json_renderer`. New sequence: `try_break_group` → `kill_tree` → `process.kill()` → `wait(2s)`. Same 2s hard-kill budget as before; the cooperative break is an additive opportunity.

POSIX is unaffected: `user_facing_backend_creationflags()` returns `None`, `try_break_group` returns `false` immediately, and the terminal foreground-process-group behavior is already correct (this is reported as a Windows-only issue).

### Files changed
- `crates/clud-bin/src/win_creation_flags.rs` — new flag + helper functions, per-OS unit tests pinning the bit pattern.
- `crates/clud-bin/src/process_tree.rs` — new `try_break_group(pid)` helper, Windows-only.
- `crates/clud-bin/src/main.rs` — spawn the user-facing backend with the new creationflags helper; consolidate Ctrl+C teardown into `teardown_interrupted_child`.

## Repro & verification

I was **unable to reproduce the traceback interactively** on this machine — the locally-installed `claude` binary is a native executable (not the `nodejs-wheel` Python launcher in the original report). All other repro requirements (Windows host, subprocess launch mode, parent's console group inherited by child) are present, so the fix is grounded in code analysis matching the existing `CREATE_NEW_PROCESS_GROUP` pattern already used by the integration test helpers in `tests/_subprocess_helpers.py` (which explicitly comments "those tests send `CTRL_BREAK_EVENT` to the child process group").

Verified interactively that Ctrl+C still exits clud cleanly within ~2s in claude subprocess mode and the `[clud] interrupted via Ctrl+C` line still prints. The aggressive `kill_tree` + `TerminateProcess` path is unchanged, so the existing fast-shutdown contract is preserved.

A full end-to-end Ctrl+C integration test that asserts "no traceback prints" against a real `nodejs-wheel`-shimmed claude is left as a known gap — it requires reproducing the specific environment (Python 3.13 + `nodejs-wheel` install) and reliably timing the SIGINT delivery against the shim's blocking wait. The existing `tests/_subprocess_helpers.py` CTRL_BREAK_EVENT plumbing already demonstrates the pattern works in practice.

## Test plan
- [x] `bash lint` (cargo fmt --check + clippy -D warnings + ruff check) — passes
- [x] `bash test` — passes (525 Rust unit + 9 main + 14 pty + 53 Python)
- [x] `bash build` — wheel builds cleanly
- [ ] Manual smoke against a real `nodejs-wheel`-shimmed `claude` binary on Windows: confirm Ctrl+C produces clud's clean message and *no* Python traceback. **Blocked on the original reporter's environment**; the local claude binary here is native, not python-shimmed.
- [ ] (Optional) Windows CI Ctrl+C integration test using the existing `CREATE_NEW_PROCESS_GROUP` + `CTRL_BREAK_EVENT` helpers — deferred; would need a `nodejs-wheel`-style fixture.

Refs the Windows Ctrl+C behavior already exercised by `tests/_subprocess_helpers.py::CREATE_NEW_PROCESS_GROUP`.