### PR TITLE
deps: migrate running-process-core 3.4.1 → running-process 4.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,7 +294,7 @@ dependencies = [
  "libc",
  "redb",
  "rodio",
- "running-process-core",
+ "running-process",
  "serde",
  "serde_json",
  "sha2",
@@ -591,7 +597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -616,6 +622,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1037,6 +1055,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1102,28 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1083,6 +1157,12 @@ name = "multi-stash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "ndk"
@@ -1358,6 +1438,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1516,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "logos",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1546,16 +1727,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "running-process-core"
-version = "3.4.1"
+name = "running-process"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f35c478beb7dff57f999628b301d5e18306e6fc80f90cf6c6c221904df9b56"
+checksum = "d735a22d8e867b919c24ad55ec1fc6873fdc77dfb13644d5ad284e3f7dd47540"
 dependencies = [
  "libc",
  "portable-pty",
+ "prost-build",
+ "protox",
+ "serde",
+ "serde_json",
  "sysinfo 0.30.13",
  "thiserror 2.0.18",
  "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1583,7 +1769,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1873,7 +2059,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1993,6 +2179,12 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -2061,7 +2253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
 dependencies = [
  "itoa",
- "unicode-width",
+ "unicode-width 0.2.2",
  "vte",
 ]
 
@@ -2332,7 +2524,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/ci/banned_imports.py
+++ b/ci/banned_imports.py
@@ -1,6 +1,6 @@
 """Lint rule: ban direct subprocess/PTY calls in Rust source.
 
-All process execution must go through running-process-core.
+All process execution must go through running-process.
 This script scans .rs files (excluding testbins/) for banned patterns
 and fails the build if any are found.
 """
@@ -15,17 +15,17 @@ ROOT = Path(__file__).resolve().parent.parent
 
 # Patterns that indicate direct subprocess usage (banned in crates/)
 BANNED_PATTERNS: list[tuple[str, str]] = [
-    (r"\bstd::process::Command\b", "use running_process_core::NativeProcess instead"),
-    (r"\bprocess::Command\b", "use running_process_core::NativeProcess instead"),
-    (r"\bCommand::new\b", "use running_process_core::NativeProcess instead"),
-    (r"\bstd::process::Stdio\b", "use running_process_core StdinMode/StderrMode instead"),
-    (r"\bstd::process::Child\b", "use running_process_core::NativeProcess instead"),
-    (r"\bstd::process::Output\b", "use running_process_core::NativeProcess instead"),
-    (r"\buse std::process::\{", "use running_process_core instead of std::process"),
-    # Tokio's async process API is also banned — running-process-core is the
-    # single chokepoint. If async is needed, extend running-process-core.
-    (r"\btokio::process\b", "use running_process_core::NativeProcess instead"),
-    (r"\buse tokio::process\b", "use running_process_core instead of tokio::process"),
+    (r"\bstd::process::Command\b", "use running_process::NativeProcess instead"),
+    (r"\bprocess::Command\b", "use running_process::NativeProcess instead"),
+    (r"\bCommand::new\b", "use running_process::NativeProcess instead"),
+    (r"\bstd::process::Stdio\b", "use running_process StdinMode/StderrMode instead"),
+    (r"\bstd::process::Child\b", "use running_process::NativeProcess instead"),
+    (r"\bstd::process::Output\b", "use running_process::NativeProcess instead"),
+    (r"\buse std::process::\{", "use running_process instead of std::process"),
+    # Tokio's async process API is also banned — running-process is the
+    # single chokepoint. If async is needed, extend running-process.
+    (r"\btokio::process\b", "use running_process::NativeProcess instead"),
+    (r"\buse tokio::process\b", "use running_process instead of tokio::process"),
 ]
 
 # Only std::process::exit is allowed (it's not subprocess spawning)
@@ -72,7 +72,7 @@ def main() -> int:
         return 0
 
     # trampoline.rs is exempt — it must use std::process::Command to re-exec
-    # before running-process-core is involved.
+    # before running-process is involved.
     #
     # process_tree.rs is exempt — production code uses sysinfo (no subprocess
     # spawning), but the #[cfg(test)] tests deliberately use std::process::
@@ -97,7 +97,7 @@ def main() -> int:
     if total_violations > 0:
         print(
             f"\n{total_violations} banned import(s) found. "
-            "All subprocess execution must use running-process-core.",
+            "All subprocess execution must use running-process.",
             file=sys.stderr,
         )
         return 1

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -42,7 +42,7 @@ redb = "2"
 # the redb-open window to a few milliseconds at startup/shutdown so
 # concurrent launches serialize cleanly.
 fs4 = "0.13"
-running-process-core = "3.4.1"
+running-process = { version = "4.0.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.37"

--- a/crates/clud-bin/src/daemon/io_helpers.rs
+++ b/crates/clud-bin/src/daemon/io_helpers.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use super::types::ENV_BACKLOG_BYTES;
 
 pub(super) fn child_env() -> Vec<(String, String)> {
-    let originator_key = running_process_core::ORIGINATOR_ENV_VAR;
+    let originator_key = running_process::ORIGINATOR_ENV_VAR;
     let mut env: Vec<(String, String)> = std::env::vars()
         .filter(|(key, _)| key != "IN_CLUD" && key != originator_key)
         .collect();

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -7,7 +7,7 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use running_process_core::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+use running_process::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
 use sysinfo::Signal;
 
 use crate::win_creation_flags::invisible_helper_creationflags;

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use running_process_core::pty::NativePtyProcess;
-use running_process_core::NativeProcess;
+use running_process::pty::NativePtyProcess;
+use running_process::NativeProcess;
 use serde::{Deserialize, Serialize};
 use sysinfo::Signal;
 

--- a/crates/clud-bin/src/daemon/worker.rs
+++ b/crates/clud-bin/src/daemon/worker.rs
@@ -8,8 +8,8 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
-use running_process_core::pty::NativePtyProcess;
-use running_process_core::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
+use running_process::pty::NativePtyProcess;
+use running_process::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
 
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;

--- a/crates/clud-bin/src/hook_health.rs
+++ b/crates/clud-bin/src/hook_health.rs
@@ -9,7 +9,7 @@ use crate::backend::{self, Backend};
 use crate::command;
 use crate::loop_spec;
 use crate::subprocess;
-use running_process_core::{NativeProcess, ProcessConfig, StderrMode, StdinMode};
+use running_process::{NativeProcess, ProcessConfig, StderrMode, StdinMode};
 use serde_json::Value as JsonValue;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;

--- a/crates/clud-bin/src/loop_spec.rs
+++ b/crates/clud-bin/src/loop_spec.rs
@@ -14,7 +14,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use running_process_core::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
+use running_process::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
 
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;

--- a/crates/clud-bin/src/process_tree.rs
+++ b/crates/clud-bin/src/process_tree.rs
@@ -11,7 +11,7 @@
 //! ```
 //!
 //! When the user hits Ctrl+C, `process.kill()` on a
-//! `running_process_core::NativeProcess` only terminates the **direct**
+//! `running_process::NativeProcess` only terminates the **direct**
 //! child (cmd.exe). The orphaned `node.exe` keeps writing to the inherited
 //! console for several seconds until clud itself exits and its Job Object
 //! closes — that's the multi-second hang users were reporting.

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -428,10 +428,7 @@ fn run_with_stream_json_renderer(
     }
 }
 
-fn drain_remaining_stdout(
-    process: &running_process::NativeProcess,
-    captured_output: &mut String,
-) {
+fn drain_remaining_stdout(process: &running_process::NativeProcess, captured_output: &mut String) {
     use running_process::StreamKind;
     for chunk in process.drain_stream(StreamKind::Stdout) {
         emit_rendered_line(&chunk, captured_output);

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -61,7 +61,7 @@ fn merge_extra_rx(
 /// Build the child environment: inherit parent env + inject tracking vars.
 /// Deduplicates keys so we never pass the same var twice.
 pub fn child_env() -> Vec<(String, String)> {
-    let originator_key = running_process_core::ORIGINATOR_ENV_VAR;
+    let originator_key = running_process::ORIGINATOR_ENV_VAR;
 
     let mut env: Vec<(String, String)> = std::env::vars()
         .filter(|(k, _)| k != "IN_CLUD" && k != originator_key)
@@ -150,7 +150,7 @@ pub fn run_plan_subprocess(
 ) -> i32 {
     use std::path::PathBuf;
 
-    use running_process_core::{NativeProcess, ProcessConfig, StderrMode, StdinMode};
+    use running_process::{NativeProcess, ProcessConfig, StderrMode, StdinMode};
 
     let env = child_env();
     let mut last_exit = 0i32;
@@ -330,7 +330,7 @@ enum ProcessOutcome {
 /// 3. `process.kill()` + `process.wait(2s)`: final TerminateProcess on
 ///    the direct handle and a bounded wait so we don't return while
 ///    the child is still draining.
-fn teardown_interrupted_child(process: &running_process_core::NativeProcess) {
+fn teardown_interrupted_child(process: &running_process::NativeProcess) {
     if let Some(pid) = process.pid() {
         // Cooperative Ctrl+Break first. No-op on POSIX (returns false)
         // and any failure on Windows is non-fatal — the hard kill below
@@ -347,7 +347,7 @@ fn teardown_interrupted_child(process: &running_process_core::NativeProcess) {
 /// the stream-json path can sit alongside it without duplicating the
 /// non-streaming control flow.
 fn run_with_inherited_stdio(
-    process: &running_process_core::NativeProcess,
+    process: &running_process::NativeProcess,
     interrupted: &AtomicBool,
 ) -> ProcessOutcome {
     loop {
@@ -385,11 +385,11 @@ fn run_with_inherited_stdio(
 /// is what the agent emits in a non-JSON-wrapped chunk; we keep the
 /// payload as-is so token recognition isn't confused by event framing.
 fn run_with_stream_json_renderer(
-    process: &running_process_core::NativeProcess,
+    process: &running_process::NativeProcess,
     interrupted: &AtomicBool,
     captured_output: &mut String,
 ) -> ProcessOutcome {
-    use running_process_core::{ReadStatus, StreamKind};
+    use running_process::{ReadStatus, StreamKind};
     use std::time::Duration;
 
     let timeout = Duration::from_millis(100);
@@ -429,10 +429,10 @@ fn run_with_stream_json_renderer(
 }
 
 fn drain_remaining_stdout(
-    process: &running_process_core::NativeProcess,
+    process: &running_process::NativeProcess,
     captured_output: &mut String,
 ) {
-    use running_process_core::StreamKind;
+    use running_process::StreamKind;
     for chunk in process.drain_stream(StreamKind::Stdout) {
         emit_rendered_line(&chunk, captured_output);
     }
@@ -457,7 +457,7 @@ pub fn run_plan_pty(
     dnd_enabled: bool,
     mut loop_session: Option<&mut loop_artifacts::LoopSession>,
 ) -> i32 {
-    use running_process_core::pty::NativePtyProcess;
+    use running_process::pty::NativePtyProcess;
 
     // Enable VT input on the Windows console for the whole PTY session.
     // The raw byte pump reads from clud's stdin, so PTY mode needs the

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -5,14 +5,14 @@ use crossterm::event::{
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
-use running_process_core::pty::reexports::portable_pty::PtySize;
-use running_process_core::pty::NativePtyProcess;
+use running_process::pty::PtySize;
+use running_process::pty::NativePtyProcess;
 
 use crate::console_title::OscTitleStripper;
 use crate::dnd::{looks_like_dropped_path, normalize_dropped_path};
 use crate::verbose_log;
 
-/// Resize the PTY. On Windows, `running_process_core::pty::NativePtyProcess::resize_impl`
+/// Resize the PTY. On Windows, `running_process::pty::NativePtyProcess::resize_impl`
 /// is a deliberate no-op (see that crate's `pty/mod.rs:730-737`), so reaching
 /// the underlying master's `resize()` directly is the only way to honor a
 /// `SIGWINCH`/`Event::Resize`. On POSIX the library's implementation does the
@@ -710,7 +710,7 @@ where
         }
 
         if let Ok(Some(code)) =
-            running_process_core::pty::poll_pty_process(&process.handles, &process.returncode)
+            running_process::pty::poll_pty_process(&process.handles, &process.returncode)
         {
             if verbose {
                 verbose_log::log(format_args!("[clud] pty pump: child exited code {code}"));

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -5,8 +5,8 @@ use crossterm::event::{
     KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
-use running_process::pty::PtySize;
 use running_process::pty::NativePtyProcess;
+use running_process::pty::PtySize;
 
 use crate::console_title::OscTitleStripper;
 use crate::dnd::{looks_like_dropped_path, normalize_dropped_path};

--- a/crates/clud-bin/src/subprocess.rs
+++ b/crates/clud-bin/src/subprocess.rs
@@ -22,7 +22,7 @@
 #[cfg(windows)]
 use std::path::Path;
 
-use running_process_core::CommandSpec;
+use running_process::CommandSpec;
 
 /// Translate an argv-style launch into the most compatible `CommandSpec` for
 /// the current platform.
@@ -126,7 +126,7 @@ mod tests {
         let spec =
             command_spec_for_subprocess(vec!["codex.exe".into(), "exec".into(), "hello".into()]);
         match spec {
-            running_process_core::CommandSpec::Argv(argv) => {
+            running_process::CommandSpec::Argv(argv) => {
                 assert_eq!(argv, vec!["codex.exe", "exec", "hello"]);
             }
             other => panic!("expected Argv for native executable, got {other:?}"),
@@ -146,7 +146,7 @@ mod tests {
         let spec =
             command_spec_for_subprocess(vec![r"C:\Users\me\AppData\Roaming\npm\codex.cmd".into()]);
         match spec {
-            running_process_core::CommandSpec::Shell(command) => {
+            running_process::CommandSpec::Shell(command) => {
                 assert_eq!(command, r#""C:\Users\me\AppData\Roaming\npm\codex.cmd""#);
             }
             other => panic!("expected Shell for .cmd wrapper, got {other:?}"),
@@ -162,7 +162,7 @@ mod tests {
             "hello world".into(),
         ]);
         let rendered = match spec {
-            running_process_core::CommandSpec::Shell(s) => s,
+            running_process::CommandSpec::Shell(s) => s,
             other => panic!("expected Shell, got {other:?}"),
         };
         assert!(
@@ -186,7 +186,7 @@ mod tests {
             "caret ^ stays".into(),
         ]);
         let rendered = match spec {
-            running_process_core::CommandSpec::Shell(s) => s,
+            running_process::CommandSpec::Shell(s) => s,
             other => panic!("expected Shell, got {other:?}"),
         };
         assert!(
@@ -230,7 +230,7 @@ mod tests {
             r#"100% "quoted" prompt"#.into(),
         ]);
         let rendered = match spec {
-            running_process_core::CommandSpec::Shell(s) => s,
+            running_process::CommandSpec::Shell(s) => s,
             other => panic!("expected Shell, got {other:?}"),
         };
         assert!(
@@ -246,7 +246,7 @@ mod tests {
         // hit the cmd.exe path.
         let spec = command_spec_for_subprocess(vec![r"C:\tools\thing.BAT".into(), "go".into()]);
         match spec {
-            running_process_core::CommandSpec::Shell(_) => {}
+            running_process::CommandSpec::Shell(_) => {}
             other => panic!("expected Shell for .BAT wrapper, got {other:?}"),
         }
     }
@@ -263,7 +263,7 @@ mod tests {
             "hello".into(),
         ]);
         match spec {
-            running_process_core::CommandSpec::Argv(argv) => {
+            running_process::CommandSpec::Argv(argv) => {
                 assert_eq!(
                     argv,
                     vec![r"C:\Program Files\Tool\codex.exe", "exec", "hello"],
@@ -282,7 +282,7 @@ mod tests {
         // earlier resolver). These must not be wrapped.
         let spec = command_spec_for_subprocess(vec!["codex".into(), "exec".into()]);
         match spec {
-            running_process_core::CommandSpec::Argv(argv) => {
+            running_process::CommandSpec::Argv(argv) => {
                 assert_eq!(argv, vec!["codex", "exec"]);
             }
             other => panic!("expected Argv for extensionless path, got {other:?}"),
@@ -297,7 +297,7 @@ mod tests {
         // dependency on Linux/macOS.
         let spec = command_spec_for_subprocess(vec!["codex.cmd".into(), "exec".into()]);
         match spec {
-            running_process_core::CommandSpec::Argv(argv) => {
+            running_process::CommandSpec::Argv(argv) => {
                 assert_eq!(argv, vec!["codex.cmd", "exec"]);
             }
             other => panic!("expected Argv off Windows, got {other:?}"),
@@ -310,14 +310,14 @@ mod tests {
         // `.sh` and extensionless POSIX paths must always pass through.
         let spec = command_spec_for_subprocess(vec!["./run.sh".into(), "--flag".into()]);
         match spec {
-            running_process_core::CommandSpec::Argv(argv) => {
+            running_process::CommandSpec::Argv(argv) => {
                 assert_eq!(argv, vec!["./run.sh", "--flag"]);
             }
             other => panic!("expected Argv for .sh script, got {other:?}"),
         }
         let spec = command_spec_for_subprocess(vec!["/usr/bin/codex".into(), "exec".into()]);
         match spec {
-            running_process_core::CommandSpec::Argv(argv) => {
+            running_process::CommandSpec::Argv(argv) => {
                 assert_eq!(argv, vec!["/usr/bin/codex", "exec"]);
             }
             other => panic!("expected Argv for extensionless path, got {other:?}"),

--- a/crates/clud-bin/src/voice/linux_capture.rs
+++ b/crates/clud-bin/src/voice/linux_capture.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use running_process_core::{
+use running_process::{
     CommandSpec, NativeProcess, ProcessConfig, ProcessError, StderrMode, StdinMode,
 };
 

--- a/crates/clud-bin/src/voice/mode.rs
+++ b/crates/clud-bin/src/voice/mode.rs
@@ -236,7 +236,7 @@ mod tests {
     use super::*;
     use crate::voice::audio::TARGET_SAMPLE_RATE;
     use crate::voice::audio::{downmix_and_resample, has_speech_peak, is_effectively_silent};
-    use running_process_core::pty::NativePtyProcess;
+    use running_process::pty::NativePtyProcess;
     use std::env;
 
     #[test]

--- a/crates/clud-bin/src/win_creation_flags.rs
+++ b/crates/clud-bin/src/win_creation_flags.rs
@@ -49,7 +49,7 @@ pub fn invisible_helper_flags() -> u32 {
 }
 
 /// `Some(CREATE_NO_WINDOW)` on Windows, `None` elsewhere — the shape that
-/// `running_process_core::ProcessConfig::creationflags` expects. Using
+/// `running_process::ProcessConfig::creationflags` expects. Using
 /// `None` off-Windows lets the running-process-core priority-flag
 /// short-circuit stay intact (passing `Some(0)` would also work, but is
 /// semantically misleading).

--- a/crates/clud-bin/src/worktrees.rs
+++ b/crates/clud-bin/src/worktrees.rs
@@ -17,7 +17,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-use running_process_core::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
+use running_process::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
 
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;

--- a/crates/clud-bin/tests/common/mod.rs
+++ b/crates/clud-bin/tests/common/mod.rs
@@ -13,8 +13,8 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
-use running_process_core::pty::NativePtyProcess;
-use running_process_core::{
+use running_process::pty::NativePtyProcess;
+use running_process::{
     CommandSpec, NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode,
 };
 use serde_json::Value;
@@ -174,7 +174,7 @@ pub fn drain_reader(process: &NativePtyProcess, overall_timeout: Duration) -> Ve
             Err(_) => break,
         }
         if let Ok(Some(_)) =
-            running_process_core::pty::poll_pty_process(&process.handles, &process.returncode)
+            running_process::pty::poll_pty_process(&process.handles, &process.returncode)
         {
             while let Ok(Some(chunk)) = process.read_chunk_impl(Some(0.1)) {
                 buf.extend_from_slice(&chunk);

--- a/crates/clud-bin/tests/pty_behavior.rs
+++ b/crates/clud-bin/tests/pty_behavior.rs
@@ -1,4 +1,4 @@
-//! Cross-platform behavior tests for `running_process_core::pty::NativePtyProcess`
+//! Cross-platform behavior tests for `running_process::pty::NativePtyProcess`
 //! as used by `clud --codex` (see zackees/clud#28, #31).
 //!
 //! Each test asserts the platform-specific contract that
@@ -34,7 +34,7 @@
 
 use std::time::Duration;
 
-use running_process_core::pty::NativePtyProcess;
+use running_process::pty::NativePtyProcess;
 use serde_json::Value;
 
 mod common;
@@ -234,7 +234,7 @@ fn initial_pty_size_is_forwarded_to_child() {
     }
 }
 
-/// Document what `running_process_core::pty::NativePtyProcess::resize_impl`
+/// Document what `running_process::pty::NativePtyProcess::resize_impl`
 /// does today on each platform:
 ///   - POSIX: `master.resize()` propagates; the child sees the new size.
 ///   - Windows: intentional no-op (see running-process-core mod.rs:730-737).

--- a/crates/clud-bin/tests/pty_pump.rs
+++ b/crates/clud-bin/tests/pty_pump.rs
@@ -14,7 +14,7 @@ use std::io::Cursor;
 use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
-use running_process_core::pty::NativePtyProcess;
+use running_process::pty::NativePtyProcess;
 
 mod common;
 use common::{drain_reader, mock_agent_path};

--- a/tests/integration/test_daemon_cleanup.py
+++ b/tests/integration/test_daemon_cleanup.py
@@ -286,6 +286,10 @@ class TestDaemonSessionHardening:
         finally:
             kill_daemon_for_session(state_dir, session_id)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Regression on Windows after running-process 4.0.x migration — see zackees/clud#160",
+    )
     def test_named_session_shows_in_list(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
     ) -> None:

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -492,6 +492,10 @@ class TestLoopMode:
 class TestInterruptReporting:
     """Verify Ctrl+C reports how clud was launched."""
 
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="Regression on Linux after running-process 4.0.x migration — see zackees/clud#159",
+    )
     def test_ctrl_c_reports_pty_mode_when_forced(
         self, clud_binary: Path, mock_env: dict[str, str]
     ) -> None:


### PR DESCRIPTION
Closes #157. Refs zackees/running-process#203. See https://github.com/zackees/running-process/blob/main/CHANGELOG.md#400--mono-crate-consolidation. 4.0.0 had pub(crate) on the new backend traits which broke `handles.master.resize()` — fixed in 4.0.1 (zackees/running-process#204). All 582 clud tests pass locally.