### PR TITLE
fix(centralized): revert interactive default + force PTY on centralized launches

### DIFF
--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -1,9 +1,9 @@
-use std::io::{self, IsTerminal};
+use std::io;
 use std::sync::atomic::AtomicBool;
 
 use crate::args::{Args, Command};
 use crate::backend::LaunchMode;
-use crate::command::LaunchPlan;
+use crate::command::{has_noninteractive_prompt, LaunchPlan};
 use crate::verbose_log;
 
 use super::attach::{attach_to_session, run_attach};
@@ -17,17 +17,20 @@ use super::types::{
     DaemonRequest, DaemonResponse, SessionKind, WorkerLaunchSpec, ENV_FEATURE_FLAG,
 };
 use super::worker::run_worker;
-use crate::gc_daemon::ENV_NO_DAEMON;
 
 /// True when the launch should be routed through the centralized session
 /// daemon (`daemon::run_centralized_session`) instead of the direct
 /// runner in `runner::run_plan_{subprocess,pty}`.
 ///
-/// **As of PR3 the centralized path is now the default for *interactive*
-/// launches** — when both stdin and stdout are TTYs. Piped invocations
-/// (`clud -p "x" | jq`, `echo foo | clud`, CI test harnesses) keep using
-/// the direct runner so they don't pay the daemon round-trip and so
-/// stdio framing stays byte-identical with what scripts expect.
+/// The centralized path is **opt-in**. Defaulting it on for interactive
+/// launches (the PR #151 experiment) exposed a latent bug: the attach
+/// pump (`run_remote_interactive`) reads stdin through `crossterm::event`,
+/// which drops DSR / DA / OSC replies the child TUI writes on startup
+/// (same lossy-demultiplexer issue #46 already fixed for the local-PTY
+/// runner). With nothing answering claude's `\x1b[6n` query, the TUI
+/// hangs and the user sees a blank screen. Until the attach pump is
+/// rewritten to forward raw stdin bytes (like `run_raw_pty_pump` does),
+/// the safe default is to leave plain `clud` on the direct runner.
 ///
 /// Override matrix:
 ///
@@ -36,16 +39,11 @@ use crate::gc_daemon::ENV_NO_DAEMON;
 /// | `--detach` / `--detachable` / repeat job | **forced on** |
 /// | `--experimental-daemon-centralized`      | **forced on** (legacy alias) |
 /// | `CLUD_EXPERIMENTAL_DAEMON=1`             | **forced on** (legacy alias) |
-/// | `--no-daemon`                            | off |
-/// | `CLUD_NO_DAEMON=1`                       | off |
-/// | Interactive (stdin & stdout both TTYs)   | **on** ← new default |
-/// | Piped (anything else)                    | off (direct runner) |
+/// | `--no-daemon` / `CLUD_NO_DAEMON=1`       | off (no-ops here, kept for explicitness) |
+/// | Everything else                          | off (direct runner) |
 ///
-/// The legacy "experimental" opt-in still forces centralized so any
-/// script that was setting `CLUD_EXPERIMENTAL_DAEMON=1` keeps working
-/// unchanged. The function name `experimental_enabled` is preserved for
-/// the same reason (one external call site in `main.rs`); a rename can
-/// land as a follow-up cleanup.
+/// The function name `experimental_enabled` is preserved for back-compat
+/// (one external call site in `main.rs`); a rename can land in a follow-up.
 pub fn experimental_enabled(args: &Args) -> bool {
     let repeat_enabled = matches!(
         args.command,
@@ -55,30 +53,11 @@ pub fn experimental_enabled(args: &Args) -> bool {
         })
     );
 
-    let force_on = args.detach
+    args.detach
         || args.detachable
         || repeat_enabled
         || args.experimental_daemon_centralized
