### PR TITLE
Speed up CI with setup-soldr shims

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -36,10 +36,7 @@ jobs:
       # killed in Cargo.toml [profile.dev]/[profile.release].
       CFLAGS: "-g0"
       CXXFLAGS: "-g0"
-      # Future-proof: when cargo is routed through soldr (issue #285) this
-      # picks mold on Linux / lld elsewhere. No-op for the current direct-
-      # cargo path; mold is also forced via RUSTFLAGS below on Linux.
-      SOLDR_LINKER: "fast"
+      CLUD_USE_SOLDR_SHIMS: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -60,20 +57,6 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      # Issue #68: replace dtolnay/rust-toolchain + mozilla-actions/sccache-action
-      # + Swatinem/rust-cache with setup-soldr. soldr pins the MSVC toolchain on
-      # Windows (issue #27) and owns build + target caching for every platform.
-      # Pinned SHA: floating `v0` regressed to a Node20 rewrite that fails
-      # to honor `components` from `rust-toolchain.toml`. See
-      # zackees/setup-soldr#76.
-      - name: Setup soldr
-        uses: zackees/setup-soldr@8bc6da394b8ad370654826a0b3d8f5e3615d10d6 # v0 (pre-Node20-rewrite)
-        with:
-          toolchain: "1.94.1"
-          version: "0.7.11"
-          cache: true
-          build-cache-mode: thin
-
       - name: Install mold linker (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -81,9 +64,24 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends mold
-          # Force mold even when cargo isn't routed through soldr. Halves
-          # peak linker RSS vs. BFD/gold on clud's release link.
-          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS:-}" >> "$GITHUB_ENV"
+
+      # Issue #68: setup-soldr owns Rust provisioning plus build/target caching.
+      # Shims keep every cargo entry point, including maturin-spawned cargo,
+      # routed through soldr/zccache. Install mold before setup so dependency
+      # cooking and the real build see the same `linker: fast` environment.
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: "1.94.1"
+          version: "0.7.32"
+          cache: true
+          build-cache-mode: thin
+          shims: true
+          linker: ${{ runner.os == 'macOS' && 'platform-default' || 'fast' }}
+          preserve-source-mtimes: true
+          solo-toolchain-cache: true
+          prebuild-deps: cargo-chef
+          prebuild-deps-flags: ${{ inputs.build-mode == 'release' && '--release --workspace' || '--workspace' }}
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -6,6 +6,10 @@ on:
       runs-on:
         required: true
         type: string
+      artifact-name:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   integration-test:
@@ -22,7 +26,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
       CFLAGS: "-g0"
       CXXFLAGS: "-g0"
-      SOLDR_LINKER: "fast"
+      CLUD_USE_SOLDR_SHIMS: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -43,21 +47,6 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
-      # `build-cache-mode: thin` avoids the setup-soldr#53 pitfall where the
-      # dev build + cargo test --no-run + cargo test pipeline shares one
-      # target dir.
-      # Pinned SHA: floating `v0` regressed to a Node20 rewrite that fails
-      # to honor `components` from `rust-toolchain.toml`. See
-      # zackees/setup-soldr#76.
-      - name: Setup soldr
-        uses: zackees/setup-soldr@8bc6da394b8ad370654826a0b3d8f5e3615d10d6 # v0 (pre-Node20-rewrite)
-        with:
-          toolchain: "1.94.1"
-          version: "0.7.11"
-          cache: true
-          build-cache-mode: thin
-
       - name: Install mold linker (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -65,7 +54,24 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends mold
-          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS:-}" >> "$GITHUB_ENV"
+
+      # Issue #68: setup-soldr owns Rust provisioning plus build/target caching.
+      # Shims keep the dev wheel build and integration helper cargo build
+      # routed through soldr/zccache. Install mold before setup so dependency
+      # cooking and the dev wheel build share the same linker fingerprint.
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: "1.94.1"
+          version: "0.7.32"
+          cache: true
+          build-cache-mode: thin
+          shims: true
+          linker: ${{ runner.os == 'macOS' && 'platform-default' || 'fast' }}
+          preserve-source-mtimes: true
+          solo-toolchain-cache: true
+          prebuild-deps: cargo-chef
+          prebuild-deps-flags: "--workspace"
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
@@ -87,6 +93,18 @@ jobs:
             ulimit -v 13000000
           fi
           uv run --no-editable -m ci.test --integration
