### PR TITLE
deps+perf: running-process-core 3.4.1 upgrade + daemon kill perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.1.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981f9b790e0737a122aea2d0a9f5735163995223c8dcad1ec2e846d3685aefce"
+checksum = "03f35c478beb7dff57f999628b301d5e18306e6fc80f90cf6c6c221904df9b56"
 dependencies = [
  "libc",
  "portable-pty",

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -42,7 +42,7 @@ redb = "2"
 # the redb-open window to a few milliseconds at startup/shutdown so
 # concurrent launches serialize cleanly.
 fs4 = "0.13"
-running-process-core = "3.1.0"
+running-process-core = "3.4.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.37"

--- a/crates/clud-bin/src/daemon/process_utils.rs
+++ b/crates/clud-bin/src/daemon/process_utils.rs
@@ -1,14 +1,27 @@
 use std::collections::HashMap;
 
-use sysinfo::{Pid, Signal, System};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System};
+
+/// Minimal sysinfo refresh: just the parent-PID graph, no CPU/memory/cmdline.
+/// `System::new_all()` enumerates every process's full metadata and takes
+/// **tens of seconds on Windows** (the same trap that `process_tree::kill_tree`
+/// already documents). For `pid_is_alive` and `signal_process_tree` we only
+/// need the PID graph, which the minimal refresh provides in sub-second time
+/// — critical on the `clud kill --all` path where a daemon-terminate request
+/// calls into these helpers multiple times per session.
+fn fresh_minimal_system() -> System {
+    let mut system = System::new();
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, ProcessRefreshKind::nothing());
+    system
+}
 
 pub(super) fn pid_is_alive(pid: u32) -> bool {
-    let system = System::new_all();
+    let system = fresh_minimal_system();
     system.process(Pid::from_u32(pid)).is_some()
 }
 
 pub(super) fn signal_process_tree(root_pid: u32, signal: Signal) {
-    let system = System::new_all();
+    let system = fresh_minimal_system();
     let root = Pid::from_u32(root_pid);
     if system.process(root).is_none() {
         return;

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -7,9 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use running_process_core::{
-    CommandSpec, Containment, NativeProcess, ProcessConfig, StderrMode, StdinMode,
-};
+use running_process_core::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
 use sysinfo::Signal;
 
 use crate::win_creation_flags::invisible_helper_creationflags;
@@ -143,7 +141,12 @@ fn daemon_create_session(
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,
-        containment: Some(Containment::Detached),
+        // `running-process-core` 3.4 removed the explicit `Containment`
+        // knob; every `NativeProcess` is now automatically bound to a
+        // kill-on-close Job Object on Windows. The worker can no longer
+        // outlive the daemon on Windows, but the worker already polls
+        // `pid_is_alive(daemon_pid)` to clean up if the daemon dies, so
+        // the OS-level link only tightens that contract.
     }));
     worker
         .start()

--- a/crates/clud-bin/src/daemon/worker.rs
+++ b/crates/clud-bin/src/daemon/worker.rs
@@ -9,9 +9,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
 use running_process_core::pty::NativePtyProcess;
-use running_process_core::{
-    Containment, NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode,
-};
+use running_process_core::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
 
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;
@@ -271,7 +269,6 @@ fn run_repeat_once(
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,
-        containment: Some(Containment::Contained),
     }));
     if let Err(err) = process.start() {
         shared
@@ -327,7 +324,6 @@ fn start_subprocess_session(
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,
-        containment: Some(Containment::Contained),
     }));
     process
         .start()

--- a/crates/clud-bin/src/hook_health.rs
+++ b/crates/clud-bin/src/hook_health.rs
@@ -9,7 +9,7 @@ use crate::backend::{self, Backend};
 use crate::command;
 use crate::loop_spec;
 use crate::subprocess;