-        || env_truthy(ENV_FEATURE_FLAG);
-    if force_on {
-        return true;
-    }
-
-    // PR3: centralized daemon is now the default for interactive launches.
-    // Honor the user's explicit opt-out flags first.
-    if args.no_daemon || env_truthy(ENV_NO_DAEMON) {
-        return false;
-    }
-
-    // Interactive (both TTYs) → centralized. Piped → direct runner.
-    //
-    // Rationale: every meaningful win of the centralized path (kill-on-
-    // close Job Object lifetime, attach/detach, replay, session listing,
-    // voice + DnD) only matters when there's a human at the keyboard.
-    // For piped one-shots the direct runner is simpler, faster, and
-    // produces byte-identical stdio framing that script automation
-    // relies on.
-    io::stdin().is_terminal() && io::stdout().is_terminal()
+        || env_truthy(ENV_FEATURE_FLAG)
 }
 
 fn env_truthy(name: &str) -> bool {
@@ -193,6 +172,38 @@ pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i
     }
 }
 
+/// Pick the worker's `SessionKind` for a centralized-daemon launch.
+///
+/// The daemon worker's subprocess path wires the backend's stdin to a
+/// NULL handle (see `worker::start_subprocess_session`). For interactive
+/// claude that's fatal: claude detects no TTY and drops into its built-in
+/// `--print` mode, which requires a prompt and errors otherwise
+/// ("Input must be provided either through stdin or as a prompt
+/// argument when using --print"). The direct runner avoided this by
+/// inheriting clud's TTY; the daemon worker can't because the user's
+/// terminal belongs to the foreground attach client, not the long-lived
+/// worker. Force PTY for interactive launches so the backend gets a
+/// pseudo-terminal it can drive.
+///
+/// `repeat_enabled` keeps overriding to subprocess — repeat jobs run in
+/// the background, have their own prompt embedded, and never need a TTY.
+fn select_session_kind(
+    plan_mode: LaunchMode,
+    repeat_enabled: bool,
+    noninteractive_prompt: bool,
+) -> SessionKind {
+    if repeat_enabled {
+        return SessionKind::Subprocess;
+    }
+    if !noninteractive_prompt {
+        return SessionKind::Pty;
+    }
+    match plan_mode {
+        LaunchMode::Subprocess => SessionKind::Subprocess,
+        LaunchMode::Pty => SessionKind::Pty,
+    }
+}
+
 pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &AtomicBool) -> i32 {
     let state_dir = state_dir(args);
     if args.verbose {
@@ -213,14 +224,11 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
     }
 
     let repeat_enabled = plan.repeat_schedule.is_some();
-    let kind = if repeat_enabled {
-        SessionKind::Subprocess
-    } else {
-        match plan.launch_mode {
-            LaunchMode::Subprocess => SessionKind::Subprocess,
-            LaunchMode::Pty => SessionKind::Pty,
-        }
-    };
+    let kind = select_session_kind(
+        plan.launch_mode,
+        repeat_enabled,
+        has_noninteractive_prompt(args),
+    );
     let (rows, cols) = terminal_dimensions();
     let backlog_bytes = resolve_backlog_bytes(args.backlog_size.as_deref());
     let name = args
@@ -358,4 +366,73 @@ fn build_repeat_once_command(args: &Args) -> io::Result<Vec<String>> {
         command.extend(args.passthrough.iter().cloned());
     }
     Ok(command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression for the symptom reported after PR #151:
+    //   clud  (no args, interactive terminal)
+    //   → [clud] daemon session sess-...
+    //   → Error: Input must be provided either through stdin or as a
+    //     prompt argument when using --print
+    //
+    // Cause: the centralized daemon mapped `LaunchMode::Subprocess`
+    // straight through to `SessionKind::Subprocess`, and the worker's
+    // subprocess path uses `StdinMode::Null`. Claude saw no TTY,
+    // dropped into `--print` mode, and bailed for lack of a prompt.
+    // Interactive launches must force PTY so the worker hands the
+    // backend a pseudo-terminal it can drive.
+    #[test]
+    fn interactive_launch_forces_pty_even_when_plan_says_subprocess() {
+        assert!(matches!(
+            select_session_kind(LaunchMode::Subprocess, false, false),
+            SessionKind::Pty
+        ));
+    }
+
+    #[test]
+    fn interactive_pty_plan_stays_pty() {
+        assert!(matches!(
+            select_session_kind(LaunchMode::Pty, false, false),
+            SessionKind::Pty
+        ));
+    }
+
+    #[test]
+    fn prompted_subprocess_plan_stays_subprocess() {
+        // `clud -p "hi"` — claude consumes the prompt arg, no TTY needed.
+        assert!(matches!(
+            select_session_kind(LaunchMode::Subprocess, false, true),
+            SessionKind::Subprocess
+        ));
+    }
+
+    #[test]
+    fn prompted_pty_plan_stays_pty() {
+        assert!(matches!(
+            select_session_kind(LaunchMode::Pty, false, true),
+            SessionKind::Pty
+        ));
+    }
+
+    #[test]
+    fn repeat_jobs_always_subprocess() {
+        // Repeat jobs are background, have their own embedded prompt,
+        // and never need an attached TTY — even for the interactive
+        // case the override must win.
+        assert!(matches!(
+            select_session_kind(LaunchMode::Subprocess, true, false),
+            SessionKind::Subprocess
+        ));
+        assert!(matches!(
+            select_session_kind(LaunchMode::Pty, true, false),
+            SessionKind::Subprocess
+        ));
+        assert!(matches!(
+            select_session_kind(LaunchMode::Subprocess, true, true),
+            SessionKind::Subprocess
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

PR #151 made the centralized daemon the **default for interactive launches**. After it landed, plain `clud` hangs with a blank screen on some terminals, and on others bails out with:

> Error: Input must be provided either through stdin or as a prompt argument when using --print

Two distinct bugs underneath one symptom — this PR addresses both.

### 1. Revert the interactive default

`experimental_enabled` no longer auto-promotes interactive launches. The centralized path is opt-in again. Explicit overrides still force it on:

| Trigger | Centralized? |
| --- | --- |
| `--detach` / `--detachable` / repeat job | ✅ forced on |
| `--experimental-daemon-centralized` | ✅ forced on (legacy alias) |
| `CLUD_EXPERIMENTAL_DAEMON=1` | ✅ forced on (legacy alias) |
| `--no-daemon` / `CLUD_NO_DAEMON=1` | off (kept as no-ops for clarity) |
| Everything else (incl. interactive TTY) | off (direct runner) |

**Why** — the attach pump (`run_remote_interactive`) reads stdin via `crossterm::event`, which drops DSR/DA/OSC replies from the child TUI (same lossy-demultiplexer pattern as #46, which was already fixed for the local-PTY runner). With nothing answering claude's `\x1b[6n` query, the TUI hangs. Until `run_remote_interactive` is rewritten to forward raw stdin bytes (like `run_raw_pty_pump` does), the safe default is to leave plain `clud` on the direct runner.

### 2. Force PTY for centralized interactive launches

New `select_session_kind(plan_mode, repeat_enabled, noninteractive_prompt)` upgrades any non-prompted plan to `SessionKind::Pty` when going through the centralized daemon.

**Why** — the daemon worker's subprocess path wires the backend's stdin to a NULL handle. Without a prompt arg, claude detects no TTY, drops into `--print` mode, and errors out. The direct runner sidesteps this by inheriting clud's TTY; the daemon worker can't (the TTY belongs to the foreground attach client). Repeat jobs keep going to subprocess (background, embedded prompt, no TTY needed).

## Test plan

- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `ruff check src tests ci` clean
- [x] `soldr cargo test -p clud --lib` → **562 passed; 0 failed** (includes 5 new tests for `select_session_kind`)
- [ ] Full CI matrix (24 jobs across 6 platforms)
- [ ] Manual verification: `clud` no longer hangs / errors with `--print` message on interactive launch
- [ ] Manual verification: `clud --experimental-daemon-centralized` still works
- [ ] Manual verification: `clud --detach` still goes through centralized path

## Follow-ups (not in this PR)

- Rewrite `run_remote_interactive` to forward raw stdin bytes so DSR/DA/OSC replies aren't dropped. Once that lands, the interactive-by-default can be re-enabled.
- Rename `experimental_enabled` → something accurate (kept for back-compat; one external call site in `main.rs`).