+
+      - name: Verify Windows wheel has no MinGW runtime imports
+        if: ${{ runner.os == 'Windows' }}
+        run: uv run python -m ci.check_windows_wheel --dist-dir dist/
+
+      - name: Upload dist artifacts
+        if: ${{ inputs.artifact-name != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: dist/*
+          if-no-files-found: error
 
       - name: Diagnose Linux build failure
         if: ${{ failure() && runner.os == 'Linux' }}

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -21,7 +21,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
       CFLAGS: "-g0"
       CXXFLAGS: "-g0"
-      SOLDR_LINKER: "fast"
+      CLUD_USE_SOLDR_SHIMS: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -42,20 +42,6 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
-      # Pinned to a specific SHA because the floating `v0` tag moved to a
-      # Node20 TypeScript port that fails to read `components` from
-      # `rust-toolchain.toml`, leaving the toolchain without rustfmt/clippy
-      # and causing `cargo fmt --check` to fail with "'cargo-fmt' is not
-      # installed for the toolchain". See zackees/setup-soldr#76.
-      - name: Setup soldr
-        uses: zackees/setup-soldr@8bc6da394b8ad370654826a0b3d8f5e3615d10d6 # v0 (pre-Node20-rewrite)
-        with:
-          toolchain: "1.94.1"
-          version: "0.7.11"
-          cache: true
-          build-cache-mode: thin
-
       - name: Install mold linker (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -63,7 +49,24 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends mold
-          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS:-}" >> "$GITHUB_ENV"
+
+      # Issue #68: setup-soldr owns Rust provisioning plus build/target caching.
+      # Shims keep cargo fmt, clippy-driver, and all cargo subcommands routed
+      # through soldr/zccache. Install mold before setup so dependency cooking
+      # and clippy share the same linker fingerprint.
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: "1.94.1"
+          version: "0.7.32"
+          cache: true
+          build-cache-mode: thin
+          shims: true
+          linker: ${{ runner.os == 'macOS' && 'platform-default' || 'fast' }}
+          preserve-source-mtimes: true
+          solo-toolchain-cache: true
+          prebuild-deps: cargo-chef
+          prebuild-deps-flags: "--workspace"
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -21,7 +21,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
       CFLAGS: "-g0"
       CXXFLAGS: "-g0"
-      SOLDR_LINKER: "fast"
+      CLUD_USE_SOLDR_SHIMS: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -42,21 +42,6 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      # Issue #68: replace the dtolnay + sccache + rust-cache stack with soldr.
-      # `build-cache-mode: thin` avoids the setup-soldr#53 pitfall where
-      # ci/test.py's back-to-back cargo build / cargo test --no-run / cargo
-      # test invocations share a single target dir.
-      # Pinned SHA: floating `v0` regressed to a Node20 rewrite that fails
-      # to honor `components` from `rust-toolchain.toml`. See
-      # zackees/setup-soldr#76.
-      - name: Setup soldr
-        uses: zackees/setup-soldr@8bc6da394b8ad370654826a0b3d8f5e3615d10d6 # v0 (pre-Node20-rewrite)
-        with:
-          toolchain: "1.94.1"
-          version: "0.7.11"
-          cache: true
-          build-cache-mode: thin
-
       - name: Install mold linker (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -64,19 +49,36 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends mold
-          echo "RUSTFLAGS=-C link-arg=-fuse-ld=mold ${RUSTFLAGS:-}" >> "$GITHUB_ENV"
+
+      # Issue #68: setup-soldr owns Rust provisioning plus build/target caching.
+      # Shims keep ci/test.py's back-to-back cargo build / cargo test --no-run /
+      # cargo test invocations routed through soldr/zccache. Install mold before
+      # setup so dependency cooking and tests share the same linker fingerprint.
+      - name: Setup soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          toolchain: "1.94.1"
+          version: "0.7.32"
+          cache: true
+          build-cache-mode: thin
+          shims: true
+          linker: ${{ runner.os == 'macOS' && 'platform-default' || 'fast' }}
+          preserve-source-mtimes: true
+          solo-toolchain-cache: true
+          prebuild-deps: cargo-chef
+          prebuild-deps-flags: "--workspace"
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
-      - name: Dev build
+      - name: Lint
         shell: bash
         run: |
           set -euo pipefail
           if [ "${RUNNER_OS}" = "Linux" ]; then
             ulimit -v 13000000
           fi
-          uv run --no-editable -m ci.build_wheel --dev
+          uv run --no-editable -m ci.lint
 
       - name: Unit Tests
         shell: bash

--- a/.github/workflows/linux-arm-build.yml
+++ b/.github/workflows/linux-arm-build.yml
@@ -1,8 +1,5 @@
 name: Linux ARM Build
 on:
-  push:
-    branches:
-      - "**"
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/linux-arm-integration-test.yml
+++ b/.github/workflows/linux-arm-integration-test.yml
@@ -1,8 +1,12 @@
 name: Linux ARM Integration Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml
     with:
       runs-on: ubuntu-24.04-arm
+      artifact-name: wheels-linux-arm

--- a/.github/workflows/linux-arm-lint.yml
+++ b/.github/workflows/linux-arm-lint.yml
@@ -1,6 +1,6 @@
 name: Linux ARM Lint
 on:
-  push:
+  workflow_dispatch:
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/linux-arm-unit-test.yml
+++ b/.github/workflows/linux-arm-unit-test.yml
@@ -1,6 +1,9 @@
 name: Linux ARM Unit Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/linux-x86-build.yml
+++ b/.github/workflows/linux-x86-build.yml
@@ -1,8 +1,5 @@
 name: Linux x86 Build
 on:
-  push:
-    branches:
-      - "**"
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/linux-x86-integration-test.yml
+++ b/.github/workflows/linux-x86-integration-test.yml
@@ -1,8 +1,12 @@
 name: Linux x86 Integration Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml
     with:
       runs-on: ubuntu-24.04
+      artifact-name: wheels-linux-x86

--- a/.github/workflows/linux-x86-lint.yml
+++ b/.github/workflows/linux-x86-lint.yml
@@ -1,6 +1,6 @@
 name: Linux x86 Lint
 on:
-  push:
+  workflow_dispatch:
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/linux-x86-unit-test.yml
+++ b/.github/workflows/linux-x86-unit-test.yml
@@ -1,6 +1,9 @@
 name: Linux x86 Unit Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/macos-arm-build.yml
+++ b/.github/workflows/macos-arm-build.yml
@@ -1,8 +1,5 @@
 name: macOS ARM Build
 on:
-  push:
-    branches:
-      - "**"
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/macos-arm-integration-test.yml
+++ b/.github/workflows/macos-arm-integration-test.yml
@@ -1,8 +1,12 @@
 name: macOS ARM Integration Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml
     with:
       runs-on: macos-15
+      artifact-name: wheels-macos-arm

--- a/.github/workflows/macos-arm-lint.yml
+++ b/.github/workflows/macos-arm-lint.yml
@@ -1,6 +1,6 @@
 name: macOS ARM Lint
 on:
-  push:
+  workflow_dispatch:
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/macos-arm-unit-test.yml
+++ b/.github/workflows/macos-arm-unit-test.yml
@@ -1,6 +1,9 @@
 name: macOS ARM Unit Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/macos-x86-build.yml
+++ b/.github/workflows/macos-x86-build.yml
@@ -1,8 +1,5 @@
 name: macOS x86 Build
 on:
-  push:
-    branches:
-      - "**"
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/macos-x86-integration-test.yml
+++ b/.github/workflows/macos-x86-integration-test.yml
@@ -1,8 +1,12 @@
 name: macOS x86 Integration Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml
     with:
       runs-on: macos-15-intel
+      artifact-name: wheels-macos-x86

--- a/.github/workflows/macos-x86-lint.yml
+++ b/.github/workflows/macos-x86-lint.yml
@@ -1,6 +1,6 @@
 name: macOS x86 Lint
 on:
-  push:
+  workflow_dispatch:
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/macos-x86-unit-test.yml
+++ b/.github/workflows/macos-x86-unit-test.yml
@@ -1,6 +1,9 @@
 name: macOS x86 Unit Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/windows-arm-build.yml
+++ b/.github/workflows/windows-arm-build.yml
@@ -1,8 +1,5 @@
 name: Windows ARM Build
 on:
-  push:
-    branches:
-      - "**"
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/windows-arm-integration-test.yml
+++ b/.github/workflows/windows-arm-integration-test.yml
@@ -1,8 +1,12 @@
 name: Windows ARM Integration Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml
     with:
       runs-on: windows-11-arm
+      artifact-name: wheels-windows-arm

--- a/.github/workflows/windows-arm-lint.yml
+++ b/.github/workflows/windows-arm-lint.yml
@@ -1,6 +1,6 @@
 name: Windows ARM Lint
 on:
-  push:
+  workflow_dispatch:
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/windows-arm-unit-test.yml
+++ b/.github/workflows/windows-arm-unit-test.yml
@@ -1,6 +1,9 @@
 name: Windows ARM Unit Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/.github/workflows/windows-x86-build.yml
+++ b/.github/workflows/windows-x86-build.yml
@@ -1,8 +1,5 @@
 name: Windows x86 Build
 on:
-  push:
-    branches:
-      - "**"
   workflow_dispatch:
     inputs:
       build-mode:

--- a/.github/workflows/windows-x86-integration-test.yml
+++ b/.github/workflows/windows-x86-integration-test.yml
@@ -1,8 +1,12 @@
 name: Windows x86 Integration Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_integration-test.yml
     with:
       runs-on: windows-2025
+      artifact-name: wheels-windows-x86

--- a/.github/workflows/windows-x86-lint.yml
+++ b/.github/workflows/windows-x86-lint.yml
@@ -1,6 +1,6 @@
 name: Windows x86 Lint
 on:
-  push:
+  workflow_dispatch:
 jobs:
   call:
     uses: ./.github/workflows/_lint.yml

--- a/.github/workflows/windows-x86-unit-test.yml
+++ b/.github/workflows/windows-x86-unit-test.yml
@@ -1,6 +1,9 @@
 name: Windows x86 Unit Test
 on:
   push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   call:
     uses: ./.github/workflows/_unit-test.yml

--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -36,10 +36,10 @@ def build_command(mode: BuildMode, env: dict[str, str] | None = None) -> list[st
             subcommand.extend(["--zig", "--compatibility", "manylinux2014"])
         else:
             subcommand.extend(["--compatibility", "pypi"])
-    # Use the dev-venv maturin via `python -m maturin`. The MSVC rustup-toolchain
-    # pin from issue #27 is preserved by `_windows_build_env` exporting CARGO/
-    # RUSTC/RUSTUP_TOOLCHAIN; routing maturin itself through soldr fails on
-    # Linux because PyO3/maturin only publishes musl Linux release assets.
+    # Use the dev-venv maturin via `python -m maturin`. setup-soldr shims keep
+    # maturin-spawned cargo in the soldr/zccache path; routing maturin itself
+    # through soldr fails on Linux because PyO3/maturin only publishes musl
+    # Linux release assets.
     return maturin_argv(subcommand, env=env)
 
 

--- a/ci/env.py
+++ b/ci/env.py
@@ -101,6 +101,36 @@ def toolchain_bin() -> Path:
     return rustup_home() / "toolchains" / toolchain_name() / "bin"
 
 
+def _env_flag_enabled(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _path_is_within(path: str | Path, directory: str | Path) -> bool:
+    try:
+        path_norm = os.path.normcase(os.path.abspath(str(path)))
+        directory_norm = os.path.normcase(os.path.abspath(str(directory)))
+        return os.path.commonpath([path_norm, directory_norm]) == directory_norm
+    except ValueError:
+        return False
+
+
+def _soldr_shims_requested(env: dict[str, str] | None = None) -> bool:
+    source = os.environ if env is None else env
+    if _env_flag_enabled(source.get("CLUD_USE_SOLDR_SHIMS")):
+        return True
+
+    path = source.get("PATH")
+    if path is None:
+        return False
+    cargo = shutil.which("cargo", path=path)
+    shims_dir = source.get("SOLDR_SHIMS_DIR")
+    if cargo and shims_dir and _path_is_within(cargo, shims_dir):
+        return True
+
+    soldr = shutil.which("soldr", path=path)
+    return bool(cargo and soldr and Path(cargo).parent.name.lower() == "shims")
+
+
 def _find_vswhere() -> Path | None:
     candidates = [
         Path(r"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"),
@@ -143,14 +173,16 @@ def _find_vsdevcmd() -> Path | None:
 def _windows_build_env() -> dict[str, str]:
     env = os.environ.copy()
     toolchain_bin_dir = toolchain_bin()
+    use_soldr_shims = _soldr_shims_requested(env)
     if toolchain_bin_dir.is_dir():
-        env["PATH"] = str(toolchain_bin_dir) + os.pathsep + env.get("PATH", "")
-        cargo_exe = toolchain_bin_dir / "cargo.exe"
-        rustc_exe = toolchain_bin_dir / "rustc.exe"
-        if cargo_exe.is_file():
-            env["CARGO"] = str(cargo_exe)
-        if rustc_exe.is_file():
-            env["RUSTC"] = str(rustc_exe)
+        if not use_soldr_shims:
+            env["PATH"] = str(toolchain_bin_dir) + os.pathsep + env.get("PATH", "")
+            cargo_exe = toolchain_bin_dir / "cargo.exe"
+            rustc_exe = toolchain_bin_dir / "rustc.exe"
+            if cargo_exe.is_file():
+                env["CARGO"] = str(cargo_exe)
+            if rustc_exe.is_file():
+                env["RUSTC"] = str(rustc_exe)
         env["RUSTUP_TOOLCHAIN"] = toolchain_name()
         env["CARGO_BUILD_TARGET"] = host_target_triple()
 
@@ -204,6 +236,15 @@ def activate() -> None:
     normalized_parts = {
         os.path.normcase(os.path.normpath(part)) for part in path_parts if part
     }
+    if _soldr_shims_requested(os.environ):
+        filtered_parts = [
+            part
+            for part in path_parts
+            if os.path.normcase(os.path.normpath(part)) != normalized_cargo_bin
+        ]
+        filtered_parts.append(str(bin_dir))
+        os.environ["PATH"] = os.pathsep.join(filtered_parts)
+        return
     if normalized_cargo_bin in normalized_parts:
         return
     os.environ["PATH"] = (
@@ -212,6 +253,8 @@ def activate() -> None:
 
 
 def _apply_sccache(env: dict[str, str]) -> dict[str, str]:
+    if _soldr_shims_requested(env):
+        return env
     if env.get("RUSTC_WRAPPER"):
         return env
     sccache = shutil.which("sccache", path=env.get("PATH"))
@@ -230,6 +273,10 @@ def clean_env() -> dict[str, str]:
         env.pop("VIRTUAL_ENV", None)
         env.setdefault("PYTHONUTF8", "1")
     env.setdefault("RUSTUP_TOOLCHAIN", toolchain_name())
+    if _soldr_shims_requested(env):
+        env.pop("CARGO", None)
+        env.pop("RUSTC", None)
+        env.pop("RUSTC_WRAPPER", None)
     env = _apply_sccache(env)
     return env
 
@@ -241,10 +288,9 @@ def build_env() -> dict[str, str]:
 def soldr_path(env: dict[str, str] | None = None) -> str | None:
     """Return the path to the soldr binary, or None if not available.
 
-    This remains for legacy callers and tests that need to discover the
-    optional soldr helper. CI cargo/maturin invocations use the explicit
-    tool paths and environment from this module rather than routing through
-    soldr by default.
+    This remains for callers and tests that need to discover the optional
+    soldr helper. CI routes cargo through setup-soldr's PATH shims when
+    CLUD_USE_SOLDR_SHIMS is enabled.
     """
     path = None if env is None else env.get("PATH")
     return shutil.which("soldr", path=path)
@@ -253,15 +299,12 @@ def soldr_path(env: dict[str, str] | None = None) -> str | None:
 def cargo_argv(subcommand: list[str], env: dict[str, str] | None = None) -> list[str]:
     """Return the cargo argv for CI and local helper scripts.
 
-    Explicit `CARGO` wins because Windows build_env() pins it to the MSVC
-    rustup toolchain. Otherwise use bare `cargo`: setup-soldr still installs
-    the requested toolchain and restores the target cache, while routing
-    through `soldr cargo` starts zccache. In PR #114 CI, that zccache layer
-    exited early on Linux x86 integration and was killed with 137 on Linux ARM
-    lint, so cargo itself is the stable execution path.
+    When setup-soldr shims are enabled, use bare `cargo` so PATH resolves to
+    the shim and maturin/cargo subcommands go through soldr/zccache. Otherwise
+    explicit `CARGO` still wins for local and non-soldr CI environments.
     """
     cargo = None if env is None else env.get("CARGO")
-    if cargo:
+    if cargo and not _soldr_shims_requested(env):
         return [cargo, *subcommand]
 
     return ["cargo", *subcommand]
@@ -280,13 +323,12 @@ def maturin_argv(subcommand: list[str], env: dict[str, str] | None = None) -> li
     fire here), producing `tool not found: no asset matches target
     x86_64-unknown-linux-gnu` and breaking every Linux Build job.
 
-    maturin is already pinned in pyproject.toml dev deps and installed
-    into the uv-managed venv on every runner, so `python -m maturin`
-    works uniformly across platforms without any GitHub-Releases lookup.
-    The Windows MSVC pin from issue #27 is preserved through the cargo
-    side: `_windows_build_env` exports `CARGO`/`RUSTC`/`RUSTUP_TOOLCHAIN`
-    + prepends the MSVC toolchain bin to PATH, so when this maturin
-    invocation spawns cargo it picks up the same MSVC toolchain that
-    `soldr cargo` would have given it.
+    maturin is already pinned in pyproject.toml dev deps and installed into
+    the uv-managed venv on every runner, so `python -m maturin` works uniformly
+    across platforms without any GitHub-Releases lookup. In CI, setup-soldr's
+    cargo shim remains first on PATH and `clean_env()` removes explicit
+    CARGO/RUSTC/RUSTC_WRAPPER overrides, so the cargo process spawned by
+    maturin still goes through soldr/zccache. The Windows MSVC pin is
+    preserved with RUSTUP_TOOLCHAIN and CARGO_BUILD_TARGET.
     """
     return [sys.executable, "-m", "maturin", *subcommand]

--- a/ci/test.py
+++ b/ci/test.py
@@ -1,4 +1,8 @@
-"""Test orchestrator for clud: cargo test + pytest."""
+"""Test orchestrator for clud: cargo test + pytest.
+
+Default mode runs unit coverage. `--integration` runs only integration tests;
+`--full` runs both.
+"""
 
 from __future__ import annotations
 
@@ -13,68 +17,136 @@ ROOT = Path(__file__).resolve().parent.parent
 _PYTEST_NO_TESTS_COLLECTED = 5
 
 
+def _select_suites(argv: list[str]) -> tuple[bool, bool, list[str]]:
+    full = "--full" in argv
+    integration = "--integration" in argv or full
+    unit = not integration or full
+    pytest_args = [a for a in argv if a not in ("--integration", "--full")]
+    return unit, integration, pytest_args
+
+
 def _pytest_ok(returncode: int) -> bool:
     return returncode in (0, _PYTEST_NO_TESTS_COLLECTED)
 
 
-def run(cmd: list[str]) -> int:
+def run(cmd: list[str], *, env: dict[str, str] | None = None) -> int:
     from ci.env import clean_env
 
-    return subprocess.run(cmd, cwd=ROOT, env=clean_env()).returncode
+    return subprocess.run(cmd, cwd=ROOT, env=env if env is not None else clean_env()).returncode
 
 
-def _cargo(subcommand: list[str]) -> list[str]:
+def _cargo(subcommand: list[str], *, env: dict[str, str] | None = None) -> list[str]:
     """Return the cargo argv for the configured CI environment."""
     from ci.env import cargo_argv, clean_env
 
-    return cargo_argv(subcommand, env=clean_env())
+    return cargo_argv(subcommand, env=env if env is not None else clean_env())
+
+
+def _binary_name(name: str) -> str:
+    return f"{name}.exe" if sys.platform == "win32" else name
+
+
+def _target_debug_dirs(env: dict[str, str]) -> list[Path]:
+    dirs: list[Path] = []
+    target = env.get("CARGO_BUILD_TARGET")
+    if target:
+        dirs.append(ROOT / "target" / target / "debug")
+    dirs.append(ROOT / "target" / "debug")
+    return dirs
+
+
+def _find_target_binary(name: str, env: dict[str, str]) -> Path | None:
+    binary = _binary_name(name)
+    for directory in _target_debug_dirs(env):
+        candidate = directory / binary
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _installed_clud_script() -> Path | None:
+    candidate = Path(sys.executable).parent / _binary_name("clud")
+    if candidate.is_file():
+        return candidate
+    return None
+
+
+def _prepare_pytest_binaries(
+    env: dict[str, str],
+    *,
+    prefer_installed_clud: bool,
+) -> dict[str, str] | None:
+    installed_clud = _installed_clud_script() if prefer_installed_clud else None
+    packages = ["mock-agent"] if installed_clud is not None else ["clud", "mock-agent"]
+    cmd = _cargo(["build", *[arg for package in packages for arg in ("-p", package)]], env=env)
+    if run(cmd, env=env) != 0:
+        return None
+
+    clud_binary = installed_clud or _find_target_binary("clud", env)
+    mock_agent_binary = _find_target_binary("mock-agent", env)
+    if clud_binary is None or mock_agent_binary is None:
+        missing = [
+            name
+            for name, binary in (
+                ("clud", clud_binary),
+                ("mock-agent", mock_agent_binary),
+            )
+            if binary is None
+        ]
+        print(f"missing built pytest binaries: {', '.join(missing)}", file=sys.stderr)
+        return None
+
+    pytest_env = env.copy()
+    pytest_env["CLUD_TEST_BINARY"] = str(clud_binary)
+    pytest_env["CLUD_TEST_MOCK_AGENT_BINARY"] = str(mock_agent_binary)
+    return pytest_env
 
 
 def main(argv: list[str] | None = None) -> int:
-    from ci.env import activate
+    from ci.env import activate, clean_env
 
     activate()
+    env = clean_env()
 
     argv = list(sys.argv[1:] if argv is None else argv)
-    run_integration = "--integration" in argv or "--full" in argv
-    pytest_args = [a for a in argv if a not in ("--integration", "--full")]
+    run_unit, run_integration, pytest_args = _select_suites(argv)
 
-    # Rust tests. The pty_behavior integration tests need the `mock-agent`
-    # binary on disk at `target/.../debug/mock-agent`, but `cargo test --no-run`
-    # only compiles test binaries, not workspace bins. Without an explicit
-    # pre-build the test falls back to a self-issued `cargo build -p mock-agent`
-    # whose `--message-format json` parsing has been seen to flake under
-    # sccache (issue: macos-x86 unit-test job, run 24694769083). Build the
-    # bin up front so the test path that needs it always finds it.
-    if run(_cargo(["build", "-p", "mock-agent"])) != 0:
+    # Rust and Python tests need workspace binaries on disk, but
+    # `cargo test --no-run` only compiles test binaries, not workspace bins.
+    # Build them once up front and pass their paths into pytest so module
+    # collection does not trigger extra cargo builds.
+    pytest_env = _prepare_pytest_binaries(
+        env,
+        prefer_installed_clud=run_integration and not run_unit,
+    )
+    if pytest_env is None:
         return 1
-    if run(_cargo(["test", "--workspace", "--no-run"])) != 0:
-        return 1
-    cargo_test = _cargo(["test", "--workspace"])
-    if sys.platform == "win32":
-        cargo_test += ["--", "--test-threads=1"]
-    if run(cargo_test) != 0:
-        return 1
+    if run_unit:
+        if run(_cargo(["test", "--workspace", "--no-run"], env=env), env=env) != 0:
+            return 1
+        cargo_test = _cargo(["test", "--workspace"], env=env)
+        if sys.platform == "win32":
+            cargo_test += ["--", "--test-threads=1"]
+        if run(cargo_test, env=env) != 0:
+            return 1
 
-    # Python unit tests (skip integration by default)
-    pytest_cmd = [sys.executable, "-m", "pytest", "-m", "not integration", *pytest_args]
-    if not _pytest_ok(run(pytest_cmd)):
-        return 1
+        # Python unit tests (skip integration by default)
+        pytest_cmd = [sys.executable, "-m", "pytest", "-m", "not integration", *pytest_args]
+        if not _pytest_ok(run(pytest_cmd, env=pytest_env)):
+            return 1
 
     # Integration tests (only when requested). `-v` prints each test name
     # before it runs so a hang in CI is pinned to the exact test rather than
     # appearing as silent dead air.
     if run_integration:
-        from ci.env import clean_env
-
-        env = clean_env()
-        env["CLUD_INTEGRATION_TESTS"] = "1"
+        int_env = pytest_env.copy()
+        int_env["CLUD_INTEGRATION_TESTS"] = "1"
         # Disable the Windows exe-unlock dance for every clud subprocess
         # spawned by tests. See #37: the rename+copy+GC pattern appears to
         # keep stdout/stderr pipe handles alive on Windows CI, which wedges
         # subprocess.run in a pipe-EOF wait. Tests don't need hot-reload
         # protection, so this is strictly safer for the test harness.
-        env["CLUD_NO_UNLOCK"] = "1"
+        int_env["CLUD_NO_UNLOCK"] = "1"
         int_cmd = [
             sys.executable,
             "-m",
@@ -84,7 +156,7 @@ def main(argv: list[str] | None = None) -> int:
             "-v",
             *pytest_args,
         ]
-        rc = subprocess.run(int_cmd, cwd=ROOT, env=env).returncode
+        rc = subprocess.run(int_cmd, cwd=ROOT, env=int_env).returncode
         if not _pytest_ok(rc):
             return 1
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,9 +26,9 @@ def _cargo_argv(subcommand: list[str]) -> list[str]:
     aren't present on stock Windows, so the resulting debug binary fails
     with STATUS_ENTRYPOINT_NOT_FOUND when launched as a subprocess.
 
-    `ci.env.build_env()` exports the rustup-managed MSVC cargo/rustc paths,
-    which link against VCRUNTIME140.dll / MSVCP140.dll. The `soldr` branch
-    below is only an emergency fallback if this file is run outside the repo.
+    `ci.env.build_env()` selects the rustup-managed MSVC toolchain, which
+    links against VCRUNTIME140.dll / MSVCP140.dll. The `soldr` branch below is
+    only an emergency fallback if this file is run outside the repo.
     """
     if sys.platform == "win32":
         try:
@@ -68,8 +68,9 @@ def _build_env_without_sccache() -> dict[str, str]:
     its whole idle lifetime — so `capture_output=True` never sees EOF and
     `communicate()` hangs indefinitely on Windows runners. Stripping the
     wrapper for the fixture's cargo call avoids the inheritance entirely.
-    The outer workflow's `Dev build` step already warmed the cache; this
-    fixture call is usually a no-op incremental build anyway. See #37.
+    The CI test orchestrator already builds the workspace binaries and passes
+    their paths through the environment; this fallback call is usually a local
+    no-op incremental build. See #37.
     """
     env = _cargo_build_env()
     env.pop("RUSTC_WRAPPER", None)
@@ -183,6 +184,12 @@ def _cargo_build_inherit_stdio(package: str) -> None:
 
 def _find_clud() -> Path:
     """Build the current repo's clud binary and return its path."""
+    env_binary = os.environ.get("CLUD_TEST_BINARY")
+    if env_binary:
+        candidate = Path(env_binary)
+        if candidate.is_file():
+            return candidate
+
     _cargo_build_inherit_stdio("clud")
     binary = _find_built_binary("clud")
     if binary is None:
@@ -192,6 +199,12 @@ def _find_clud() -> Path:
 
 def _build_mock_agent() -> Path:
     """Build the mock-agent binary and return its path."""
+    env_binary = os.environ.get("CLUD_TEST_MOCK_AGENT_BINARY")
+    if env_binary:
+        candidate = Path(env_binary)
+        if candidate.is_file():
+            return candidate
+
     _cargo_build_inherit_stdio("mock-agent")
     binary = _find_built_binary("mock-agent")
     if binary is None:

--- a/tests/test_ci_env.py
+++ b/tests/test_ci_env.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from ci import env as ci_env
 
 
@@ -12,6 +14,48 @@ def test_cargo_argv_prefers_explicit_cargo(monkeypatch) -> None:
         r"C:\rust\bin\cargo.exe",
         "check",
     ]
+
+
+def test_cargo_argv_uses_path_when_soldr_shims_requested() -> None:
+    assert ci_env.cargo_argv(
+        ["check"],
+        env={"CARGO": r"C:\rust\bin\cargo.exe", "CLUD_USE_SOLDR_SHIMS": "1"},
+    ) == ["cargo", "check"]
+
+
+def test_activate_preserves_soldr_shims_ahead_of_cargo_bin(monkeypatch, tmp_path) -> None:
+    cargo_home = tmp_path / "cargo"
+    cargo_bin = cargo_home / "bin"
+    cargo_bin.mkdir(parents=True)
+    shims_dir = tmp_path / "setup-soldr" / "shims"
+    shims_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("CARGO_HOME", str(cargo_home))
+    monkeypatch.setenv("CLUD_USE_SOLDR_SHIMS", "1")
+    monkeypatch.setenv("PATH", str(shims_dir))
+
+    ci_env.activate()
+
+    path_parts = os.environ["PATH"].split(os.pathsep)
+    assert path_parts[0] == str(shims_dir)
+    assert path_parts[-1] == str(cargo_bin)
+
+
+def test_activate_moves_existing_cargo_bin_behind_soldr_shims(monkeypatch, tmp_path) -> None:
+    cargo_home = tmp_path / "cargo"
+    cargo_bin = cargo_home / "bin"
+    cargo_bin.mkdir(parents=True)
+    shims_dir = tmp_path / "setup-soldr" / "shims"
+    shims_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("CARGO_HOME", str(cargo_home))
+    monkeypatch.setenv("CLUD_USE_SOLDR_SHIMS", "1")
+    monkeypatch.setenv("PATH", os.pathsep.join([str(cargo_bin), str(shims_dir)]))
+
+    ci_env.activate()
+
+    path_parts = os.environ["PATH"].split(os.pathsep)
+    assert path_parts == [str(shims_dir), str(cargo_bin)]
 
 
 def test_cargo_argv_uses_bare_cargo_when_no_explicit_cargo(monkeypatch) -> None:

--- a/tests/test_ci_test.py
+++ b/tests/test_ci_test.py
@@ -1,0 +1,76 @@
+"""Tests for CI test-suite selection."""
+
+from __future__ import annotations
+
+from ci import test as ci_test
+
+
+def test_select_suites_defaults_to_unit_only() -> None:
+    assert ci_test._select_suites([]) == (True, False, [])
+
+
+def test_select_suites_integration_is_integration_only() -> None:
+    assert ci_test._select_suites(["--integration", "-k", "daemon"]) == (
+        False,
+        True,
+        ["-k", "daemon"],
+    )
+
+
+def test_select_suites_full_runs_unit_and_integration() -> None:
+    assert ci_test._select_suites(["--full", "-x"]) == (True, True, ["-x"])
+
+
+def test_prepare_pytest_binaries_reuses_installed_clud(monkeypatch, tmp_path) -> None:
+    target_dir = tmp_path / "target" / "debug"
+    target_dir.mkdir(parents=True)
+    mock_agent = target_dir / ci_test._binary_name("mock-agent")
+    mock_agent.write_text("", encoding="utf-8")
+    installed_clud = tmp_path / ci_test._binary_name("clud")
+    installed_clud.write_text("", encoding="utf-8")
+    captured: list[list[str]] = []
+
+    monkeypatch.setattr(ci_test, "_installed_clud_script", lambda: installed_clud)
+    monkeypatch.setattr(ci_test, "ROOT", tmp_path)
+
+    def fake_run(cmd: list[str], *, env=None) -> int:
+        captured.append(cmd)
+        return 0
+
+    monkeypatch.setattr(ci_test, "run", fake_run)
+
+    env = ci_test._prepare_pytest_binaries({}, prefer_installed_clud=True)
+
+    assert env is not None
+    assert env["CLUD_TEST_BINARY"] == str(installed_clud)
+    assert env["CLUD_TEST_MOCK_AGENT_BINARY"] == str(mock_agent)
+    assert captured == [["cargo", "build", "-p", "mock-agent"]]
+
+
+def test_prepare_pytest_binaries_builds_clud_without_installed_script(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    target_dir = tmp_path / "target" / "debug"
+    target_dir.mkdir(parents=True)
+    clud = target_dir / ci_test._binary_name("clud")
+    mock_agent = target_dir / ci_test._binary_name("mock-agent")
+    clud.write_text("", encoding="utf-8")
+    mock_agent.write_text("", encoding="utf-8")
+    captured: list[list[str]] = []
+
+    monkeypatch.setattr(ci_test, "_installed_clud_script", lambda: None)
+    monkeypatch.setattr(ci_test, "ROOT", tmp_path)
+
+    def fake_run(cmd: list[str], *, env=None) -> int:
+        captured.append(cmd)
+        return 0
+
+    monkeypatch.setattr(ci_test, "run", fake_run)
+
+    env = ci_test._prepare_pytest_binaries({}, prefer_installed_clud=True)
+
+    assert env is not None
+    assert env["CLUD_TEST_BINARY"] == str(clud)
+    assert env["CLUD_TEST_MOCK_AGENT_BINARY"] == str(mock_agent)
+    assert captured == [["cargo", "build", "-p", "clud", "-p", "mock-agent"]]

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -53,6 +53,10 @@ def _cargo_argv(subcommand: list[str]) -> list[str]:
 
 def _clud_binary() -> str:
     """Build the current repo's clud binary and return its path."""
+    env_binary = os.environ.get("CLUD_TEST_BINARY")
+    if env_binary and Path(env_binary).is_file():
+        return env_binary
+
     result = subprocess.run(
         _cargo_argv(["build", "-p", "clud", "--message-format=json"]),
         cwd=ROOT,

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -9,6 +10,10 @@ from pathlib import Path
 
 def _clud_binary() -> str:
     """Find the clud binary in the venv."""
+    env_binary = os.environ.get("CLUD_TEST_BINARY")
+    if env_binary and Path(env_binary).is_file():
+        return env_binary
+
     venv = Path(sys.executable).parent
     if sys.platform == "win32":
         candidate = venv / "clud.exe"


### PR DESCRIPTION
## Summary
- switch CI templates to current `zackees/setup-soldr@v0` / soldr `0.7.32` with shims, source mtime preservation, solo toolchain cache, and cargo-chef dependency prebuilds
- merge lint into unit jobs and move wheel build/artifact upload into integration jobs so push CI no longer launches standalone build/lint jobs
- keep maturin on the uv-installed Python module while allowing maturin-spawned cargo to route through setup-soldr shims
- harden CI env setup so Windows explicit cargo/rustc pins do not bypass shims, and so `~/.cargo/bin` stays behind setup-soldr shims
- split `ci.test --integration` into integration-only mode and reuse the installed dev wheel for clud in integration tests
- guard macOS back to `linker: platform-default` while soldr#509 tracks `SOLDR_LINKER=fast` injecting `-fuse-ld=lld` on macOS

## Validation
- `actionlint` over all workflows
- `git diff --check`
- `python -m py_compile ci/test.py ci/env.py ci/build_wheel.py tests/test_hello.py tests/test_wasm.py tests/integration/conftest.py tests/test_ci_env.py tests/test_ci_test.py`
- `UV_LINK_MODE=copy uv run --no-editable -m ruff check ci/test.py ci/env.py ci/build_wheel.py tests/test_ci_env.py tests/test_ci_test.py tests/test_hello.py tests/test_wasm.py tests/integration/conftest.py`
- `UV_LINK_MODE=copy uv run --no-editable -m pytest tests/test_ci_env.py tests/test_ci_test.py`
- branch CI green on all 12 push workflows: https://github.com/zackees/clud/actions/runs/26373416236

## CI impact from branch run
- push workflow count: 24 -> 12
- summed job runtime: 184.6 min -> 133.7 min (-50.9 min, about 28% less runner time)
- slowest single job: 16:23 -> 16:04 in the sampled runs

Note: wall-clock for the branch run was 19:05 versus 16:29 on the sampled main run because some macOS/Windows jobs queued behind cancelled superseded attempts. The job durations still show the compute reduction.