### PR TITLE
feat(pty): wire ReadConsoleInputW into PTY pump for Shift+Enter (#141)

### DIFF
--- a/crates/clud-bin/src/console_input.rs
+++ b/crates/clud-bin/src/console_input.rs
@@ -27,6 +27,20 @@
 //! - Non-key input records (mouse / focus / buffer-size / menu / window
 //!   events from `ReadConsoleInputW`) are dropped at the
 //!   `InputEvent::NonKey` variant.
+//!
+//! ## Wiring (PR follow-up to #142)
+//!
+//! [`spawn_console_input_reader`] returns a [`ConsoleInputHandle`]
+//! containing a receiver the PTY pump can plug into its `extra_rx`
+//! slot. A background thread calls `ReadConsoleInputW`, runs the
+//! events through [`translate`], and forwards the resulting bytes.
+//! [`ConsoleModeGuard`] saves/restores the console mode bits so the
+//! reader gets raw key events while it runs and the terminal returns
+//! to its previous state on Drop.
+//!
+//! [`spawn_with_source`] is the testable seam: tests can substitute
+//! any `FnMut() -> Vec<InputEvent>` for the real `ReadConsoleInputW`
+//! call so the worker can be exercised without an actual console.
 
 #![cfg(windows)]
 
@@ -92,6 +106,248 @@ pub fn translate(events: &[InputEvent]) -> Vec<u8> {
         }
     }
     out