-use running_process_core::{Containment, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+use running_process_core::{NativeProcess, ProcessConfig, StderrMode, StdinMode};
 use serde_json::Value as JsonValue;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;
@@ -808,7 +808,6 @@ fn run_backend_prompt(
         create_process_group: false,
         stdin_mode: StdinMode::Inherit,
         nice: None,
-        containment: Some(Containment::Contained),
     };
     let process = NativeProcess::new(config);
     process

--- a/crates/clud-bin/src/loop_spec.rs
+++ b/crates/clud-bin/src/loop_spec.rs
@@ -341,7 +341,6 @@ fn run_gh_capture(args: &[&str]) -> Result<(i32, String), String> {
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,
-        containment: None,
     };
     let process = NativeProcess::new(config);
     process

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -114,7 +114,7 @@ pub fn run_plan_subprocess(
 ) -> i32 {
     use std::path::PathBuf;
 
-    use running_process_core::{Containment, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+    use running_process_core::{NativeProcess, ProcessConfig, StderrMode, StdinMode};
 
     let env = child_env();
     let mut last_exit = 0i32;
@@ -173,13 +173,15 @@ pub fn run_plan_subprocess(
             stdin_mode: StdinMode::Inherit,
             nice: None,
             // Issue #9: Claude/Codex spawn tool subprocesses (cargo test,
-            // npm test, long builds) that leak as zombies when a clud
-            // session dies abnormally (crash, terminal close, Task Manager
-            // kill). `Containment::Contained` binds the child tree's
-            // lifetime to ours: PR_SET_PDEATHSIG(SIGKILL) on Linux, a
-            // kill-on-close Job Object on Windows. The daemon path already
-            // sets this (daemon.rs); direct subprocess runs now do too.
-            containment: Some(Containment::Contained),
+            // npm test, long builds) that leak as zombies when clud dies
+            // abnormally. Since `running-process-core` 3.4, every
+            // `NativeProcess` is automatically placed in a kill-on-close
+            // Job Object on Windows, which gives us the same blast-radius
+            // bound as the old `Containment::Contained` opt-in. On Linux
+            // the wrapper no longer sets `PR_SET_PDEATHSIG(SIGKILL)`
+            // implicitly; orphan reaping there falls back to the daemon
+            // worker's `pid_is_alive` watchdog (foreground sessions still
+            // rely on the OS killing the process tree at terminal close).
         };
 
         let process = NativeProcess::new(config);

--- a/crates/clud-bin/src/voice/linux_capture.rs
+++ b/crates/clud-bin/src/voice/linux_capture.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use running_process_core::{
-    CommandSpec, Containment, NativeProcess, ProcessConfig, ProcessError, StderrMode, StdinMode,
+    CommandSpec, NativeProcess, ProcessConfig, ProcessError, StderrMode, StdinMode,
 };
 
 pub(super) struct LinuxCapture {
@@ -44,7 +44,6 @@ impl LinuxCapture {
             create_process_group: false,
             stdin_mode: StdinMode::Null,
             nice: None,
-            containment: Some(Containment::Contained),
         });
 
         if let Err(err) = process.start() {

--- a/crates/clud-bin/src/worktrees.rs
+++ b/crates/clud-bin/src/worktrees.rs
@@ -424,7 +424,6 @@ pub(crate) fn run_git(cwd: &Path, args: &[&str]) -> Result<String, String> {
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,
-        containment: None,
     };
     let process = NativeProcess::new(config);
     process

--- a/crates/clud-bin/tests/pty_behavior.rs
+++ b/crates/clud-bin/tests/pty_behavior.rs
@@ -121,7 +121,6 @@ fn mock_agent_path() -> PathBuf {
         create_process_group: false,
         stdin_mode: StdinMode::Null,
         nice: None,
-        containment: None,
     };
     let process = NativeProcess::new(config);
     process.start().expect("spawn cargo build -p mock-agent");

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -499,9 +499,15 @@ class TestInterruptReporting:
         if sys.platform == "win32":
             kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
 
+        # PR #145 gated the "[clud] interrupted via Ctrl+C (pty)" diagnostic
+        # behind `--verbose`; pass that flag here so the assertion below has
+        # the message to check against. Without `--verbose` the diagnostic is
+        # silenced by design and the test had been failing on every platform's
+        # integration run since #145 landed.
         proc = subprocess.Popen(
             [
                 str(clud_binary),
+                "--verbose",
                 "--pty",
                 "-p",
                 "hello",


### PR DESCRIPTION
## Summary

Two related changes bundled as the first of a 3-PR migration that routes more sessions through the daemon (`daemon::run_centralized_session`):

- **deps**: `running-process-core` 3.1.0 → 3.4.1. Breaking change: the `ProcessConfig.containment` field and root `Containment` enum were removed — every `NativeProcess` is now automatically bound to a kill-on-close Job Object on Windows, which preserves the old `Contained` semantics. Detached spawns moved to the separate `spawn_daemon()` / `DaemonChild` API; the daemon worker call site relies instead on the existing `pid_is_alive(daemon_pid)` watchdog so the worker still cleans itself up if the daemon dies. On Linux, `NativeProcess` no longer sets `PR_SET_PDEATHSIG(SIGKILL)` implicitly — that moved to the new `spawn::spawn()` free function. Foreground sessions on Linux now rely on the terminal closing to reap the tree; daemon-managed sessions still have the watchdog.

- **perf(daemon)**: `pid_is_alive` and `signal_process_tree` were using `System::new_all()`, which enumerates every process's full metadata and takes tens of seconds on Windows — the same trap `process_tree::kill_tree` already documents. On the `clud kill --all` path, `daemon_terminate_session` calls into those helpers up to 4× per session, which made `test_kill_all_sessions` flake under the 10s timeout. Switched to the minimal `refresh_processes_specifics(All, true, ProcessRefreshKind::nothing())` pattern that `process_tree::kill_tree` already uses — same effect, sub-second. Test now completes end-to-end in ~6.5s.

## Test plan

- [x] `bash lint` (cargo fmt + clippy + ruff) — green
- [x] `bash test` (557 Rust unit + 14 PTY behavior + 53 Python unit) — green
- [x] `bash test --integration -k "test_daemon_managed_sessions or test_daemon_cleanup"` — 20/20 pass, 1 pre-existing xfail (#38)
- [ ] Cross-platform CI matrix (Linux x86/ARM, Windows x86/ARM, macOS x86/ARM)

## Follow-ups (next PRs in this thread)

- PR2: PTY + voice + DnD through the centralized daemon path
- PR3: flip `experimental_enabled` to default-on; opt-out via `CLUD_NO_DAEMON` / `--no-daemon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)