### PR TITLE
Enhance verbose logging with launch log file

### DIFF
--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicBool;
 use crate::args::{Args, Command};
 use crate::backend::LaunchMode;
 use crate::command::LaunchPlan;
+use crate::verbose_log;
 
 use super::attach::{attach_to_session, run_attach};
 use super::client::{ensure_daemon, send_daemon_request};
@@ -142,9 +143,21 @@ pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i
 
 pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &AtomicBool) -> i32 {
     let state_dir = state_dir(args);
+    if args.verbose {
+        verbose_log::log(format_args!(
+            "[clud] daemon: ensure state_dir={}",
+            verbose_log::display_path(&state_dir)
+        ));
+    }
     if let Err(err) = ensure_daemon(&state_dir) {
         eprintln!("[clud] failed to start daemon: {}", err);
+        if args.verbose {
+            verbose_log::log(format_args!("[clud] daemon: ensure failed: {err}"));
+        }
         return 1;
+    }
+    if args.verbose {
+        verbose_log::log("[clud] daemon: ready");
     }
 
     let repeat_enabled = plan.repeat_schedule.is_some();
@@ -173,6 +186,14 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
     } else {
         None
     };
+    if args.verbose {
+        verbose_log::log(format_args!(
+            "[clud] daemon: create session kind={:?} detach={} repeat={}",
+            kind,
+            args.detach || args.detachable,
+            repeat_enabled
+        ));
+    }
     let request = DaemonRequest::Create {
         spec: Box::new(WorkerLaunchSpec {
             plan: plan.clone(),
@@ -192,12 +213,18 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         Ok(response) => response,
         Err(err) => {
             eprintln!("[clud] daemon request failed: {}", err);
+            if args.verbose {
+                verbose_log::log(format_args!("[clud] daemon: request failed: {err}"));
+            }
             return 1;
         }
     };
 
     match response {
         DaemonResponse::Created { session } => {
+            if args.verbose {
+                verbose_log::log(format_args!("[clud] daemon: session {}", session.id));
+            }
             if repeat_enabled {
                 eprintln!("[clud] repeat job {} running in background", session.id);
                 eprintln!("[clud] list jobs with: clud list");
@@ -215,6 +242,9 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         }
         DaemonResponse::Error { message } => {
             eprintln!("[clud] daemon error: {}", message);
+            if args.verbose {
+                verbose_log::log(format_args!("[clud] daemon: error: {message}"));
+            }
             1
         }
         DaemonResponse::Session { .. } | DaemonResponse::Terminated { .. } => 1,

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -44,6 +44,20 @@ fn main() {
     skill_install::ensure_installed();
 
     let mut args = args::Args::parse_with_passthrough();
+    if args.verbose {
+        match verbose_log::enable_file_logging() {
+            Ok(path) => {
+                verbose_log::log(format_args!(
+                    "[clud] verbose log: {}",
+                    verbose_log::display_path(&path)
+                ));
+            }
+            Err(err) => {
+                verbose_log::log(format_args!("[clud] verbose log unavailable: {err}"));
+            }
+        }
+        verbose_log::log(format_args!("[clud] pid {}", std::process::id()));
+    }
 
     // Issue #135: hidden `__gc-daemon` subcommand is the GC-only daemon
     // entry point. Owns `~/.clud/data.redb` exclusively and serves the
@@ -140,12 +154,18 @@ fn main() {
     }
 
     if hook_health::should_check_launch(&args) {
+        if args.verbose {
+            verbose_log::log("[clud] hooks: checking launch parity");
+        }
         hook_health::emit_launch_warnings();
     }
 
     if !args.clean_worktrees && !args.fix_hooks {
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
         let root = loop_spec::git_root_from(&cwd);
+        if args.verbose {
+            verbose_log::log("[clud] large-file guard: scanning project");
+        }
         large_file_guard::run(&root);
     }
 
@@ -170,9 +190,17 @@ fn main() {
     // launches) still trigger the auto-spawn, so the gc daemon is
     // available as soon as it's first actually needed.
     if !args.no_daemon && !args.dry_run && !daemon::experimental_enabled(&args) {
+        if args.verbose {
+            verbose_log::log("[clud] gc daemon: ensure running");
+        }
         if let Err(e) = gc_daemon::ensure_running() {
             eprintln!("[clud] note: gc daemon unavailable: {}", e);
+            if args.verbose {
+                verbose_log::log(format_args!("[clud] gc daemon: unavailable: {e}"));
+            }
         }
+    } else if args.verbose {
+        verbose_log::log("[clud] gc daemon: skipped");
     }
 
     let backend = backend::resolve_backend(args.claude, args.codex);
@@ -192,6 +220,15 @@ fn main() {
     };
 
     let plan = command::build_launch_plan(&args, backend, &backend_path);
+    if args.verbose {
+        verbose_log::log(format_args!(
+            "[clud] plan: backend={} mode={} iterations={} stream_json={}",
+            backend.executable_name(),
+            plan.launch_mode.as_str(),
+            plan.iterations,
+            plan.stream_json_progress
+        ));
+    }
 
     if args.dry_run {
         let json = serde_json::json!({
@@ -224,8 +261,14 @@ fn main() {
     let _dnd_subprocess_guard = if startup::should_register_drop_target(&args)
         && plan.launch_mode == backend::LaunchMode::Subprocess
     {
+        if args.verbose {
+            verbose_log::log("[clud] dnd: registering subprocess drop target");
+        }
         startup::try_register_console_drop_target_subprocess()
     } else {
+        if args.verbose {
+            verbose_log::log("[clud] dnd: subprocess drop target skipped");
+        }
         None
     };
 
@@ -236,6 +279,9 @@ fn main() {
     // re-acquires the lock to remove our row. Holding redb for the
     // lifetime of `main` would race with concurrent `clud` launches and
     // print spurious `Database already open` warnings (issue #138).
+    if args.verbose {
+        verbose_log::log("[clud] session registry: enforcing cap");
+    }
     let _session_guard = startup::enforce_session_cap();
 
     // Issue #110: spawn the background worktree scanner. Polls the
@@ -244,11 +290,17 @@ fn main() {
     // Existing rows are left alone — the scanner is insert-only, no
     // write churn. `Drop` joins the worker thread; explicit `drop` below
     // sequences cancellation before the session-registry guard.
+    if args.verbose {
+        verbose_log::log("[clud] worktree scanner: starting");
+    }
     let _scanner_guard = gc::WorktreeScanner::maybe_spawn();
 
     // Clear stale DONE/BLOCKED markers from a prior run so that loops don't
     // short-circuit on iteration 1. See loop_spec for semantics.
     if let Some(ref markers) = plan.loop_markers {
+        if args.verbose {
+            verbose_log::log("[clud] loop markers: clearing stale DONE/BLOCKED files");
+        }
         loop_spec::clear_markers_at(&loop_spec::MarkerPaths {
             done: std::path::PathBuf::from(&markers.done_path),
             blocked: std::path::PathBuf::from(&markers.blocked_path),
@@ -261,6 +313,9 @@ fn main() {
     // `clud loop`; other commands skip the bookkeeping entirely.
     let mut loop_session: Option<loop_artifacts::LoopSession> =
         if let Some(args::Command::Loop { task, .. }) = &args.command {
+            if args.verbose {
+                verbose_log::log("[clud] loop artifacts: starting session");
+            }
             let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
             let git_root = loop_spec::git_root_from(&cwd);
             let _ = loop_spec::ensure_loop_dir(&git_root);
@@ -277,7 +332,15 @@ fn main() {
             None
         };
 
-    let exit_code = if daemon::experimental_enabled(&args) {
+    let centralized = daemon::experimental_enabled(&args);
+    if args.verbose {
+        verbose_log::log(if centralized {
+            "[clud] launch: centralized daemon"
+        } else {
+            "[clud] launch: direct runner"
+        });
+    }
+    let exit_code = if centralized {
         daemon::run_centralized_session(&args, &plan, interrupted.as_ref())
     } else {
         match plan.launch_mode {
@@ -303,5 +366,8 @@ fn main() {
     drop(_scanner_guard);
     drop(_session_guard);
     drop(_dnd_subprocess_guard);
+    if args.verbose {
+        verbose_log::log(format_args!("[clud] exit: code {exit_code}"));
+    }
     std::process::exit(exit_code);
 }

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -185,10 +185,16 @@ pub fn run_plan_subprocess(
         let process = NativeProcess::new(config);
         if let Err(e) = process.start() {
             eprintln!("[clud] failed to execute {}: {}", plan.command[0], e);
+            if verbose {
+                verbose_log::log(format_args!("[clud] subprocess: start failed: {e}"));
+            }
             if let Some(s) = loop_session.as_deref_mut() {
                 s.on_iteration_end(iter_num, 1, Some(format!("failed to start: {e}")));
             }
             return 1;
+        }
+        if verbose {
+            verbose_log::log("[clud] subprocess: started");
         }
 
         // Issue #95: in stream-json mode we also accumulate the rendered
@@ -206,6 +212,9 @@ pub fn run_plan_subprocess(
         match exit_code {
             ProcessOutcome::Exited(code) => {
                 last_exit = code;
+                if verbose {
+                    verbose_log::log(format_args!("[clud] subprocess: exited code {code}"));
+                }
                 if let Some(s) = loop_session.as_deref_mut() {
                     s.on_iteration_end(iter_num, code, None);
                 }
@@ -227,6 +236,9 @@ pub fn run_plan_subprocess(
                 return 130;
             }
             ProcessOutcome::Error => {
+                if verbose {
+                    verbose_log::log("[clud] subprocess: runner error");
+                }
                 if let Some(s) = loop_session.as_deref_mut() {
                     s.on_iteration_end(iter_num, 1, Some("runner error".to_string()));
                 }
@@ -436,6 +448,11 @@ pub fn run_plan_pty(
     let env = child_env();
     let mut last_exit = 0i32;
     let (rows, cols) = get_terminal_size();
+    if verbose {
+        verbose_log::log(format_args!(
+            "[clud] pty: terminal size rows={rows} cols={cols}"
+        ));
+    }
 
     for iteration in 0..plan.iterations {
         // Re-check the interrupted flag at the top of every iteration. See
@@ -473,6 +490,9 @@ pub fn run_plan_pty(
             Ok(p) => p,
             Err(e) => {
                 eprintln!("[clud] failed to create pty: {}", e);
+                if verbose {
+                    verbose_log::log(format_args!("[clud] pty: create failed: {e}"));
+                }
                 if let Some(s) = loop_session.as_deref_mut() {
                     s.on_iteration_end(iter_num, 1, Some(format!("pty create failed: {e}")));
                 }
@@ -490,10 +510,16 @@ pub fn run_plan_pty(
 
         if let Err(e) = process.start_impl() {
             eprintln!("[clud] failed to execute {}: {}", plan.command[0], e);
+            if verbose {
+                verbose_log::log(format_args!("[clud] pty: start failed: {e}"));
+            }
             if let Some(s) = loop_session.as_deref_mut() {
                 s.on_iteration_end(iter_num, 1, Some(format!("pty start failed: {e}")));
             }
             return 1;
+        }
+        if verbose {
+            verbose_log::log("[clud] pty: started");
         }
 
         let mut hooks = voice::VoiceMode::from_env();
@@ -514,6 +540,9 @@ pub fn run_plan_pty(
         );
         drop(_raw_guard);
         last_exit = normalize_exit_code(exit_code);
+        if verbose {
+            verbose_log::log(format_args!("[clud] pty: exited code {last_exit}"));
+        }
         if let Some(s) = loop_session.as_deref_mut() {
             let err = if last_exit == 130 {
                 Some("Interrupted by user".to_string())

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -530,6 +530,12 @@ where
     let normalize_console_stdin =
         should_normalize_interactive_console_stdin(interactive_real_stdin);
     let interrupt_on_ctrl_c_byte = interactive_real_stdin;
+    if verbose {
+        verbose_log::log(format_args!(
+            "[clud] pty pump: start interactive_stdin={} normalize_console_stdin={}",
+            interactive_real_stdin, normalize_console_stdin
+        ));
+    }
 
     // Detached reader: pumps `stdin_source` → channel until EOF or error.
     // Detached (not joined) so a blocked `read()` on real stdin doesn't
@@ -646,6 +652,14 @@ where
             }
 
             if requested_interrupt || interrupted.load(Ordering::SeqCst) {
+                if verbose {
+                    let source = if requested_interrupt {
+                        "stdin Ctrl+C byte"
+                    } else {
+                        "interrupt flag"
+                    };
+                    verbose_log::log(format_args!("[clud] pty pump: interrupt via {source}"));
+                }
                 return interrupt_pty_process(process, verbose);
             }
         }
@@ -657,10 +671,16 @@ where
         if let Ok(Some(code)) =
             running_process_core::pty::poll_pty_process(&process.handles, &process.returncode)
         {
+            if verbose {
+                verbose_log::log(format_args!("[clud] pty pump: child exited code {code}"));
+            }
             return code;
         }
 
         if interrupted.load(Ordering::SeqCst) {
+            if verbose {
+                verbose_log::log("[clud] pty pump: interrupt flag observed");
+            }
             return interrupt_pty_process(process, verbose);
         }
     }

--- a/crates/clud-bin/src/verbose_log.rs
+++ b/crates/clud-bin/src/verbose_log.rs
@@ -1,13 +1,127 @@
-use std::sync::OnceLock;
-use std::time::Instant;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 static LAUNCH_START: OnceLock<Instant> = OnceLock::new();
+static LOG_FILE: OnceLock<Mutex<Option<File>>> = OnceLock::new();
+
+const ENV_VERBOSE_LOG_DIR: &str = "CLUD_VERBOSE_LOG_DIR";
 
 pub fn init_launch_clock() {
     let _ = LAUNCH_START.set(Instant::now());
 }
 
+pub fn enable_file_logging() -> io::Result<PathBuf> {
+    let dir = default_log_dir()?;
+    std::fs::create_dir_all(&dir)?;
+    let (path, file) = create_launch_log_file(&dir)?;
+    let file_slot = LOG_FILE.get_or_init(|| Mutex::new(None));
+    *file_slot
+        .lock()
+        .map_err(|err| io::Error::other(err.to_string()))? = Some(file);
+    Ok(path)
+}
+
 pub fn log(message: impl std::fmt::Display) {
     let start = LAUNCH_START.get_or_init(Instant::now);
-    eprintln!("{:.2} {}", start.elapsed().as_secs_f64(), message);
+    let line = format!("{:.2} {}", start.elapsed().as_secs_f64(), message);
+    eprintln!("{line}");
+    if let Some(file_slot) = LOG_FILE.get() {
+        if let Ok(mut guard) = file_slot.lock() {
+            if let Some(file) = guard.as_mut() {
+                let _ = writeln!(file, "{line}");
+                let _ = file.flush();
+            }
+        }
+    }
+}
+
+pub fn display_path(path: &Path) -> String {
+    if let Some(home) = dirs::home_dir() {
+        if let Ok(rest) = path.strip_prefix(&home) {
+            return format!("~{}{}", std::path::MAIN_SEPARATOR, rest.display());
+        }
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Ok(rest) = path.strip_prefix(cwd) {
+            return format!(".{}{}", std::path::MAIN_SEPARATOR, rest.display());
+        }
+    }
+    path.file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn default_log_dir() -> io::Result<PathBuf> {
+    if let Ok(path) = std::env::var(ENV_VERBOSE_LOG_DIR) {
+        return Ok(PathBuf::from(path));
+    }
+    let home = dirs::home_dir()
+        .ok_or_else(|| io::Error::other("no home directory; cannot resolve verbose log dir"))?;
+    Ok(home.join(".clud").join("state").join("verbose"))
+}
+
+fn create_launch_log_file(dir: &Path) -> io::Result<(PathBuf, File)> {
+    let unix_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let pid = std::process::id();
+    for suffix in 0..100 {
+        let name = if suffix == 0 {
+            format!("clud-{unix_ms}-{pid}.log")
+        } else {
+            format!("clud-{unix_ms}-{pid}-{suffix}.log")
+        };
+        let path = dir.join(name);
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate unique verbose log file",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_path_strips_home_prefix() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let path = home
+            .join(".clud")
+            .join("state")
+            .join("verbose")
+            .join("x.log");
+        let rendered = display_path(&path);
+        assert!(rendered.starts_with('~'), "rendered={rendered}");
+        assert!(rendered.ends_with("x.log"), "rendered={rendered}");
+    }
+
+    #[test]
+    fn enabled_file_logging_writes_timestamped_lines() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var(ENV_VERBOSE_LOG_DIR, tmp.path());
+        let path = enable_file_logging().expect("enable file logging");
+
+        log("[clud] test message");
+
+        let text = std::fs::read_to_string(&path).expect("read log");
+        assert!(text.contains("[clud] test message"), "text={text:?}");
+        assert!(
+            text.lines()
+                .any(|line| line.split_once(' ').is_some_and(|(ts, _)| ts.contains('.'))),
+            "text={text:?}"
+        );
+        std::env::remove_var(ENV_VERBOSE_LOG_DIR);
+    }
 }


### PR DESCRIPTION
## Summary
- Make `clud --verbose` create a per-launch log file under `~/.clud/state/verbose/`.
- Mirror timestamped verbose diagnostics to both stderr and the launch log file.
- Add more lifecycle diagnostics for planning, daemon/direct launch selection, DnD/session setup, subprocess/PTTY start/exit, PTY pump interrupts, and final exit.
- Keep executable display names tidy by avoiding absolute paths in verbose command logs.

## Tests
- `soldr --no-cache cargo check -p clud --bin clud`
- `soldr --no-cache cargo test -p clud verbose_log:: --lib`
- `soldr --no-cache cargo test -p clud runner:: --lib`
- `soldr --no-cache cargo test -p clud session:: --lib`