+}
+
+// ---------- INPUT_RECORD adapter ----------
+
+use windows::Win32::System::Console::{
+    FOCUS_EVENT, INPUT_RECORD, KEY_EVENT, MENU_EVENT, MOUSE_EVENT, WINDOW_BUFFER_SIZE_EVENT,
+};
+
+/// Convert one `windows` crate `INPUT_RECORD` into the simpler
+/// [`InputEvent`] the translator works with. Returns `Some(NonKey)` for
+/// every record type that isn't `KEY_EVENT` so the caller still observes
+/// the event (useful for rate-limiting / diagnostics).
+///
+/// SAFETY: the inner union access is gated on `EventType`. The
+/// `windows` crate marks the union access unsafe; we localize that
+/// `unsafe` block here so every other call site stays safe.
+pub fn from_input_record(record: &INPUT_RECORD) -> Option<InputEvent> {
+    // `EventType` values are u16 constants from `Win32_System_Console`.
+    let is_key = record.EventType == KEY_EVENT as u16;
+    let is_other = matches!(
+        record.EventType,
+        x if x == MOUSE_EVENT as u16
+            || x == WINDOW_BUFFER_SIZE_EVENT as u16
+            || x == FOCUS_EVENT as u16
+            || x == MENU_EVENT as u16
+    );
+    if !is_key && !is_other {
+        return None;
+    }
+    if is_other {
+        return Some(InputEvent::NonKey);
+    }
+    // SAFETY: we just verified EventType == KEY_EVENT, so reading the
+    // KeyEvent union field is well-defined.
+    let key = unsafe { record.Event.KeyEvent };
+    Some(InputEvent::Key(KeyEvent {
+        key_down: key.bKeyDown.as_bool(),
+        virtual_key_code: key.wVirtualKeyCode,
+        // The `windows` crate exposes the union as `uChar` with both
+        // `UnicodeChar` and `AsciiChar` views — we always read the
+        // Unicode view since `translate` expects a UTF-16 code unit.
+        unicode_char: unsafe { key.uChar.UnicodeChar },
+        control_key_state: key.dwControlKeyState,
+    }))
+}
+
+// ---------- reader worker thread ----------
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread;
+
+/// Handle returned from [`spawn_with_source`] / [`spawn_console_input_reader`].
+///
+/// Owns the receiver the PTY pump will read from, a cancel flag the
+/// pump sets on shutdown, and the worker thread join handle. Dropping
+/// the handle signals cancel and joins the worker.
+#[derive(Debug)]
+pub struct ConsoleInputHandle {
+    rx: Option<mpsc::Receiver<Vec<u8>>>,
+    cancel: Arc<AtomicBool>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl ConsoleInputHandle {
+    /// Take the receiver out so it can be plugged into the pump's
+    /// `extra_rx`. After this returns `Some`, subsequent calls return
+    /// `None`.
+    pub fn take_receiver(&mut self) -> Option<mpsc::Receiver<Vec<u8>>> {
+        self.rx.take()
+    }
+
+    /// Signal the worker to stop. The Drop impl does this too; this
+    /// method exists for callers that want to stop the worker without
+    /// dropping the handle (rare).
+    pub fn cancel(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for ConsoleInputHandle {
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.join.take() {
+            // Best-effort join: the worker checks `cancel` between each
+            // call to `read_events`, which may block up to ~100ms on
+            // `WaitForSingleObject` in the production reader.
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Spawn a worker that calls `read_events` in a loop, runs each
+/// returned slice through [`translate`], and sends non-empty byte
+/// chunks on the returned channel.
+///
+/// Tests substitute a canned `read_events` closure; production callers
+/// use [`spawn_console_input_reader`].
+pub fn spawn_with_source<F>(mut read_events: F) -> ConsoleInputHandle
+where
+    F: FnMut() -> Vec<InputEvent> + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let worker_cancel = Arc::clone(&cancel);
+    let join = thread::Builder::new()
+        .name("clud-console-input".into())
+        .spawn(move || {
+            while !worker_cancel.load(Ordering::Relaxed) {
+                let events = read_events();
+                if events.is_empty() {
+                    continue;
+                }
+                let bytes = translate(&events);
+                if bytes.is_empty() {
+                    continue;
+                }
+                if tx.send(bytes).is_err() {
+                    // Receiver dropped — pump shut down; exit cleanly.
+                    break;
+                }
+            }
+        })
+        .expect("spawn clud-console-input thread");
+    ConsoleInputHandle {
+        rx: Some(rx),
+        cancel,
+        join: Some(join),
+    }
+}
+
+// ---------- production reader + console-mode guard ----------
+
+use std::io;
+use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0};
+use windows::Win32::System::Console::{
+    GetConsoleMode, GetStdHandle, ReadConsoleInputW, SetConsoleMode, CONSOLE_MODE,
+    ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+    ENABLE_WINDOW_INPUT, STD_INPUT_HANDLE,
+};
+use windows::Win32::System::Threading::WaitForSingleObject;
+
+/// RAII guard that flips the console input mode into the raw-key-event
+/// regime expected by the reader and restores the previous mode on
+/// Drop. The guard MUST outlive any [`ConsoleInputHandle`] that wraps
+/// the production reader — dropping it while the worker is running
+/// would leave the console in the wrong mode if the user's terminal
+/// observes input directly between batches.
+pub struct ConsoleModeGuard {
+    handle: HANDLE,
+    saved: CONSOLE_MODE,
+}
+
+impl ConsoleModeGuard {
+    /// Set the console input mode for raw key-event reads.
+    ///
+    /// Toggles off `ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT |
+    /// ENABLE_PROCESSED_INPUT | ENABLE_VIRTUAL_TERMINAL_INPUT` and
+    /// turns on `ENABLE_WINDOW_INPUT`. Mouse input stays as-is — we
+    /// don't need it but classifying mouse records as
+    /// [`InputEvent::NonKey`] is cheap.
+    pub fn set_raw() -> io::Result<Self> {
+        let handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) }
+            .map_err(|e| io::Error::other(format!("GetStdHandle: {e}")))?;
+        let mut saved = CONSOLE_MODE(0);
+        unsafe { GetConsoleMode(handle, &mut saved) }
+            .map_err(|e| io::Error::other(format!("GetConsoleMode: {e}")))?;
+        let raw = (saved
+            & !ENABLE_LINE_INPUT
+            & !ENABLE_ECHO_INPUT
+            & !ENABLE_PROCESSED_INPUT
+            & !ENABLE_VIRTUAL_TERMINAL_INPUT)
+            | ENABLE_WINDOW_INPUT;
+        unsafe { SetConsoleMode(handle, raw) }
+            .map_err(|e| io::Error::other(format!("SetConsoleMode: {e}")))?;
+        Ok(Self { handle, saved })
+    }
+}
+
+impl Drop for ConsoleModeGuard {
+    fn drop(&mut self) {
+        // Best-effort: a failure here would mean the terminal is left
+        // in raw-input mode, which is annoying but recoverable by the
+        // user (closing the terminal restores defaults).
+        let _ = unsafe { SetConsoleMode(self.handle, self.saved) };
+    }
+}
+
+/// Pull a batch of input events from STDIN. Blocks up to ~100ms in
+/// `WaitForSingleObject` so the worker checks its cancel flag at that
+/// cadence without busy-spinning.
+fn read_console_input_w_batch(handle: HANDLE) -> Vec<InputEvent> {
+    let wait = unsafe { WaitForSingleObject(handle, 100) };
+    if wait != WAIT_OBJECT_0 {
+        return Vec::new();
+    }
+    let mut buf = [INPUT_RECORD::default(); 32];
+    let mut read: u32 = 0;
+    let ok = unsafe { ReadConsoleInputW(handle, &mut buf, &mut read) };
+    if ok.is_err() || read == 0 {
+        return Vec::new();
+    }
+    buf[..read as usize]
+        .iter()
+        .filter_map(from_input_record)
+        .collect()
+}
+
+/// Newtype wrapper that asserts `Send` for the Windows `HANDLE`. Raw
+/// `HANDLE` (`*mut c_void`) is not `Send` in the type system, but a
+/// kernel handle for STDIN is just an integer identifier the OS
+/// dispatches per-thread — passing it to a worker thread is sound.
+///
+/// `Copy` is important: the production spawn closure uses `move` and
+/// must capture the *whole* `SendHandle` (not the inner field via
+/// disjoint-capture), otherwise the closure's capture set contains the
+/// raw `*mut c_void` and the auto-Send analysis fails.
+#[derive(Clone, Copy)]
+struct SendHandle(HANDLE);
+// SAFETY: kernel handles are thread-safe identifiers; the worker
+// thread only uses this for `WaitForSingleObject` + `ReadConsoleInputW`
+// against the process-shared stdin handle, which Windows guarantees is
+// usable from any thread in the process.
+unsafe impl Send for SendHandle {}
+
+/// Production reader: set the console mode and spawn a worker that
+/// drains `ReadConsoleInputW`. Returns the input handle plus a guard
+/// that restores the original console mode on Drop. Both should live
+/// for the duration of the PTY session.
+pub fn spawn_console_input_reader() -> io::Result<(ConsoleInputHandle, ConsoleModeGuard)> {
+    let guard = ConsoleModeGuard::set_raw()?;
+    let thread_handle = SendHandle(guard.handle);
+    let inner = spawn_with_source(move || {
+        // Force the closure to capture the whole `SendHandle` (Send)
+        // rather than its inner `*mut c_void` field via disjoint
+        // capture. Binding via the wrapper inside the closure body
+        // pins the capture at the wrapper level.
+        let h = thread_handle;
+        read_console_input_w_batch(h.0)
+    });
+    Ok((inner, guard))
 }
 
 #[cfg(test)]
@@ -194,5 +450,196 @@ mod tests {
             key_down(VK_RETURN, b'\r' as u16, 0),
         ];
         assert_eq!(translate(&events), b"hi\nm\r");
+    }
+
+    // ---------- from_input_record tests ----------
+
+    use windows::Win32::System::Console::{
+        FOCUS_EVENT_RECORD, INPUT_RECORD_0, KEY_EVENT_RECORD, KEY_EVENT_RECORD_0,
+        MOUSE_EVENT_RECORD, WINDOW_BUFFER_SIZE_RECORD,
+    };
+    use windows_core::BOOL;
+
+    fn make_key_record(key_down_v: bool, vk: u16, ch: u16, ctrl: u32) -> INPUT_RECORD {
+        INPUT_RECORD {
+            EventType: KEY_EVENT as u16,
+            Event: INPUT_RECORD_0 {
+                KeyEvent: KEY_EVENT_RECORD {
+                    bKeyDown: BOOL(if key_down_v { 1 } else { 0 }),
+                    wRepeatCount: 1,
+                    wVirtualKeyCode: vk,
+                    wVirtualScanCode: 0,
+                    uChar: KEY_EVENT_RECORD_0 { UnicodeChar: ch },
+                    dwControlKeyState: ctrl,
+                },
+            },
+        }
+    }
+
+    /// Key-event INPUT_RECORD with Shift+Enter unpacks into the
+    /// right `KeyEvent` fields. This is the adapter's most important
+    /// case — every layer above sees Shift via this path.
+    #[test]
+    fn from_input_record_decodes_shift_enter() {
+        let rec = make_key_record(true, VK_RETURN, b'\r' as u16, SHIFT_PRESSED);
+        let event = from_input_record(&rec).expect("some");
+        match event {
+            InputEvent::Key(k) => {
+                assert!(k.key_down);
+                assert_eq!(k.virtual_key_code, VK_RETURN);
+                assert_eq!(k.control_key_state & SHIFT_PRESSED, SHIFT_PRESSED);
+            }
+            InputEvent::NonKey => panic!("expected key event"),
+        }
+        // Sanity: the round-trip through translate produces \n.
+        assert_eq!(translate(&[event]), vec![b'\n']);
+    }
+
+    /// Key-event INPUT_RECORD with plain Enter unpacks with no shift.
+    /// Pair to the test above so regressions on either side surface.
+    #[test]
+    fn from_input_record_decodes_plain_enter() {
+        let rec = make_key_record(true, VK_RETURN, b'\r' as u16, 0);
+        let event = from_input_record(&rec).expect("some");
+        assert_eq!(translate(&[event]), vec![b'\r']);
+    }
+
+    /// Mouse INPUT_RECORD becomes `NonKey`. Same for focus,
+    /// buffer-size, and menu records — collapsing them lets the
+    /// caller observe activity without caring about the variant.
+    #[test]
+    fn from_input_record_collapses_non_key_variants() {
+        let mouse = INPUT_RECORD {
+            EventType: MOUSE_EVENT as u16,
+            Event: INPUT_RECORD_0 {
+                MouseEvent: MOUSE_EVENT_RECORD::default(),
+            },
+        };
+        let focus = INPUT_RECORD {
+            EventType: FOCUS_EVENT as u16,
+            Event: INPUT_RECORD_0 {
+                FocusEvent: FOCUS_EVENT_RECORD::default(),
+            },
+        };
+        let bufsize = INPUT_RECORD {
+            EventType: WINDOW_BUFFER_SIZE_EVENT as u16,
+            Event: INPUT_RECORD_0 {
+                WindowBufferSizeEvent: WINDOW_BUFFER_SIZE_RECORD::default(),
+            },
+        };
+        for rec in [mouse, focus, bufsize] {
+            assert_eq!(from_input_record(&rec), Some(InputEvent::NonKey));
+        }
+    }
+
+    /// Unknown EventType yields None. Defensive: future Windows
+    /// versions could add record types; the adapter shouldn't
+    /// silently classify them as NonKey (which would block downstream
+    /// detection logic).
+    #[test]
+    fn from_input_record_returns_none_for_unknown_event_type() {
+        let rec = INPUT_RECORD {
+            EventType: 0xFFFF,
+            Event: INPUT_RECORD_0 {
+                MouseEvent: MOUSE_EVENT_RECORD::default(),
+            },
+        };
+        assert_eq!(from_input_record(&rec), None);
+    }
+
+    // ---------- spawn_with_source tests ----------
+
+    use std::sync::atomic::{AtomicUsize, Ordering as StdOrdering};
+    use std::sync::Arc as StdArc;
+    use std::time::Duration;
+
+    /// The worker translates events from `read_events` and forwards
+    /// the bytes on the channel. Feeding a Shift+Enter event must
+    /// surface as `\n` on the receiver.
+    #[test]
+    fn spawn_with_source_emits_translated_bytes() {
+        let events_emitted = StdArc::new(AtomicUsize::new(0));
+        let emitted = StdArc::clone(&events_emitted);
+        let mut handle = spawn_with_source(move || {
+            // Emit the canned events once, then return empty forever
+            // so the worker spins (cancelled by Drop).
+            if emitted.fetch_add(1, StdOrdering::SeqCst) == 0 {
+                vec![
+                    InputEvent::Key(KeyEvent {
+                        key_down: true,
+                        virtual_key_code: VK_RETURN,
+                        unicode_char: b'\r' as u16,
+                        control_key_state: SHIFT_PRESSED,
+                    }),
+                    InputEvent::Key(KeyEvent {
+                        key_down: true,
+                        virtual_key_code: VK_RETURN,
+                        unicode_char: b'\r' as u16,
+                        control_key_state: 0,
+                    }),
+                ]
+            } else {
+                // Avoid 100% CPU in the test's "no events" period.
+                std::thread::sleep(Duration::from_millis(5));
+                Vec::new()
+            }
+        });
+        let rx = handle.take_receiver().expect("take_receiver");
+        let chunk = rx.recv_timeout(Duration::from_secs(2)).expect("chunk");
+        assert_eq!(chunk, b"\n\r");
+        // Drop the handle — worker should observe cancel and exit.
+        drop(handle);
+    }
+
+    /// When the source emits non-key events only, translate returns
+    /// nothing and the worker MUST NOT send empty chunks. Verifies the
+    /// empty-bytes guard in `spawn_with_source`.
+    #[test]
+    fn spawn_with_source_skips_empty_output() {
+        let count = StdArc::new(AtomicUsize::new(0));
+        let c = StdArc::clone(&count);
+        let mut handle = spawn_with_source(move || {
+            if c.fetch_add(1, StdOrdering::SeqCst) < 3 {
+                vec![InputEvent::NonKey]
+            } else {
+                std::thread::sleep(Duration::from_millis(5));
+                Vec::new()
+            }
+        });
+        let rx = handle.take_receiver().expect("take_receiver");
+        // No chunks should ever arrive — the receiver times out.
+        let result = rx.recv_timeout(Duration::from_millis(200));
+        assert!(result.is_err(), "received unexpected chunk: {:?}", result);
+        drop(handle);
+    }
+
+    /// Dropping the handle signals cancel and joins the worker.
+    /// Without this the worker thread would outlive the test process
+    /// in some cases (and definitely outlive the PTY session in
+    /// production).
+    #[test]
+    fn drop_cancels_worker() {
+        let count = StdArc::new(AtomicUsize::new(0));
+        let c = StdArc::clone(&count);
+        let handle = spawn_with_source(move || {
+            c.fetch_add(1, StdOrdering::SeqCst);
+            std::thread::sleep(Duration::from_millis(5));
+            Vec::new()
+        });
+        // Let the worker loop a few times.
+        std::thread::sleep(Duration::from_millis(40));
+        let observed_before_drop = count.load(StdOrdering::SeqCst);
+        drop(handle);
+        // After drop, the count should stop advancing (worker exited).
+        // Give it a little time to fully exit.
+        std::thread::sleep(Duration::from_millis(50));
+        let observed_after_drop = count.load(StdOrdering::SeqCst);
+        // Worst case the worker did 1-2 more iterations during the
+        // cancel-check window (10ms sleep + cancel check). Allow up to
+        // 5 extra to keep the test stable on slow CI runners.
+        assert!(
+            observed_after_drop - observed_before_drop <= 5,
+            "worker kept iterating after drop: {observed_before_drop} -> {observed_after_drop}"
+        );
     }
 }

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -22,6 +22,42 @@ use crate::verbose_log;
 use crate::voice;
 use crate::win_creation_flags;
 
