### PR TITLE
fix(ci): restore branch-push trigger on platform build workflows

### DIFF
--- a/.github/workflows/linux-arm-build.yml
+++ b/.github/workflows/linux-arm-build.yml
@@ -1,7 +1,7 @@
 name: Linux ARM Build
 on:
   push:
-    tags-ignore:
+    branches:
       - "**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/linux-x86-build.yml
+++ b/.github/workflows/linux-x86-build.yml
@@ -1,7 +1,7 @@
 name: Linux x86 Build
 on:
   push:
-    tags-ignore:
+    branches:
       - "**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/macos-arm-build.yml
+++ b/.github/workflows/macos-arm-build.yml
@@ -1,7 +1,7 @@
 name: macOS ARM Build
 on:
   push:
-    tags-ignore:
+    branches:
       - "**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/macos-x86-build.yml
+++ b/.github/workflows/macos-x86-build.yml
@@ -1,7 +1,7 @@
 name: macOS x86 Build
 on:
   push:
-    tags-ignore:
+    branches:
       - "**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-arm-build.yml
+++ b/.github/workflows/windows-arm-build.yml
@@ -1,7 +1,7 @@
 name: Windows ARM Build
 on:
   push:
-    tags-ignore:
+    branches:
       - "**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-x86-build.yml
+++ b/.github/workflows/windows-x86-build.yml
@@ -1,7 +1,7 @@
 name: Windows x86 Build
 on:
   push:
-    tags-ignore:
+    branches:
       - "**"
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

Regression introduced by #154. I added `on: push: tags-ignore: ['**']` to all 6 platform build workflows to skip duplicate dev builds on tag pushes. GitHub Actions interprets a `push` filter with only `tags-ignore` (and no `branches`) as "tag pushes only, but ignore all tags" — net result: the workflow fires on **no** push events, not just tag pushes.

This swaps to `branches: ['**']`, which means "any branch, no tags" — the documented idiom.

## Evidence

Merge commit `6cda78a` (the one that introduced #154) only triggered 18/24 expected CI runs: 6 platforms × {Lint, Unit Test, Integration Test} = 18. The 6 build workflows were silently skipped.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm the merge commit fires all 24 CI runs (6 build + 6 lint + 6 unit + 6 integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)