### PR TITLE
docs: tier-2 progressive disclosure (topic docs + ADRs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ crates/                    → see crates/README.md
 testbins/                  → see testbins/README.md
   mock-agent/              → see testbins/mock-agent/README.md
     src/                   → see testbins/mock-agent/src/README.md
+docs/                      → see docs/README.md
+  ARCHITECTURE.md          # index of subsystem topic docs
+  DESIGN_DECISIONS.md      # ADR-style records (DD-001 … DD-010)
+  architecture/            # one file per cross-cutting subsystem
 src/clud/__init__.py       # Minimal Python package (version shim only)
 ci/                        # CI scripts (env, build, lint, test)
 tests/                     # Python tests (unit + integration)
@@ -48,18 +52,37 @@ tests/                     # Python tests (unit + integration)
 
 ### How to navigate
 
-- **Where is X implemented?** Start at [`crates/clud-bin/src/README.md`](crates/clud-bin/src/README.md). It groups every top-level `.rs` file by concern (CLI surface, console/terminal, loop subsystem, GC, platform glue) and includes a "Quick lookup — which file owns a given subcommand" table.
-- **How does a subsystem work?** Each subdirectory README (`command/`, `daemon/`, `dnd/`, `voice/`) describes its purpose, files, key public items with `file:line` refs, and who calls into it.
+- **Where is X implemented?** Start at [`crates/clud-bin/src/README.md`](crates/clud-bin/src/README.md). It groups every top-level `.rs` file by concern and includes a "Quick lookup — which file owns a given subcommand" table.
+- **What's in this directory?** Each directory's `README.md` lists its files, key public items with `file:line` refs, and who calls into it.
+- **How does a subsystem work end-to-end?** [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — topic docs that span multiple directories (loop, daemon IPC, session lifecycle, skill system, gc/registry, Windows quirks, launch plan).
+- **Why was it designed this way?** [`docs/DESIGN_DECISIONS.md`](docs/DESIGN_DECISIONS.md) — ADR-style rationale for non-obvious choices.
 - **How does a test work?** [`crates/clud-bin/tests/README.md`](crates/clud-bin/tests/README.md) for Rust integration tests; [`testbins/mock-agent/README.md`](testbins/mock-agent/README.md) for the mock backend.
-- **How do bundled skills ship?** [`crates/clud-bin/assets/skills/README.md`](crates/clud-bin/assets/skills/README.md) — note the two-installer caveat (`skills.rs` vs `skill_install.rs`).
 
-## Key Design Decisions
+## Architecture & design docs
 
-- **YOLO by default**: always injects `--dangerously-skip-permissions` unless `--safe`.
-- **Backend agnostic**: supports both `claude` and `codex` via `--claude` / `--codex`.
-- **Unknown flag passthrough**: unrecognized CLI flags are forwarded to the backend.
-- **Single `LaunchPlan`**: every code path goes through `command::build_launch_plan` (see [`src/command/README.md`](crates/clud-bin/src/command/README.md)). `--dry-run` emits this plan as JSON.
-- **Test-first**: every feature has both Rust `#[test]` and Python subprocess tests.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — index of subsystem topic docs (each ~150–400 lines, self-contained).
+- [`docs/DESIGN_DECISIONS.md`](docs/DESIGN_DECISIONS.md) — 10 ADRs covering the non-obvious choices below and more.
+
+## Where to put new docs
+
+Tiered to keep agent context windows small and prevent duplication:
+
+1. **Per-directory README** (`<dir>/README.md`) covers **what's in this directory** — files, key types with `file:line`, callers. If a fact applies only inside one directory, write it here.
+2. **Subsystem topic doc** (`docs/architecture/<topic>.md`) covers **how a subsystem works across directories**. If a concept spans 2+ directories or 3+ files, write it here and have the per-dir READMEs link in with a one-line breadcrumb.
+3. **Design decision** (`docs/DESIGN_DECISIONS.md`, append-only `DD-NNN`) covers **why** a non-obvious choice was made. If a reader could plausibly ask "why didn't you do it the other way?", add a DD.
+4. **Never duplicate.** One doc owns each fact; everyone else links. When you find yourself copying a paragraph, replace the copy with a breadcrumb.
+
+For a new cross-cutting feature: add the topic doc → register it in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) → add a breadcrumb in each touched per-dir README → if the design is non-obvious, append a `DD-NNN` to `DESIGN_DECISIONS.md`.
+
+## Key Design Decisions (summary)
+
+See [`docs/DESIGN_DECISIONS.md`](docs/DESIGN_DECISIONS.md) for full rationale.
+
+- **YOLO by default** — `--dangerously-skip-permissions` is auto-injected unless `--safe` ([DD-002](docs/DESIGN_DECISIONS.md#dd-002-yolo-mode-is-the-default-safe-is-the-opt-out)).
+- **Backend agnostic** — supports both `claude` and `codex` via `--claude` / `--codex` ([DD-004](docs/DESIGN_DECISIONS.md#dd-004-backend-agnostic--support-both-claude-and-codex)).
+- **Single `LaunchPlan`** — every code path goes through `command::build_launch_plan`; `--dry-run` emits it as JSON ([DD-005](docs/DESIGN_DECISIONS.md#dd-005-single-launchplan-as-source-of-truth-for-everything-clud-runs), [launch-plan.md](docs/architecture/launch-plan.md)).
+- **Unknown flag passthrough** — unrecognized CLI flags are forwarded to the backend.
+- **Test-first** — every feature has both Rust `#[test]` and Python subprocess tests.
 
 ## Code Quality Standards
 

--- a/crates/clud-bin/assets/skills/README.md
+++ b/crates/clud-bin/assets/skills/README.md
@@ -11,17 +11,13 @@ Claude Code "skills" bundled into the `clud` binary as compile-time assets. On e
 
 ## How skills ship
 
-Each `SKILL.md` here is embedded into the binary via `include_str!` and written out on launch. Two installer paths exist and contributors should be aware of both:
+Each `SKILL.md` here is embedded into the binary via `include_str!` and written out on launch. Two installers run on every launch:
 
-- **`crates/clud-bin/src/skills.rs`** is the multi-backend installer. It iterates `BUNDLED_SKILLS` (sourced from this directory) and `SKILL_BACKENDS` (currently `~/.claude` and `~/.codex`), writes only when the target `SKILL.md` is missing, and never overwrites user edits.
-- **`crates/clud-bin/src/skill_install.rs`** is a Claude-only installer that reads from a separate top-level `skills/` directory in the repo (not this one) and *does* overwrite when content diverges semantically from the embedded copy (whitespace/CRLF differences are tolerated).
+- **`crates/clud-bin/src/skills.rs`** — multi-backend (`~/.claude`, `~/.codex`), never overwrites user edits, reads from this directory.
+- **`crates/clud-bin/src/skill_install.rs`** — Claude-only, overwrites on semantic divergence, reads from a separate top-level `skills/` directory in the repo.
 
-Both run on every launch and degrade silently on error. If you change a bundled skill, confirm which installer (or both) owns the on-disk copy.
+The two source trees ship different subsets — see [docs/architecture/skill-system.md](../../../../docs/architecture/skill-system.md) for the full divergence map, rationale, and the eventual consolidation plan ([DD-008](../../../../docs/DESIGN_DECISIONS.md#dd-008-dual-skill-installer-skillsrs-vs-skill_installrs--interim-state)).
 
 ## Adding a skill
 
-- Create `assets/skills/<name>/SKILL.md` with the standard frontmatter (`name:`, `description:`, `triggers:`) and the `<!-- managed-by: clud -->` marker.
-- Append a `BundledSkill { name, skill_md: include_str!("../assets/skills/<name>/SKILL.md") }` entry to `BUNDLED_SKILLS` in `crates/clud-bin/src/skills.rs`.
-- Decide whether the skill also needs to ship via `crates/clud-bin/src/skill_install.rs` (overwriting installer, top-level `skills/<name>/SKILL.md` source) and update that bundle list if so.
-- Add a short `README.md` next to the new `SKILL.md` and link it from the **Skills** section above.
-- Run `bash lint` and `bash test`; the existing unit tests assert the bundle is non-empty, names are unique, and every entry carries the `managed-by: clud` marker.
+See the checklist in [docs/architecture/skill-system.md](../../../../docs/architecture/skill-system.md#adding-a-skill) — it covers which installer to register with, where to place `SKILL.md`, the unit-test invariants, and the README expectation. Confirm both installers are updated if the skill should ship to Codex as well.

--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -72,31 +72,23 @@ Quick lookup — which file owns a given subcommand:
 - `clud --clean-worktrees` → `worktrees.rs`.
 - `clud --fix-hooks` → `hook_health.rs`.
 
-## Cross-cutting conventions
+## Cross-cutting subsystems
 
-- **Single launch source of truth.** Every code path that needs to know "what would clud actually run" goes through `command::build_launch_plan` and consumes the resulting `LaunchPlan`. `--dry-run` JSON, `runner.rs`, the daemon worker, and the hook-health remediator all share this struct rather than reconstructing argv.
-- **Windows-first care.** Several modules exist purely to absorb Windows quirks: `subprocess` (BatBadBat / `.cmd` rewrite), `trampoline` (exe self-rename for `pip install`), `win_creation_flags` (`CREATE_NO_WINDOW` for invisible helpers), `console_setup` (`ENABLE_VIRTUAL_TERMINAL_INPUT`), `console_input` (Shift+Enter via `ReadConsoleInputW`), and `console_title` (OSC-title keeper). All of them degrade to no-ops on POSIX.
-- **Best-effort, non-fatal startup nudges.** `skills`, `skill_install`, `hook_health` (warn mode), `large_file_guard`, and `console_title` are all wrapped so a failure logs to stderr and continues — none of them can block a launch.
-- **`lib.rs` is the single module instantiation site.** `main.rs` imports through `clud::{...}`; integration tests link the same library. There is no `mod ...;` declaration anywhere in `main.rs`.
-- **`redb` is touched in exactly one place per file.** `~/.clud/data.redb` is owned by the `gc_daemon` process (issue #135 Phase 1); the in-process `gc::WorktreeScanner` and the `clud gc list` / `purge` clients all funnel through the daemon's JSON-over-loopback-TCP protocol. The per-launch session cap lives in a separate `redb` table accessed via `session_registry`, which serializes with a sidecar `sessions.lock` so multiple `clud` processes never race on the file.
-- **Ctrl+C is cooperative.** `startup::install_ctrlc_flag` arms a `Arc<AtomicBool>` consumed by the loop iteration in `runner.rs`, the daemon attach loop in `daemon/attach.rs`, and the GC scanner thread in `gc.rs`. Forced reaping of orphan descendants is delegated to `process_tree::kill_tree`.
+Subsystems that span multiple files have their own topic docs under `docs/architecture/`:
 
-## Launch flow
+- **Loop subsystem** (`command/`, `loop_spec`, `loop_check`, `loop_artifacts`, `stream_json`, `runner`) → [docs/architecture/loop-subsystem.md](../../../docs/architecture/loop-subsystem.md)
+- **Daemon IPC** (everything under `daemon/`) → [docs/architecture/daemon-ipc.md](../../../docs/architecture/daemon-ipc.md)
+- **Session lifecycle** (`session`, `console_*`, `capture`, `dnd` injection, `voice` hooks) → [docs/architecture/session-lifecycle.md](../../../docs/architecture/session-lifecycle.md)
+- **Skill system** (`skills`, `skill_install`, `assets/skills/`) → [docs/architecture/skill-system.md](../../../docs/architecture/skill-system.md)
+- **GC and registry** (`gc`, `gc_daemon`, `session_registry`, `worktrees`) → [docs/architecture/gc-and-registry.md](../../../docs/architecture/gc-and-registry.md)
+- **Windows quirks** (`trampoline`, `subprocess` BatBadBat, `console_*`, `dnd`, `win_creation_flags`, `voice` ARM carveout) → [docs/architecture/windows-quirks.md](../../../docs/architecture/windows-quirks.md)
+- **Launch plan** (`command/types::LaunchPlan` + all consumers) → [docs/architecture/launch-plan.md](../../../docs/architecture/launch-plan.md)
 
-A typical interactive launch hits the modules in roughly this order:
-
-1. `main.rs` initializes the launch clock (`verbose_log`), unlocks the exe (`trampoline`), stamps the console title (`console_title`), installs bundled skills (`skills`, `skill_install`), checks hook health (`hook_health`), and warns on large files (`large_file_guard`).
-2. `args.rs` parses the CLI; `backend.rs` resolves which agent and launch mode to use; `startup.rs` registers the session in `session_registry` (enforcing `CLUD_MAX_INSTANCES`) and installs the Ctrl+C atomic flag.
-3. `command::build_launch_plan` (from `command/`) assembles the `LaunchPlan` — argv, env, prompt, optional loop markers, optional `--repeat` schedule. For `clud loop`, `loop_spec` resolves the task and `loop_artifacts` initializes `<git-root>/.clud/loop/`.
-4. `main.rs` hands the plan to `runner.rs`, which dispatches to either the subprocess path (via `subprocess.rs`, with `stream_json` rendering progress) or the PTY path (via `session.rs`, with `console_input` translating Shift+Enter and `dnd` injecting drops).
-5. In PTY mode `voice::VoiceMode` attaches an `InteractiveHooks` impl so F3 press/release flows the captured audio through `voice/worker.rs` and writes the transcript back into the PTY master.
-6. After each iteration, `loop_check` polls DONE/BLOCKED markers; `loop_artifacts` rolls forward `info.json` / `log.txt`; on terminal signals, `process_tree::kill_tree` reaps the descendant tree before exit.
-
-When `--detach` / `attach` / `list` / `kill` / `logs` is used, `main.rs` routes into `daemon/` instead, and the daemon process re-enters this same binary as a `__daemon` or `__worker` to host or run the session.
+Non-obvious design choices (single `LaunchPlan`, `lib.rs` as the only `mod ...` site, cooperative Ctrl+C, redb single-owner) have ADRs in [docs/DESIGN_DECISIONS.md](../../../docs/DESIGN_DECISIONS.md).
 
 ## Entry point
 
-`main.rs` is the binary entry; `lib.rs` re-exports every top-level module (and the four subdirs) as `pub mod ...` so the integration tests under `crates/clud-bin/tests/` can link against internals (notably `session::run_raw_pty_pump` and `session::F3Observer`). Production builds resolve each module through the library, so there is exactly one instance of each module in the final binary.
+`main.rs` is the binary entry; `lib.rs` re-exports every top-level module (and the four subdirs) as `pub mod ...` so integration tests under `crates/clud-bin/tests/` can link against internals (notably `session::run_raw_pty_pump` and `session::F3Observer`). See [DD-007](../../../docs/DESIGN_DECISIONS.md#dd-007-librs-is-the-only-place-that-declares-modules-mainrs-imports-through-clud) for why the single-instantiation pattern matters.
 
 ## See also
 

--- a/crates/clud-bin/src/command/README.md
+++ b/crates/clud-bin/src/command/README.md
@@ -2,6 +2,8 @@
 
 Builds the `LaunchPlan` that downstream runners execute: backend-specific argv assembly (`claude` vs `codex`), YOLO/safe-mode injection, subcommand-driven prompt construction (`loop`, `up`, `rebase`, `fix`), `--repeat` schedule parsing, DONE/BLOCKED marker contract wiring, and Claude `stream-json` progress injection for subprocess-mode loops.
 
+The `LaunchPlan` contract (construction pipeline, consumers, `--dry-run` JSON) is documented at [docs/architecture/launch-plan.md](../../../../docs/architecture/launch-plan.md); the DONE/BLOCKED contract and `--repeat` no-overlap scheduler at [docs/architecture/loop-subsystem.md](../../../../docs/architecture/loop-subsystem.md).
+
 ## Files
 
 - `mod.rs` — module facade; re-exports `build_launch_plan`, `has_noninteractive_prompt`, `next_run_at_millis`, `repeat_implies_no_done_warning`, `summarize_task_name`, and the `LaunchPlan` / `LoopMarkers` / `RepeatSchedule` types.

--- a/crates/clud-bin/src/daemon/README.md
+++ b/crates/clud-bin/src/daemon/README.md
@@ -2,6 +2,8 @@
 
 Centralized session manager for backgrounded, detachable, and repeating clud runs. A long-lived daemon process (one per state-dir) accepts TCP JSON requests to spawn per-session worker subprocesses; each worker owns one backend (`claude` or `codex`) running under a PTY or a captured subprocess, persists snapshots + an append-only log to disk, and brokers attach/detach from interactive clients. Clients use this layer for `clud --detach`, `clud attach`, `clud list`, `clud kill`, `clud logs`, and `clud loop --repeat`. Internal helper commands `__daemon` and `__worker` re-enter the same binary in their respective roles.
 
+For the wire protocol, attach flow, snapshot/log persistence, and failure modes, see [docs/architecture/daemon-ipc.md](../../../../docs/architecture/daemon-ipc.md). This README is the per-file inventory.
+
 ## Files
 
 - `mod.rs` — module root. Only re-exports `experimental_enabled`, `handle_special_command`, `run_centralized_session` from `entry`.

--- a/crates/clud-bin/src/dnd/README.md
+++ b/crates/clud-bin/src/dnd/README.md
@@ -2,6 +2,8 @@
 
 Drag-and-drop handling for terminal-embedded `clud` sessions. Provides two complementary paths: (1) a cross-platform string normalizer that canonicalizes the path-shaped byte sequences each terminal injects on a drop (cmd.exe quoted paths, mintty `/c/...` MSYS paths, PowerShell `& 'C:\...'`, macOS backslash-escaped spaces, GNOME `file://` URIs), and (2) a Windows-only OLE `IDropTarget` adapter that intercepts drops at the COM layer (fixing issue #65 where conhost rejects the drop) and forwards parsed paths to a per-launch-mode injector (subprocess via `WriteConsoleInputW`, PTY via the master writer).
 
+The Windows COM lifecycle (`OleInitialize` worker thread, `RegisterDragDrop` displacement strategy for issue #79, `IDropTarget` vtable, RAII teardown) is covered in [docs/architecture/windows-quirks.md](../../../../docs/architecture/windows-quirks.md). The PTY-side injection path (how bytes reach the master) is in [docs/architecture/session-lifecycle.md](../../../../docs/architecture/session-lifecycle.md).
+
 ## Files
 
 - `mod.rs` — public `normalize_dropped_path` / `looks_like_dropped_path` string transforms plus `pub mod` re-exports of the submodules.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# clud Architecture
+
+Index of subsystem architecture docs. Each file is self-contained for one cross-cutting concept; per-directory READMEs link in here instead of re-explaining.
+
+## Subsystem docs
+
+| Document | Lines | What it covers |
+|---|---|---|
+| [architecture/loop-subsystem.md](architecture/loop-subsystem.md) | ~250 | `clud loop`: task resolution, plan synthesis, iteration run, DONE/BLOCKED marker contract, artifact rollover, repeat scheduling |
+| [architecture/daemon-ipc.md](architecture/daemon-ipc.md) | ~250 | Centralized session daemon: TCP JSON IPC, daemon/worker re-entry model, snapshot persistence, attach broker |
+| [architecture/session-lifecycle.md](architecture/session-lifecycle.md) | ~300 | PTY session pump, console mode setup, OSC title keeper, capture for attach, drag-drop and voice injection points |
+| [architecture/skill-system.md](architecture/skill-system.md) | ~200 | Skill bundling (`include_str!`), dual-installer model (`skills.rs` vs `skill_install.rs`), multi-backend install |
+| [architecture/gc-and-registry.md](architecture/gc-and-registry.md) | ~250 | `gc_daemon` single-owner redb model, session cap registry, worktree scanner, GC subcommands |
+| [architecture/windows-quirks.md](architecture/windows-quirks.md) | ~300 | Windows-only platform code: trampoline, BatBadBat `.cmd` rewrite, console modes, Shift+Enter key translation, `IDropTarget`, `CREATE_NO_WINDOW`, ARM whisper carveout |
+| [architecture/launch-plan.md](architecture/launch-plan.md) | ~180 | `LaunchPlan` as the single source of truth: construction, consumers, `--dry-run` JSON |
+
+## Quick reference
+
+- **"How does `clud loop` decide when to stop?"** → [loop-subsystem.md](architecture/loop-subsystem.md)
+- **"How do `attach` / `list` / `kill` talk to the daemon?"** → [daemon-ipc.md](architecture/daemon-ipc.md)
+- **"What happens between Ctrl-D and process exit in a PTY session?"** → [session-lifecycle.md](architecture/session-lifecycle.md)
+- **"Why are there two skill installers?"** → [skill-system.md](architecture/skill-system.md)
+- **"Why is `~/.clud/data.redb` behind a daemon?"** → [gc-and-registry.md](architecture/gc-and-registry.md)
+- **"Why does Windows do X differently?"** → [windows-quirks.md](architecture/windows-quirks.md)
+- **"Where does the argv that clud runs come from?"** → [launch-plan.md](architecture/launch-plan.md)
+
+See also: [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md) for rationale behind the choices these subsystems embody.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -1,0 +1,272 @@
+# clud Design Decisions
+
+ADR-style records for non-obvious design choices in clud. Each entry follows the structure: Context, Decision, Rationale, Alternatives Considered, Consequences.
+
+Decisions are numbered for stable cross-references (e.g. `DD-005`). Numbers are append-only; superseded decisions stay in place with a "Superseded by" note.
+
+---
+
+## DD-001: Rust binary distributed as a Python wheel via maturin `bindings = "bin"`
+
+**Context:** clud is a CLI that orchestrates other CLIs (`claude`, `codex`) on Windows, Linux, and macOS. Its distribution channel needs to reach Python developers (the primary audience already running `pip install` for AI tooling) without forcing them to install a Rust toolchain or hand-pick a binary for their platform.
+
+**Decision:** Implement clud as a pure Rust binary in `crates/clud-bin`, then package and distribute it as a Python wheel using `maturin` with `[tool.maturin] bindings = "bin"`. Installing the wheel places the native `clud` executable onto the user's `PATH`. The Python package (`src/clud/__init__.py`) is a thin version shim with no runtime code.
+
+**Rationale:**
+- Single artifact per platform: `pip install clud` works the same on Windows, macOS, and Linux without users picking a binary.
+- maturin's `bindings = "bin"` is the supported way to ship a CLI binary through PyPI; no custom wheel-building code needed.
+- Rust gives us the runtime characteristics clud needs: predictable startup, no GC pauses on the PTY hot path, easy static binaries, and the `windows-rs`/`ConPTY`/COM ecosystem for Windows quirks (DD'd separately).
+- PyPI also reaches the audience that runs `uv tool install` and `pipx install`, both of which extract the binary into a managed `PATH`.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Pure Python | Cannot meet startup latency goals; PTY/COM/IDropTarget work is painful or impossible in pure Python on Windows. |
+| Standalone binary releases (GitHub releases only) | Users must download, chmod, and place on PATH manually. Loses the `pip install` workflow that this audience already uses. |
+| Cargo install (`cargo install clud`) | Requires every user to have a working Rust toolchain. Painful on Windows. |
+| Python C extension (`bindings = "pyo3"`) | Forces a Python runtime in the hot path. clud is a CLI, not a library — it doesn't need Python at all once it's on PATH. |
+
+**Consequences:**
+- The release pipeline has to build platform-specific wheels (6 platforms x 4 CI jobs = 24 jobs).
+- Wheel updates trigger a hot-overwrite of `Scripts/clud.exe` on Windows, which is why `trampoline.rs` exists (rename-self-then-copy-back). See [windows-quirks.md](architecture/windows-quirks.md).
+- A `clud` upgrade is `pip install -U clud` rather than a separate self-update mechanism.
+
+---
+
+## DD-002: YOLO mode is the default; `--safe` is the opt-out
+
+**Context:** clud's primary value is reducing friction when running Claude Code and Codex in agent mode. The upstream agents prompt for permission on every tool call by default, which makes long-running automation impossible.
+
+**Decision:** clud always injects `--dangerously-skip-permissions` into the backend argv unless the user explicitly passes `--safe`. This applies to every backend invocation (interactive, loop, daemon).
+
+**Rationale:**
+- Users reach for clud specifically to skip per-call prompting. Defaulting to "prompt for everything" would defeat the purpose.
+- The opt-out (`--safe`) is one word, easy to remember, and preserves the safe path for users who want it.
+- Single decision point in `command::build_launch_plan` means there is no path that forgets to apply the policy.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Off by default, opt-in `--yolo` | Most invocations would need `--yolo`, adding noise and creating muscle memory that defeats the safety value of the off-by-default. |
+| Per-backend default (claude on, codex off) | Inconsistent UX; hard to explain. |
+| Read from a config file | Adds a hidden global setting; behavior depends on machine state. |
+
+**Consequences:**
+- New users must be told about `--safe` (covered in `README.md`).
+- Any code path that bypasses `build_launch_plan` would silently lose YOLO injection; see [DD-005](#dd-005-single-launchplan-as-source-of-truth-for-everything-clud-runs).
+
+---
+
+## DD-003: All Rust toolchain calls go through `soldr`
+
+**Context:** clud is developed on Windows where `cargo` and `rustc` are routinely shadowed by stale shims — chocolatey's bundled cargo, rustup proxies for the wrong toolchain, system `rustc` from package managers. Builds that work locally for one developer fail for another for path-shadowing reasons that are tedious to diagnose.
+
+**Decision:** Every `cargo`, `rustc`, and `rustfmt` invocation in this repo (developer workflow, CI, scripts) must go through `soldr <tool>` (https://github.com/zackees/soldr). soldr resolves the rustup-managed toolchain via `rustup which` and invokes that binary directly, bypassing whatever shim is on `PATH`. A `.claude/hooks/check-soldr.py` PreToolUse hook blocks any bare `cargo`/`rustc`/`rustfmt` Bash command and tells the user to install soldr.
+
+**Rationale:**
+- Eliminates "works on my machine" caused by shim drift on Windows.
+- Mechanical enforcement (the hook) means new contributors hit a clear error message instead of a mysterious build break.
+- soldr is a standalone binary; no Python dep, no toolchain coupling.
+- CI uses `zackees/setup-soldr@v0` so local and CI invocations are identical.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Document "use rustup-managed cargo" in CLAUDE.md | Tried this; relied on each contributor reading and remembering. Drift recurred. |
+| `cargo +<toolchain>` invocations | Still relies on `cargo` itself resolving to the right binary first. |
+| Pin the toolchain via `rust-toolchain.toml` only | Rust-toolchain.toml works for rustup-managed cargo but not for shadowed `cargo`. Necessary but not sufficient. |
+
+**Consequences:**
+- New contributors must install soldr before they can build (`./install` or `./install --global`).
+- All shell snippets in docs, `bash build`, `bash test`, etc. use `soldr cargo …` everywhere.
+
+---
+
+## DD-004: Backend-agnostic — support both Claude and Codex
+
+**Context:** Users run different upstream agents (`claude` and `codex`) with similar but not identical CLI surfaces. Each backend has its own arg conventions, model-flag placement, prompt-injection mechanism, and skill-install location.
+
+**Decision:** clud detects which backends are on `PATH` and supports either via `--claude` / `--codex` flags. The `Backend` enum is plumbed through every code path that constructs argv. Where backends diverge (`--model` placement, `-p` semantics, `stream-json` injection, the `exec`/`resume` keywords), the divergence is encoded inside `command/`. Skills bundled into the `clud` binary install to both `~/.claude/skills/` and `~/.codex/skills/` when those homes already exist.
+
+**Rationale:**
+- Locks clud into supporting users on either backend without forking the binary.
+- The single-`LaunchPlan` discipline ([DD-005](#dd-005-single-launchplan-as-source-of-truth-for-everything-clud-runs)) absorbs backend divergence in one place (`command/`), so downstream code never branches on backend.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Claude-only | Cuts off users who prefer Codex or are evaluating both. |
+| Two separate binaries | Code duplication; bug fixes have to land twice. |
+| Adapter layer that homogenizes the backends | Premature abstraction; backend diffs are small enough to encode directly. |
+
+**Consequences:**
+- `command/` carries `if backend == Backend::Claude { … } else { … }` branches; concentrated, easy to audit.
+- The skill system needs to handle two install targets, which complicates [DD-008](#dd-008-dual-skill-installer-skillsrs-vs-skill_installrs-interim-state).
+
+---
+
+## DD-005: Single `LaunchPlan` as source of truth for everything clud runs
+
+**Context:** clud has many code paths that need to know "what argv will clud actually run with these flags?" — the runner itself, the daemon worker, `--dry-run` JSON output for tests, the loop iteration loop, hook health remediation, and so on. Each path independently reconstructing argv is a recipe for divergence (one path forgets YOLO injection, another places `--model` in the wrong slot).
+
+**Decision:** Every code path goes through `command::build_launch_plan` and consumes the resulting `LaunchPlan` struct (`crates/clud-bin/src/command/types.rs`). The struct carries argv, env, prompt, optional loop markers, and optional repeat schedule. `--dry-run` serializes this struct to JSON. The runner, daemon worker, and remediator each consume the same struct.
+
+**Rationale:**
+- One implementation of "what runs" means no drift between dry-run output and actual execution.
+- Tests that exercise plan construction (via `--dry-run`) automatically exercise the same path runtime uses.
+- Adding a new code path that needs argv is mechanical: call `build_launch_plan`, consume the struct.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Each path builds its own argv | Verified to cause drift; YOLO and `stream-json` injection bugs found in early iterations. |
+| Function-based ("`build_argv(args) -> Vec<String>`") | Loses the structured fields (prompt, markers, schedule) and forces every consumer to re-parse strings. |
+
+**Consequences:**
+- Any new launch-affecting feature must extend `LaunchPlan` rather than wire data through side channels.
+- The `--dry-run` JSON contract is load-bearing for tests; breaking changes need test updates.
+- See [launch-plan.md](architecture/launch-plan.md) for the construction pipeline and consumer list.
+
+---
+
+## DD-006: `~/.clud/data.redb` is owned exclusively by a single GC daemon process; clients access it over loopback TCP
+
+**Context:** clud needs persistent state for tracked entries (used by `clud gc list` / `purge` / `reconcile`) and the worktree scanner. Initial implementations had every `clud` process open the redb file directly. This was unreliable under concurrent access: cross-platform advisory file locking is platform-specific, redb's own locking assumed single-process ownership, and we saw lock-contention hangs on Windows.
+
+**Decision:** A single daemon process (`gc_daemon`) owns `~/.clud/data.redb` exclusively for its lifetime. All other `clud` processes (CLI commands, in-process worktree scanner) talk to the daemon via JSON line-delimited messages over a loopback TCP socket. The daemon serializes all redb access through a dedicated registry-worker thread. (Issue #135 Phase 1.)
+
+The separate session-cap registry (`sessions.redb`) keeps file-lock-based serialization via a sidecar `sessions.lock` advisory lock (issue #138) because the cap-registry workload is much simpler — a per-launch row insert/remove that can tolerate brief blocking.
+
+**Rationale:**
+- One process owns the file → no cross-process locking required for the GC store.
+- Loopback TCP gives us a well-understood IPC layer with no platform-specific code (Unix sockets vs named pipes).
+- JSON line-delimited keeps the protocol debuggable and matches the daemon-ipc style elsewhere in clud.
+- The cap-registry stays file-locked because its access pattern is rare and short; spinning a separate daemon for it would be overkill.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Continue with direct file access + advisory locks | Failed under concurrent invocations on Windows. |
+| Use named pipes / Unix sockets directly | Platform-specific code; TCP loopback is portable and equally fast for this workload. |
+| Move everything to a single redb file with file locks | Doesn't solve the original concurrency problem. |
+| Use sqlite or a daemon-less embedded DB with better locking | redb is already used elsewhere; introducing another store fragments storage. |
+
+**Consequences:**
+- An extra process (`gc_daemon`) runs in the background; users see it in process listings.
+- The daemon binary is the same `clud` executable re-entered via a hidden subcommand, so there's no separate artifact to ship.
+- Connection failure to the daemon is a soft error: `clud gc list` reports unavailable, doesn't crash the user's foreground command.
+- See [gc-and-registry.md](architecture/gc-and-registry.md) for the protocol.
+
+---
+
+## DD-007: `lib.rs` is the only place that declares modules; `main.rs` imports through `clud::{…}`
+
+**Context:** `clud-bin` has both a binary (`main.rs`) and a library target (`lib.rs`) because Rust integration tests under `tests/` can only link against the library. If `main.rs` declares `mod session;` and `lib.rs` also declares `mod session;`, those are two separate compilation units; static state diverges, traits implemented in one aren't recognized in the other.
+
+**Decision:** Every top-level module declaration (`mod session;`, `mod runner;`, `mod command;`, …) lives in `lib.rs` only. `main.rs` does not declare any `mod` — it imports the modules it needs via `use clud::{…}`. Integration tests in `tests/*.rs` likewise link against `clud::…`.
+
+**Rationale:**
+- Single instantiation of every module: no duplicate static state, no trait-impl mismatches between binary and tests.
+- Tests can exercise internals (`session::run_raw_pty_pump`, `session::F3Observer`) by linking the library.
+- Refactors that move code only need to update one declaration site.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Declare in both `main.rs` and `lib.rs` | The duplicate-instantiation problem above. |
+| Declare in `main.rs` only | Tests can't import internals; would force a public-API split. |
+| Make `clud-bin` a library only and have a separate `clud-cli` binary crate | More crates, slower builds, more crate-boundary friction. |
+
+**Consequences:**
+- New top-level modules require editing `lib.rs`, not `main.rs`. Easy to forget; PR review must catch.
+- `main.rs` becomes a thin orchestration file rather than the project's hub. `lib.rs` is where the structural map lives.
+
+---
+
+## DD-008: Dual skill installer (`skills.rs` vs `skill_install.rs`) — interim state
+
+**Context:** Skills are slash-commands (`/clud-pr`, `/clud-issue`, etc.) bundled into the `clud` binary via `include_str!` and installed into the user's backend home(s) on launch. Two installer implementations exist in the codebase today:
+
+- `src/skills.rs` — multi-backend (`~/.claude/skills/`, `~/.codex/skills/`), non-overwriting (preserves user edits), reads from `crates/clud-bin/assets/skills/`.
+- `src/skill_install.rs` — Claude-only (`~/.claude/skills/`), overwrites on semantic divergence (whitespace-tolerant compare), reads from a separate top-level `skills/` directory.
+
+Their `BUNDLED_SKILLS` constants ship different subsets of skills.
+
+**Decision:** Accept the duality as interim state. Both installers run on every launch. Document the divergence explicitly in [skill-system.md](architecture/skill-system.md) and the dir READMEs so contributors aren't surprised. Plan to consolidate later (single installer, single source tree).
+
+**Rationale:**
+- The two installers evolved independently — `skill_install.rs` predates `skills.rs` — and consolidating now would be a non-trivial change with its own design questions (which overwrite policy wins? which source tree?).
+- Documenting the current state immediately is cheap; consolidating prematurely risks losing user edits or shipping the wrong subset.
+- The non-overwriting behavior of `skills.rs` is the right policy for skills the user might edit; the overwrite behavior of `skill_install.rs` is the right policy for skills clud strictly owns. The eventual consolidation needs to preserve both modes.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Consolidate now | Requires deciding overwrite policy and source-tree layout under time pressure; risks regression. |
+| Delete one installer | Either drops Codex support (`skill_install.rs` alone) or drops semantic overwrite (`skills.rs` alone). |
+
+**Consequences:**
+- Two install passes run on every `clud` launch; cost is negligible (compile-time strings, file existence checks).
+- Adding a new skill requires editing `BUNDLED_SKILLS` in **both** files (and possibly placing the `SKILL.md` in both source trees). [skill-system.md](architecture/skill-system.md) documents the checklist.
+- This DD should be revisited when consolidation lands; mark superseded then.
+
+---
+
+## DD-009: Cooperative Ctrl+C via `Arc<AtomicBool>` + best-effort descendant kill via `process_tree::kill_tree`
+
+**Context:** clud has long-running operations (loop iterations, daemon attach, GC scan) that the user might interrupt with Ctrl+C. The interrupt needs to propagate to backend processes and clean up child processes (especially on Windows where `clud --codex` spawns `cmd.exe → node.exe`, which can orphan if the parent dies first). A tokio-style cancellation-token system would require pulling tokio into every code path.
+
+**Decision:** Two mechanisms working together:
+
+1. **Cooperative flag.** `startup::install_ctrlc_flag()` installs a Ctrl+C handler that sets a shared `Arc<AtomicBool>`. The flag is consumed by the iteration loop in `runner.rs`, the daemon attach loop in `daemon/attach.rs`, and the GC scanner thread in `gc.rs`. Each polling site checks the flag and exits gracefully.
+2. **Best-effort descendant reap.** On exit, `process_tree::kill_tree` (via `sysinfo`) walks descendants of the current process and kills them. This fixes the multi-second Ctrl+C hang seen on Windows where `cmd.exe → node.exe` orphans the real child if only the immediate child is killed.
+
+**Rationale:**
+- The flag is dependency-free and works in sync and async code identically.
+- `kill_tree` is best-effort because process trees can race (a child spawns a grandchild between enumeration and kill). Acceptable: the user's intent is "stop now"; a stray surviving process is a smaller failure mode than a several-second hang.
+- Together they cover the realistic Ctrl+C scenarios without forcing every module onto tokio.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| `tokio::select!` with cancellation tokens | Forces tokio onto sync code paths; large refactor for marginal benefit. |
+| Job objects (Windows) / process groups (Unix) | Platform-specific; more complex; doesn't avoid the need for an AtomicBool for sync poll sites. |
+| Send SIGTERM to PID and wait | Doesn't reach grandchildren; the original codex orphan problem. |
+
+**Consequences:**
+- Every long-running loop must remember to poll the flag. If a loop forgets, Ctrl+C feels slow.
+- `kill_tree` can produce stderr noise from `sysinfo` access errors on locked-down systems; suppressed where benign.
+
+---
+
+## DD-010: `testbins/` lives outside `crates/` for non-shipping binaries
+
+**Context:** clud has a `mock-agent` crate that pretends to be `claude`/`codex` during integration tests. It's a Rust binary, a workspace member, and a real Cargo crate — but it's never shipped to users.
+
+**Decision:** Test-only Rust binaries live in `testbins/` (workspace members declared in the root `Cargo.toml`), separate from `crates/` which holds the shipped binary (`clud-bin`).
+
+**Rationale:**
+- The directory name communicates intent: anything under `crates/` ships, anything under `testbins/` does not.
+- Newcomers reading the repo layout immediately understand the distinction without checking each crate's `publish = false` line.
+- Release tooling can mass-include `crates/*` and ignore `testbins/*` without per-crate logic.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Put `mock-agent` in `crates/mock-agent` with `publish = false` | Easy to miss the `publish = false`; mixes shipping and non-shipping crates in one directory. |
+| Inline mock binary inside `clud-bin/tests/` | Cargo doesn't compile test directories as separate binaries you can find on `PATH`. The test would need to invoke the mock via library functions, which loses the integration-test value. |
+| Separate test-only workspace | Two workspaces is more painful than one with a directory convention. |
+
+**Consequences:**
+- Build commands need `-p mock-agent` to target it, but that's already standard Cargo.
+- Anyone adding a new test binary should put it in `testbins/`, not `crates/`. See `testbins/README.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Documentation
+
+Architecture and design records for clud. Read whichever doc matches what you're working on; nothing here needs to be read in order.
+
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — index of subsystem topic docs (loop, daemon IPC, session lifecycle, skill system, gc/registry, Windows quirks, launch plan).
+- **[DESIGN_DECISIONS.md](DESIGN_DECISIONS.md)** — ADR-style records for non-obvious design choices.
+- **[architecture/](architecture/)** — the subsystem docs themselves.
+
+Per-directory `README.md` files under `crates/` and `testbins/` describe **what's in this directory**. The docs here describe **how subsystems work across directories**.
+
+See the root [`CLAUDE.md`](../CLAUDE.md) for build / lint / test commands and the rule for where new docs go.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,15 @@
+# Architecture Documents
+
+Subsystem-level architecture for clud, split by topic so each doc is self-contained.
+
+| Document | Covers |
+|---|---|
+| [loop-subsystem.md](loop-subsystem.md) | `clud loop`: spec → plan → iteration → marker → artifact cycle |
+| [daemon-ipc.md](daemon-ipc.md) | Centralized session daemon, TCP JSON IPC, worker re-entry, attach broker |
+| [session-lifecycle.md](session-lifecycle.md) | PTY pump, console setup, title keeper, capture/replay, input injection |
+| [skill-system.md](skill-system.md) | Skill bundling and the dual-installer model (multi-backend vs Claude-overwrite) |
+| [gc-and-registry.md](gc-and-registry.md) | `gc_daemon` single-owner redb, session cap, worktree scanner, GC subcommands |
+| [windows-quirks.md](windows-quirks.md) | Windows-only platform code consolidated in one place |
+| [launch-plan.md](launch-plan.md) | `LaunchPlan` as the single source of truth for what clud actually runs |
+
+See the parent [ARCHITECTURE.md](../ARCHITECTURE.md) for the quick-reference table and [DESIGN_DECISIONS.md](../DESIGN_DECISIONS.md) for the "why" behind these designs.

--- a/docs/architecture/daemon-ipc.md
+++ b/docs/architecture/daemon-ipc.md
@@ -1,0 +1,185 @@
+# Daemon IPC
+
+The daemon is a long-lived, single-binary session manager that owns backgrounded `clud` runs and brokers `attach` / `list` / `kill` / `logs` / `--repeat`. Without it, every `clud` invocation would be its own foreground process tied to one terminal; with it, a user can `clud --detach -p ...` to spawn a backend (`claude` or `codex`) that survives terminal close, then later `clud attach <id>` to rejoin its PTY from a different TTY. The IPC layer is two pairs of JSON-line-delimited TCP messages on loopback: client-to-daemon (creates / queries / terminates sessions) and client-to-worker (attach handshake, then bidirectional input / output). State lives under a per-user state directory and the daemon process re-enters the same `clud` binary as hidden `__daemon` and `__worker` subcommands.
+
+## Component map
+
+Three processes, one binary. All files in `crates/clud-bin/src/daemon/`.
+
+**Daemon process** — at most one per state-dir. Spawned lazily by the first client that needs it, accepts loopback TCP, dispatches `Create` / `Session` / `Terminate`, spawns and reaps worker children.
+- `server.rs` — listener, request dispatch, worker spawn, reap thread.
+- `paths.rs` — on-disk layout helpers under `<state_dir>/`.
+- `process_utils.rs` — `pid_is_alive`, `signal_process_tree` (Term then Kill across the descendant tree via `sysinfo`).
+
+**Worker process** — one per session. Owns the backend PTY or captured subprocess, persists `SessionSnapshot`, appends to the rotating log, brokers exactly one attached client at a time.
+- `worker.rs` — main loop: bind worker port, start backend, accept attach connections, watchdog the daemon pid.
+- `worker_shared.rs` — `WorkerShared`: snapshot, in-memory backlog, optional `TerminalCapture`, log file, single-client gate, dead-peer eviction.
+- `types.rs` — wire types and runtime structs (`SessionRuntime`, `AttachedClient`, `RawTerminalGuard`).
+
+**Client side** — invoked from every `clud` front-end and from every `clud attach` / `list` / `kill` / `logs`.
+- `client.rs` — `ensure_daemon`, `send_daemon_request`, `request_session_termination`, `cleanup_stale_state`.
+- `attach.rs` — interactive attach loop, raw-terminal keyboard forwarding, Ctrl+C → background-prompt flow, exit-code propagation.
+- `commands.rs` — `clud kill`, `clud list`, `clud logs` (pm2-style tail / follow with rotation handling).
+- `sessions.rs` — `resolve_session_id` (exact / name / unique prefix), `most_recent_session[_any]`, `list_attachable_sessions`.
+- `keys.rs` — `crossterm::KeyEvent` → terminal byte sequences (Ctrl chords, arrow keys, F-keys).
+- `entry.rs` — single dispatch point: feature-flag check, special-command routing, `run_centralized_session`.
+- `io_helpers.rs` — JSON line read / write, atomic file writes, session-id generator, backlog-size parser.
+
+## Process model
+
+`clud` is one binary; the daemon and the worker are the same exe re-entered with hidden internal subcommands. The trampoline that detaches the daemon lives in `crate::trampoline`; client invocation is in `ensure_daemon` at `client.rs:18`.
+
+1. A normal `clud` invocation calls `experimental_enabled` (`entry.rs:21`). If `--detach` / `--detachable` / repeat / `CLUD_EXPERIMENTAL_DAEMON=1` is set, the front-end shells out to `run_centralized_session` (`entry.rs:144`) instead of running the backend directly.
+2. `run_centralized_session` calls `ensure_daemon` which probes the port in `daemon.json`; if no live daemon answers, it spawns `current_exe` with argv `["__daemon", "--state-dir", <path>]` via `trampoline::spawn_detached_self` (`client.rs:27`-`32`) and waits up to 5s for the new daemon to write `daemon.json` and accept a probe.
+3. On a `Create` request, the daemon spawns `current_exe` again with `["__worker", "--state-dir", ..., "--session-id", ..., "--daemon-pid", ..., "--spec-file", ...]` (`server.rs:120`-`133`). The worker is launched with `Containment::Detached`, `StdinMode::Null`, `StderrMode::Stdout`, and on Windows uses `invisible_helper_creationflags` to suppress a conhost flash (issue #55).
+4. Both internal subcommands are dispatched in `handle_special_command` (`entry.rs:38`): `Command::InternalDaemon` → `run_daemon` (`server.rs:23`), `Command::InternalWorker` → `run_worker` (`worker.rs:28`). The same dispatch handles all user-facing subcommands (`Attach`, `Kill`, `List`, `Logs`) so a single early-return covers every "not a normal run" path.
+
+The hidden subcommands are declared in `crates/clud-bin/src/args.rs` and accept their state-dir / session-id / pid / spec-file as explicit flags rather than env vars, so a stuck worker shows up in `ps` with a self-describing argv.
+
+## Wire protocol
+
+Loopback TCP (`127.0.0.1:0`, OS-assigned ephemeral port), one request per connection for the daemon side, a persistent connection per attached client for the worker side. Every message is a single line of UTF-8 JSON terminated by `\n`; see `write_json_line` at `io_helpers.rs:25`. All enums are tagged with `"op"` (serde `tag = "op"`, snake_case variants).
+
+**Client → daemon** (`DaemonRequest`, `types.rs:103`):
+
+| `"op"` | Payload | Reply | Notes |
+|---|---|---|---|
+| `create` | `spec: WorkerLaunchSpec` (boxed) | `created { session }` | Daemon spawns worker, waits up to 5s for snapshot + port-probe before responding. |
+| `session` | `session_id: String` | `session { session }` | Read-only fetch of the on-disk snapshot. |
+| `terminate` | `session_id: String` | `terminated { session }` | Signals worker tree (Term, sleep 150ms, Kill), marks snapshot `exit_code = 130`. |
+
+**Daemon → client** (`DaemonResponse`, `types.rs:111`): `created` / `session` / `terminated` each carry one `SessionSnapshot`; `error { message: String }` is the catch-all failure.
+
+**Client → worker** (`WorkerClientMessage`, `types.rs:120`):
+
+| `"op"` | Payload | Notes |
+|---|---|---|
+| `attach` | — | Mandatory handshake; any other first message gets `error "expected attach handshake"` and the connection drops (`worker.rs:460`). |
+| `input` | `data_b64: String`, `submit: bool` | Base64-encoded bytes. `submit` is the "press Enter after this paste" hint forwarded to the PTY's `write_impl`. |
+| `resize` | `rows: u16`, `cols: u16` | Forwarded to the PTY and to the server-side `TerminalCapture` parser (`worker.rs:527`-`530`). |
+| `interrupt` | — | Subprocess gets `kill()`, PTY gets `send_interrupt_impl()` (`types.rs:150`-`159`). |
+
+**Worker → client** (`WorkerServerMessage`, `types.rs:129`):
+
+| `"op"` | Payload | Notes |
+|---|---|---|
+| `attached` | `session: SessionSnapshot` | Always the first message, contains the snapshot at attach time. |
+| `output` | `data_b64: String` | Stream of base64-encoded chunks; on PTY sessions the first one is the synthesized repaint. |
+| `exited` | `exit_code: i32` | Terminal: writer thread breaks, client returns this code. |
+| `error` | `message: String` | Either pre-handshake (no attach) or during attach (slot taken). |
+
+Forward-compat: `SessionSnapshot` has `#[serde(default)]` on every non-essential field (`types.rs:48`-`74`) and `WorkerLaunchSpec.backlog_bytes` is `Option<usize>` (`types.rs:97`) precisely so older daemons can read spec files written by newer clients without crashing. Add fields the same way; do not rename or retag existing variants.
+
+## Daemon lifecycle
+
+`run_daemon` (`server.rs:23`):
+
+1. `fs::create_dir_all(state_dir)`.
+2. `cleanup_stale_state` (`client.rs:96`) — mark snapshots whose `worker_pid` is dead as `exit_code = Some(137)`, GC dangling spec files older than 10s (the grace window for slow worker startup), drop `daemon.json` if its pid is dead.
+3. Bind `TcpListener` on `127.0.0.1:0`, write `DaemonInfo { pid, port }` to `daemon.json` (`server.rs:31`-`52`).
+4. Accept loop spawns one thread per connection running `handle_daemon_connection` (`server.rs:68`). Each connection reads exactly one `DaemonRequest`, dispatches, writes one `DaemonResponse`, closes.
+5. Worker handles are stored in `HashMap<String, Arc<NativeProcess>>` and reaped by `reap_worker_when_done` (`server.rs:206`), which `wait()`s in a thread and removes the entry once the child exits.
+6. There is no graceful shutdown — the daemon exits when the process is killed. State on disk is the source of truth; a restarted daemon picks up where the previous one left off (modulo the stale-state cleanup pass).
+
+## Worker lifecycle
+
+`run_worker` (`worker.rs:28`):
+
+1. Load `WorkerLaunchSpec` from the spec file the daemon wrote. If `repeat_run_command` is set, divert to `run_repeat_worker` (`worker.rs:171`) — a polling loop that re-spawns `clud loop` once per `repeat_interval_secs`, never accepts attach connections.
+2. Bind a non-blocking `TcpListener` on `127.0.0.1:0` for attaching clients; record `worker_port`.
+3. Build the initial `SessionSnapshot` (`worker.rs:64`) and `WorkerShared` (`worker_shared.rs:50`); open the append-only log file (`init_log_file`, `worker_shared.rs:73`).
+4. Start the backend: `start_subprocess_session` (`worker.rs:312`) or `start_pty_session` (`worker.rs:384`). Both spawn a stdout-drain thread that calls `shared.push_output(chunk)` and a wait-thread that joins the drain *before* calling `broadcast_exit` (`worker.rs:344`-`378`). That join is load-bearing: without it, `Exited` can race ahead of the final `Output` chunk on the per-client mpsc channel and an attached client silently loses the last line. macOS-ARM hit this most often in `test_attach_last` (PR #136).
+5. Persist the snapshot, now with `root_pid` populated.
+6. Spawn two background threads:
+   - **Daemon-pid watchdog** (`worker.rs:114`-`132`): polls `pid_is_alive(daemon_pid)` every 200ms. If the daemon dies, the worker `runtime.cleanup_tree()`s the backend (Term, sleep 150ms, Kill across descendants), broadcasts exit 137, persists, removes the spec file, and exits.
+   - **Heartbeat / dead-peer evictor** (`worker.rs:138`-`146`): every 2s calls `evict_dead_client` which zero-byte-peeks the attached TCP socket and releases the slot on `Ok(0)` / `ConnectionReset` / `ConnectionAborted`.
+7. Accept loop runs `handle_worker_client` (`worker.rs:446`) per connection. Exits the outer loop when `stop_accepting` is set *and* no client is currently attached, then persists a final snapshot and removes the spec file.
+
+## Attach flow
+
+`clud attach <key>` walks through `run_attach` (`attach.rs:26`):
+
+1. `ensure_daemon` — fast-paths if `daemon.json`'s listener answers a probe.
+2. `resolve_session_id` (`sessions.rs:11`) tries exact id, then unique `name` match, then unique prefix match. Ambiguous matches list the candidates so the user can disambiguate.
+3. `DaemonRequest::Session` fetches the current `SessionSnapshot` to read `worker_port`. Reject if `!session.attachable` (repeat jobs cannot be attached).
+4. `attach_to_session` (`attach.rs:70`) opens a `TcpStream` to `worker_port`, writes `WorkerClientMessage::Attach`, reads the first reply. Three cases:
+   - `Attached { session }` → enter the bidirectional bridge.
+   - `Error "session already has an attached client"` → retry for up to 5s (`attach.rs:136`-`142`). Covers the brief window when an old client is still being evicted by the worker's heartbeat.
+   - Any other reply (`Error`, premature `Output`, `Exited`) → print and return.
+5. On the worker side, `handle_worker_client` (`worker.rs:446`) reads the `Attach` line, calls `attach_client` (`worker_shared.rs:195`) which takes the single-client slot, sets `background = false`, and returns the replay payload:
+   - **PTY sessions**: exactly one chunk — `TerminalCapture::snapshot_bytes()` — a synthesized repaint of the current grid + cursor + alt-screen state. Raw backlog cannot be replayed mid-session because cursor moves and partial redraws stack into garbage when played from the middle of a session (issue #34). See `session-lifecycle.md` for the capture parser internals.
+   - **Subprocess sessions**: the raw backlog — a deque of byte chunks capped at `DEFAULT_BACKLOG_LIMIT_BYTES` (256 KiB, overridable via `--backlog-size` or `CLUD_BACKLOG_BYTES`). Line-oriented output replays cleanly because each line is self-contained.
+   - If `snapshot.exit_code` is already set the worker writes a final `Exited` and closes immediately.
+6. The worker spawns a writer thread that drains its per-client mpsc receiver into the TCP stream, and the main connection thread enters a `read_worker_line` loop dispatching `Input` / `Resize` / `Interrupt` to the `SessionRuntime`.
+7. On the client, a reader thread parses `Output` / `Exited` / `Error` and writes to stdout. In parallel, `run_remote_interactive` (`attach.rs:249`) puts the terminal in raw mode (`RawTerminalGuard`, `types.rs:212`), polls `crossterm` events, and runs each `KeyEvent` through `translate_key_event` (`keys.rs:5`):
+   - `KeyAction::Forward(bytes)` → `WorkerClientMessage::Input { submit: bytes == b"\r" }`.
+   - `Event::Paste(text)` → `Input { submit: false }`.
+   - `Event::Resize(cols, rows)` → `WorkerClientMessage::Resize`.
+   - `KeyAction::Interrupt` (Ctrl+C) → break the loop with `LocalAttachResult::InterruptRequested`.
+8. On `InterruptRequested`: if `session.detachable`, show the 5s `BACKGROUND_PROMPT_TIMEOUT` prompt (`attach.rs:342`). Y/Enter/timeout → `shutdown_worker_connection` and return 0 (session continues in background). N/Esc → `request_session_termination` and return 130. If not detachable, send `WorkerClientMessage::Interrupt` to the worker and wait up to 5s for `Exited`.
+
+## Snapshot and log persistence
+
+Under `state_dir` (resolved by `paths.rs:7` — CLI flag > `CLUD_DAEMON_STATE_DIR` env > `temp_dir()/clud-daemon`):
+
+```
+daemon.json                    DaemonInfo { pid, port }       written once at daemon startup
+sessions/<id>.json             SessionSnapshot                overwritten on every state change
+specs/<id>.json                WorkerLaunchSpec               written by daemon, removed by worker on exit
+logs/<id>.log                  append-only stdout/stderr      soft cap 10 MiB (LOG_ROTATE_BYTES)
+logs/<id>.log.1                single rotation backup         overwritten on each rotation
+```
+
+All JSON files use `write_json_file` (`io_helpers.rs:33`): write to `.tmp`, `remove_file` existing, `rename` into place — atomic on POSIX and Windows. Snapshot writes happen on root-pid set, exit, repeat-state change, and `background` flip (`worker_shared.rs:155`-`193`). The log file is opened once in `init_log_file` and rotated when `metadata().len() >= LOG_ROTATE_BYTES` (`worker_shared.rs:93`-`127`); only one backup is kept because clud sessions are ephemeral and the on-disk footprint shouldn't grow unboundedly for a stale session nobody reattaches to.
+
+Every `push_output` chunk goes to three sinks (`worker_shared.rs:299`-`331`): the in-memory backlog (with eviction at the byte cap), the `TerminalCapture` parser if active, and the log file. The Output mpsc to the attached client is fed last, after all persistence side-effects, so a crash mid-`push_output` cannot leave the client ahead of the on-disk state.
+
+## Key types
+
+- `SessionSnapshot` — on-disk + wire session metadata — `types.rs:48`
+- `WorkerLaunchSpec` — daemon → worker launch contract (boxed inside `DaemonRequest::Create`) — `types.rs:77`
+- `DaemonRequest` / `DaemonResponse` — `types.rs:103`, `types.rs:111`
+- `WorkerClientMessage` / `WorkerServerMessage` — `types.rs:120`, `types.rs:129`
+- `SessionRuntime` — runtime abstraction over subprocess and PTY — `types.rs:137`
+- `SessionKind` (`Subprocess` / `Pty`) — `types.rs:36`
+- `WorkerShared` — per-worker shared state, owns the single-client gate — `worker_shared.rs:22`
+- `AttachedClient` — single-client slot (id, mpsc sender, shutdown handle, attach instant) — `types.rs:234`
+- `BacklogState` — bounded chunk deque + total byte count — `types.rs:242`
+- `RawTerminalGuard` — RAII raw-mode guard — `types.rs:212`
+- `LocalAttachResult` / `BackgroundPromptDecision` — attach-flow control enums — `types.rs:201`, `types.rs:207`
+- `ENV_FEATURE_FLAG = "CLUD_EXPERIMENTAL_DAEMON"` — `types.rs:17`
+- `ENV_STATE_DIR = "CLUD_DAEMON_STATE_DIR"` — `types.rs:18`
+- `ENV_BACKLOG_BYTES = "CLUD_BACKLOG_BYTES"` — `types.rs:19`
+- `DEFAULT_BACKLOG_LIMIT_BYTES = 256 KiB` — `types.rs:20`
+- `LOG_ROTATE_BYTES = 10 MiB` — `types.rs:28`
+- `BACKGROUND_PROMPT_TIMEOUT = 5s` — `types.rs:21`
+
+## Failure modes
+
+**Daemon dead, client wants to start a session.** `ensure_daemon` (`client.rs:18`) probes the port from `daemon.json`; on failure it runs `cleanup_stale_state` to drop the stale `daemon.json` and spawns a fresh `__daemon`. The client retries up to 5s for the new listener to come up; longer than 5s returns `io::ErrorKind::TimedOut`.
+
+**Daemon dead, worker still running.** `run_worker`'s watchdog thread polls `pid_is_alive(daemon_pid)` every 200ms (`worker.rs:114`-`132`). On daemon death it calls `runtime.cleanup_tree()` (Term, 150ms sleep, Kill across every descendant via `signal_process_tree`), broadcasts exit 137, persists the snapshot, removes the spec file, and the worker process exits. The orphaned session shows up in the next `clud list` only after a daemon restart triggers `cleanup_stale_state` — but the snapshot already has `exit_code = Some(137)`.
+
+**Worker crashes mid-session (e.g. SIGSEGV).** The daemon's `reap_worker_when_done` removes the entry from the workers map but does NOT touch `sessions/<id>.json`. The stale snapshot is reaped on the next `cleanup_stale_state` call (next `ensure_daemon`): `pid_is_alive(snapshot.worker_pid)` is false, the snapshot is flipped to `exit_code = Some(137)` and `background = false`. Subsequent `clud list` / `clud attach` see an exited session and a `clud logs` post-mortem still works because the log file was append-only and survives.
+
+**Snapshot file unwritable.** Worker startup aborts (`worker.rs:109`-`112`) and the daemon's create-response readiness loop (`server.rs:152`-`196`) times out at 5s — either no snapshot ever appeared, or it appeared but the worker port never accepts connections. Daemon replies `error "worker wrote snapshot but TCP port N is not accepting connections"`.
+
+**Attach to non-existent session.** `resolve_session_id` returns `session 'X' not found`. Same path for an ambiguous prefix/name; the error lists the candidate ids. `clud logs` additionally falls back to checking for a bare `logs/<X>.log` file (`commands.rs:175`-`182`) so post-mortem log access works even after the snapshot has been GC'd.
+
+**Two clients race to attach.** The second one gets `error "session already has an attached client"`. The client side retries that specific message for up to 5s (`attach.rs:136`-`142`) so the common case of "old client just disconnected" succeeds without manual retry. After 5s the client gives up and returns 1.
+
+**Attached client's terminal crashes (SSH drop, terminal app killed, etc.).** The worker's 2s heartbeat probes the TCP peer with a zero-byte `peek`; `Ok(0)` / `ConnectionReset` / `ConnectionAborted` trigger `evict_dead_client` (`worker_shared.rs:264`) which releases the single-client slot and flips `background` back to true. A new `clud attach` succeeds immediately and gets a fresh capture snapshot.
+
+**Spec file orphaned.** If a worker dies before writing its snapshot, `cleanup_stale_state` removes spec files older than 10s with no matching snapshot. The 10s grace covers normal worker startup latency.
+
+**`Output` after `Exited` race (historical).** Subprocess and PTY backends both spawn a drain thread that calls `push_output` and a separate wait thread that calls `broadcast_exit`. Before PR #136, the wait thread could enqueue `Exited` on the client mpsc before the drain's final `Output` chunk had landed, silently dropping the backend's last line. The fix joins the drain handle inside the wait thread before `broadcast_exit` (`worker.rs:373`-`378` and `worker.rs:436`-`440`). Keep this invariant when modifying either start function.
+
+**Repeat-job worker tries to accept attach.** `attachable: false` is set in the spec for repeat jobs (`entry.rs:204`); `run_attach` rejects with `session ... is a repeat job and cannot be attached`; `list_attachable_sessions` filters them out of the auto-attach single-session shortcut.
+
+## See also
+
+- `../../crates/clud-bin/src/daemon/README.md` — per-file directory README with the full `file:line` index of public items.
+- `session-lifecycle.md` — `TerminalCapture` parser, PTY pump, input injection, the exact bytes the repaint payload contains.
+- `gc-and-registry.md` — separate redb-backed registry for cross-session GC (`gc_daemon`), not to be confused with this daemon.
+- `launch-plan.md` — `LaunchPlan` is the inner payload that `WorkerLaunchSpec` wraps and ships to the worker.
+- `../DESIGN_DECISIONS.md` — rationale for TCP+JSON over named pipes / Unix sockets, single-binary re-entry over a separate daemon executable, and atomic file writes over a real database.

--- a/docs/architecture/gc-and-registry.md
+++ b/docs/architecture/gc-and-registry.md
@@ -1,0 +1,249 @@
+# GC & Registry
+
+`clud` maintains two separate `redb` databases for two separate concerns: a per-launch
+**session cap** that bounds how many sibling `clud` processes may run concurrently, and a
+**tracked-entry GC** that owns the lifecycle of `.claude/worktrees/agent-*` directories across
+repos and across invocations. The two stores live in different files, on different code paths,
+with different ownership models — they have nothing to do with each other besides both being
+`redb`-backed, and confusing them is the single fastest way to wedge the system. This doc covers
+both, plus the worktree scanner that feeds the GC store and the unrelated `--clean-worktrees`
+subcommand.
+
+## Two redb databases
+
+| File | Concern | Ownership | Lifetime |
+|---|---|---|---|
+| `sessions.redb` (POSIX: `$XDG_STATE_HOME/clud/`; Windows: `%LOCALAPPDATA%\clud\`) | Per-launch session cap | File-lock serialized via `sessions.lock` | Opened for ms at startup and again at shutdown; never across the session |
+| `~/.clud/data.redb` | Tracked-entry GC (`agent-*` worktrees) | Single-owner `clud __gc-daemon` process; everyone else uses JSON-over-TCP | Opened once by the daemon; lives until the daemon dies |
+
+Why two files? The session cap is a *guardrail* — it needs the simplest possible "open, decide,
+close" semantics so a crashed `clud` can never deadlock the next one. The tracked-entry GC is a
+*long-running registry* with reconcile/list/purge operations, concurrent insert traffic from the
+scanner thread, and a CLI surface that benefits from being able to ask "what's tracked?" without
+re-walking every repo.
+
+Splitting them lets each pick the right concurrency model. Mixing them would force the daemon to
+also be in the startup-cap critical path, which is a recipe for fork-bomb-with-a-twist when the
+daemon hangs.
+
+Both files use the redb invariant **one writer per process** (`flock` on POSIX, `LockFileEx` on
+Windows). The two architectures below are different solutions to that one constraint.
+
+## Session cap registry
+
+Background: issue #73 — a buggy test spawned 100+ console windows from a single terminal. The cap
+is a hard guardrail against that class of mistake.
+
+The schema is a single `redb` table `sessions` keyed by `pid: u32` → JSON-serialized `SessionRow`
+(`crates/clud-bin/src/session_registry.rs:94`, `crates/clud-bin/src/session_registry.rs:103`). A
+sibling `meta` table records `schema_version` (`crates/clud-bin/src/session_registry.rs:97`).
+
+Lifecycle on each `clud` launch:
+
+1. **Acquire** the cross-process advisory lock at `sessions.lock` next to `sessions.redb`
+   (`crates/clud-bin/src/session_registry.rs:613`). Blocks until exclusive.
+2. **Open** the redb file (`crates/clud-bin/src/session_registry.rs:402`).
+3. **GC** dead rows whose PID no longer names a live process, using `OsLivenessProbe`
+   (`crates/clud-bin/src/session_registry.rs:471`). On Windows the probe is
+   `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION) + GetExitCodeProcess`; on POSIX it is
+   `kill(pid, 0)`.
+4. **Check** the cap (`crates/clud-bin/src/session_registry.rs:512`). Three outcomes: `Allow`,
+   `Warn(n)` (at or above `cap/2`), or `Refuse(n)` (at or above cap).
+5. **Register** this PID via `register_self` if not refused
+   (`crates/clud-bin/src/session_registry.rs:520`). On `Refuse`, the row is **not** inserted —
+   the caller exits, and inserting would inflate the count for the next sibling.
+6. **Drop** the redb handle, then **release** the lock. The lock is held for a few ms — not for
+   the lifetime of the session.
+
+Shutdown re-acquires the lock briefly and removes the row via `unregister`
+(`crates/clud-bin/src/session_registry.rs:546`). A crashed `clud` leaves a stale row that the
+next startup's GC pass cleans up.
+
+The whole startup sequence is wrapped by `run_startup_under_lock`
+(`crates/clud-bin/src/session_registry.rs:677`) and the shutdown counterpart by
+`run_shutdown_under_lock` (`crates/clud-bin/src/session_registry.rs:713`). The lock-then-redb
+ordering is important: redb's file lock is released when its `Drop` runs, and we want that to
+happen *before* the `sessions.lock` releases so the next sibling can open redb the instant it
+acquires the advisory lock.
+
+**Env overrides:**
+
+- `CLUD_MAX_INSTANCES` (default 64; `0` disables the cap entirely;
+  `crates/clud-bin/src/session_registry.rs:70`).
+- `CLUD_WARN_INSTANCES` (default `cap/2`).
+- `CLUD_SESSION_DB`, `CLUD_SESSION_LOCK` — test overrides for the file paths.
+
+## GC daemon (single-owner data.redb)
+
+`~/.clud/data.redb` is held by **exactly one process**: the `clud __gc-daemon` subprocess. Issue
+#135 Phase 1 introduced this; the design rationale (`crates/clud-bin/src/gc_daemon.rs:13`) is
+that redb's locking is intra-process and any attempt to coordinate multi-process access via the
+file lock was unreliable in practice — startup races, partial-write windows, and the cost of
+opening/closing redb on every CLI invocation all pushed us toward funneling everything through
+one owner.
+
+The daemon process:
+
+1. Binds a loopback TCP port on `127.0.0.1:0` (kernel-assigned).
+2. Spawns one **registry worker thread** that owns the `Registry` handle and is the sole
+   reader/writer of the redb file (`crates/clud-bin/src/gc_daemon.rs:224`).
+3. Atomically writes `(pid, port)` JSON to `~/.clud/state/gc-daemon.info`
+   (`crates/clud-bin/src/gc_daemon.rs:119`).
+4. Serves connections forever: accept thread → per-connection thread →
+   `mpsc::Sender<GcRequestMsg>` → worker thread → reply on a per-request `mpsc::sync_channel(1)`
+   (`crates/clud-bin/src/gc_daemon.rs:469`).
+
+Wire protocol is JSON-over-loopback-TCP, one request per connection, versioned envelope
+`{"v": 1, "op": "...", ...}`. Operations: `gc.list`, `gc.purge`, `gc.reconcile`, `gc.insert`
+(`crates/clud-bin/src/gc_daemon.rs:144`). Replies are `gc.list.ok`, `gc.purge.ok`,
+`gc.reconcile.ok`, `gc.insert.ok`, `gc.insert.skipped`, or `error`
+(`crates/clud-bin/src/gc_daemon.rs:186`).
+
+`ensure_running()` (`crates/clud-bin/src/gc_daemon.rs:547`) is the idempotent bringup entry
+point. It reads `gc-daemon.info`, probes the PID, and if alive + accepting TCP, returns.
+Otherwise it acquires `<state_dir>/gc-daemon.lock` (issue #138 — serializes concurrent bringup so
+two `clud` startups don't both spawn a daemon and race on the TCP bind), **re-probes** under the
+lock, and only spawns if still absent.
+
+Spawn is `clud __gc-daemon --state-dir <state_dir>` detached via
+`trampoline::spawn_detached_self` with `invisible_helper_creationflags()` on Windows. Caller
+polls up to 5 seconds for the info file plus a successful TCP connect.
+
+## GC subcommands
+
+All three subcommands are thin IPC clients against the daemon. `--no-daemon` (or
+`CLUD_NO_DAEMON=1`) is **an error**, not a fallback — there is no read-only path in v1
+(`crates/clud-bin/src/gc.rs:594`).
+
+- **`clud gc list [--json]`** — `cmd_list` (`crates/clud-bin/src/gc.rs:631`) sends `gc.list`,
+  prints a table (or JSON). Each row reports `kind / age / agent_id / branch / path` plus a
+  `live_locked` flag computed by the daemon by parsing `git worktree list --porcelain` and
+  extracting `(pid <N>)` from any `locked <reason>` line.
+- **`clud gc purge [--duration 7d] [--kind worktree] [--dry-run] [--yes]`** — `cmd_purge`
+  (`crates/clud-bin/src/gc.rs:676`) pre-validates the duration string locally, then sends
+  `gc.purge`. The daemon selects candidates (all rows, or rows older than `now - duration`),
+  partitions out live-locked worktrees, and either reports the count (dry-run) or runs `git
+  worktree remove --force` (falling back to `remove_dir_all` if git refuses) and deletes the
+  row. Bare `clud gc purge` (no `--duration`) is interactive and asks for `y/N` confirmation
+  unless `--yes`.
+- **`clud gc reconcile`** — `cmd_reconcile` (`crates/clud-bin/src/gc.rs:653`) sends
+  `gc.reconcile` with the current repo root. The daemon walks `<repo>/.claude/worktrees/` and
+  inserts any agent-* subdir that isn't already tracked. Returns the count of new rows.
+
+Bare `clud gc` (no subcommand) prints help and exits 0 without contacting the daemon
+(`crates/clud-bin/src/gc.rs:591`).
+
+## Worktree scanner
+
+`WorktreeScanner` (`crates/clud-bin/src/gc.rs:459`) is a polling thread spawned at clud startup
+from `main.rs:296` via `WorktreeScanner::maybe_spawn()`. It walks `<repo>/.claude/worktrees/`
+every ~2 seconds and sends `gc.insert` IPC ops for any `agent-*` subdir it sees. The scanner is
+**insert-only**: rows that already exist are no-ops (`Registry::insert_if_new` at
+`crates/clud-bin/src/gc.rs:198`), so there is no per-cycle write churn.
+
+Sleep is **chunked** — 20 × 100ms = ~2s total, but cancellable within 100ms — so Ctrl+C teardown
+does not block for two seconds waiting for the next iteration (`crates/clud-bin/src/gc.rs:568`).
+
+Cancellation is cooperative via `Arc<AtomicBool>`. `Drop` (`crates/clud-bin/src/gc.rs:506`) joins
+the thread; the startup-side guard `_scanner_guard` in `main.rs` triggers this on normal
+shutdown.
+
+If the daemon is unreachable, the scanner logs once (debug level, gated by
+`CLUD_GC_SCANNER_VERBOSE`) and **stops trying for the rest of the session**. It does not retry
+on a backoff. This is intentional: in single-user CI/dev contexts there's no daemon to contact,
+and quiet failure is preferable to a 2s-per-cycle stream of error logs.
+
+## `--clean-worktrees`
+
+`--clean-worktrees` (`crates/clud-bin/src/worktrees.rs`) is **unrelated to the GC store**. It is
+a one-shot CLI flag for cleaning up git worktrees in the current repo, with no `redb`
+involvement.
+
+It enumerates via `git worktree list --porcelain`, classifies each entry as
+`clean / dirty / unpushed / no-upstream / branch-gone` (`crates/clud-bin/src/worktrees.rs:53`),
+and removes those that are *safe* — clean AND (older than `--stale-after` OR upstream `[gone]`).
+`--force` widens the safe set to include `dirty` and `unpushed`.
+
+**Locked worktrees are never removed, even with `--force`**
+(`crates/clud-bin/src/worktrees.rs:268`). `--dry-run` is a faithful preview: nothing is mutated
+until the actual `git worktree remove` invocation.
+
+The GC daemon does borrow `parse_worktree_porcelain` and the "extract pid from locked-reason"
+helper from this module to compute the `live_locked` flag on `gc.list` output, but the two flows
+are otherwise independent.
+
+## Key types
+
+Session cap:
+
+- `SessionRegistry` (`crates/clud-bin/src/session_registry.rs:358`) — open redb handle plus
+  own-pid + liveness probe.
+- `CapConfig`, `CapDecision` (`crates/clud-bin/src/session_registry.rs:171`,
+  `crates/clud-bin/src/session_registry.rs:191`) — pure cap-check inputs/outputs.
+- `SessionInfo`, `SessionRow` (`crates/clud-bin/src/session_registry.rs:206`,
+  `crates/clud-bin/src/session_registry.rs:103`) — public + on-disk row shapes.
+- `LockGuard` (`crates/clud-bin/src/session_registry.rs:602`) — RAII for `sessions.lock`.
+
+GC store / daemon:
+
+- `Registry` (`crates/clud-bin/src/gc.rs:149`) — owns the redb handle inside the daemon worker
+  thread.
+- `TrackedEntry`, `InsertInput` (`crates/clud-bin/src/gc.rs:119`,
+  `crates/clud-bin/src/gc.rs:133`) — public row + insert-input shapes.
+- `WorktreeScanner` (`crates/clud-bin/src/gc.rs:459`) — polling thread.
+- `DaemonInfo`, `DaemonHandle` (`crates/clud-bin/src/gc_daemon.rs:74`,
+  `crates/clud-bin/src/gc_daemon.rs:532`) — info-file shape + ensure-running return value.
+- `ListRow` (`crates/clud-bin/src/gc_daemon.rs:205`) — public JSON row.
+
+`--clean-worktrees`:
+
+- `WorktreeEntry`, `WorktreeStatus` (`crates/clud-bin/src/worktrees.rs:30`,
+  `crates/clud-bin/src/worktrees.rs:53`).
+- `CleanOptions` (`crates/clud-bin/src/worktrees.rs:91`).
+
+## Failure modes
+
+- **Daemon crash mid-request.** Client's TCP `read_line` returns 0 bytes; `client_*` surfaces
+  as `io::Error`. CLI prints `error: <op> failed: <msg>` and exits 1. The next `ensure_running()`
+  from any clud process re-spawns the daemon. The worker's `recv_timeout(30s)` in
+  `handle_connection` (`crates/clud-bin/src/gc_daemon.rs:508`) prevents a wedged worker from
+  hanging the accept thread indefinitely.
+
+- **Bringup race.** Two `clud` startups call `ensure_running()` simultaneously. Both see no
+  daemon. Both try to acquire `gc-daemon.lock`. The winner spawns; the loser blocks, then
+  re-probes under the lock, finds the daemon, and returns its handle. Issue #138.
+
+- **`sessions.redb` lock contention.** N concurrent `clud` launches serialize on `sessions.lock`,
+  never on the redb file lock. The lock is held for ~ms per launch; even hundreds of
+  simultaneous spawns drain in well under a second on the host.
+
+- **`sessions.redb` corruption.** `Database::create` returns a `redb::DatabaseError`;
+  `run_startup_under_lock` surfaces it; `main.rs` logs and skips the cap check rather than
+  refusing to launch (the cap is best-effort safety, not a hard requirement). The user can `rm`
+  the file to recover.
+
+- **Scanner thread panic.** The scanner thread is independent of the main launch path; a panic
+  logs to stderr but does not affect the running session. `Drop::cancel` joins, so a panic in
+  the worker also won't leak the thread.
+
+- **Worktree dir gone mid-scan.** `read_dir` returns `NotFound` → `scan_once_via_ipc` treats as
+  empty (`crates/clud-bin/src/gc.rs:518`). Individual `agent-*` dirs disappearing between
+  `read_dir` and the `gc.insert` IPC are benign: the daemon will accept the insert, and a future
+  `gc purge` (or a `git worktree remove` from outside clud) cleans the row.
+
+- **PID reuse.** The session-cap registry's `Drop` only deletes its row if `register_self` was
+  called successfully (`crates/clud-bin/src/session_registry.rs:565`), so an early-aborted `clud`
+  cannot clobber a sibling that happened to inherit its PID via POSIX PID reuse. `unregister`
+  clears the flag too, for the same reason.
+
+- **`CLUD_NO_DAEMON=1`.** All `clud gc *` subcommands exit 2 with "gc operations require the GC
+  daemon; remove --no-daemon". The scanner's IPC fails silently and the thread idles for the
+  rest of the session. The session cap is unaffected (it doesn't use the daemon).
+
+## See also
+
+- [`daemon-ipc.md`](daemon-ipc.md) — the long-lived session daemon uses the same
+  JSON-over-loopback-TCP pattern but is a *different* daemon process serving a different concern
+  (interactive sessions, not GC). The GC daemon's protocol is private to this subsystem.
+- [`../DESIGN_DECISIONS.md`](../DESIGN_DECISIONS.md) — DD-006 covers the "redb is single-owner"
+  rule and the rationale for the daemon-fronted design over per-process file-lock coordination.

--- a/docs/architecture/launch-plan.md
+++ b/docs/architecture/launch-plan.md
@@ -1,0 +1,170 @@
+# Launch Plan
+
+Every code path that decides "what would clud actually run" funnels through
+`command::build_launch_plan` and consumes the resulting `LaunchPlan`. There is
+no other place in the binary where the backend argv, iteration budget, working
+directory, repeat schedule, DONE/BLOCKED marker paths, or stream-json injection
+get reconstructed — the runners, the daemon worker, the `--dry-run` JSON
+emitter, the hook-health remediator, and the durable loop artifacts all read
+the same struct. If you are changing the argv clud sends to `claude` or
+`codex`, or adding a new subcommand, this is the only place in the tree that
+needs to learn about it.
+
+## The struct
+
+`LaunchPlan` lives in `crates/clud-bin/src/command/types.rs:6`. Trimmed shape:
+
+```rust
+pub struct LaunchPlan {
+    pub command: Vec<String>,           // argv: command[0] is the backend exe
+    pub iterations: u32,                // 1 for one-shot; >1 for `clud loop`
+    pub backend: Backend,               // Claude | Codex
+    pub launch_mode: LaunchMode,        // Subprocess | Pty
+    pub cwd: Option<String>,            // snapshot of std::env::current_dir()
+    pub repeat_schedule: Option<RepeatSchedule>, // Some(interval_secs) iff --repeat
+    pub task_summary: Option<String>,   // short label for session name
+    pub loop_markers: Option<LoopMarkers>,       // DONE/BLOCKED absolute paths
+    pub stream_json_progress: bool,     // claude subprocess-mode loop only
+}
+```
+
+`LoopMarkers { done_path, blocked_path }` is at `types.rs:28`,
+`RepeatSchedule { interval_secs }` at `types.rs:34`. All three derive
+`Serialize` / `Deserialize` so the plan round-trips through the daemon's
+`WorkerLaunchSpec` (`crates/clud-bin/src/daemon/types.rs:78`) and through
+`--dry-run` JSON.
+
+## Construction pipeline
+
+`build_launch_plan(args, backend, backend_path) -> LaunchPlan` is at
+`crates/clud-bin/src/command/builder.rs:24`. In order, it:
+
+1. **Seeds `cmd` with `backend_path`** (`builder.rs:25`).
+2. **Resolves codex sub-keyword.** Codex needs `exec` for non-interactive
+   prompts and `resume` for `-c` / `--resume` continuations. The
+   `has_noninteractive_prompt` predicate (`builder.rs:13`) decides which.
+3. **Injects YOLO** unless `args.safe` — `--dangerously-skip-permissions` for
+   Claude, `--dangerously-bypass-approvals-and-sandbox` for Codex
+   (`builder.rs:41`).
+4. **Threads `--model` / `-m`** with the backend-specific spelling
+   (`builder.rs:48`).
+5. **Synthesizes the prompt** per subcommand:
+   - `Loop` resolves the positional via
+     `command::loop_task::resolve_loop_task` (GH URL → `gh` fetch + cache,
+     `#42` shortform, file path, or literal — see
+     `crates/clud-bin/src/command/loop_task.rs:29`), then optionally appends
+     the `done_marker_contract(...)` so the model writes to the exact path
+     clud is polling (`builder.rs:98`, issue #95).
+   - `Up`, `Rebase`, `Fix` route through the static templates in
+     `crates/clud-bin/src/command/prompts.rs` and the backend-aware
+     `push_prompt` helper (`prompts.rs:74`): Claude gets `-p <prompt>`, Codex
+     gets the prompt as a positional argument.
+6. **Materializes `loop_markers`** when DONE/BLOCKED polling is on
+   (`builder.rs:112`), via `resolve_marker_paths` (`loop_task.rs:8`).
+7. **Parses `--repeat`** with `parse_repeat_interval` (`builder.rs:250`):
+   `30s` / `5m` / `1h` only, integer-positive, no compound or fractional
+   forms.
+8. **Forwards unknown flags** from `args.passthrough` (`builder.rs:176`).
+9. **Resolves launch mode** via `backend::resolve_launch_mode`, taking
+   `--pty`/`--subprocess`, the backend, the codex-exec bit, the
+   is-loop bit, and parent-TTY detection into account (`builder.rs:181`).
+10. **Injects stream-json progress flags** for Claude subprocess-mode loops
+    (`builder.rs:200`): `--output-format stream-json --verbose` is spliced
+    in immediately before the `-p` so the prompt stays at `command[-1]`.
+
+## Consumers
+
+Every code path that runs (or describes) the resolved argv reads from a
+`LaunchPlan`:
+
+- `crates/clud-bin/src/main.rs:222` — `build_launch_plan` is called once.
+- `crates/clud-bin/src/main.rs:233` — `--dry-run` JSON emission (see contract
+  below); exits 0 without spawning.
+- `crates/clud-bin/src/runner.rs:110` (`run_plan_subprocess`) and
+  `crates/clud-bin/src/runner.rs:416` (`run_plan_pty`) — per-iteration child
+  spawn, reading `plan.command`, `plan.cwd`, `plan.iterations`, and
+  `plan.stream_json_progress`.
+- `crates/clud-bin/src/daemon/entry.rs:144` — `run_centralized_session` clones
+  the plan into a `WorkerLaunchSpec` and ships it over IPC.
+- `crates/clud-bin/src/daemon/worker.rs:67` and `:317` — worker process
+  re-spawns the backend using `spec.plan.command` and `spec.plan.cwd`.
+- `crates/clud-bin/src/hook_health.rs:800` — `run_backend_prompt` synthesizes
+  a private `Args`, calls `build_launch_plan`, and runs the resulting argv
+  as a one-shot subprocess for hook-migration prompting (`--fix-hooks`).
+- `crates/clud-bin/src/loop_artifacts.rs:184` — `LoopSession::start` consumes
+  `plan.iterations` to seed `TaskInfo::total_iterations` written to
+  `<git-root>/.clud/loop/info.json`.
+
+## Backend-specific divergence
+
+| Concern | Claude | Codex |
+|---|---|---|
+| Subcommand keyword | (none) | `exec` for non-interactive prompt; `resume` for `-c`/`--resume` (`builder.rs:35`) |
+| YOLO flag | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` (`builder.rs:41`) |
+| Model flag | `--model <id>` | `-m <id>` (`builder.rs:48`) |
+| Prompt delivery | `-p <prompt>` | bare positional (`prompts.rs:74`) |
+| `-m <message>` | `-m <message>` passthrough | dropped (would clobber `--model`; `builder.rs:148`) |
+| `--continue` | `--continue` | `resume --last` (`builder.rs:62`) |
+| `--resume <id>` | `--resume <id>` | `resume <id>` positional (`builder.rs:156`) |
+| Stream-json progress | `--output-format stream-json --verbose` injected before `-p` for subprocess-mode loops (`builder.rs:200`) | not exposed by codex; skipped |
+
+## YOLO injection
+
+YOLO is on by default. The `--safe` flag is the opt-out — when set,
+`build_launch_plan` skips the YOLO push entirely (`builder.rs:41`). This
+matches DD-002 (yolo-by-default with explicit `--safe` override): every
+clud-launched backend agent has permissions bypassed unless the user
+explicitly asked otherwise. There is no per-subcommand override; the
+decision is a single branch at the top of plan construction.
+
+## Unknown-flag passthrough
+
+`args.passthrough` is the bucket clap fills with anything it didn't recognize.
+The builder appends it verbatim after the synthesized prompt and before any
+launch-mode-specific splices (`builder.rs:176`). Adding a new clud flag means
+declaring it in `crates/clud-bin/src/args.rs`; anything not declared falls
+through to the backend.
+
+## `--dry-run` contract
+
+`main.rs:233` emits this JSON shape and exits 0:
+
+```json
+{
+  "command": ["claude", "--dangerously-skip-permissions", "-p", "..."],
+  "iterations": 1,
+  "backend": "claude",
+  "launch_mode": "subprocess",
+  "repeat_interval_secs": null,
+  "loop_markers": null
+}
+```
+
+When a loop is active, `loop_markers` becomes `{"done_path": ..., "blocked_path": ...}`.
+When `--repeat` is set, `repeat_interval_secs` is a positive integer.
+Consumers: the Python integration suite under `tests/`, end-users debugging
+their argv, and the hook-health remediator's preflight (it builds a plan,
+inspects the command vector, and only then decides whether to spawn).
+**Stability contract:** `command[-1]` is always the prompt body for prompt-
+bearing invocations. The stream-json splice in `builder.rs:200` is the load-
+bearing reason this invariant holds, and downstream tooling depends on it.
+
+## Key types
+
+- `LaunchPlan` — `crates/clud-bin/src/command/types.rs:6`
+- `LoopMarkers` — `crates/clud-bin/src/command/types.rs:28`
+- `RepeatSchedule` — `crates/clud-bin/src/command/types.rs:34`
+- `LaunchMode` — `crates/clud-bin/src/backend.rs:31`
+- `Backend` — `crates/clud-bin/src/backend.rs:7`
+- `build_launch_plan` — `crates/clud-bin/src/command/builder.rs:24`
+- `has_noninteractive_prompt` — `crates/clud-bin/src/command/builder.rs:13`
+- `push_prompt` — `crates/clud-bin/src/command/prompts.rs:74`
+- `resolve_loop_task` — `crates/clud-bin/src/command/loop_task.rs:29`
+- `WorkerLaunchSpec` (daemon wire-format wrapper) — `crates/clud-bin/src/daemon/types.rs:78`
+
+## See also
+
+- [loop-subsystem.md](loop-subsystem.md) — spec → plan → iteration → marker → artifact cycle.
+- [daemon-ipc.md](daemon-ipc.md) — how `WorkerLaunchSpec { plan, ... }` rides the wire.
+- [`../../crates/clud-bin/src/command/README.md`](../../crates/clud-bin/src/command/README.md) — file-level map of the `command/` submodules.
+- [`../DESIGN_DECISIONS.md`](../DESIGN_DECISIONS.md) — DD-002 (YOLO default + `--safe`), DD-005 (single source of truth for backend argv).

--- a/docs/architecture/loop-subsystem.md
+++ b/docs/architecture/loop-subsystem.md
@@ -1,0 +1,245 @@
+# Loop Subsystem
+
+`clud loop <task>` runs the backend agent repeatedly against the same task
+until either (a) the agent writes a `DONE` or `BLOCKED` marker file under
+`<git-root>/.clud/loop/`, (b) the agent emits a `<<<CLUD_LOOP_DONE: ...>>>`
+fallback token on stdout (subprocess + Claude mode only), or (c) the
+configured iteration budget is exhausted. The subsystem is split across
+`command::builder` (plan + prompt assembly), `loop_spec` (task-spec
+resolution and marker contract), `loop_artifacts` (durable on-disk artifacts),
+`loop_check` (post-iteration polling), `stream_json` (subprocess progress
+rendering for Claude), and `runner` (the actual per-iteration spawn loop).
+The `--repeat <duration>` variant takes a different path: it disables
+the marker contract entirely and hands the plan to the daemon worker
+(`daemon/worker.rs`) for cron-style re-invocation.
+
+## Component map
+
+- `command/builder.rs` — `build_launch_plan` (line 24) builds the prompt,
+  injects the marker contract, parses `--repeat`, decides launch mode.
+- `command/loop_task.rs` — `resolve_loop_task` (line 29) classifies the
+  positional, fetches/caches GH issues, returns prompt text.
+- `command/types.rs` — `LaunchPlan` (line 6) with `loop_markers`,
+  `repeat_schedule`, `stream_json_progress` fields.
+- `loop_spec.rs` — `TaskSpec` (line 41), `classify` (line 80),
+  `done_marker_contract`, `scan_completion_token` (line 557),
+  `read_markers_or_token` (line 596).
+- `loop_artifacts.rs` — `TaskInfo` (line 50), `LoopSession` driver,
+  `ensure_loop_in_gitignore`, `materialize_working_copy`.
+- `loop_check.rs` — `check_loop_markers` (line 13, PTY/file-only),
+  `check_loop_markers_with_output` (line 24, subprocess + token scan),
+  `loop_unconverged_exit` (line 64).
+- `stream_json.rs` — `render_line` turns one Claude stream-json event into
+  one human-readable progress line.
+- `runner.rs` — `run_plan_subprocess` (line 109) and `run_plan_pty`
+  (line 415): the actual iteration loops.
+- `daemon/worker.rs` — `run_repeat_worker` (line 171) for the
+  `--repeat`-as-cron path inside the daemon.
+
+## Lifecycle (one iteration)
+
+1. User runs `clud loop <task>` (optional `--loop-count N`, `--done <path>`,
+   `--no-done`, `--refresh`, `--repeat <dur>`).
+2. `args.rs` parses the subcommand; `main.rs` calls
+   `command::build_launch_plan`.
+3. `build_launch_plan` resolves git root (`loop_spec::git_root_from`),
+   resolves marker paths (`resolve_marker_paths`), calls
+   `resolve_loop_task` to materialize the prompt body, appends
+   `done_marker_contract(done_abs, blocked_abs)` (skipped if `--no-done`
+   or `--repeat` is set without an explicit `--done`).
+4. For Claude in subprocess mode with `loop`, the builder splices
+   `--output-format stream-json --verbose` in front of `-p` so the runner
+   can render live progress (`builder.rs:200`).
+5. `main.rs` constructs a `loop_artifacts::LoopSession`, calls
+   `ensure_loop_in_gitignore` and `materialize_working_copy`, then hands
+   the plan to `runner::run_plan_subprocess` or `runner::run_plan_pty`.
+6. The runner clears stale markers, then per iteration `N` (1-indexed):
+   - Logs `[clud] iteration N/total` to stderr.
+   - `LoopSession::on_iteration_start(N)` updates `info.json` and writes
+     `motivation.md` on `N >= 2`.
+   - Spawns the backend (subprocess via `running-process-core`, or PTY
+     via `NativePtyProcess`).
+   - On subprocess + stream-json: drains stdout through
+     `stream_json::render_line`, accumulating raw output for the token
+     fallback (`runner.rs:349`).
+   - On PTY: pumps stdin/stdout via `session::run_raw_pty_pump_*`.
+   - `LoopSession::on_iteration_end(N, rc, err)` flushes `info.json`.
+   - `check_loop_markers(_with_output)` polls the marker files (and, in
+     subprocess mode, scans captured output for the token). On `DONE`
+     returns `0`; on `BLOCKED` returns `3`; otherwise continues.
+7. After the budget is exhausted, `loop_unconverged_exit` returns `2` and
+   prints a diagnostic block listing the expected marker paths plus the
+   actual contents of `.clud/loop/`.
+
+## Task-spec resolution
+
+`loop_spec::classify` (line 80) tries, in order: GH issue/PR URL
+(`https://github.com/owner/repo/{issues,pull}/N`), short-form (`#42` or
+`42`), local file path, otherwise literal prompt. GH URLs and short-forms
+flow into `fetch_via_gh` (`gh issue/pr view --json ...`); short-form
+additionally calls `gh repo view` to discover owner/repo. Results are
+cached under `<git-root>/.clud/loop/<owner>__<repo>__{issue,pull}-N.md`
+with a YAML frontmatter (`url`, `fetched_at`, `updated_at`). Subsequent
+runs reuse the cache unless `--refresh` is passed. Literal prompts and
+file paths are also mirrored under the loop dir by
+`loop_artifacts::materialize_working_copy` (literal → `LOOP.md`, file →
+`<original-filename>`), with skip-if-exists semantics so user edits
+survive across iterations.
+
+## DONE/BLOCKED contract
+
+`loop_spec::done_marker_contract(done_abs, blocked_abs)` returns a fixed
+text block appended to the prompt body when marker injection is active.
+It instructs the agent to write the **exact absolute** path on completion
+(issue #95: relative paths led agents to invent `~/.loop/LOOP.md` and
+similar). The default paths are `<git-root>/.clud/loop/DONE` and
+`<git-root>/.clud/loop/BLOCKED`; `--done <path>` overrides DONE, and the
+BLOCKED path is derived via `blocked_path_from_done` (`DONE.md` →
+`BLOCKED.md`).
+
+The contract also documents a token fallback for agents that cannot
+write files: a line that starts with `<<<CLUD_LOOP_DONE:` and ends with
+`>>>`. `scan_completion_token` (`loop_spec.rs:557`) parses captured
+stdout for the LAST such token; the marker file always wins if both are
+present. Token scanning is only wired in the subprocess path because PTY
+mode never sees the child's bytes — they go straight to the user's
+terminal.
+
+After each iteration, the runner calls `loop_check::check_loop_markers`
+(PTY) or `check_loop_markers_with_output` (subprocess). Marker poll is
+synchronous and happens once per iteration boundary; there is no
+in-flight watcher.
+
+## Artifacts
+
+Everything durable lives under `<git-root>/.clud/loop/`:
+
+- `info.json` — `TaskInfo` (`loop_artifacts.rs:50`): `start_time`,
+  `end_time`, `total_iterations`, `current_iteration`, `completed`,
+  `error`, and a `Vec<IterationInfo>` with per-iteration
+  `start_time`/`end_time`/`exit_code`/`error`. Flushed at
+  iteration-start, iteration-end, and loop-end via `LoopSession`.
+- `log.txt` — append-only text log of `=== loop start ===`,
+  `=== iteration N start ===`, `=== iteration N end rc=X ===`, and
+  `=== loop end <summary> ===` lines. Best-effort; never aborts on
+  write failure.
+- `motivation.md` — fixed prompt fragment written on iteration `>= 2`
+  to anchor the agent in continuation mode.
+- `LOOP.md` / `<task-file-name>` — working copy of the literal/file
+  task spec; skip-if-exists.
+- `<owner>__<repo>__{issue,pull}-N.md` — GH fetch cache.
+- `DONE` / `BLOCKED` — marker files written by the agent (or, with
+  `--done <path>`, wherever the user pointed).
+
+`ensure_loop_in_gitignore` appends `.clud/loop` to an existing
+`<git-root>/.gitignore` (and warns to stderr) if no covering entry is
+already present. It does **not** create `.gitignore` if missing.
+
+## stream-json rendering
+
+Wired only when `backend == Claude && Command::Loop && launch_mode ==
+Subprocess` (`builder.rs:200`). The builder splices
+`--output-format stream-json --verbose` in front of `-p`, sets
+`plan.stream_json_progress = true`, and the runner switches to
+`run_with_stream_json_renderer` (`runner.rs:349`). Each captured stdout
+line goes through `stream_json::render_line`, which returns one
+human-readable line per `system/assistant/result` event (tool uses,
+assistant prose, session start). Unknown events drop silently;
+non-JSON lines pass through verbatim. The raw bytes are also
+accumulated into `captured_output` so the token fallback still works.
+
+PTY mode skips all of this — Claude already renders its own live TUI
+into the user's terminal.
+
+## --repeat scheduling
+
+`parse_repeat_interval` (`builder.rs:250`) accepts `30s`, `5m`, `1h`,
+`24h` (rejects zero, fractional, negative, compound, and unknown
+units). When `--repeat` is set without `--done` and without
+`--no-done`, `repeat_implies_no_done_warning` (`builder.rs:290`) prints
+a warning and the DONE contract is omitted.
+
+`next_run_at_millis(completed_at_millis, interval_secs)`
+(`builder.rs:316`) computes the next fire time as
+`completed_at + interval`, **not** `started_at + interval`. This is the
+no-overlap invariant: if a run takes longer than the interval, the next
+run is pushed out — runs serialize and never stack.
+
+The actual scheduling loop lives in the daemon worker
+(`daemon/worker.rs:171`, `run_repeat_worker`): per cycle it sets
+`repeat_running = true`, calls `run_repeat_once`, then sets
+`repeat_running = false` with `repeat_next_run_at` populated and sleeps
+in 250 ms ticks until that wall-clock instant, checking each tick that
+the daemon is still alive. Each `run_repeat_once`
+(`daemon/worker.rs:253`) spawns the child with
+`creationflags = invisible_helper_creationflags()` (no conhost popup on
+Windows) and `Containment::Contained` (kill-on-close Job Object). Output
+is captured into a TCP-broadcast log, not the user's terminal.
+
+## Key types
+
+- `LoopMarkers { done_path: String, blocked_path: String }` —
+  `command/types.rs:28`
+- `RepeatSchedule { interval_secs: u64 }` — `command/types.rs:34`
+- `LaunchPlan` (carries `loop_markers`, `repeat_schedule`,
+  `stream_json_progress`) — `command/types.rs:6`
+- `TaskSpec` enum (`GhIssue` / `ShortForm` / `File` / `Literal`) —
+  `loop_spec.rs:41`
+- `TaskInfo` + `IterationInfo` — `loop_artifacts.rs:50`,
+  `loop_artifacts.rs:80`
+- `LoopSession` (iteration-boundary driver) — `loop_artifacts.rs:168`
+- `build_launch_plan` — `command/builder.rs:24`
+- `next_run_at_millis` (no-overlap scheduler) —
+  `command/builder.rs:316`
+- `scan_completion_token` (token fallback) — `loop_spec.rs:557`
+- `read_markers_or_token` (file-wins-over-token resolver) —
+  `loop_spec.rs:596`
+- `check_loop_markers` / `check_loop_markers_with_output` /
+  `loop_unconverged_exit` — `loop_check.rs:13`, `:24`, `:64`
+- Iteration loop entry: `run_plan_subprocess` (`runner.rs:109`) and
+  `run_plan_pty` (`runner.rs:415`)
+- Repeat-mode entry: `run_repeat_worker` (`daemon/worker.rs:171`)
+
+## Failure modes
+
+- **GH fetch failure** — `fetch_and_cache_or_die`
+  (`command/loop_task.rs:59`) prints `error: failed to fetch GH ...`
+  and `std::process::exit(1)` from inside `build_launch_plan`. No loop
+  artifacts are created.
+- **Short-form without `gh` repo context** — `resolve_current_repo`
+  fails; same `exit(1)` path.
+- **Marker file unwritable** — All `loop_artifacts` writes
+  (`info.json`, `log.txt`, `motivation.md`, `.gitignore` append) are
+  best-effort: IO errors are swallowed and the loop continues. The
+  agent's own DONE/BLOCKED write going EACCES is invisible to clud —
+  the loop will run to its iteration cap and exit `2` (unconverged).
+- **Child crash mid-iteration** — runner records the non-zero exit
+  via `LoopSession::on_iteration_end` and (if `plan.iterations > 1`)
+  returns that exit code immediately rather than continuing. The
+  next-iteration spawn is **not** attempted on a non-zero exit.
+- **Ctrl+C mid-iteration** — `interrupted: &AtomicBool` is checked at
+  the top of every iteration and inside both stdio drain loops. On
+  trip: subprocess mode runs `teardown_interrupted_child` (Ctrl+Break,
+  then `process_tree::kill_tree`, then `process.kill()`+2 s wait); PTY
+  mode lets `session::run_raw_pty_pump_*` tear down. Final exit code
+  is `130`, and `LoopSession::on_iteration_end(N, 130, Some("Interrupted by user"))`
+  is recorded.
+- **Repeat overlap** — structurally impossible: `run_repeat_worker`
+  schedules off `completed_at`, not `started_at`. A slow run delays
+  the next run; it cannot trigger a concurrent one.
+- **Agent invents a completion filename** — `loop_unconverged_exit`
+  (`loop_check.rs:64`) prints the expected absolute paths plus the
+  actual contents of `.clud/loop/`, calling out stray `*.md` files
+  that aren't `DONE.md`/`BLOCKED.md` so the user sees why the loop
+  didn't converge.
+
+## See also
+
+- [`../../crates/clud-bin/src/command/README.md`](../../crates/clud-bin/src/command/README.md)
+  — `build_launch_plan`, prompt assembly, `--repeat` parsing.
+- [`../../crates/clud-bin/src/daemon/README.md`](../../crates/clud-bin/src/daemon/README.md)
+  — daemon IPC, worker re-entry, repeat scheduling host.
+- [`launch-plan.md`](launch-plan.md) — `LaunchPlan` as the single
+  source of truth for what clud runs.
+- [`daemon-ipc.md`](daemon-ipc.md) — TCP JSON protocol the repeat
+  worker reports through.

--- a/docs/architecture/session-lifecycle.md
+++ b/docs/architecture/session-lifecycle.md
@@ -1,0 +1,289 @@
+# Session Lifecycle
+
+From the moment `runner::run_plan_pty` asks `NativePtyProcess::new` for a child
+PTY, clud owns the bidirectional byte stream between the user's terminal and
+the backend agent (`claude` or `codex`). `console_setup` flips the Windows
+console into VT-input mode under an RAII guard, `console_title` stamps the
+title and arms a keeper, then `session::run_raw_pty_pump` runs the cooperative
+input/output/resize loop. Inside that loop, `dnd::injectors::pty_master_injector`
+feeds drag-drop bytes via a side channel, `voice::VoiceMode` consumes F3 events
+from `session::F3Observer` and writes transcripts back to the PTY master, and
+`console_title::OscTitleStripper` removes the backend's OSC 0/2 title noise
+before it can reach the user's terminal. The session ends when the child
+exits, when Ctrl+C is observed, or when the iteration loop in `runner.rs`
+moves on; the RAII guards restore console mode on drop.
+
+## Component map
+
+| File | Role in the session |
+|---|---|
+| `crates/clud-bin/src/runner.rs` | `run_plan_pty` allocates the PTY, holds `_console_guard` + `_raw_guard` + dnd registration for the iteration, calls `run_raw_pty_pump_with_extra_rx_verbose`. |
+| `crates/clud-bin/src/session.rs` | The pump loop, `F3Observer`, `BracketedPasteNormalizer`, `resize_pty`, `spawn_os_resize_watcher`, `interrupt_pty_process`, `RawTerminalGuard`. |
+| `crates/clud-bin/src/console_setup.rs` | `ConsoleVtGuard` RAII for `ENABLE_VIRTUAL_TERMINAL_INPUT`. |
+| `crates/clud-bin/src/console_title.rs` | One-shot title stamp, daemon keeper thread, `OscTitleStripper` stream filter. |
+| `crates/clud-bin/src/console_input.rs` | Issue #141 Shift+Enter translator (`KEY_EVENT_RECORD` → bytes). |
+| `crates/clud-bin/src/capture.rs` | `TerminalCapture` — `vt100` parser plus the sticky-mode `vte` sniffer. Used by the daemon worker for attach repaint. |
+| `crates/clud-bin/src/dnd/injectors.rs` | `pty_master_injector` adapter that the OLE callback writes through. |
+| `crates/clud-bin/src/voice/mode.rs` | `VoiceMode::on_f3_press` / `on_f3_release` / `on_tick`, the only `InteractiveHooks` implementor in production. |
+
+## Startup
+
+`main.rs` stamps `clud <cwd-name>` and spawns the keeper before any backend
+process exists:
+
+- `console_title::set_for_current_cwd` (`console_title.rs:48`) writes the
+  desired title to a shared `Mutex<String>` and calls `SetConsoleTitleW`.
+- `console_title::keep_setting_in_background` (`console_title.rs:70`) uses
+  `OnceLock` to spawn the daemon thread at most once per process; the thread
+  re-stamps the title every 750 ms if the live console title has drifted.
+
+When the PTY branch is selected, `runner::run_plan_pty` (`runner.rs:415`)
+arms the per-session guards in this order before allocating the PTY:
+
+1. `_console_guard = enable_console_vt_input()` (`runner.rs:429`,
+   `console_setup.rs:26`) — sets `ENABLE_VIRTUAL_TERMINAL_INPUT` (0x0200) on
+   the stdin console handle and captures the original mode. Without this bit,
+   `ReadConsoleW` delivers ANSI sequences that the backend's TUI cannot parse,
+   and Backspace arrives as 0x08 instead of the xterm-style 0x7f that
+   Ink-based UIs expect. No-op on POSIX.
+2. The optional dnd registration (`runner.rs:436-446`) — guarded behind
+   `--no-dnd` / `--dry-run`. Holds an `Option<ConsoleDropTargetGuard>` plus a
+   `Receiver<Vec<u8>>` for the duration of the launch.
+3. `NativePtyProcess::new` (`runner.rs:482`) at the resolved
+   `get_terminal_size()` (`runner.rs:42`), then `process.set_echo(false)`
+   (`runner.rs:509`) so the library's built-in stdout writer is silent and
+   the pump owns forwarding.
+4. `_raw_guard = session::enter_raw_mode_if_tty()` (`runner.rs:526`,
+   `session.rs:273`) — `crossterm::terminal::enable_raw_mode` plus
+   `PushKeyboardEnhancementFlags(REPORT_EVENT_TYPES |
+   DISAMBIGUATE_ESCAPE_CODES)` so the kitty keyboard protocol carries F3
+   release events through. Dropped at `runner.rs:541`.
+
+## The pump loop (`run_raw_pty_pump`)
+
+The pump entry chain is `run_raw_pty_pump` (`session.rs:349`) →
+`run_raw_pty_pump_with_extra_rx` (`session.rs:370`) →
+`run_raw_pty_pump_with_extra_rx_verbose` (`session.rs:392`), which constructs
+the resize channel and spawns the watcher before calling
+`run_raw_pty_pump_full_verbose` (`session.rs:513`). One iteration of the inner
+loop does, in order:
+
+**Output side** (`session.rs:585-597`):
+`process.read_chunk_impl(Some(0.01))` drains one chunk of child output. The
+chunk runs through `OscTitleStripper::process` (`console_title.rs:204`); the
+filtered bytes are written to `io::stdout().lock()`. The library still keeps
+the un-filtered chunk in its internal `chunks` queue, which is what
+`TerminalCapture` consumes on the daemon path — see "Capture for attach".
+
+**Resize channel** (`session.rs:601-605`): drained before stdin so a
+late-arriving resize doesn't wait on a typing chunk. `resize_pty`
+(`session.rs:20`) unwraps `process.handles.lock()` and calls
+`master.resize(PtySize { rows, cols, .. })` directly on Windows because
+`NativePtyProcess::resize_impl` is a deliberate no-op there; POSIX delegates
+to the library. Issue #31 T2.
+
+**Drag-drop side channel** (`session.rs:616-625`): one chunk per iteration
+out of `extra_rx`. The bytes are already newline-joined and trailing-space
+terminated by `dnd::injectors::join_paths_for_injection` and are forwarded
+straight to `process.write_impl(&chunk, false)` — bypassing the
+bracketed-paste normalizer because the OLE callback has already canonicalized
+them.
+
+**Input side** (`session.rs:627-665`): one chunk from `stdin_rx`. The chunk
+runs through `BracketedPasteNormalizer::process` (`session.rs:734`), which
+detects `\x1b[200~ … \x1b[201~` envelopes and, when the inner content matches
+`dnd::looks_like_dropped_path`, rewrites it through `normalize_dropped_path`
+before forwarding. Non-paste bytes pass through with O(1) cost. The
+normalized chunk is then written to the PTY master with `write_impl(..,
+false)`.
+
+**Voice F3 hook insertion** (`session.rs:637-652`): when
+`hooks.intercept_f3()` returns true, the same chunk (pre-normalization,
+because we want detection symmetry with raw byte forwarding) is fed to
+`F3Observer::observe`. Each reported press fires `hooks.on_f3_press(process)`;
+each release fires `hooks.on_f3_release(process)`. Repeats are silently
+dropped — they signal autorepeat, not a fresh press.
+
+**Ctrl+C cooperation** (`session.rs:654-664`): `stdin_chunk_requests_interrupt`
+flags a 0x03 byte in the chunk. If set, or if the external `interrupted`
+atomic flips, the pump calls `interrupt_pty_process` (`session.rs:856`) and
+returns. On Windows the escalation closes the PTY (ConPTY translates that
+into `CTRL_CLOSE_EVENT` to the child); on POSIX it sends SIGINT to the
+child's pgroup and waits up to 2 s.
+
+**Tick + child-exit check** (`session.rs:667-685`): `hooks.on_tick` always
+runs, even on idle iterations, so VAD auto-stop and voice transcript draining
+make progress. `poll_pty_process` checks for child exit and returns the code.
+
+## Capture for attach
+
+`TerminalCapture` (`capture.rs:22`) is the daemon worker's emulator. The
+worker feeds every PTY output chunk into `TerminalCapture::feed`
+(`capture.rs:101`), which drives a `vt100::Parser` for the cell grid plus a
+parallel `vte::Parser` (`StickySniffer`) that tracks two modes vt100 0.16
+doesn't round-trip — `DECSTBM` scroll region and `DECAWM` autowrap-off.
+
+When a `clud attach` client connects mid-session, the daemon calls
+`TerminalCapture::snapshot_bytes` (`capture.rs:132`) to synthesize a repaint:
+
+1. `\x1bc` (RIS) to reset SGR, modes, scroll region, cursor style.
+2. `\x1b[?1049h` if the app is on the alternate screen, so the cells land on
+   the alt buffer.
+3. The sticky `DECSTBM` and `DECAWM` re-asserts, since RIS clears them.
+4. `screen.state_formatted()` — cells, SGR, cursor position, bracketed-paste,
+   application cursor, application keypad, mouse protocol mode.
+
+A fresh terminal replaying that byte stream ends up at the same final frame
+the source TUI is currently rendering. Known limitations (window title, saved
+cursor register, DEC graphics charset, cursor shape) are documented inline in
+`capture.rs`; see issue #36.
+
+## Input injection
+
+Three sources can put bytes onto the PTY master during a session. Two run on
+the pump thread (synchronous, single-writer), one runs on the GUI thread
+that owns the console window:
+
+1. **Keyboard** — `stdin_source` (production = `io::stdin`) is read by the
+   detached reader thread at `session.rs:544-562`. On Windows interactive
+   stdin, `normalize_interactive_console_stdin_chunk` rewrites 0x08 → 0x7f so
+   Backspace aligns with xterm. The Shift+Enter translation in
+   `console_input::translate` (`console_input.rs:71`) maps `VK_RETURN` +
+   `SHIFT_PRESSED` → `\n` and plain Enter → `\r`. The translator is a pure
+   function over `&[InputEvent]`; the thread that calls `ReadConsoleInputW`
+   and feeds it lands in a follow-up patch — see issue #141.
+2. **Drag-and-drop** — `pty_master_injector`
+   (`crates/clud-bin/src/dnd/injectors.rs:138`) wraps the PTY master in
+   `Arc<Mutex<Box<dyn Write + Send>>>` so the OLE `IDropTarget::Drop`
+   callback can call `guard.write_all(payload.as_bytes())` directly. The
+   payload is `join_paths_for_injection(paths)` (newline-joined, trailing
+   space). In the pump loop, `extra_rx` delivers an equivalent
+   pre-normalized chunk via the side channel
+   (`runner.rs:438`, `session.rs:616`). The COM/IDropTarget side belongs to
+   `windows-quirks.md`; this doc covers only the "bytes get written to the
+   PTY master" path.
+3. **Voice** — `voice::VoiceMode` (`crates/clud-bin/src/voice/mode.rs:16`)
+   implements `InteractiveHooks` (`voice/mode.rs:194`). `on_f3_press`
+   starts recording, `on_f3_release` plays the stop cue and enqueues
+   audio on the `VoiceWorker` thread, and `on_tick` drains
+   `WorkerEvent::Transcript` and writes the transcript via
+   `process.write_impl(trimmed.as_bytes(), false)` (`voice/mode.rs:175`).
+   `false` means "not a paste", so the text appears at the cursor without
+   bracketed-paste markers and the backend prompt does not auto-submit.
+
+## Title management
+
+`set_for_current_cwd` (`console_title.rs:48`) runs once at process start and
+records the desired title in a static `Mutex<String>`. The keeper thread
+spawned by `spawn_keeper_thread` (`console_title.rs:76`) polls
+`GetConsoleTitleW` every 750 ms and re-stamps when the live title has
+drifted. This is the only defense in subprocess mode, where the child
+inherits stdio handles directly and clud cannot intercept OSC bytes.
+
+In PTY mode the pump runs every output chunk through `OscTitleStripper`
+before stdout. The stripper is a stream-resumable state machine
+(`console_title.rs:176`) with seven states (`Normal`, `AfterEsc`,
+`InOscNumber`, `SwallowOscBody`, `SwallowAfterEsc`, `PassthroughOscBody`,
+`PassthroughAfterEsc`). It drops OSC 0 (icon + title) and OSC 2 (title only)
+sequences terminated by `BEL` (0x07) or `ST` (`ESC \\`), and passes
+everything else through verbatim — including OSC 8 hyperlinks, OSC 10/11
+color queries, OSC 52 clipboard, and OSC 133 prompt marks. With the stripper
+in place the keeper rarely fires; it is the safety net for sequences split
+across reads or for terminals that bypass our stdout.
+
+## Shutdown
+
+The pump exits in one of three ways:
+
+- **Child exit**: `poll_pty_process` (`session.rs:671`) returns
+  `Ok(Some(code))`. The pump returns the code; `run_plan_pty` runs it
+  through `normalize_exit_code` (`runner.rs:79`).
+- **Ctrl+C cooperation**: either a 0x03 byte on stdin or the external
+  `interrupted` atomic flipping. The pump calls `interrupt_pty_process`
+  (`session.rs:856`). On Windows the helper closes the PTY (ConPTY's
+  `CTRL_CLOSE_EVENT` path) so the child does not receive a second 0x03 that
+  Ink-based TUIs interpret as "Ctrl+C twice = exit". On POSIX it sends
+  SIGINT to the child's pgroup and waits up to 2 s before falling back to
+  `close_impl`. Returns 130.
+- **PTY read error**: `read_chunk_impl` returning `Err` is treated as a
+  child-gone signal; the pump calls `reap_pty_exit` (`session.rs:848`) which
+  invokes `wait_impl(Some(1.0))` and returns 1 on timeout.
+
+On every return, `_raw_guard` drops first (`runner.rs:541`), restoring
+crossterm raw mode and popping keyboard enhancement flags. The
+`_dnd_pty_guard` and `_console_guard` drop when the `run_plan_pty` frame
+unwinds: `ConsoleDropTargetGuard::Drop` signals the worker thread, revokes
+the `IDropTarget`, and calls `OleUninitialize`; `ConsoleVtGuard::Drop`
+(`console_setup.rs:13`) restores the captured original console mode bits.
+The resize-watcher thread observes the closed `resize_tx` and exits.
+
+## Key types
+
+| Symbol | Location |
+|---|---|
+| `run_raw_pty_pump` | `crates/clud-bin/src/session.rs:349` |
+| `run_raw_pty_pump_with_extra_rx_verbose` | `crates/clud-bin/src/session.rs:392` |
+| `run_raw_pty_pump_full_verbose` (inner loop) | `crates/clud-bin/src/session.rs:513` |
+| `F3Observer` struct | `crates/clud-bin/src/session.rs:92` |
+| `F3Observer::observe` | `crates/clud-bin/src/session.rs:125` |
+| `InteractiveHooks` trait | `crates/clud-bin/src/session.rs:243` |
+| `BracketedPasteNormalizer` | `crates/clud-bin/src/session.rs:734` |
+| `resize_pty` | `crates/clud-bin/src/session.rs:20` |
+| `spawn_os_resize_watcher` | `crates/clud-bin/src/session.rs:431` |
+| `interrupt_pty_process` | `crates/clud-bin/src/session.rs:856` |
+| `RawTerminalGuard` | `crates/clud-bin/src/session.rs:265` |
+| `TerminalCapture` | `crates/clud-bin/src/capture.rs:22` |
+| `TerminalCapture::snapshot_bytes` | `crates/clud-bin/src/capture.rs:132` |
+| `ConsoleVtGuard` | `crates/clud-bin/src/console_setup.rs:8` |
+| `enable_console_vt_input` | `crates/clud-bin/src/console_setup.rs:26` |
+| `console_input::translate` | `crates/clud-bin/src/console_input.rs:71` |
+| `console_title::set_for_current_cwd` | `crates/clud-bin/src/console_title.rs:48` |
+| `console_title::keep_setting_in_background` | `crates/clud-bin/src/console_title.rs:70` |
+| Title keeper thread entry (Windows) | `crates/clud-bin/src/console_title.rs:76` |
+| `OscTitleStripper` | `crates/clud-bin/src/console_title.rs:176` |
+| `VoiceMode` (`InteractiveHooks` impl) | `crates/clud-bin/src/voice/mode.rs:194` |
+| `pty_master_injector` | `crates/clud-bin/src/dnd/injectors.rs:138` |
+| `run_plan_pty` (call site) | `crates/clud-bin/src/runner.rs:415` |
+
+## Failure modes
+
+- **PTY allocation fails.** `NativePtyProcess::new` returns `Err`;
+  `run_plan_pty` logs `[clud] failed to create pty` and returns 1 without
+  spinning the pump (`runner.rs:491-501`). Nested Windows shells where
+  ConPTY silently no-ops are the usual cause; the unit test in `session.rs`
+  detects this and skips.
+- **vt100 parse error.** The vt100 parser is a streaming VTE and recovers
+  from any byte sequence; it cannot panic on input. A malformed CSI just
+  resets parser state and the next valid sequence renders correctly. See
+  `capture.rs:malformed_csi_is_recovered_from`.
+- **Child crashes.** `read_chunk_impl` returns `Err` and the pump calls
+  `reap_pty_exit` (`session.rs:848`), which waits 1 s before returning 1.
+  `process_tree::kill_tree` runs from the outer Ctrl+C path, not from a
+  child-exit path.
+- **Hot resize during a write.** Resize events are drained before stdin in
+  every loop iteration (`session.rs:601`), so the next write goes to a
+  correctly-sized PTY. A resize that fires mid-`write_impl` is harmless —
+  ConPTY serializes the master writer, and the new size only affects
+  subsequent writes.
+- **OSC sequence split mid-buffer.** Both `OscTitleStripper` and
+  `BracketedPasteNormalizer` are stream-resumable; the unit tests cover
+  byte-by-byte fragmentation. A title `ESC ] 0 ; … BEL` split across two
+  `read_chunk_impl` calls still gets swallowed exactly once.
+- **F3 sequence split mid-buffer.** `F3Observer` keeps state across
+  `observe` calls; even one-byte-at-a-time fragmentation of `\x1bOR` or
+  `\x1b[13;1:3~` fires exactly one event. CSI parameter overrun is bounded
+  by `MAX_CSI_LEN = 64` (`session.rs:113`).
+
+## See also
+
+- [`../../crates/clud-bin/src/dnd/README.md`](../../crates/clud-bin/src/dnd/README.md)
+  — `IDropTarget` adapter, `DropInjector` factories, COM lifecycle.
+- [`../../crates/clud-bin/src/voice/README.md`](../../crates/clud-bin/src/voice/README.md)
+  — F3 hold-to-record, Whisper worker thread, model auto-download.
+- [`daemon-ipc.md`](daemon-ipc.md) — the attach flow that consumes
+  `TerminalCapture::snapshot_bytes`.
+- [`windows-quirks.md`](windows-quirks.md) — key translation rationale,
+  console mode bits, ConPTY resize no-op, `CTRL_CLOSE_EVENT` semantics.
+- [`../DESIGN_DECISIONS.md`](../DESIGN_DECISIONS.md) — ADR-style records for
+  the raw-pump refactor (issue #46), the OSC stripper / keeper split, and
+  the voice F3 observer/hook design.

--- a/docs/architecture/skill-system.md
+++ b/docs/architecture/skill-system.md
@@ -1,0 +1,163 @@
+# Skill System
+
+Skills are slash-command playbooks (`/clud-pr`, `/clud-issue`, etc.) that ship
+embedded inside the `clud` binary as compile-time string assets and are
+installed into the user's backend home directories (`~/.claude/skills/`,
+`~/.codex/skills/`) on every launch. A fresh `clud` install always carries the
+current canonical copy of every bundled skill without any extra setup step.
+
+## Component map
+
+| Component | Path | Role |
+|---|---|---|
+| Multi-backend installer | `crates/clud-bin/src/skills.rs` | Iterates `BUNDLED_SKILLS` and `SKILL_BACKENDS`; writes only when the target file is missing. |
+| Claude-only drift installer | `crates/clud-bin/src/skill_install.rs` | Reads from top-level `skills/`; overwrites on semantic divergence. |
+| Multi-backend source tree | `crates/clud-bin/assets/skills/<name>/` | Holds `SKILL.md` + `README.md` for skills consumed by `skills.rs`. |
+| Top-level source tree | `skills/<name>/SKILL.md` | Holds skills consumed by `skill_install.rs` (no per-skill READMEs). |
+| `BUNDLED_SKILLS` (multi-backend) | `crates/clud-bin/src/skills.rs:32` | Compile-time list paired with `include_str!("../assets/skills/<name>/SKILL.md")`. |
+| `BUNDLED_SKILLS` (Claude-only) | `crates/clud-bin/src/skill_install.rs:32` | Same name, different content — paired with `include_str!("../../../skills/<name>/SKILL.md")`. |
+| Launch dispatch | `crates/clud-bin/src/main.rs:36-44` | Calls both installers in sequence at startup. |
+
+## Why two installers
+
+The two installers are an interim historical reality, not a designed-in
+split. `skill_install.rs` predates `skills.rs` (introduced in PR #88 for the
+single `/clud-pr` skill) and was kept in place when the broader multi-backend
+expander landed. The two flows now serve overlapping but distinct purposes:
+
+| Concern | `skills.rs` | `skill_install.rs` |
+|---|---|---|
+| Backends targeted | Every entry in `SKILL_BACKENDS` whose home subdir exists (Claude + Codex today) | Hard-coded `~/.claude/skills/` only |
+| Source tree | `crates/clud-bin/assets/skills/` | Top-level `skills/` |
+| Behavior on existing file | Skip — user edits are preserved | Compare modulo whitespace; overwrite when semantically divergent |
+| Bundled skill set | `clud-issue`, `clud-issue-triage`, `clud-pr`, `clud-tag-release` | `clud-pr`, `clud-pr-merge`, `clud-issue` |
+| Error policy | Non-fatal; one `[clud] note: ...` on failure | Non-fatal; one `[clud] note: ...` on failure |
+
+Both invariants are enforced by tests in their respective modules: see
+`skips_existing_and_preserves_user_edits` in `skills.rs:225` and
+`semantic_diff_overwrites_with_embedded_copy` in `skill_install.rs:258`.
+
+## Install-on-launch flow
+
+`main()` runs both installers near the top of `clud` startup, after the
+trampoline unlock and the console-title stamp but before argument parsing.
+The order (see `crates/clud-bin/src/main.rs:36-44`):
+
+1. `skills::ensure_installed()` — multi-backend, preserve-existing pass.
+   Returns a per-backend `InstallReport` listing what was installed vs
+   skipped. Errors only when `$HOME`/`$USERPROFILE` cannot be resolved.
+2. `skill_install::ensure_installed()` — Claude-only drift pass. No return
+   value; logs `[clud] installed /<name>` on first install and
+   `[clud] updated /<name>` (green) on a semantic overwrite.
+
+Both are wrapped so a failure logs a `[clud] note: ...` line on stderr and
+launch continues. A skills hiccup must never block the backend from
+starting — see the "best-effort startup nudges" entry in
+`crates/clud-bin/src/README.md`.
+
+## Bundling mechanism
+
+Each `SKILL.md` is pulled into the binary at compile time with
+`include_str!`. There is no `include_dir` crate in `Cargo.toml` and no
+runtime filesystem lookup of source content — the embedded string is the
+single source of truth. Consequences:
+
+- Adding a `SKILL.md` to the source tree without registering it in the
+  matching `BUNDLED_SKILLS` constant does nothing at runtime.
+- A typo in the `include_str!` path is a build-time error.
+- A zero-byte source file compiles cleanly but ships an empty skill — the
+  `bundled_skills_are_non_empty` test in `skills.rs:263` and
+  `every_bundled_skill_has_real_content` in `skill_install.rs:296` guard
+  against that.
+
+## Source-tree divergence
+
+Two source trees back the two installers, and their contents do not match:
+
+| Skill | `assets/skills/` (`skills.rs`) | top-level `skills/` (`skill_install.rs`) |
+|---|---|---|
+| `clud-issue` | yes | yes |
+| `clud-pr` | yes | yes |
+| `clud-issue-triage` | yes | no |
+| `clud-tag-release` | yes | no |
+| `clud-pr-merge` | no | yes |
+
+Practical consequences:
+
+- `clud-pr-merge` is Claude-only — Codex users never get it.
+- `clud-issue-triage` and `clud-tag-release` are installed only via the
+  preserve-existing path, so once written they are never refreshed by the
+  drift installer.
+- For `clud-issue` and `clud-pr`, the two source files can drift apart in
+  the repo. The drift installer treats the top-level `skills/<name>/SKILL.md`
+  as canonical for Claude and will overwrite a Claude install whose content
+  matches the `assets/skills/` copy but not the top-level one.
+
+The `assets/skills/` README flags this explicitly as a future-consolidation
+target — see `crates/clud-bin/assets/skills/README.md:14-19`.
+
+## Adding a skill
+
+Use this checklist:
+
+1. **Decide which installer(s) the skill ships through.** Multi-backend
+   coverage requires `skills.rs`; drift-on-divergence semantics require
+   `skill_install.rs`. Most new skills want `skills.rs` only.
+2. **Drop the source file.**
+   - For `skills.rs`: `crates/clud-bin/assets/skills/<name>/SKILL.md`
+     with standard frontmatter (`name:`, `description:`, `triggers:`) and
+     the `<!-- managed-by: clud -->` marker. Add a sibling `README.md`
+     describing the skill for contributors.
+   - For `skill_install.rs`: `skills/<name>/SKILL.md` at the repo root.
+     The frontmatter must include `name: <name>` — the
+     `every_bundled_skill_has_real_content` test asserts it.
+3. **Register the entry.** Append a `BundledSkill { name, skill_md:
+   include_str!("...") }` to the relevant `BUNDLED_SKILLS` constant
+   (`skills.rs:32` or `skill_install.rs:32`). The two constants share a
+   name but have different field shapes (`skill_md` vs `content`) and live
+   in different modules.
+4. **Link the README** from the **Skills** section of
+   `crates/clud-bin/assets/skills/README.md` if applicable.
+5. **Run `bash lint` and `bash test`.** The bundle tests assert non-empty
+   content, unique names, and the `managed-by: clud` marker.
+
+## Key types / constants
+
+- `BundledSkill` (`skills.rs:25`): public struct with `name` and `skill_md`
+  fields; used by `install_to` in tests and by external callers.
+- `Skill` (`skill_install.rs:25`): private struct with `name` and `content`
+  fields; module-internal only.
+- `BUNDLED_SKILLS` (both modules): same identifier in both files,
+  different element type, different source-tree backing. **This collision
+  is the single biggest footgun when navigating between the two installers
+  — always check which module you are in.**
+- `SKILL_BACKENDS` (`skills.rs:83`): the list of `(home_subdir,
+  skills_subdir)` pairs the multi-backend installer iterates. Adding a new
+  CLI is a one-line append; see the commented OpenRouter example.
+- `ensure_installed` (both modules): the public launch-time entry point;
+  same name, different return type (`Result<Vec<...>, InstallError>` vs
+  `()`).
+- `normalize` (`skill_install.rs:96`): the whitespace-tolerant equality
+  helper that makes CRLF-vs-LF a no-op on Windows checkouts.
+- `Existing` (`skill_install.rs:71`): four-variant state classifier
+  (`Missing` / `Matches` / `Diverges` / `Unreadable`) that drives the
+  drift-installer's action choice.
+- `InstallReport` (`skills.rs:127`): per-backend result of an install
+  pass, listing `installed` and `skipped_existing` skills by name.
+
+## Consolidation plan (open)
+
+The dual installer is acknowledged interim state. The
+`assets/skills/README.md` notes the redundancy and the per-skill READMEs
+document which installer each skill ships through. Future work should
+collapse this into a single installer with a single source tree; the
+resolution (which behavior wins on existing files, which source tree
+survives, how to keep Codex coverage while preserving drift detection for
+Claude) is not prescribed here.
+
+## See also
+
+- `../../crates/clud-bin/assets/skills/README.md` — bundled-skill index and
+  the original dual-installer caveat.
+- `../DESIGN_DECISIONS.md` (DD-008) — design rationale for the skill-system
+  shape.

--- a/docs/architecture/windows-quirks.md
+++ b/docs/architecture/windows-quirks.md
@@ -1,0 +1,416 @@
+# Windows Quirks
+
+This doc is the inventory of every place `clud` has Windows-specific code,
+with the symptom each piece solves and the `file:line` where it lives. There
+are nine such carve-outs today: a self-rename trampoline so `pip install`
+can overwrite a running `clud.exe`, the BatBadBat `.cmd`/`.bat` rewrite
+mandated by Rust 1.77+, an RAII guard for `ENABLE_VIRTUAL_TERMINAL_INPUT`, a
+`ReadConsoleInputW` translator that disambiguates Shift+Enter from plain
+Enter, a console-title keeper that re-stamps `clud <cwd>` when child TUIs
+overwrite it, an OLE `IDropTarget` adapter so dragging a file onto the
+console window actually drops paths into the prompt, `CREATE_NO_WINDOW` for
+daemon-helper subprocesses that would otherwise flash a conhost window, a
+`whisper-rs` carve-out on `aarch64-pc-windows-msvc` where the sys-crate
+doesn't build, and a descendant-tree killer to reap orphaned `node.exe`
+grandchildren when the user hits Ctrl+C on `clud --codex`. All nine degrade
+to no-ops (or different mechanisms entirely) on POSIX.
+
+## Why so many?
+
+Each of these is individually small. Cumulatively they exist because Windows
+differs from POSIX in five distinct ways `clud` cares about: ConPTY
+semantics are not VT100 (so we have to opt into virtual-terminal input and
+re-translate console input records); COM (`IDropTarget`, `OleInitialize`)
+is the only supported integration point for drag-and-drop into a console
+window; running executables are file-locked, so the standard
+`pip install --force-reinstall` overwrite path silently fails; cmd.exe's
+command-line parser is idiosyncratic enough that Rust's stdlib
+(post-CVE-2024-24576) refuses to launch a `.cmd` directly; and the console
+process group sends `CTRL_C_EVENT` to every attached process, including
+grandchildren we don't directly control. None of these are bugs in `clud`;
+they are platform contracts that we absorb in one module each so the rest of
+the codebase stays portable.
+
+## Inventory
+
+### (a) Trampoline: exe self-rename for `pip install` overwrite
+
+- **Symptom**: `pip install --force-reinstall clud` fails with a permission
+  error when any `clud.exe` is already running, because Windows file-locks
+  every running executable. The error is surfaced by pip with a generic
+  "could not install" message that doesn't make the root cause obvious.
+
+- **Solution**: At the top of `main`, rename `Scripts/clud.exe` to
+  `Scripts/clud.exe.old.<rand>` and copy the renamed file back to
+  `clud.exe`. The running process continues executing from the
+  `.old.<rand>` file (which is now the locked one), while `Scripts/clud.exe`
+  becomes a fresh, unlocked copy that `pip` can overwrite. A background
+  thread GCs stale `.old.*` files on the next launch. The detached-spawn
+  helper additionally strips `HANDLE_FLAG_INHERIT` from the parent's three
+  stdio handles around `CreateProcess` so the child cannot keep a pipe
+  writer alive past EOF — that was the root cause of the 45-minute Windows
+  GHA cancellation investigated in issue #37.
+
+- **File**: `crates/clud-bin/src/trampoline.rs:141` (`unlock_exe`); detached
+  spawn at `:39` (`spawn_detached_self`); the RAII handle-flag guard at
+  `:75` (`windows_stdio::NonInheritableStdioGuard`).
+
+- **POSIX behavior**: No-op. Unix lets you `unlink` a running binary; the
+  rename dance is unnecessary, so `unlock_exe()` returns immediately on the
+  `cfg!(target_os = "windows")` check at `:142`. The detached-spawn helper
+  also has a `#[cfg(unix)]` branch at `:55` that uses `setsid()` instead
+  of the Windows `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` flags.
+
+### (b) BatBadBat: `.cmd`/`.bat` rewrite (CVE-2024-24576)
+
+- **Symptom**: `clud --codex` fails with `failed to spawn process: batch
+  file arguments are invalid`. Since Rust 1.77 (the CVE-2024-24576 fix),
+  `std::process::Command` refuses any batch invocation whose arguments
+  don't round-trip losslessly through cmd.exe's parser. npm installs Codex
+  as a `.cmd` shim at `%APPDATA%\npm\codex.cmd`, which triggers exactly
+  this refusal (issue #59).
+
+- **Solution**: Rewrite the launch as `cmd.exe /D /S /C "<bat-path>" <args>`
+  so Rust is spawning cmd.exe (a real `.exe`) and the batch invocation
+  lives inside a shell command line where `clud` controls the quoting.
+  `running-process-core::CommandSpec::Shell` already provides the outer
+  wrapper via `raw_arg` (it builds `cmd /D /S /C "<command>"` verbatim);
+  `subprocess.rs` is the *single decision point* that picks `Shell` vs
+  `Argv` based on the `argv[0]` extension. Inside the quoted region each
+  token is independently wrapped in `"..."` with `%` → `%%` and `"` → `""`
+  escapes; everything else (`&`, `|`, `<`, `>`, `^`, `;`) stays literal
+  thanks to the outer quotes. The `/D` flag suppresses any user-installed
+  `AutoRun` registry key; `/S` makes cmd's quote handling predictable
+  (outermost `"..."` stripped verbatim); `/C` runs and exits.
+
+- **File**: `crates/clud-bin/src/subprocess.rs:34`
+  (`command_spec_for_subprocess`); the case-insensitive `.cmd`/`.bat` check
+  at `:47` (`is_windows_batch_wrapper`); per-arg quoting at `:106`
+  (`quote_for_cmd`).
+
+- **POSIX behavior**: No-op. `is_windows_batch_wrapper` is gated
+  `#[cfg(windows)]`; on POSIX every argv stays as `CommandSpec::Argv` and a
+  file literally named `codex.cmd` is just treated as an executable (test
+  at `subprocess.rs:294`).
+
+### (c) `ENABLE_VIRTUAL_TERMINAL_INPUT` RAII
+
+- **Symptom**: Inside `clud --codex`, Backspace doesn't delete anything in
+  the Ink TUI. The cause: without `ENABLE_VIRTUAL_TERMINAL_INPUT` (0x0200)
+  on the console input handle, `ReadConsoleW` delivers Backspace as `0x08`,
+  but xterm-style TUIs (Ink, Codex) expect `0x7F`. The same bit is also
+  required for bracketed-paste and other ANSI input sequences to pass
+  through unmangled.
+
+- **Solution**: An RAII guard (`ConsoleVtGuard`) that ORs
+  `ENABLE_VIRTUAL_TERMINAL_INPUT` into the console-input mode for the
+  lifetime of a PTY session and `SetConsoleMode`-restores the saved
+  original on drop. The guard returns early without touching the mode if
+  stdin is not a real TTY (piped `cargo test`, CI without a console) —
+  it remembers `original_mode: None` so the drop impl skips the restore.
+
+- **File**: `crates/clud-bin/src/console_setup.rs:8` (`ConsoleVtGuard`);
+  construction at `:26` (`enable_console_vt_input`); the actual
+  `Get/SetConsoleMode` calls at `:51` (`set_console_vt_input`) and `:82`
+  (`restore_console_mode`).
+
+- **POSIX behavior**: No-op. The `ConsoleVtGuard` struct has no
+  `original_mode` field off Windows (see the `#[cfg(windows)]` field at
+  `:9`); the `Drop` impl is empty on POSIX; the `enable_console_vt_input`
+  constructor at `:44` returns the empty-struct form. POSIX terminals are
+  already in canonical VT mode and need no opt-in.
+
+### (d) Shift+Enter via `ReadConsoleInputW` (issue #141)
+
+- **Symptom**: Pressing Shift+Enter in `clud` should insert a literal
+  newline into the backend's prompt (so the user can type a multi-line
+  message), but conhost strips modifier-key state before producing the
+  `\r` byte on stdin. A byte-stream reader can't distinguish Enter from
+  Shift+Enter.
+
+- **Solution**: Read input via `ReadConsoleInputW` (which exposes
+  `KEY_EVENT_RECORD::dwControlKeyState`) and translate the records to
+  PTY-stdin bytes:
+  - `VK_RETURN` (0x0D) key-down with `SHIFT_PRESSED` (0x0010) set → `\n`
+    (0x0A) — the "insert newline in the prompt" byte.
+  - `VK_RETURN` key-down without `SHIFT_PRESSED` → `\r` (0x0D) — the usual
+    "submit" byte. Ctrl+Enter and Alt+Enter intentionally fall through to
+    plain `\r` so we don't silently change behavior of any existing
+    backend binding.
+  - Any other key-down with a non-zero `unicode_char` emits the UTF-8
+    encoding of that UTF-16 code unit.
+  - Key-up events and non-key records (mouse, focus, buffer-size, menu,
+    window) are dropped at the `InputEvent::NonKey` variant.
+
+  The translator itself is a pure function
+  (`translate(&[InputEvent]) -> Vec<u8>`), which is what makes the unit
+  tests runnable on every CI host.
+
+- **File**: `crates/clud-bin/src/console_input.rs:71` (`translate`);
+  `VK_RETURN` constant at `:36`; `SHIFT_PRESSED` constant at `:40`. The
+  whole module is gated `#![cfg(windows)]` at `:31`.
+
+- **POSIX behavior**: Different mechanism. POSIX terminals deliver
+  Shift+Enter as the same `\r` as plain Enter at the kernel layer —
+  disambiguation is the terminal emulator's job (for example iTerm's
+  "Send literal newline for Shift+Enter") and is out of `clud`'s scope.
+
+### (e) Console title OSC keeper
+
+- **Symptom**: In cmd.exe / Windows Terminal, the title bar otherwise reads
+  `Command Prompt` or the path to cmd.exe. Worse, the backend
+  (`claude.exe` / `codex.exe`) and any tool it invokes (`git`, `npm`) emit
+  OSC 0/2 title-set escape sequences continuously, so even if `clud`
+  stamps the title once at launch, the child immediately overwrites it.
+
+- **Solution**: Two complementary defenses.
+  1. `set_for_current_cwd()` calls `SetConsoleTitleW` once at launch with
+     `clud <cwd-basename>` and records the desired title in a process-wide
+     `OnceLock<Arc<Mutex<String>>>` cell.
+  2. A daemon thread (`clud-title-keeper`) polls every ~750 ms; whenever
+     `GetConsoleTitleW` reports drift from the desired value, it
+     re-stamps via `SetConsoleTitleW`. `OnceLock` guarantees at most one
+     keeper thread per process even if `keep_setting_in_background` is
+     called multiple times.
+
+  For PTY-mode launches (`--pty` / POSIX `clud loop`) the `OscTitleStripper`
+  stream filter in the same file eats OSC 0/2 sequences from the child's
+  output before they reach the terminal, so the keeper rarely fires.
+  Numeric OSC bodies other than `0`/`2` (8 hyperlinks, 10/11 color queries,
+  52 clipboard, 133 prompt marks, etc.) pass through verbatim — stripping
+  them would break TUIs that rely on the response.
+
+- **File**: `crates/clud-bin/src/console_title.rs:48`
+  (`set_for_current_cwd`); keeper at `:70` (`keep_setting_in_background`)
+  and `:76` (`spawn_keeper_thread`, Windows); `OscTitleStripper` at `:176`.
+
+- **POSIX behavior**: No-op for the keeper half. `spawn_keeper_thread` at
+  `:95` is an empty `#[cfg(not(windows))]` stub; `set_title` at `:158` is
+  also a no-op. The `OscTitleStripper` is platform-agnostic because the
+  PTY pump runs on every OS.
+
+### (f) `IDropTarget` adapter for terminal drag-drop
+
+- **Symptom**: Dragging a file onto a console window running `clud` on
+  Windows produces the OS "no-drop" cursor; conhost rejects the drop at
+  the OLE layer (`IDropTarget::DragEnter` → `DROPEFFECT_NONE`) so no bytes
+  ever reach `clud`'s stdin (issue #65). Even when registration succeeds,
+  Claude Code's backend later registers its own `IDropTarget` and
+  displaces ours (issue #79).
+
+- **Solution**: Spawn an STA (Single-Threaded-Apartment) worker thread
+  that calls `OleInitialize` and `RegisterDragDrop` on
+  `GetConsoleWindow()` — and on the top-level `WindowsTerminal.exe`
+  window when present (under Windows Terminal `GetConsoleWindow()` returns
+  a `PseudoConsoleWindow` and Explorer hovers over the terminal window
+  instead). The thread waits a default 2 s initial delay so Claude Code
+  registers first, then re-calls `RegisterDragDrop` every 3 s to displace
+  any later re-registration. The IDropTarget callback parses the
+  `CF_HDROP` payload via the panic-free `parse_dropfiles_buffer`,
+  normalizes each path via `dnd::normalize_dropped_path`, and hands the
+  list to a per-launch-mode `DropInjector`:
+  - **Subprocess mode**: synthesizes Win32 `INPUT_RECORD` bytes (20-byte
+    records, key-down + key-up per char, `VK_RETURN` for `\n`) into the
+    console input buffer via `WriteConsoleInputW`.
+  - **PTY mode**: writes the joined bytes (`\n`-separated paths plus a
+    trailing space) into the PTY master so the slave's TTY reader sees
+    them as if typed.
+
+  The RAII guard (`ConsoleDropTargetGuard`) signals the worker, revokes
+  each registered window, and calls `OleUninitialize` on the same STA
+  thread when dropped — COM lifecycle has to stay on the thread that
+  initialized it.
+
+- **File**: `crates/clud-bin/src/dnd/console_drop_target.rs:384`
+  (`register_console_drop_target`, Windows); `:392` (POSIX stub);
+  `ConsoleDropTargetGuard` at `:333`; platform-agnostic dispatch at `:407`
+  (`dispatch_dropfiles_to_injector`). Injectors at
+  `crates/clud-bin/src/dnd/injectors.rs:71` (`build_input_records`),
+  `:138` (`pty_master_injector`), `:157` (`subprocess_console_injector`,
+  Windows only).
+
+- **POSIX behavior**: Different mechanism. POSIX terminals deliver drops as
+  stdin bytes (cmd-style quoted paths, mintty `/c/...` MSYS paths,
+  PowerShell `& 'C:\...'`, macOS backslash-escaped spaces, GNOME
+  `file://` URIs); the cross-platform `dnd::normalize_dropped_path` and
+  `looks_like_dropped_path` string transforms in `dnd/mod.rs:49,77`
+  handle those. The non-Windows stub of `register_console_drop_target`
+  at `:392` returns `Err(RegisterError::UnsupportedPlatform)` so POSIX
+  call sites simply no-op.
+
+### (g) `CREATE_NO_WINDOW` for invisible helper spawns
+
+- **Symptom**: When `clud` spawns daemon-helper / worker / repeat-job
+  subprocesses with fully piped stdio on Windows, the OS allocates a
+  brand-new conhost window for each child — each allocation is a visible
+  flash that steals focus from the developer's window during the
+  integration test suite, and from the user's window in production for
+  `clud --detach` (issue #55).
+
+- **Solution**: A single source-of-truth helper
+  `invisible_helper_creationflags()` that returns
+  `Some(CREATE_NO_WINDOW)` (`0x0800_0000`) on Windows and `None`
+  elsewhere — exactly the shape `running_process_core::ProcessConfig::creationflags`
+  expects. Daemon-side spawn sites OR this into their flags; the
+  user-facing backend spawn intentionally does *not* — the user wants
+  to see that child's output, and the inherited console means no new
+  window is created anyway. A separate helper
+  `user_facing_backend_creationflags()` returns
+  `Some(CREATE_NEW_PROCESS_GROUP)` (`0x0000_0200`) for the interactive
+  backend so the OS skips the child (and its descendants) when delivering
+  console `CTRL_C_EVENT`. That keeps confusing Python tracebacks from the
+  `nodejs-wheel` distribution out of clud's clean Ctrl+C output — clud
+  is then responsible for tearing the child tree down, which it does via
+  quirk (i).
+
+- **File**: `crates/clud-bin/src/win_creation_flags.rs:40`
+  (`invisible_helper_flags`); `:56` (`invisible_helper_creationflags`);
+  `:88` (`new_process_group_flags`); `:108`
+  (`user_facing_backend_creationflags`); the `CREATE_NO_WINDOW` literal
+  anchored at `:25` and the `CREATE_NEW_PROCESS_GROUP` literal at `:35`.
+
+- **POSIX behavior**: All four helpers return `0` / `None` on non-Windows.
+  POSIX has no equivalent of `CREATE_NO_WINDOW` — there is no separate
+  console window to suppress — and the foreground-process-group /
+  `SIGINT` semantics already match what Windows is opting into with
+  `CREATE_NEW_PROCESS_GROUP`. Returning `None` (rather than `Some(0)`)
+  lets `running-process-core`'s "no override" short-circuit stay intact.
+
+### (h) `whisper-rs` ARM carve-out
+
+- **Symptom**: `whisper-rs-sys`'s vendored C++ source does not compile on
+  `aarch64-pc-windows-msvc`. Shipping that dep unconditionally would
+  break the entire Windows ARM build of `clud`.
+
+- **Solution**: The `whisper-rs` dep is target-gated in `Cargo.toml`. In
+  `voice/worker.rs` the `WhisperContextHandle` type alias resolves to
+  `WhisperContext` on supported targets and to `()` on Windows ARM; the
+  real `transcribe_audio` (which loads the model and runs the Whisper
+  inference) is `#[cfg(not(all(target_arch = "aarch64", target_os = "windows")))]`,
+  and a stub at `:153` returns a descriptive error explaining the
+  platform limitation. The test-bypass path
+  (`CLUD_VOICE_TEST_TRANSCRIPT`) is preserved on both branches so the F3
+  state-machine tests still run on Windows ARM. Mic capture, cue
+  playback, the F3 push-to-talk state machine, and downsampling all ship
+  unchanged on every target — the carve-out is scoped to the
+  transcription call only.
+
+- **File**: `crates/clud-bin/src/voice/worker.rs:9` (target-gated
+  `use whisper_rs`); `:18`–`:21` (`WhisperContextHandle` alias); `:80`
+  (real `transcribe_audio`); `:153` (Windows ARM stub).
+
+- **POSIX behavior**: Same as Windows x86_64 — the real `transcribe_audio`
+  is compiled. Only `aarch64-pc-windows-msvc` is carved out; Linux ARM
+  and macOS ARM build `whisper-rs` normally.
+
+### (i) `process_tree::kill_tree` for `--codex` Ctrl+C orphan reap
+
+- **Symptom**: User hits Ctrl+C in `clud --codex` and the prompt takes
+  several seconds to come back; in the meantime an orphaned `node.exe`
+  (the real Codex) keeps writing garbage to the inherited console. The
+  cause is structural: because of quirk (b) the real process tree at
+  runtime is `clud.exe → cmd.exe → node.exe`, and `process.kill()` on
+  the direct child reaps only the cmd.exe — the node.exe survives until
+  clud itself exits and its Job Object closes.
+
+- **Solution**: Walk the descendant tree with `sysinfo` (using
+  `ProcessRefreshKind::nothing()` so the snapshot stays sub-second on
+  Windows, where `System::new_all()` takes tens of seconds), then
+  `kill_with(Signal::Kill)` + `process.kill()` every descendant
+  deepest-first, ending with the root. The cooperative companion
+  `try_break_group` calls
+  `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)` so a well-behaved
+  agent with a `SetConsoleCtrlHandler` for `CTRL_BREAK_EVENT` can flush
+  state during the short grace window before the hard kill follows.
+
+- **File**: `crates/clud-bin/src/process_tree.rs:46` (`kill_tree`); `:75`
+  (`descendant_pids`); `:113` (`try_break_group`).
+
+- **POSIX behavior**: Same `kill_tree` code path runs (`sysinfo` is
+  cross-platform; `Signal::Kill` is SIGKILL on Unix; `process.kill()`
+  is a redundant follow-up there but a no-op). `try_break_group` is a
+  no-op stub at `:125` — POSIX has no `CREATE_NEW_PROCESS_GROUP` concept
+  and the terminal already delivers SIGINT to clud's foreground process
+  group directly. The cross-platform test at `:202`
+  (`kill_tree_terminates_real_descendant_on_unix`) spawns
+  `sh -c 'sleep 30'` to mirror the `clud → cmd → child` shape and
+  asserts the parent is reaped within 5 s.
+
+## Cross-cutting patterns
+
+- **`#[cfg(windows)]` placement is module-local.** Each quirk lives in its
+  own module; `cfg`-gating happens at the function, field, or impl
+  boundary so call sites can call the public API unconditionally.
+  `ConsoleVtGuard` returns the same type on every OS (the field is gated);
+  `invisible_helper_creationflags` returns `Option<u32>` on every OS (the
+  value, not the signature, is gated); `try_break_group` returns `bool`
+  on every OS (the body is gated). The rest of the codebase never wraps
+  its own call sites in a `cfg!` check.
+
+- **RAII for console state.** Anything that mutates global console state
+  returns a guard whose `Drop` impl restores the previous state:
+  - `console_setup::ConsoleVtGuard` (`console_setup.rs:8`) restores the
+    saved console-input mode.
+  - `dnd::console_drop_target::ConsoleDropTargetGuard`
+    (`dnd/console_drop_target.rs:333`) revokes each registered window
+    and calls `OleUninitialize` on the same STA thread.
+  - `trampoline::windows_stdio::NonInheritableStdioGuard`
+    (`trampoline.rs:75`) restores `HANDLE_FLAG_INHERIT` on the three
+    stdio handles after the detached spawn returns.
+
+- **Single decision point for the `.cmd` rewrite.** `subprocess.rs` is the
+  *only* file that knows about BatBadBat. Every backend spawn goes
+  through `command_spec_for_subprocess` and gets the right `CommandSpec`
+  variant back — nothing else has a special case for `.cmd` / `.bat`.
+
+- **Single source of truth for `CREATE_NO_WINDOW`.** Every daemon-helper
+  spawn imports from `win_creation_flags` rather than defining the
+  `0x0800_0000` literal locally. The literal is anchored by
+  `create_no_window_value_matches_winapi` at `win_creation_flags.rs:125`
+  (Windows) and `invisible_helper_flags_is_zero_off_windows` at `:136`
+  (POSIX) so a typo in either branch fails CI.
+
+- **Best-effort, non-fatal startup.** The trampoline, the title keeper,
+  the IDropTarget worker, and the `.old.*` GC are all wrapped so a
+  failure logs to stderr (or stays silent) and the launch continues.
+  None of them can block a `clud` invocation.
+
+## Testing on non-Windows
+
+Most of these modules are no-op stubs on POSIX, which means the Linux/macOS
+unit-test runs cover only the dispatch logic, not the OS calls themselves.
+Two exceptions worth flagging:
+
+- `console_input::translate` (the Shift+Enter translator) is a pure
+  function over a `&[InputEvent]` slice. Tests construct
+  `InputEvent::Key { ... }` values directly and assert on the output
+  `Vec<u8>`, so the full translation contract is unit-tested on every
+  platform — see the seven `#[test]` cases in
+  `crates/clud-bin/src/console_input.rs:97-198`.
+
+- `console_title::OscTitleStripper` is also a pure byte filter and is
+  fully unit-tested cross-platform — including split-across-chunks,
+  back-to-back OSCs, and passthrough for OSC 8/10/52/133. See the test
+  cases at `crates/clud-bin/src/console_title.rs:395-513`.
+
+The other quirks (`trampoline::unlock_exe`,
+`subprocess::command_spec_for_subprocess` Windows branch,
+`console_setup::enable_console_vt_input`,
+`dnd::console_drop_target::register_console_drop_target`,
+`process_tree::kill_tree` Windows tree shape) have `#[cfg(windows)]` tests
+that only run on the Windows x86 and ARM matrix jobs. The cross-platform
+side of `process_tree::kill_tree` is covered by the Unix-only test at
+`process_tree.rs:202` so the descendant-walk contract is enforced on every
+host.
+
+## See also
+
+- [session-lifecycle.md](session-lifecycle.md) — how `console_setup`,
+  `console_title`, and `console_input` feed into the PTY pump and the
+  interactive-hooks loop.
+- [../../crates/clud-bin/src/dnd/README.md](../../crates/clud-bin/src/dnd/README.md)
+  — the drag-and-drop subsystem in detail, including the per-launch-mode
+  injector contract and the `CF_HDROP` wire format.
+- [../../crates/clud-bin/src/voice/README.md](../../crates/clud-bin/src/voice/README.md)
+  — the F3 voice-mode pipeline, including the Windows ARM carve-out for
+  transcription.


### PR DESCRIPTION
## Summary

Builds on PR #147 by adopting zccache's progressive-disclosure tier-2 pattern: cross-cutting subsystems get their own topic docs under `docs/architecture/`, non-obvious design choices get ADR-style records in `docs/DESIGN_DECISIONS.md`, and `CLAUDE.md` gets a "where to put new docs" rule set so future contributors know which tier each kind of fact belongs in.

Skipped from the zccache comparison: the readme-guard PostToolUse hook (user opted out — manual coverage for now).

## What landed

- **7 subsystem topic docs** under `docs/architecture/` (~1700 lines), each self-contained for one cross-cutting concept:
  - `loop-subsystem.md` — `clud loop` end-to-end
  - `daemon-ipc.md` — centralized session daemon protocol + lifecycle
  - `session-lifecycle.md` — PTY pump, console handling, input injection
  - `skill-system.md` — bundling + dual-installer divergence
  - `gc-and-registry.md` — two-redb split (sessions cap + single-owner gc_daemon)
  - `windows-quirks.md` — every Windows-only carveout with symptom/solution/file/POSIX
  - `launch-plan.md` — `LaunchPlan` as the single source of truth
- **`docs/DESIGN_DECISIONS.md`** — 10 ADR-style records (DD-001..DD-010) capturing rationale previously buried in commits.
- **`docs/README.md`** + **`docs/ARCHITECTURE.md`** + **`docs/architecture/README.md`** — index files.
- **`CLAUDE.md`** updated with `docs/` pointers, an "Architecture & design docs" section, and a 4-rule "Where to put new docs" policy.
- **5 per-dir READMEs trimmed** to replace duplicated cross-cutting paragraphs with one-line breadcrumbs into the topic docs (never-duplicate rule).

## Goal

`CLAUDE.md` → `docs/ARCHITECTURE.md` → topic doc → code answers any cross-cutting question in ≤3 hops. `CLAUDE.md` → `docs/DESIGN_DECISIONS.md` answers any "why was it done this way?" question.

## Test plan

- [x] Link sanity: all relative links in `docs/`, `CLAUDE.md`, and the 5 modified READMEs resolve (verified by script across 17 files, 0 broken).
- [ ] 3-hop check: pick 5 cross-cutting questions and trace each from `CLAUDE.md` to source.
- [ ] CI: `bash lint` — docs-only diff, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)