+/// Merge two optional byte channels into one. Used by `run_plan_pty`
+/// to combine the drag-drop side channel with the Windows console-input
+/// reader (issue #141 follow-up) before handing the result to the
+/// pump's `extra_rx` slot.
+///
+/// Zero or one input returns the inputs themselves (no extra thread).
+/// Two inputs spawn a small forwarder thread per channel that drains
+/// each input and forwards bytes to a unified output channel. The
+/// forwarders exit when their input closes or the output drops.
+fn merge_extra_rx(
+    a: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+    b: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+) -> Option<std::sync::mpsc::Receiver<Vec<u8>>> {
+    match (a, b) {
+        (None, None) => None,
+        (Some(rx), None) | (None, Some(rx)) => Some(rx),
+        (Some(a), Some(b)) => {
+            let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
+            for input in [a, b] {
+                let tx = tx.clone();
+                std::thread::Builder::new()
+                    .name("clud-extra-rx-merge".into())
+                    .spawn(move || {
+                        while let Ok(chunk) = input.recv() {
+                            if tx.send(chunk).is_err() {
+                                break;
+                            }
+                        }
+                    })
+                    .ok();
+            }
+            Some(rx)
+        }
+    }
+}
+
 /// Build the child environment: inherit parent env + inject tracking vars.
 /// Deduplicates keys so we never pass the same var twice.
 pub fn child_env() -> Vec<(String, String)> {
@@ -447,6 +483,33 @@ pub fn run_plan_pty(
         (None, None)
     };
 
+    // Issue #141 follow-up: spawn the Windows console-input reader so
+    // Shift+Enter inserts `\n` even under bare cmd.exe in conhost. The
+    // reader produces a `Receiver<Vec<u8>>` we merge with `dnd_rx` for
+    // the pump's first iteration. Held for the whole function so the
+    // console mode is restored on Drop. Skipped if stdin isn't a real
+    // console (the reader can't function on a piped stdin).
+    #[cfg(windows)]
+    let (mut console_input_rx, _console_input_guards) = if session::terminals_are_interactive() {
+        match crate::console_input::spawn_console_input_reader() {
+            Ok((mut handle, mode_guard)) => {
+                let rx = handle.take_receiver();
+                (rx, Some((handle, mode_guard)))
+            }
+            Err(e) => {
+                eprintln!("[clud] note: console-input reader unavailable: {e}");
+                (None, None)
+            }
+        }
+    } else {
+        (None, None)
+    };
+    #[cfg(not(windows))]
+    let (mut console_input_rx, _console_input_guards): (
+        Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+        Option<()>,
+    ) = (None, None);
+
     let env = child_env();
     let mut last_exit = 0i32;
     let (rows, cols) = get_terminal_size();
@@ -526,12 +589,22 @@ pub fn run_plan_pty(
 
         let mut hooks = voice::VoiceMode::from_env();
         let _raw_guard = session::enter_raw_mode_if_tty();
-        // First iteration takes ownership of the dnd_rx (if any);
-        // subsequent iterations get None. We can't clone the receiver
-        // and the OLE registration is a one-shot for the whole
-        // process anyway (see RefreshConfig — the worker thread is
-        // shared across iterations).
-        let extra_rx = if iteration == 0 { dnd_rx.take() } else { None };
+        // First iteration takes ownership of the side-channel receivers
+        // (drag-drop bytes and, on Windows, console-input bytes from
+        // the Shift+Enter reader); subsequent iterations get None. We
+        // can't clone an `mpsc::Receiver`, and the OLE registration is
+        // a one-shot for the whole process anyway (see `RefreshConfig`
+        // — the worker thread is shared across iterations). The console
+        // reader behaves similarly: its worker keeps running for the
+        // life of `run_plan_pty`, but only iteration 0 sees its bytes.
+        // For typical single-iteration invocations this is irrelevant;
+        // for `clud loop` it's an accepted limitation tracked in the
+        // PR body.
+        let extra_rx = if iteration == 0 {
+            merge_extra_rx(dnd_rx.take(), console_input_rx.take())
+        } else {
+            None
+        };
         let exit_code = session::run_raw_pty_pump_with_extra_rx_verbose(
             &process,
             interrupted,

--- a/crates/clud-bin/tests/pty_behavior.rs
+++ b/crates/clud-bin/tests/pty_behavior.rs
@@ -1109,3 +1109,101 @@ fn raw_pump_restores_raw_mode_on_panic() {
     let _ = process.wait_impl(Some(2.0));
     let _ = process.close_impl();
 }
+
+/// Issue #141 follow-up: bytes from `extra_rx` reach the child PTY
+/// exactly as `console_input::translate()` produces them. The pump
+/// doesn't know or care that the bytes came from a console-input
+/// translator — it forwards `extra_rx` chunks to the child the same
+/// way it would forward stdin. This integration test asserts that
+/// invariant by:
+///
+///   1. Building `console_input::translate()` over a synthetic event
+///      stream containing Shift+Enter and plain Enter.
+///   2. Sending the translated bytes through `extra_rx`.
+///   3. Capturing the child's stdin via `--mock-stdin-raw-to`.
+///   4. Asserting both `\n` (Shift+Enter) and `\r` (plain Enter) made
+///      the round trip.
+///
+/// Windows-only because `console_input` is `#[cfg(windows)]`. The
+/// underlying pump path (`run_raw_pty_pump_with_extra_rx`) works on
+/// every platform; this test just exercises the Windows path.
+#[cfg(windows)]
+#[test]
+fn extra_rx_forwards_shift_enter_translated_bytes_to_pty() {
+    require_pty_or_skip!("extra_rx_forwards_shift_enter_translated_bytes_to_pty");
+
+    use clud::console_input::{translate, InputEvent, KeyEvent, SHIFT_PRESSED, VK_RETURN};
+
+    let agent = mock_agent_path();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let raw_stdin = tmp.path().join("stdin_raw.bin");
+
+    let argv = vec![
+        agent.to_string_lossy().to_string(),
+        "--mock-read-stdin-ms".to_string(),
+        "800".to_string(),
+        "--mock-stdin-raw-to".to_string(),
+        raw_stdin.to_string_lossy().to_string(),
+    ];
+
+    let process = NativePtyProcess::new(argv, None, None, 24, 80, None).expect("new pty");
+    process.set_echo(false);
+    process.start_impl().expect("start");
+    std::thread::sleep(Duration::from_millis(150));
+
+    // What the production reader would emit for a Shift+Enter + plain
+    // Enter sequence. The pump treats these bytes as opaque — exactly
+    // the surface this test pins.
+    let translated = translate(&[
+        InputEvent::Key(KeyEvent {
+            key_down: true,
+            virtual_key_code: VK_RETURN,
+            unicode_char: b'\r' as u16,
+            control_key_state: SHIFT_PRESSED,
+        }),
+        InputEvent::Key(KeyEvent {
+            key_down: true,
+            virtual_key_code: VK_RETURN,
+            unicode_char: b'\r' as u16,
+            control_key_state: 0,
+        }),
+    ]);
+    assert_eq!(translated, b"\n\r", "translator output drifted");
+
+    // Send the translated bytes via extra_rx. A short sleep before
+    // sending lets the pump enter its main loop; the child's stdin
+    // line-mode buffer holds the bytes until newline (mock-sleep then
+    // reads them all).
+    let (extra_tx, extra_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(80));
+        let _ = extra_tx.send(translated.clone());
+    });
+
+    let interrupted = AtomicBool::new(false);
+    let mut hooks = CountingHooks::new(false);
+
+    let _exit = clud::session::run_raw_pty_pump_with_extra_rx(
+        &process,
+        &interrupted,
+        &mut hooks,
+        Cursor::new(Vec::<u8>::new()),
+        Some(extra_rx),
+    );
+
+    let _ = process.wait_impl(Some(5.0));
+    let _ = drain_reader(&process, Duration::from_millis(300));
+    let _ = process.close_impl();
+
+    let got = std::fs::read(&raw_stdin).unwrap_or_default();
+    assert!(
+        got.contains(&b'\n'),
+        "Shift+Enter translation must produce a literal \\n in the child's stdin; got {:?}",
+        got
+    );
+    assert!(
+        got.contains(&b'\r'),
+        "plain Enter translation must produce a \\r in the child's stdin; got {:?}",
+        got
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #142 (translator). Wires `console_input::translate` into the actual PTY input pump so Shift+Enter produces a literal `\n` end-to-end on Windows — works even under bare cmd.exe in conhost where `/terminal-setup` can't help.

Refs #141 (resolves the wiring acceptance criteria from that issue).

## What changed

- **`console_input::from_input_record`** — adapter from the `windows` crate's `INPUT_RECORD` to the simpler `InputEvent`. Key events decode to `KeyEvent`; mouse/focus/buffer-size/menu/window records collapse to `NonKey`; unknown record types yield `None`.
- **`console_input::spawn_with_source<F>`** — testable seam. Takes any `FnMut() -> Vec<InputEvent>` closure, spins it on a worker thread, runs each batch through `translate`, forwards non-empty bytes on an `mpsc::Receiver<Vec<u8>>`. Tests substitute canned closures so the worker can be exercised without a real console.
- **`console_input::ConsoleModeGuard`** — RAII guard that switches the console input mode into raw key-event regime (off: `ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_VIRTUAL_TERMINAL_INPUT`; on: `ENABLE_WINDOW_INPUT`) and restores the original mode on Drop.
- **`console_input::spawn_console_input_reader`** — production wrapper. Sets the console mode, spawns a worker that drains `ReadConsoleInputW` with a 100ms `WaitForSingleObject` cadence so the cancel flag is observed in bounded time.
- **`runner::run_plan_pty`** — on Windows + interactive stdin, spawns the reader, holds the handle + mode guard for the function's lifetime, and merges its receiver with the existing drag-drop side channel via a new `merge_extra_rx` helper before handing the result to the pump's `extra_rx` slot.

## Design choice: merge vs. signature change

Approach B from the issue body (channel merger) over A (pump signature change): the pump's `extra_rx: Option<Receiver<Vec<u8>>>` signature stays unchanged. A small `merge_extra_rx(a, b)` helper in `runner.rs` returns the lone input if only one channel exists, or spawns a forwarder-per-channel into a unified output otherwise. Keeps the surface area minimal and matches the existing style (per-feature channels each spawned next to their producers).

## Multi-iteration limitation (documented, not fixed)

The pump consumes `extra_rx` by value, so the receiver dies after iteration 0. Just like the existing drag-drop path, console-input bytes are delivered only on iteration 0 of a multi-iteration `clud loop` run. Single-iteration usage — the vast majority — is unaffected. Fix would require either changing the pump signature to borrow the receiver across iterations or wrapping it in `Arc<Mutex<_>>`. Tracked as a future cleanup; out of scope here.

## End-to-end verification

I did **not** test against a real bare-cmd.exe terminal interactively from this harness — the agent's Bash tool runs inside an existing console, so I can't reliably exercise the Shift+Enter chord. The integration test below verifies the byte-flow contract (translator → extra_rx → pump → child PTY); confirming the same chord against a fresh cmd.exe session is suggested before merging.

## Test plan

- [x] `soldr cargo test -p clud --lib` — 560 pass (553 prior + 7 new console_input tests).
- [x] 4 `from_input_record` adapter tests (Shift+Enter, plain Enter, NonKey collapse, unknown-EventType -> None).
- [x] 3 `spawn_with_source` tests (translated bytes flow, empty output skip, Drop cancels worker).
- [x] `pty_behavior::extra_rx_forwards_shift_enter_translated_bytes_to_pty` — end-to-end via mock-agent + `--mock-stdin-raw-to`, asserts `\n` and `\r` both reach the child.
- [x] `bash lint` clean (cargo fmt, clippy -D warnings, ruff).
- [ ] **Manual:** open a fresh `cmd.exe`, run `clud --pty -p ...`, press Shift+Enter mid-prompt, confirm the backend sees a newline (not a submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)