### PR TITLE
Gate Ctrl-C diagnostics behind verbose logging

### DIFF
--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -30,6 +30,7 @@ pub mod startup;
 pub mod stream_json;
 pub mod subprocess;
 pub mod trampoline;
+pub mod verbose_log;
 pub mod voice;
 pub mod wasm;
 pub mod win_creation_flags;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,12 +1,14 @@
 use clud::{
     args, backend, command, console_setup, console_title, daemon, gc, gc_daemon, hook_health,
     large_file_guard, loop_artifacts, loop_spec, runner, skill_install, skills, startup,
-    trampoline, wasm, worktrees,
+    trampoline, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, Read};
 
 fn main() {
+    verbose_log::init_launch_clock();
+
     // Windows: rename ourselves so pip can always overwrite clud.exe.
     trampoline::unlock_exe();
 

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -18,6 +18,7 @@ use crate::process_tree;
 use crate::session;
 use crate::stream_json;
 use crate::subprocess;
+use crate::verbose_log;
 use crate::voice;
 use crate::win_creation_flags;
 
@@ -41,6 +42,25 @@ pub fn child_env() -> Vec<(String, String)> {
 pub fn get_terminal_size() -> (u16, u16) {
     let probe = terminal_size::terminal_size().map(|(w, h)| (w.0, h.0));
     resolve_terminal_size(probe)
+}
+
+fn display_verbose_command(command: &[String]) -> String {
+    let Some((program, args)) = command.split_first() else {
+        return String::new();
+    };
+    let mut rendered = Vec::with_capacity(command.len());
+    rendered.push(display_program_name(program));
+    rendered.extend(args.iter().cloned());
+    rendered.join(" ")
+}
+
+fn display_program_name(program: &str) -> String {
+    let tail = program.rsplit(['\\', '/']).next().unwrap_or(program);
+    if tail.is_empty() {
+        program.to_string()
+    } else {
+        tail.to_string()
+    }
 }
 
 /// Translate a `(cols, rows)` probe result into a `(rows, cols)` size to hand
@@ -106,7 +126,9 @@ pub fn run_plan_subprocess(
         // launch another codex run. 130 is the conventional SIGINT exit
         // code and mirrors what `ProcessOutcome::Interrupted` produces.
         if interrupted.load(Ordering::SeqCst) {
-            eprintln!("[clud] interrupted via Ctrl+C");
+            if verbose {
+                verbose_log::log("[clud] interrupted via Ctrl+C");
+            }
             return 130;
         }
 
@@ -119,7 +141,10 @@ pub fn run_plan_subprocess(
         }
 
         if verbose {
-            eprintln!("[clud] exec (subprocess): {}", plan.command.join(" "));
+            verbose_log::log(format_args!(
+                "[clud] exec (subprocess): {}",
+                display_verbose_command(&plan.command)
+            ));
         }
 
         let config = ProcessConfig {
@@ -193,7 +218,9 @@ pub fn run_plan_subprocess(
                 }
             }
             ProcessOutcome::Interrupted => {
-                eprintln!("[clud] interrupted via Ctrl+C");
+                if verbose {
+                    verbose_log::log("[clud] interrupted via Ctrl+C");
+                }
                 if let Some(s) = loop_session.as_deref_mut() {
                     s.on_iteration_end(iter_num, 130, Some("Interrupted by user".to_string()));
                 }
@@ -414,7 +441,9 @@ pub fn run_plan_pty(
         // Re-check the interrupted flag at the top of every iteration. See
         // the matching guard in `run_plan_subprocess` — same rationale.
         if interrupted.load(Ordering::SeqCst) {
-            eprintln!("[clud] interrupted via Ctrl+C");
+            if verbose {
+                verbose_log::log("[clud] interrupted via Ctrl+C");
+            }
             return 130;
         }
 
@@ -427,7 +456,10 @@ pub fn run_plan_pty(
         }
 
         if verbose {
-            eprintln!("[clud] exec (pty): {}", plan.command.join(" "));
+            verbose_log::log(format_args!(
+                "[clud] exec (pty): {}",
+                display_verbose_command(&plan.command)
+            ));
         }
 
         let process = match NativePtyProcess::new(
@@ -472,12 +504,13 @@ pub fn run_plan_pty(
         // process anyway (see RefreshConfig — the worker thread is
         // shared across iterations).
         let extra_rx = if iteration == 0 { dnd_rx.take() } else { None };
-        let exit_code = session::run_raw_pty_pump_with_extra_rx(
+        let exit_code = session::run_raw_pty_pump_with_extra_rx_verbose(
             &process,
             interrupted,
             &mut hooks,
             io::stdin(),
             extra_rx,
+            verbose,
         );
         drop(_raw_guard);
         last_exit = normalize_exit_code(exit_code);
@@ -536,5 +569,38 @@ mod tests {
     fn launch_mode_defaults_to_subprocess() {
         let launch_mode = crate::backend::LaunchMode::Subprocess;
         assert_eq!(launch_mode.as_str(), "subprocess");
+    }
+
+    #[test]
+    fn display_verbose_command_strips_program_paths() {
+        let command = vec![
+            r"C:\tools\node\claude.exe".to_string(),
+            "--verbose".to_string(),
+            "-p".to_string(),
+            "hello".to_string(),
+        ];
+        assert_eq!(
+            display_verbose_command(&command),
+            "claude.exe --verbose -p hello"
+        );
+
+        let command = vec![
+            "/usr/local/bin/codex".to_string(),
+            "--dangerously-bypass-approvals-and-sandbox".to_string(),
+        ];
+        assert_eq!(
+            display_verbose_command(&command),
+            "codex --dangerously-bypass-approvals-and-sandbox"
+        );
+    }
+
+    #[test]
+    fn display_verbose_command_keeps_plain_program_names() {
+        let command = vec![
+            "claude".to_string(),
+            "--model".to_string(),
+            "opus".to_string(),
+        ];
+        assert_eq!(display_verbose_command(&command), "claude --model opus");
     }
 }

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -10,6 +10,7 @@ use running_process_core::pty::NativePtyProcess;
 
 use crate::console_title::OscTitleStripper;
 use crate::dnd::{looks_like_dropped_path, normalize_dropped_path};
+use crate::verbose_log;
 
 /// Resize the PTY. On Windows, `running_process_core::pty::NativePtyProcess::resize_impl`
 /// is a deliberate no-op (see that crate's `pty/mod.rs:730-737`), so reaching
@@ -377,15 +378,39 @@ where
     H: InteractiveHooks,
     R: std::io::Read + Send + 'static,
 {
+    run_raw_pty_pump_with_extra_rx_verbose(
+        process,
+        interrupted,
+        hooks,
+        stdin_source,
+        extra_rx,
+        false,
+    )
+}
+
+/// Production pump entry with optional clud-level diagnostics.
+pub fn run_raw_pty_pump_with_extra_rx_verbose<H, R>(
+    process: &NativePtyProcess,
+    interrupted: &AtomicBool,
+    hooks: &mut H,
+    stdin_source: R,
+    extra_rx: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+    verbose: bool,
+) -> i32
+where
+    H: InteractiveHooks,
+    R: std::io::Read + Send + 'static,
+{
     let (resize_tx, resize_rx) = std::sync::mpsc::channel::<(u16, u16)>();
     spawn_os_resize_watcher(resize_tx);
-    run_raw_pty_pump_full(
+    run_raw_pty_pump_full_verbose(
         process,
         interrupted,
         hooks,
         stdin_source,
         resize_rx,
         extra_rx,
+        verbose,
     )
 }
 
@@ -469,6 +494,30 @@ pub fn run_raw_pty_pump_full<H, R>(
     stdin_source: R,
     resize_rx: std::sync::mpsc::Receiver<(u16, u16)>,
     extra_rx: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+) -> i32
+where
+    H: InteractiveHooks,
+    R: std::io::Read + Send + 'static,
+{
+    run_raw_pty_pump_full_verbose(
+        process,
+        interrupted,
+        hooks,
+        stdin_source,
+        resize_rx,
+        extra_rx,
+        false,
+    )
+}
+
+fn run_raw_pty_pump_full_verbose<H, R>(
+    process: &NativePtyProcess,
+    interrupted: &AtomicBool,
+    hooks: &mut H,
+    stdin_source: R,
+    resize_rx: std::sync::mpsc::Receiver<(u16, u16)>,
+    extra_rx: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+    verbose: bool,
 ) -> i32
 where
     H: InteractiveHooks,
@@ -597,7 +646,7 @@ where
             }
 
             if requested_interrupt || interrupted.load(Ordering::SeqCst) {
-                return interrupt_pty_process(process);
+                return interrupt_pty_process(process, verbose);
             }
         }
 
@@ -612,7 +661,7 @@ where
         }
 
         if interrupted.load(Ordering::SeqCst) {
-            return interrupt_pty_process(process);
+            return interrupt_pty_process(process, verbose);
         }
     }
 }
@@ -784,31 +833,39 @@ fn reap_pty_exit(process: &NativePtyProcess) -> i32 {
 /// pump has observed the flag. Platform-split because `send_interrupt_impl`
 /// is a byte-write on Windows (duplicates the 0x03 already forwarded via
 /// raw-mode stdin) and a pgroup-SIGINT on POSIX (cooperative, no duplicate).
-fn interrupt_pty_process(process: &NativePtyProcess) -> i32 {
+fn interrupt_pty_process(process: &NativePtyProcess, verbose: bool) -> i32 {
     #[cfg(windows)]
     {
         // Closing the PTY triggers ConPTY's CTRL_CLOSE_EVENT path and
         // tears the child down without writing a second 0x03 byte.
         let _ = process.close_impl();
-        eprintln!("[clud] interrupted via Ctrl+C (pty)");
+        if verbose {
+            verbose_log::log("[clud] interrupted via Ctrl+C (pty)");
+        }
         130
     }
     #[cfg(not(windows))]
     match process.send_interrupt_impl() {
         Ok(()) => match process.wait_impl(Some(2.0)) {
             Ok(code) => {
-                eprintln!("[clud] interrupted via Ctrl+C (pty)");
+                if verbose {
+                    verbose_log::log("[clud] interrupted via Ctrl+C (pty)");
+                }
                 code
             }
             Err(_) => {
                 let _ = process.close_impl();
-                eprintln!("[clud] interrupted via Ctrl+C (pty)");
+                if verbose {
+                    verbose_log::log("[clud] interrupted via Ctrl+C (pty)");
+                }
                 130
             }
         },
         Err(_) => {
             let _ = process.close_impl();
-            eprintln!("[clud] interrupted via Ctrl+C (pty)");
+            if verbose {
+                verbose_log::log("[clud] interrupted via Ctrl+C (pty)");
+            }
             130
         }
     }

--- a/crates/clud-bin/src/verbose_log.rs
+++ b/crates/clud-bin/src/verbose_log.rs
@@ -1,0 +1,13 @@
+use std::sync::OnceLock;
+use std::time::Instant;
+
+static LAUNCH_START: OnceLock<Instant> = OnceLock::new();
+
+pub fn init_launch_clock() {
+    let _ = LAUNCH_START.set(Instant::now());
+}
+
+pub fn log(message: impl std::fmt::Display) {
+    let start = LAUNCH_START.get_or_init(Instant::now);
+    eprintln!("{:.2} {}", start.elapsed().as_secs_f64(), message);
+}


### PR DESCRIPTION
## Summary
- Keep Ctrl-C diagnostics, but only emit them when `clud --verbose` is set.
- Prefix clud-owned verbose logs with launch-relative timestamps like `0.00 [clud] ...`.
- Keep verbose exec lines tidy by stripping absolute path components from the displayed backend executable.

## Tests
- `soldr --no-cache cargo check -p clud --bin clud`
- `soldr --no-cache cargo test -p clud runner:: --lib`
- `soldr --no-cache cargo test -p clud session:: --lib`