### PR TITLE
docs: progressive-disclosure README tree for crates/ and testbins/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,64 +1,79 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with this repository.
+Guidance for Claude Code when working in this repository.
+
+**This file is an index.** Per-directory `README.md` files carry the real detail — descend into them as needed instead of expanding this file.
 
 ## Quick Reference
 
 ### Essential Commands
 
-- **Build**: `bash build` - Build dev wheel (Rust binary + Python package)
-- **Lint**: `bash lint` - Run cargo fmt, clippy, and ruff (**MANDATORY** after code changes)
-- **Test**: `bash test` - Run Rust unit tests + Python unit tests
-- **Test (Full)**: `bash test --integration` - Include integration tests with mock agents
-- **Rust toolchain calls** (`cargo`, `rustc`, `rustfmt`) **must go through [soldr](https://github.com/zackees/soldr)**: `soldr cargo build`, `soldr rustc ...`, etc. soldr resolves the rustup-managed toolchain via `rustup which`, sidestepping chocolatey cargo on Windows and other stale PATH shims. A `.claude/hooks/check-soldr.py` PreToolUse hook enforces this and tells you to install soldr if it's missing.
-- **Install soldr**: run `./install` (places it in this repo's `.venv`) or `./install --global` (places it in `~/.cargo/bin` or `~/.local/bin`). soldr is intentionally **not** a Python dep — it is installed as a standalone binary from GitHub Releases. CI uses `zackees/setup-soldr@v0`.
+- **Build**: `bash build` — dev wheel (Rust binary + Python package)
+- **Lint**: `bash lint` — `cargo fmt`, `cargo clippy`, `ruff` (**MANDATORY** after any code edit)
+- **Test**: `bash test` — Rust unit tests + Python unit tests
+- **Test (full)**: `bash test --integration` — adds integration tests with mock agents
 
-### Architecture
+### Soldr (Rust toolchain wrapper)
 
-This is a Rust CLI (`clud`) distributed as a Python wheel via maturin `bindings = "bin"`.
+All `cargo` / `rustc` / `rustfmt` calls **must go through [soldr](https://github.com/zackees/soldr)**: `soldr cargo build`, `soldr cargo test -p clud-bin`, etc. soldr resolves the rustup-managed toolchain via `rustup which`, sidestepping chocolatey cargo on Windows and other stale PATH shims. A `.claude/hooks/check-soldr.py` PreToolUse hook enforces this.
+
+Install soldr: `./install` (puts it in this repo's `.venv`) or `./install --global` (puts it in `~/.cargo/bin` or `~/.local/bin`). CI uses `zackees/setup-soldr@v0`.
+
+## Repository Map
+
+This is a Rust CLI (`clud`) distributed as a Python wheel via maturin (`bindings = "bin"`). The Rust source lives under `crates/` and is mirrored by a progressive-disclosure README tree:
 
 ```
-crates/clud-bin/          # Main Rust binary crate
-  src/
-    main.rs               # Entry point: pipe detection, dry-run, execution
-    args.rs               # clap argument parsing with passthrough support
-    backend.rs            # Backend discovery (claude/codex on PATH)
-    command.rs            # Command builder: YOLO injection, prompts, loops
-testbins/mock-agent/      # Mock agent for integration testing
-src/clud/__init__.py      # Minimal Python package (version only)
-ci/                       # CI scripts (env, build, lint, test)
-tests/                    # Python tests (unit + integration)
+crates/                    → see crates/README.md
+  clud-bin/                → see crates/clud-bin/README.md
+    src/                   → see crates/clud-bin/src/README.md
+      command/             → see crates/clud-bin/src/command/README.md
+      daemon/              → see crates/clud-bin/src/daemon/README.md
+      dnd/                 → see crates/clud-bin/src/dnd/README.md
+      voice/               → see crates/clud-bin/src/voice/README.md
+    tests/                 → see crates/clud-bin/tests/README.md
+    assets/                → see crates/clud-bin/assets/README.md
+      skills/              → see crates/clud-bin/assets/skills/README.md
+        clud-issue/        → see .../clud-issue/README.md
+        clud-issue-triage/ → see .../clud-issue-triage/README.md
+        clud-pr/           → see .../clud-pr/README.md
+        clud-tag-release/  → see .../clud-tag-release/README.md
+testbins/                  → see testbins/README.md
+  mock-agent/              → see testbins/mock-agent/README.md
+    src/                   → see testbins/mock-agent/src/README.md
+src/clud/__init__.py       # Minimal Python package (version shim only)
+ci/                        # CI scripts (env, build, lint, test)
+tests/                     # Python tests (unit + integration)
 ```
 
-### Key Design Decisions
+### How to navigate
 
-- **YOLO by default**: Always injects `--dangerously-skip-permissions` unless `--safe`
-- **Backend agnostic**: Supports both `claude` and `codex` via `--claude`/`--codex` flags
-- **Unknown flag forwarding**: Unrecognized CLI flags pass through to the backend
-- **Test-first**: Every feature has both Rust `#[test]` and Python subprocess tests
-- **`--dry-run`**: Outputs JSON with the command that would be executed
+- **Where is X implemented?** Start at [`crates/clud-bin/src/README.md`](crates/clud-bin/src/README.md). It groups every top-level `.rs` file by concern (CLI surface, console/terminal, loop subsystem, GC, platform glue) and includes a "Quick lookup — which file owns a given subcommand" table.
+- **How does a subsystem work?** Each subdirectory README (`command/`, `daemon/`, `dnd/`, `voice/`) describes its purpose, files, key public items with `file:line` refs, and who calls into it.
+- **How does a test work?** [`crates/clud-bin/tests/README.md`](crates/clud-bin/tests/README.md) for Rust integration tests; [`testbins/mock-agent/README.md`](testbins/mock-agent/README.md) for the mock backend.
+- **How do bundled skills ship?** [`crates/clud-bin/assets/skills/README.md`](crates/clud-bin/assets/skills/README.md) — note the two-installer caveat (`skills.rs` vs `skill_install.rs`).
 
-### Code Quality Standards
+## Key Design Decisions
 
-After **ANY** code editing, you **MUST** run:
+- **YOLO by default**: always injects `--dangerously-skip-permissions` unless `--safe`.
+- **Backend agnostic**: supports both `claude` and `codex` via `--claude` / `--codex`.
+- **Unknown flag passthrough**: unrecognized CLI flags are forwarded to the backend.
+- **Single `LaunchPlan`**: every code path goes through `command::build_launch_plan` (see [`src/command/README.md`](crates/clud-bin/src/command/README.md)). `--dry-run` emits this plan as JSON.
+- **Test-first**: every feature has both Rust `#[test]` and Python subprocess tests.
 
-```bash
-bash lint
-```
+## Code Quality Standards
 
-This runs `cargo fmt --check`, `cargo clippy -D warnings`, and `ruff check`.
+After **any** code edit you **must** run `bash lint` (runs `cargo fmt --check`, `cargo clippy -D warnings`, and `ruff check`).
 
-### Test Coverage
+## Test Coverage
 
-- **104 Rust unit tests**: arg parsing, command building, backend resolution,
-  loop-spec (URL classification, GH-JSON parsing, marker files)
-- **21 Python unit tests**: CLI output via `--dry-run` subprocess calls
-- **Python integration tests**: end-to-end with mock claude/codex agents,
-  including the `clud loop` DONE/BLOCKED marker contract
+- ~104 Rust unit tests across arg parsing, command building, backend resolution, loop-spec (URL classification, GH-JSON parsing, marker files).
+- ~21 Python unit tests via `--dry-run` subprocess calls.
+- Python integration tests run end-to-end against [`mock-agent`](testbins/mock-agent/README.md), including the `clud loop` DONE/BLOCKED marker contract.
 
-### CI Matrix
+## CI Matrix
 
-6 platforms x 4 job types = 24 GitHub Actions jobs:
+6 platforms × 4 job types = 24 GitHub Actions jobs:
 - Linux x86 (`ubuntu-24.04`) + ARM (`ubuntu-24.04-arm`)
 - Windows x86 (`windows-2025`) + ARM (`windows-11-arm`)
 - macOS ARM (`macos-15`) + x86 (`macos-15-intel`)

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,11 @@
+# crates/
+
+Holds the Rust crates that ship as part of the `clud` distribution. Each subdirectory is a Cargo crate with its own README covering build, layout, and design notes.
+
+## Crates
+
+- [`clud-bin/`](clud-bin/README.md) — main `clud` CLI binary, packaged as a Python wheel via maturin.
+
+## Workspace
+
+These crates are workspace members declared in the root [`Cargo.toml`](../Cargo.toml). Test-only binaries (e.g. mock agents used by the integration suite) live separately under [`testbins/`](../testbins/) and are not part of the shipped distribution.

--- a/crates/clud-bin/README.md
+++ b/crates/clud-bin/README.md
@@ -1,0 +1,64 @@
+# clud-bin
+
+Main Rust binary crate for the `clud` project. Builds the `clud` executable
+(a fast CLI for running Claude Code and Codex in YOLO mode) and is distributed
+as a Python wheel via maturin with `bindings = "bin"` — installing the wheel
+drops the native binary onto `PATH`.
+
+The crate also exposes a `clud` library target (`src/lib.rs`) so integration
+tests can exercise internals directly.
+
+## Layout
+
+- [`src/`](src/README.md) — binary entry point, library modules, platform code
+- [`tests/`](tests/README.md) — integration tests (PTY behavior, etc.)
+- [`assets/`](assets/README.md) — bundled non-code resources
+- `Cargo.toml` — crate manifest (package `clud`, binary `clud`, library `clud`)
+
+## Build
+
+From the repo root:
+
+```bash
+bash build                       # dev wheel (Rust binary + Python package)
+soldr cargo build -p clud-bin    # bare Rust binary only
+```
+
+All `cargo` / `rustc` / `rustfmt` invocations must go through
+[`soldr`](https://github.com/zackees/soldr) — see the project `CLAUDE.md`.
+
+## Test
+
+```bash
+bash test                        # Rust unit tests + Python unit tests
+bash test --integration          # adds end-to-end tests with mock agents
+soldr cargo test -p clud-bin     # crate-level Rust tests only
+```
+
+## Key deps
+
+- `clap` (derive) — CLI argument parsing with passthrough for unknown flags
+- `crossterm` / `vt100` / `vte` — terminal I/O and PTY stream parsing
+- `redb` — embedded KV store for session and tracked-entry registries
+  (issues #73 / #110; replaced bundled `rusqlite`)
+- `fs4` — cross-platform advisory file lock serializing concurrent redb opens
+  (issue #138)
+- `windows` / `windows-core` — Win32 console drag-and-drop (`IDropTarget`)
+  and related shell integration (issue #79)
+- `cpal` + `rodio` (non-Linux) and `whisper-rs` (off on Windows ARM) —
+  voice-mode capture and transcription (issue #13); Linux capture shells
+  out to `arecord` to keep libasound off the hot path
+- `ureq` + `sha2` + `dirs` — sync model auto-downloader with hash verify
+- `ignore` — gitignore-aware repo walk for the large-file startup guard
+  (issue #132)
+
+## Distribution
+
+Packaged as a Python wheel via maturin (`[tool.maturin] bindings = "bin"`,
+`manifest-path = "crates/clud-bin/Cargo.toml"` in the root `pyproject.toml`).
+The wheel installs the `clud` binary onto the user's `PATH` — no Python
+runtime code ships beyond a thin version shim.
+
+CI builds across 6 platforms: Linux x86 + ARM, Windows x86 + ARM, macOS
+ARM + x86. The Windows ARM target stubs out `whisper-rs` because the
+vendored C++ source does not compile on `aarch64-pc-windows-msvc`.

--- a/crates/clud-bin/assets/README.md
+++ b/crates/clud-bin/assets/README.md
@@ -1,0 +1,11 @@
+# assets/
+
+Compile-time-embedded resources bundled directly into the `clud-bin` binary. Files here are read by `include_str!` during the Rust build, so the shipped binary carries them in its read-only data segment and never touches the filesystem to locate them at runtime.
+
+## Layout
+
+- [`skills/`](skills/README.md) — slash-command skill definitions (`SKILL.md` files) installed per-backend into `.claude/skills/` or `.codex/skills/` on first run.
+
+## Embedding mechanism
+
+Each asset is referenced from Rust source via `include_str!("../assets/...")` in [`src/skills.rs`](../src/skills.rs) (and a parallel set in [`src/skill_install.rs`](../src/skill_install.rs)). The macro inlines the file contents at compile time, so adding, removing, or modifying an asset requires a rebuild. There is no runtime lookup, no packaging step beyond `cargo build`, and no dependency on the install location of the binary.

--- a/crates/clud-bin/assets/skills/README.md
+++ b/crates/clud-bin/assets/skills/README.md
@@ -1,0 +1,27 @@
+# skills/
+
+Claude Code "skills" bundled into the `clud` binary as compile-time assets. On every `clud` launch the installer copies each skill into the user's `~/.claude/skills/` (and `~/.codex/skills/` when that backend is present), so a fresh `clud` install always carries the current canonical playbooks without any extra setup step.
+
+## Skills
+
+- [clud-issue/](clud-issue/README.md) — File a deeply-researched GitHub issue via investigate → interview → investigate → post, returning a summary plus the issue URL.
+- [clud-issue-triage/](clud-issue-triage/README.md) — Triage GitHub issues: close ones that are clearly resolved and silently file follow-ups for un-addressed CodeRabbit comments; supports single, last-week, or all (parallel sub-agents in worktrees).
+- [clud-pr/](clud-pr/README.md) — Implement a GitHub issue, PR follow-up, or freeform task inside a `.claude/` worktree and ship one clean PR.
+- [clud-tag-release/](clud-tag-release/README.md) — Tag a release after validating version match, clean `main`, and no duplicate tag, then push and surface the auto-release workflow URL.
+
+## How skills ship
+
+Each `SKILL.md` here is embedded into the binary via `include_str!` and written out on launch. Two installer paths exist and contributors should be aware of both:
+
+- **`crates/clud-bin/src/skills.rs`** is the multi-backend installer. It iterates `BUNDLED_SKILLS` (sourced from this directory) and `SKILL_BACKENDS` (currently `~/.claude` and `~/.codex`), writes only when the target `SKILL.md` is missing, and never overwrites user edits.
+- **`crates/clud-bin/src/skill_install.rs`** is a Claude-only installer that reads from a separate top-level `skills/` directory in the repo (not this one) and *does* overwrite when content diverges semantically from the embedded copy (whitespace/CRLF differences are tolerated).
+
+Both run on every launch and degrade silently on error. If you change a bundled skill, confirm which installer (or both) owns the on-disk copy.
+
+## Adding a skill
+
+- Create `assets/skills/<name>/SKILL.md` with the standard frontmatter (`name:`, `description:`, `triggers:`) and the `<!-- managed-by: clud -->` marker.
+- Append a `BundledSkill { name, skill_md: include_str!("../assets/skills/<name>/SKILL.md") }` entry to `BUNDLED_SKILLS` in `crates/clud-bin/src/skills.rs`.
+- Decide whether the skill also needs to ship via `crates/clud-bin/src/skill_install.rs` (overwriting installer, top-level `skills/<name>/SKILL.md` source) and update that bundle list if so.
+- Add a short `README.md` next to the new `SKILL.md` and link it from the **Skills** section above.
+- Run `bash lint` and `bash test`; the existing unit tests assert the bundle is non-empty, names are unique, and every entry carries the `managed-by: clud` marker.

--- a/crates/clud-bin/assets/skills/clud-issue-triage/README.md
+++ b/crates/clud-bin/assets/skills/clud-issue-triage/README.md
@@ -1,0 +1,11 @@
+# clud-issue-triage/
+
+Bundled skill that triages GitHub issues for the user — closing only issues that a merged PR on the default branch unambiguously resolves, and silently filing follow-up issues for substantive un-addressed CodeRabbit comments. Triggered when the user types `/clud-issue-triage` (optionally with an issue number/URL or `all`), or asks to "triage issues", "sweep stale issues", or "clean up the issue tracker". Supports three modes: single-issue (handled directly), last-7-days bulk (no arg), and `all` open issues; bulk modes dispatch one parallel sub-agent per issue inside disposable `.claude/worktrees/triage-<num>/` worktrees and tear them down on completion. Output is two lines per issue: closure decision plus one-line evidence, and any follow-up issues filed.
+
+## Files
+
+- `SKILL.md` — Frontmatter (`name`, `description`, `triggers`) plus the playbook the agent loads when the skill fires: single-issue and bulk workflows, failure modes, and when to defer to `/clud-issue` or `/clud-pr`.
+
+## How it ships
+
+The skill's `SKILL.md` is embedded into the `clud` binary at compile time via `include_str!` from `crates/clud-bin/src/skills.rs` (entry in `BUNDLED_SKILLS`). On every launch, `skills::ensure_installed` walks each backend in `SKILL_BACKENDS` (Claude Code's `~/.claude/skills/`, Codex's `~/.codex/skills/`) whose home subdir already exists and writes `<skills_dir>/clud-issue-triage/SKILL.md` only when missing — existing user edits are preserved. Install errors are non-fatal and log to stderr without blocking launch.

--- a/crates/clud-bin/assets/skills/clud-issue/README.md
+++ b/crates/clud-bin/assets/skills/clud-issue/README.md
@@ -1,0 +1,12 @@
+# clud-issue/
+
+Source of the `/clud-issue` skill shipped inside the `clud` binary. The skill drives a four-step workflow for filing a deeply-researched GitHub issue: silent round-1 investigation, mandatory user interview, round-2 deep dig, then `gh issue create`. It triggers when the user invokes `/clud-issue`, asks to "file an issue with research", or asks to draft an issue but needs scope clarified first. The deliverable is a posted issue URL plus a 2-3 sentence summary — never a draft left in chat.
+
+## Files
+
+- `SKILL.md` — Frontmatter (`name`, `description`, `triggers`) plus the workflow, failure modes, and "when not to use" sections that Claude Code reads when the skill fires.
+- `README.md` — This file. Progressive-disclosure docs for contributors; not shipped to users.
+
+## How it ships
+
+`SKILL.md` is embedded into the `clud` binary at compile time via `include_str!` in two registries: `crates/clud-bin/src/skills.rs` (`BUNDLED_SKILLS`, which installs into every detected backend under `~/.claude/skills/` and `~/.codex/skills/`, never overwriting existing files) and `crates/clud-bin/src/skill_install.rs` (`BUNDLED_SKILLS`, which installs into `~/.claude/skills/clud-issue/SKILL.md` and overwrites on semantic divergence so the embedded copy stays canonical). Both run on every `clud` launch and degrade silently on error — editing this file and rebuilding the binary is the only supported way to update what users see.

--- a/crates/clud-bin/assets/skills/clud-pr/README.md
+++ b/crates/clud-bin/assets/skills/clud-pr/README.md
@@ -1,0 +1,11 @@
+# clud-pr/
+
+Bundled skill that implements a GitHub issue, PR follow-up, or freeform task inside a `.claude/worktrees/<branch>/` worktree and ships it as one clean PR. Triggers on `/clud-pr`, a PR URL/number (triage mode), an issue URL/number, or any phrasing like "ship", "do-pr", or a task sentence with intent to deliver. The end product is a pushed PR (via `gh pr create`), a removed worktree, and a clean main checkout.
+
+## Files
+
+- `SKILL.md` — Frontmatter, triggers, and the full playbook (worktree gating, PR triage mode, task-to-PR workflow, failure modes).
+
+## How it ships
+
+The file is embedded into the `clud` binary at compile time via `include_str!("../assets/skills/clud-pr/SKILL.md")` from `crates/clud-bin/src/skills.rs` (entry in `BUNDLED_SKILLS`). On every `clud` launch, `ensure_installed` walks each backend in `SKILL_BACKENDS` (Claude Code at `~/.claude`, Codex at `~/.codex`) whose home subdir already exists and writes `~/<home>/skills/clud-pr/SKILL.md` only when the target file is missing — existing user edits are preserved. A parallel installer in `crates/clud-bin/src/skill_install.rs` additionally enforces the embedded copy as source of truth: whitespace-only differences are a no-op, but semantic divergence is overwritten and logged as `[clud] updated /clud-pr`. All install errors are non-fatal.

--- a/crates/clud-bin/assets/skills/clud-tag-release/README.md
+++ b/crates/clud-bin/assets/skills/clud-tag-release/README.md
@@ -1,0 +1,11 @@
+# clud-tag-release/
+
+Bundled skill that drives a tag-triggered release for Rust and Python projects. Activates on `/clud-tag-release` (with or without a version arg) or natural-language phrases like "cut a release" or "tag a release". It detects the workspace version from `Cargo.toml` or `pyproject.toml`, runs pre-flight gates (clean default branch, no duplicate tag, green CI, an auto-release workflow that listens for version tags), pushes an annotated tag to origin, and surfaces the URL of the triggered workflow run.
+
+## Files
+
+- `SKILL.md` — Skill frontmatter, triggers, the five hard rules, the step-by-step workflow, and failure modes to avoid.
+
+## How it ships
+
+The `SKILL.md` body is embedded into the `clud` binary at compile time via `include_str!` from `crates/clud-bin/src/skills.rs` (see the `BUNDLED_SKILLS` array) and again from `crates/clud-bin/src/skill_install.rs`. On every launch, `skill_install::ensure_installed` writes the embedded copy to `~/.claude/skills/clud-tag-release/SKILL.md` if it's missing and overwrites it if the on-disk copy diverges semantically (whitespace-only diffs are ignored). `skills::ensure_installed` mirrors the same payload into every detected backend (`~/.claude/skills/`, `~/.codex/skills/`) whose home subdir already exists, never overwriting an existing file. Install failures are non-fatal: they log a `[clud] note: ...` line and launch proceeds.

--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -1,0 +1,104 @@
+# src/
+
+Entry point and source tree for the `clud-bin` Rust binary. The binary launches a backend agent (`claude` or `codex`) in YOLO mode, optionally through a PTY, with first-class support for loop iterations, drag-and-drop, voice input, and a per-user daemon for backgrounded/detachable sessions. `main.rs` does cross-cutting startup work (trampoline unlock, console title, skill install, session-cap registration, GC scanner) and then hands off to `runner.rs`, which drives the per-iteration subprocess/PTY launch loop for a single [`LaunchPlan`]. Submodules under `command/`, `daemon/`, `dnd/`, and `voice/` carry the bulk of the domain logic; the top-level `.rs` files here are the orchestration glue and standalone utilities consumed by both `main.rs` and the integration tests.
+
+## Subdirectories
+
+- [command/](command/README.md) — `LaunchPlan` construction: backend argv assembly, YOLO/safe injection, `loop`/`up`/`rebase`/`fix` prompt synthesis, `--repeat` schedule parsing, DONE/BLOCKED contract.
+- [daemon/](daemon/README.md) — long-lived session manager for `--detach` / `attach` / `list` / `kill` / `logs` / `--repeat`: TCP JSON IPC, per-session worker subprocesses, snapshot + log persistence, attach broker.
+- [dnd/](dnd/README.md) — drag-and-drop into the terminal: cross-platform path-string normalizer plus Windows-only `IDropTarget` adapter with per-launch-mode injectors (subprocess `WriteConsoleInputW`, PTY master writer).
+- [voice/](voice/README.md) — F3 push-to-talk voice mode: `cpal`/`arecord` mic capture, start/stop cues, `whisper-rs` worker thread, transcript injection into the backend PTY.
+
+## Top-level modules
+
+Entry and orchestration:
+
+- `main.rs` — process entry: launch clock, trampoline unlock, console title stamp + keeper, skill install, large-file guard, session-cap registration, GC scanner, dispatch to runner / daemon / hook-health / GC subcommands.
+- `lib.rs` — library facade so integration tests under `tests/` can link against internals; `main.rs` imports through this rather than re-declaring `mod ...`.
+- `runner.rs` — per-iteration subprocess- and PTY-mode runner for a single `LaunchPlan`; owns child-env construction, stream-json fallback, Ctrl-C-aware teardown, and OLE drag-drop registration wiring.
+- `startup.rs` — launch-time helpers factored out of `main.rs`: drag-target gating (`--no-dnd`, `--dry-run`), session-cap enforcement, Ctrl+C flag installer.
+
+CLI surface and backend resolution:
+
+- `args.rs` — `clap` `Args` and `Command` definitions; passthrough for unknown flags; subcommand definitions for `loop`, `up`, `rebase`, `fix`, `gc`, etc.
+- `backend.rs` — `Backend` enum (`Claude` / `Codex`), `LaunchMode` (`Subprocess` / `Pty`), PATH lookup, and backend-path resolution.
+- `subprocess.rs` — single decision point for the Windows `.cmd`/`.bat` rewrite (BatBadBat / CVE-2024-24576) via `running-process-core`'s `CommandSpec::Shell`.
+
+Console and terminal:
+
+- `console_input.rs` — Windows `ReadConsoleInputW` translator (issue #141): pure-function map from `KEY_EVENT_RECORD` slices to PTY stdin bytes (Shift+Enter → `\n`, plain Enter → `\r`).
+- `console_setup.rs` — RAII guard that enables `ENABLE_VIRTUAL_TERMINAL_INPUT` for the lifetime of a PTY session and restores the prior console mode on drop; no-op on POSIX.
+- `console_title.rs` — stamps `clud <cwd-name>` once on launch and runs a background keeper that re-applies the title when downstream OSC 0/2 sequences overwrite it.
+- `capture.rs` — server-side terminal emulator (`vt100` + `vte` sticky-mode sniffer) that lets the daemon synthesize a repaint when a mid-session client attaches.
+- `session.rs` — raw-PTY pump (`run_raw_pty_pump`), resize handling, F3 voice observer hook, OSC-title stripper integration, dropped-path injection on the PTY master.
+
+Loop subsystem (`clud loop`):
+
+- `loop_spec.rs` — task-spec resolver: classifies the positional (GH URL, `#42`, file, literal), fetches GH issue/PR bodies via `gh` (curl fallback), caches under `.clud/loop/`, locates DONE/BLOCKED marker files.
+- `loop_check.rs` — post-iteration DONE/BLOCKED marker check; file-only and stdout-scanning variants used by PTY and subprocess paths respectively.
+- `loop_artifacts.rs` — durable `<git-root>/.clud/loop/` artifacts: `info.json` (`TaskInfo`), `log.txt`, `motivation.md`, and `.gitignore` auto-injection.
+- `stream_json.rs` — pure renderer for claude's `--output-format stream-json` events; turns one JSON event per line into one human-readable progress line for subprocess-mode loops.
+
+Process management and GC:
+
+- `process_tree.rs` — best-effort descendant-tree termination via `sysinfo`; fixes the multi-second Ctrl+C hang for `clud --codex` on Windows where `cmd.exe → node.exe` would orphan the real child.
+- `session_registry.rs` — `redb`-backed registry of live `clud` PIDs that caps concurrent siblings (default 64, `CLUD_MAX_INSTANCES`); `Drop` removes the row, startup GCs dead rows.
+- `gc.rs` — `clud gc list` / `purge` / `reconcile` and the in-process `WorktreeScanner` thread that polls `.claude/worktrees/agent-*` for new entries.
+- `gc_daemon.rs` — single-owner GC daemon process: holds `~/.clud/data.redb` exclusively and serves JSON-over-loopback-TCP from a registry-worker thread (issue #135 Phase 1).
+- `worktrees.rs` — `--clean-worktrees` (issue #83): enumerates via `git worktree list --porcelain`, classifies clean / dirty / unpushed / gone, removes safe ones; `--dry-run` faithful.
+
+Platform glue:
+
+- `trampoline.rs` — Windows-only: rename-self-and-copy-back trick so `pip install` can always overwrite `Scripts/clud.exe`. No-op on POSIX.
+- `win_creation_flags.rs` — `invisible_helper_creationflags()` returns `CREATE_NO_WINDOW` on Windows for daemon-helper spawns; `0` elsewhere so call sites stay portable.
+- `large_file_guard.rs` — startup-time `ignore`-crate walker that warns about source files large enough to choke agents (issue #132); hard 1 s deadline.
+
+Skills and hooks:
+
+- `skills.rs` — bundles slash-command skills via `include_str!` and installs them per-backend (`.claude/skills/`, `.codex/skills/`) only when the backend home already exists; never overwrites existing files.
+- `skill_install.rs` — auto-installer for the `clud-*` skill set; compares embedded vs installed `SKILL.md` modulo whitespace and overwrites divergent copies (logging `[clud] updated /<name>`).
+- `hook_health.rs` — `PreToolUse` hook parity diagnostics and `--fix-hooks` remediation (deterministic config edits plus optional agent-driven semantic hook translation).
+
+Diagnostics and misc:
+
+- `verbose_log.rs` — launch-clock + opt-in file logging (`CLUD_VERBOSE_LOG_DIR`); `log()` writes timestamped lines to the per-launch log file.
+- `wasm.rs` — `wasmi`-based runner that loads a WASM module, registers a minimal `host.log` import, invokes a named export, and propagates the integer exit code.
+
+Quick lookup — which file owns a given subcommand:
+
+- `clud loop ...` → `command::build_launch_plan` (prompt + markers) + `loop_spec` (task resolution) + `loop_artifacts` (artifact files) + `runner.rs` (iteration loop) + `loop_check` (DONE/BLOCKED scan).
+- `clud --detach`, `clud attach`, `clud list`, `clud kill`, `clud logs` → all in `daemon/` (dispatched from `daemon::handle_special_command`).
+- `clud gc list` / `purge` / `reconcile` → `gc.rs` (CLI handlers) talking to `gc_daemon` (registry owner).
+- `clud --clean-worktrees` → `worktrees.rs`.
+- `clud --fix-hooks` → `hook_health.rs`.
+
+## Cross-cutting conventions
+
+- **Single launch source of truth.** Every code path that needs to know "what would clud actually run" goes through `command::build_launch_plan` and consumes the resulting `LaunchPlan`. `--dry-run` JSON, `runner.rs`, the daemon worker, and the hook-health remediator all share this struct rather than reconstructing argv.
+- **Windows-first care.** Several modules exist purely to absorb Windows quirks: `subprocess` (BatBadBat / `.cmd` rewrite), `trampoline` (exe self-rename for `pip install`), `win_creation_flags` (`CREATE_NO_WINDOW` for invisible helpers), `console_setup` (`ENABLE_VIRTUAL_TERMINAL_INPUT`), `console_input` (Shift+Enter via `ReadConsoleInputW`), and `console_title` (OSC-title keeper). All of them degrade to no-ops on POSIX.
+- **Best-effort, non-fatal startup nudges.** `skills`, `skill_install`, `hook_health` (warn mode), `large_file_guard`, and `console_title` are all wrapped so a failure logs to stderr and continues — none of them can block a launch.
+- **`lib.rs` is the single module instantiation site.** `main.rs` imports through `clud::{...}`; integration tests link the same library. There is no `mod ...;` declaration anywhere in `main.rs`.
+- **`redb` is touched in exactly one place per file.** `~/.clud/data.redb` is owned by the `gc_daemon` process (issue #135 Phase 1); the in-process `gc::WorktreeScanner` and the `clud gc list` / `purge` clients all funnel through the daemon's JSON-over-loopback-TCP protocol. The per-launch session cap lives in a separate `redb` table accessed via `session_registry`, which serializes with a sidecar `sessions.lock` so multiple `clud` processes never race on the file.
+- **Ctrl+C is cooperative.** `startup::install_ctrlc_flag` arms a `Arc<AtomicBool>` consumed by the loop iteration in `runner.rs`, the daemon attach loop in `daemon/attach.rs`, and the GC scanner thread in `gc.rs`. Forced reaping of orphan descendants is delegated to `process_tree::kill_tree`.
+
+## Launch flow
+
+A typical interactive launch hits the modules in roughly this order:
+
+1. `main.rs` initializes the launch clock (`verbose_log`), unlocks the exe (`trampoline`), stamps the console title (`console_title`), installs bundled skills (`skills`, `skill_install`), checks hook health (`hook_health`), and warns on large files (`large_file_guard`).
+2. `args.rs` parses the CLI; `backend.rs` resolves which agent and launch mode to use; `startup.rs` registers the session in `session_registry` (enforcing `CLUD_MAX_INSTANCES`) and installs the Ctrl+C atomic flag.
+3. `command::build_launch_plan` (from `command/`) assembles the `LaunchPlan` — argv, env, prompt, optional loop markers, optional `--repeat` schedule. For `clud loop`, `loop_spec` resolves the task and `loop_artifacts` initializes `<git-root>/.clud/loop/`.
+4. `main.rs` hands the plan to `runner.rs`, which dispatches to either the subprocess path (via `subprocess.rs`, with `stream_json` rendering progress) or the PTY path (via `session.rs`, with `console_input` translating Shift+Enter and `dnd` injecting drops).
+5. In PTY mode `voice::VoiceMode` attaches an `InteractiveHooks` impl so F3 press/release flows the captured audio through `voice/worker.rs` and writes the transcript back into the PTY master.
+6. After each iteration, `loop_check` polls DONE/BLOCKED markers; `loop_artifacts` rolls forward `info.json` / `log.txt`; on terminal signals, `process_tree::kill_tree` reaps the descendant tree before exit.
+
+When `--detach` / `attach` / `list` / `kill` / `logs` is used, `main.rs` routes into `daemon/` instead, and the daemon process re-enters this same binary as a `__daemon` or `__worker` to host or run the session.
+
+## Entry point
+
+`main.rs` is the binary entry; `lib.rs` re-exports every top-level module (and the four subdirs) as `pub mod ...` so the integration tests under `crates/clud-bin/tests/` can link against internals (notably `session::run_raw_pty_pump` and `session::F3Observer`). Production builds resolve each module through the library, so there is exactly one instance of each module in the final binary.
+
+## See also
+
+- Parent crate overview: [`../README.md`](../README.md).
+- Top-level project docs and CI matrix: [`../../../CLAUDE.md`](../../../CLAUDE.md).

--- a/crates/clud-bin/src/command/README.md
+++ b/crates/clud-bin/src/command/README.md
@@ -1,0 +1,38 @@
+# command/
+
+Builds the `LaunchPlan` that downstream runners execute: backend-specific argv assembly (`claude` vs `codex`), YOLO/safe-mode injection, subcommand-driven prompt construction (`loop`, `up`, `rebase`, `fix`), `--repeat` schedule parsing, DONE/BLOCKED marker contract wiring, and Claude `stream-json` progress injection for subprocess-mode loops.
+
+## Files
+
+- `mod.rs` — module facade; re-exports `build_launch_plan`, `has_noninteractive_prompt`, `next_run_at_millis`, `repeat_implies_no_done_warning`, `summarize_task_name`, and the `LaunchPlan` / `LoopMarkers` / `RepeatSchedule` types.
+- `builder.rs` — core `build_launch_plan` orchestrator plus `parse_repeat_interval`, `repeat_implies_no_done_warning`, `next_run_at_millis`, and `summarize_task_name` helpers.
+- `loop_task.rs` — resolves the `clud loop` positional (GH issue/PR URL, `#42` shortform, file path, or literal) into prompt text, with `gh`-backed cache under `.clud/loop/`.
+- `prompts.rs` — static prompt templates (`FIX_PROMPT`, `GITHUB_FIX_TEMPLATE`, `REBASE_PROMPT`, `UP_PROMPT`) and the backend-aware `push_prompt`, `build_up_prompt`, `build_fix_prompt` builders.
+- `types.rs` — `LaunchPlan`, `LoopMarkers`, `RepeatSchedule` serde structs that flow into `--dry-run` JSON and into daemon job records.
+- `tests.rs` — 60+ unit tests covering yolo/safe, codex `exec`/`resume`, loop contract injection, stream-json placement before `-p`, `--repeat` parsing edge cases, and scheduler no-overlap invariants.
+
+## Key items
+
+- `build_launch_plan(args, backend, backend_path) -> LaunchPlan` — `builder.rs:24`
+- `has_noninteractive_prompt(args) -> bool` — `builder.rs:13`
+- `parse_repeat_interval(raw) -> Result<u64, String>` — `builder.rs:250`
+- `repeat_implies_no_done_warning(repeat, no_done, done) -> Option<&'static str>` — `builder.rs:290`
+- `next_run_at_millis(completed_at_millis, interval_secs) -> u64` — `builder.rs:316`
+- `summarize_task_name(input, max_chars) -> String` — `builder.rs:320`
+- `resolve_loop_task(task, git_root, refresh) -> String` — `loop_task.rs:29`
+- `resolve_marker_paths(cwd, git_root, done_override) -> MarkerPaths` — `loop_task.rs:8`
+- `push_prompt(cmd, backend, prompt)` — `prompts.rs:74`
+- `build_up_prompt(message, publish) -> String` — `prompts.rs:86`
+- `build_fix_prompt(url) -> String` — `prompts.rs:115`
+- `struct LaunchPlan` (command, iterations, backend, launch_mode, cwd, repeat_schedule, task_summary, loop_markers, stream_json_progress) — `types.rs:6`
+- `struct LoopMarkers { done_path, blocked_path }` — `types.rs:28`
+- `struct RepeatSchedule { interval_secs }` — `types.rs:34`
+
+## Used by
+
+- `main.rs` — calls `build_launch_plan` and `repeat_implies_no_done_warning` to assemble the plan and emit the `--repeat` warning before dispatch.
+- `runner.rs` — consumes `LaunchPlan` to spawn PTY/subprocess and drive iteration loops.
+- `loop_check.rs` — reads `plan.loop_markers` to poll DONE/BLOCKED after each iteration.
+- `hook_health.rs` — builds a plan as part of doctor-style health probes.
+- `daemon/entry.rs`, `daemon/types.rs` — persist and re-execute `LaunchPlan` records via the daemon worker.
+- `loop_artifacts.rs` — references the `chrono_like_now` algorithm pattern from `loop_task.rs`.

--- a/crates/clud-bin/src/daemon/README.md
+++ b/crates/clud-bin/src/daemon/README.md
@@ -1,0 +1,55 @@
+# daemon/
+
+Centralized session manager for backgrounded, detachable, and repeating clud runs. A long-lived daemon process (one per state-dir) accepts TCP JSON requests to spawn per-session worker subprocesses; each worker owns one backend (`claude` or `codex`) running under a PTY or a captured subprocess, persists snapshots + an append-only log to disk, and brokers attach/detach from interactive clients. Clients use this layer for `clud --detach`, `clud attach`, `clud list`, `clud kill`, `clud logs`, and `clud loop --repeat`. Internal helper commands `__daemon` and `__worker` re-enter the same binary in their respective roles.
+
+## Files
+
+- `mod.rs` — module root. Only re-exports `experimental_enabled`, `handle_special_command`, `run_centralized_session` from `entry`.
+- `entry.rs` — public dispatch: feature-flag check, routing for `attach`/`kill`/`list`/`logs`/`__daemon`/`__worker`, and the main `Create` request for normal sessions.
+- `types.rs` — shared structs, enums, env-var keys, and constants (`SessionSnapshot`, `WorkerLaunchSpec`, `DaemonRequest`/`Response`, `WorkerClientMessage`/`ServerMessage`, `SessionRuntime`, `RawTerminalGuard`, etc.).
+- `paths.rs` — filesystem layout helpers under the daemon state dir (`daemon.json`, `sessions/`, `specs/`, `logs/`).
+- `client.rs` — client-side daemon RPC: `ensure_daemon` spawns the daemon if absent, `send_daemon_request`, `request_session_termination`, stale-state cleanup.
+- `server.rs` — daemon-process entry: binds the loopback listener, accepts `Create`/`Session`/`Terminate` requests, spawns worker subprocesses, reaps them.
+- `worker.rs` — worker-process entry: starts the backend (subprocess or PTY), serves attach connections, runs the repeat-job loop.
+- `worker_shared.rs` — per-worker shared state: snapshot, in-memory backlog, optional `TerminalCapture` for PTY attach-replay, log file rotation, single-client attach gate.
+- `attach.rs` — interactive client-side attach loop: handshake, raw-terminal keyboard forwarding, Ctrl-C → background-prompt flow, exit-code propagation.
+- `commands.rs` — implementations of `clud kill`, `clud list`, `clud logs` (including pm2-style tail/follow with rotation handling).
+- `sessions.rs` — snapshot discovery + filtering: `resolve_session_id` (exact/name/prefix), `most_recent_session[_any]`, `list_background_sessions`, `list_attachable_sessions`.
+- `keys.rs` — `crossterm` `KeyEvent` → terminal byte sequence translator used by interactive attach.
+- `io_helpers.rs` — JSON read/write over TCP + atomic file writes, session-id generator, terminal-size probe, `--backlog-size` / `CLUD_BACKLOG_BYTES` parsing.
+- `process_utils.rs` — `pid_is_alive`, `signal_process_tree`, `descendant_pids` via `sysinfo`.
+
+## Key items
+
+- `pub fn experimental_enabled(&Args) -> bool` — `entry.rs:21`
+- `pub fn handle_special_command(&Args, &AtomicBool) -> Option<i32>` — `entry.rs:38`
+- `pub fn run_centralized_session(&Args, &LaunchPlan, &AtomicBool) -> i32` — `entry.rs:144`
+- `enum DaemonRequest { Create, Session, Terminate }` — `types.rs:103`
+- `enum DaemonResponse { Created, Session, Terminated, Error }` — `types.rs:111`
+- `enum WorkerClientMessage { Attach, Input, Resize, Interrupt }` — `types.rs:120`
+- `enum WorkerServerMessage { Attached, Output, Exited, Error }` — `types.rs:129`
+- `struct SessionSnapshot` — on-disk + wire session metadata — `types.rs:48`
+- `struct WorkerLaunchSpec` — daemon→worker launch contract — `types.rs:77`
+- `enum SessionRuntime { Subprocess, Pty }` — runtime handle abstraction — `types.rs:137`
+- `enum SessionKind { Subprocess, Pty }` — `types.rs:36`
+- `const ENV_FEATURE_FLAG = "CLUD_EXPERIMENTAL_DAEMON"` — `types.rs:17`
+- `const ENV_STATE_DIR = "CLUD_DAEMON_STATE_DIR"` — `types.rs:18`
+- `const DEFAULT_BACKLOG_LIMIT_BYTES = 256 KiB` — `types.rs:20`
+- `const LOG_ROTATE_BYTES = 10 MiB` — `types.rs:28`
+- `fn run_daemon(&Path) -> i32` — `server.rs:23`
+- `fn run_worker(&Path, &str, u32, &Path) -> i32` — `worker.rs:28`
+- `fn ensure_daemon(&Path) -> io::Result<()>` — `client.rs:18`
+- `fn send_daemon_request(&Path, &DaemonRequest)` — `client.rs:51`
+- `fn run_attach(&str, &Path, &AtomicBool) -> i32` — `attach.rs:26`
+- `fn run_kill / run_list / run_logs` — `commands.rs:14`, `commands.rs:82`, `commands.rs:159`
+- `fn resolve_session_id(&Path, &str)` — `sessions.rs:11`
+- `struct WorkerShared` (+ `attach_client`, `push_output`, `broadcast_exit`, `evict_dead_client`, log rotation) — `worker_shared.rs:22`
+- `fn translate_key_event(KeyEvent) -> KeyAction` — `keys.rs:5`
+- `fn resolve_backlog_bytes(Option<&str>) -> Option<usize>` — `io_helpers.rs:77`
+- `fn signal_process_tree(u32, Signal)` — `process_utils.rs:10`
+
+## Used by
+
+- `crates/clud-bin/src/main.rs` — sole external consumer; calls `experimental_enabled`, `handle_special_command`, and `run_centralized_session`.
+- `crates/clud-bin/src/process_tree.rs` — doc-only cross-reference to `signal_process_tree`.
+- Re-enters itself via the hidden `__daemon` / `__worker` subcommands defined in `crates/clud-bin/src/args.rs`.

--- a/crates/clud-bin/src/dnd/README.md
+++ b/crates/clud-bin/src/dnd/README.md
@@ -1,0 +1,37 @@
+# dnd/
+
+Drag-and-drop handling for terminal-embedded `clud` sessions. Provides two complementary paths: (1) a cross-platform string normalizer that canonicalizes the path-shaped byte sequences each terminal injects on a drop (cmd.exe quoted paths, mintty `/c/...` MSYS paths, PowerShell `& 'C:\...'`, macOS backslash-escaped spaces, GNOME `file://` URIs), and (2) a Windows-only OLE `IDropTarget` adapter that intercepts drops at the COM layer (fixing issue #65 where conhost rejects the drop) and forwards parsed paths to a per-launch-mode injector (subprocess via `WriteConsoleInputW`, PTY via the master writer).
+
+## Files
+
+- `mod.rs` — public `normalize_dropped_path` / `looks_like_dropped_path` string transforms plus `pub mod` re-exports of the submodules.
+- `dropfiles.rs` — pure `&[u8]` parser for the Win32 `CF_HDROP` / `DROPFILES` wire format (wide + narrow encodings); panic-free on malformed input.
+- `console_drop_target.rs` — Windows-only `IDropTarget` COM object, `OleInitialize`/`RegisterDragDrop` worker thread with delay-then-refresh strategy (issue #79, displaces Claude Code's own registration), RAII guard, and the platform-agnostic dispatch glue.
+- `injectors.rs` — `DropInjector` factories for the two launch modes plus `build_input_records` (synthesizes Win32 `INPUT_RECORD` bytes for `WriteConsoleInputW`) and `join_paths_for_injection` (newline-join + trailing space contract).
+
+## Key items
+
+- `normalize_dropped_path(input: &str) -> String` — `mod.rs:49`
+- `looks_like_dropped_path(input: &str) -> bool` — `mod.rs:77`
+- `parse_dropfiles_buffer(buf: &[u8]) -> Vec<String>` — `dropfiles.rs:39`
+- `DROPFILES_HEADER_SIZE` / `DROPFILES_PFILES_OFFSET` / `DROPFILES_FWIDE_OFFSET` — `dropfiles.rs:28-32`
+- `pub type DropInjector` — `console_drop_target.rs:76`
+- `enum RegisterError` — `console_drop_target.rs:80`
+- `struct RefreshConfig` with `default_displacement()` (2s/3s) and `immediate_no_refresh()` — `console_drop_target.rs:143`
+- `struct ConsoleDropTargetGuard` (RAII; signals worker, revokes, `OleUninitialize`) — `console_drop_target.rs:333`
+- `register_console_drop_target(injector, config)` — `console_drop_target.rs:384` (Windows) / `:392` (non-Windows stub)
+- `dispatch_dropfiles_to_injector(buf, injector)` — `console_drop_target.rs:407`
+- `build_input_records(s: &str) -> Vec<u8>` — `injectors.rs:71`
+- `join_paths_for_injection(paths: &[String]) -> String` — `injectors.rs:126`
+- `pty_master_injector(master) -> DropInjector` — `injectors.rs:138`
+- `subprocess_console_injector() -> DropInjector` (Windows only) — `injectors.rs:157`
+- `write_to_console_input(records_bytes: &[u8]) -> io::Result<()>` (Windows only) — `injectors.rs:176`
+- `INPUT_RECORD_SIZE = 20` — `injectors.rs:58`
+
+## Used by
+
+- `session.rs` — calls `looks_like_dropped_path` + `normalize_dropped_path` on PTY paste-buffer input to wrap dropped paths in bracketed-paste markers (`session.rs:12`, `:839`).
+- `startup.rs` — wires `register_console_drop_target` for both launch modes via `try_register_console_drop_target_subprocess` (uses `subprocess_console_injector`) and `try_register_console_drop_target_pty` (uses `pty_master_injector`) at `startup.rs:32`, `:56`.
+- `main.rs` — invokes `startup::try_register_console_drop_target_subprocess()` for subprocess launches (`main.rs:267`).
+- `runner.rs` — invokes `startup::try_register_console_drop_target_pty()` for PTY launches (`runner.rs:438`).
+- `lib.rs` — declares `pub mod dnd` (`lib.rs:15`).

--- a/crates/clud-bin/src/voice/README.md
+++ b/crates/clud-bin/src/voice/README.md
@@ -1,0 +1,44 @@
+# voice/
+
+F3 push-to-talk voice mode (issue #13). Captures microphone audio while F3 is held, plays start/stop cues, transcribes via a bundled `whisper-rs` worker thread, and writes the transcript back into the backend PTY at the user's cursor. Microphone capture uses `cpal` on Windows and macOS and `arecord` (alsa-utils) on Linux; transcription is stubbed on `aarch64-pc-windows-msvc` where `whisper-rs-sys` does not build.
+
+## Files
+
+- `mod.rs` — module root; documents the F3 flow and re-exports `VoiceMode`.
+- `mode.rs` — `VoiceMode` state machine and `InteractiveHooks` impl (press/release/tick).
+- `config.rs` — `VoiceConfig::from_env` reads `CLUD_VOICE`, `CLUD_WHISPER_MODEL`, `CLUD_VOICE_LANGUAGE`, `CLUD_VOICE_TEST_TRANSCRIPT`.
+- `recording.rs` — `ActiveRecording`: starts/stops the capture backend, runs VAD auto-stop, returns resampled samples.
+- `audio.rs` — sample-rate constants, VAD thresholds, mono downmix + linear resample to 16 kHz, silence/speech detection.
+- `cues.rs` — `play_cue(CueTone::Start|Stop)`: short sine-wave beep via `rodio` (BEL fallback on Linux).
+- `linux_capture.rs` — Linux-only `arecord` subprocess wrapper that streams S16_LE PCM into a shared sample buffer.
+- `model.rs` — Whisper model resolution, SHA-256-pinned auto-download to per-OS cache dir, background download thread.
+- `worker.rs` — `VoiceWorker` thread: lazy-loads `WhisperContext`, runs transcription, sends `WorkerEvent::Transcript|Error`.
+
+## Key items
+
+- `VoiceMode` struct: `mode.rs:16`
+- `VoiceMode::from_env` (eager model resolve + background download): `mode.rs:33`
+- `InteractiveHooks for VoiceMode` (`on_f3_press`/`on_f3_release`/`on_tick`): `mode.rs:194`
+- `VoiceConfig::from_env`: `config.rs:13`
+- `ActiveRecording::start` (cpal): `recording.rs:39`
+- `ActiveRecording::start` (Linux/arecord): `recording.rs:86`
+- `ActiveRecording::synthetic` (test/no-mic bypass): `recording.rs:116`
+- `ActiveRecording::should_auto_stop` (VAD + hard cap): `recording.rs:150`
+- `ActiveRecording::finish` (drain + resample): `recording.rs:191`
+- `downmix_and_resample`: `audio.rs:21`
+- `is_effectively_silent` / `has_speech_peak`: `audio.rs:59`, `audio.rs:66`
+- VAD constants (`MIN_CAPTURE_MS`, `MAX_SILENCE_PEAK`, `MIN_VAD_AFTER_SPEECH_MS`, `VAD_SILENCE_TAIL_MS`, `MAX_CAPTURE_MS`): `audio.rs:5`-`audio.rs:19`
+- `play_cue` + `CueTone`: `cues.rs:9`, `cues.rs:15`
+- `LinuxCapture::start` / `LinuxCapture::stop`: `linux_capture.rs:23`, `linux_capture.rs:74`
+- `resolve_if_available`: `model.rs:53`
+- `ensure_downloaded_in_background`: `model.rs:72`
+- `default_cache_path`, `MODEL_FILENAME`, `MODEL_SHA256`: `model.rs:42`, `model.rs:26`, `model.rs:34`
+- `VoiceWorker::spawn` / `request_transcription` / `try_recv`: `worker.rs:41`, `worker.rs:68`, `worker.rs:74`
+- `WorkerEvent` enum: `worker.rs:29`
+- `transcribe_audio` (Whisper) and Windows-ARM stub: `worker.rs:80`, `worker.rs:153`
+- `missing_model_message`: `worker.rs:167`
+
+## Used by
+
+- `crate::runner` (`runner.rs:22`, `runner.rs:525`) constructs `voice::VoiceMode::from_env()` and passes it as the `InteractiveHooks` for the interactive PTY session.
+- `crate::session::InteractiveHooks` is the trait `VoiceMode` implements; the session pump in `session/` calls `on_f3_press`, `on_f3_release`, and `on_tick`, and the `F3Observer` in `session/` produces the press/release events that drive this module.

--- a/crates/clud-bin/tests/README.md
+++ b/crates/clud-bin/tests/README.md
@@ -1,0 +1,21 @@
+# tests/
+
+Rust integration tests for the `clud-bin` crate. Unlike the `#[test]` units inside `src/`, these tests spawn the workspace `mock-agent` binary through `running_process_core::pty::NativePtyProcess` and exercise the real PTY pump used by `clud --codex`. They lock down platform-specific contracts (Windows ConPTY vs POSIX), cross-platform regressions from issues #28/#31/#46, and the voice/F3 + resize hooks implemented in `clud::session`. A `pty_canary()` probe runs first and skips the test if the host's stdout isn't a real console (typical in nested shells or captured `cargo test` runs).
+
+## Files
+
+- `pty_behavior.rs` — End-to-end PTY checks: `respond_to_queries_impl` DSR stub (T1), `resize_impl` propagate-on-POSIX / no-op-on-Windows (T2), extreme `cols=32767` spawn safety (T3), verbatim stdin forwarding through `run_raw_pty_pump`, F3 press/release detection (xterm + kitty CSI-u), idle `on_tick` cadence, Ctrl-C flag honoring, resize channel application, prompt exit on child death, and raw-mode recovery on hook panic.
+
+## How to run
+
+From the repo root:
+
+```bash
+bash test                                   # Rust + Python unit tests
+bash test --integration                     # adds mock-agent integration tests
+soldr cargo test -p clud-bin                # all clud-bin tests (unit + integration)
+soldr cargo test -p clud-bin --test pty_behavior   # this file only
+soldr cargo test -p clud-bin --test pty_behavior -- --nocapture   # see canary-skip diagnostics
+```
+
+All `cargo`/`rustc`/`rustfmt` invocations must go through `soldr` (see root `CLAUDE.md`). The mock-agent is auto-built on first run via `cargo build -p mock-agent --message-format json`.

--- a/testbins/README.md
+++ b/testbins/README.md
@@ -1,0 +1,19 @@
+# testbins/
+
+Rust auxiliary binaries used only by the `clud` test suite. These crates are not shipped with the Python wheel or distributed to end users; they exist solely to support integration testing.
+
+They live outside `crates/` to keep production code clearly separated from test-only fixtures.
+
+## Binaries
+
+- [`mock-agent/`](mock-agent/README.md) — Stand-in for the `claude` and `codex` backends, used by Python integration tests to exercise `clud`'s command-building and execution paths without invoking a real agent.
+
+## How they're built
+
+Each subdirectory is a regular Cargo workspace member declared in the root [`Cargo.toml`](../Cargo.toml). Build any of them explicitly with:
+
+```
+soldr cargo build -p <crate-name>
+```
+
+The test harness (`ci/test.py` and the Python `conftest.py`) builds the required testbins on demand before running integration tests, so manual builds are usually unnecessary.

--- a/testbins/mock-agent/README.md
+++ b/testbins/mock-agent/README.md
@@ -1,0 +1,42 @@
+# mock-agent/
+
+A tiny Rust binary that masquerades as `claude` or `codex` during
+integration tests. Tests copy it onto a temp `PATH` so `clud` resolves a
+real, controllable executable instead of the actual agent. See
+[`src/README.md`](src/README.md) for the behavior contract (argv echo,
+stdin capture, PTY size reporting, exit-code controls).
+
+## Layout
+
+- `Cargo.toml` — workspace member, `publish = false`, depends on
+  `serde_json`, `terminal_size`, and `libc` (unix only).
+- [`src/`](src/README.md) — single-file binary (`src/main.rs`) plus its
+  behavior contract.
+
+## Build
+
+The crate is a workspace member of the root `Cargo.toml`, so it builds
+alongside everything else. To build just this binary:
+
+```
+soldr cargo build -p mock-agent
+```
+
+Output lands at `target/debug/mock-agent` (`.exe` on Windows). All
+`cargo` invocations must go through `soldr` per the repo policy in
+`CLAUDE.md`.
+
+## Used by
+
+- **Python integration tests** (`tests/integration/`) — `conftest.py`
+  builds it once per session via the `mock_agent_binary` fixture, then
+  the `mock_env` / `mock_env_codex_cmd` fixtures copy it as
+  `claude{.exe}` and `codex{.exe}` onto a temp `PATH`. Consumed by
+  `test_mock_agents.py`, `test_loop_stream_json.py`,
+  `test_voice_mode.py`, `test_daemon_persistence.py`,
+  `test_daemon_cleanup.py`, and `test_session_registry_concurrency.py`.
+- **Rust PTY integration tests** (`crates/clud-bin/tests/pty_behavior.rs`)
+  — `mock_agent_path()` locates the freshest `target/.../mock-agent`
+  and falls back to `cargo build -p mock-agent --message-format json`
+  if the binary is missing. `ci/test.py` pre-builds it so this
+  fallback rarely runs.

--- a/testbins/mock-agent/src/README.md
+++ b/testbins/mock-agent/src/README.md
@@ -1,0 +1,54 @@
+# mock-agent/src/
+
+Source for the `mock-agent` binary (crate `mock-agent`, see
+`../Cargo.toml`). Integration tests copy or symlink this binary onto `PATH`
+under the name `claude` or `codex` so the `clud` CLI launches it instead of a
+real agent. The binary parses its own `--mock-*` flags out of `argv`, records
+the remaining (forwarded) args, optionally reads stdin, optionally writes
+marker files / probe data, and then emits a single JSON report on stdout
+before exiting with the test-requested code.
+
+## Files
+
+- `main.rs` — Entire mock-agent implementation: arg filtering, stdin capture
+  (timed + pipe modes, raw-mode on Unix TTYs), iteration counter for
+  `clud loop` marker tests, helper-process tree spawning, terminal-size
+  polling, scripted ANSI/stream-json emission, and the final JSON report.
+
+## Behavior
+
+- Reads argv. Recognized `--mock-*` flags are consumed; everything else is
+  echoed back in the report's `args` field exactly as `clud` forwarded it.
+- Recognized flags (each takes the next argv slot as its value):
+  - `--mock-exit-code <n>` — exit with `n` (default 0).
+  - `--mock-sleep-ms <ms>` — sleep before emitting the JSON report.
+  - `--mock-read-stdin-ms <ms>` — read stdin for up to N ms even on a TTY;
+    puts the TTY into raw mode on Unix so non-newline bytes flush.
+  - `--mock-stdin-raw-to <path>` — also dump captured stdin bytes to a file.
+  - `--mock-report-file <path>` — duplicate the JSON report to a file (useful
+    when stdout is owned by a PTY).
+  - `--mock-write-done <path>` / `--mock-write-done-body <s>`,
+    `--mock-write-blocked <path>` / `--mock-write-blocked-body <s>`,
+    `--mock-write-marker-on-iter <n>` — `clud loop` DONE/BLOCKED contract:
+    bumps an `iter-count` file in the marker's parent dir on each invocation
+    and writes the marker once iteration `>= n`.
+  - `--mock-helper-role <root|child|grandchild>` +
+    `--mock-spawn-tree-log <path>` — process-tree tests; the root logs itself
+    and spawns a detached child which spawns a grandchild.
+  - `--mock-report-pty-size <path>` with `--mock-pty-size-samples <n>` and
+    `--mock-pty-size-interval-ms <ms>` — poll `terminal_size` N times,
+    write the samples as JSON, and print one `PTY_SIZE_SAMPLE i {json}` line
+    per sample to stdout so the harness can resize between samples.
+  - `--mock-ansi-script <path>` — write raw bytes from the file to stdout
+    first (used by attach-replay tests).
+  - `--mock-stream-json <path>` with `--mock-stream-delay-ms <ms>` — emit one
+    pre-canned `--output-format stream-json` line per file line, flushing
+    between each, then exit (no JSON report tail).
+- Env vars `IN_CLUD` and `RUNNING_PROCESS_ORIGINATOR` are captured and
+  included under `env` in the report; current working directory is captured
+  as `cwd`.
+- Stdout: the JSON report (one line) unless a mode above short-circuits
+  (`--mock-stream-json`, `--mock-report-pty-size`, helper role). Scripted ANSI
+  or stream-json bytes are emitted before the report when configured.
+- Stderr: unused.
+- Exit code: value of `--mock-exit-code`, default 0.


### PR DESCRIPTION
## Summary
- Add `README.md` to every directory under `crates/` and `testbins/` (17 total) so each dir self-documents its purpose, files, key public items (with `file:line` refs), and callers.
- Land them bottom-up in 5 batches (deepest leaves first, each parent only after its children) so every parent README can link to children that already exist.
- Convert `CLAUDE.md` into an index/director: kept commands, soldr policy, key design decisions, and CI matrix; replaced the architecture deep-dive with pointers into the new per-dir READMEs.

## Why
Lets agents navigate the codebase by drilling from `CLAUDE.md` → directory README → leaf README on demand instead of loading the whole architecture into context every turn.

## Coverage
- `crates/{,clud-bin,clud-bin/src,clud-bin/src/{command,daemon,dnd,voice},clud-bin/tests,clud-bin/assets,clud-bin/assets/skills,clud-bin/assets/skills/{clud-issue,clud-issue-triage,clud-pr,clud-tag-release}}/README.md`
- `testbins/{,mock-agent,mock-agent/src}/README.md`
- `CLAUDE.md` rewritten

No source files were modified — docs only.

## Test plan
- [ ] Skim each README — purpose, files, and `file:line` refs accurate
- [ ] Verify all internal relative links resolve
- [ ] `bash lint` is a no-op for docs-only changes but run it to be safe