### PR TITLE
fix(windows): real-keyboard Ctrl-C ignored in interactive PTY mode

### DIFF
--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -650,13 +650,33 @@ where
         // callback) — these are pre-normalized path bytes that should
         // bypass the bracketed-paste detector and go straight to the
         // PTY.
+        //
+        // The 0x03 byte check is required on Windows: when the
+        // `console_input` reader (issue #141 / PR #144) is active, it
+        // turns off `ENABLE_PROCESSED_INPUT` so the OS no longer fires
+        // a `CTRL_C_EVENT` for Ctrl-C. The press arrives instead as a
+        // KEY_EVENT whose translated 0x03 byte is delivered via this
+        // channel — without the check, clud forwards it to the child
+        // but never observes the interrupt itself.
         if let Some(ref rx) = extra_rx {
             if let Ok(chunk) = rx.try_recv() {
+                // Unlike stdin_rx, extra_rx is by construction always
+                // user-driven (keyboard via console_input_rx on Windows,
+                // or OLE drag-drop callback) — never a piped test
+                // fixture — so we don't need the `interrupt_on_ctrl_c_byte`
+                // gate that skips 0x03 detection on piped stdin.
+                let requested_interrupt = stdin_chunk_requests_interrupt(&chunk);
                 if let Err(err) = process.write_impl(&chunk, false) {
                     eprintln!(
                         "[clud] warning: failed to forward dropped paths to pty: {}",
                         err
                     );
+                }
+                if requested_interrupt {
+                    if verbose {
+                        verbose_log::log("[clud] pty pump: interrupt via extra_rx Ctrl+C byte");
+                    }
+                    return interrupt_pty_process(process, verbose);
                 }
             }
         }

--- a/crates/clud-bin/tests/pty_pump.rs
+++ b/crates/clud-bin/tests/pty_pump.rs
@@ -631,3 +631,73 @@ fn extra_rx_forwards_shift_enter_translated_bytes_to_pty() {
         got
     );
 }
+
+/// Regression: a Ctrl-C byte (0x03) arriving via `extra_rx` must trigger
+/// the pump's interrupt path. This is the path the Windows
+/// `console_input` reader uses when `ENABLE_PROCESSED_INPUT` is off and
+/// the OS no longer fires `CTRL_C_EVENT` — without this check clud
+/// would forward the byte to the child but never observe Ctrl-C itself,
+/// leaving users unable to exit (interactive PTY mode regression from
+/// PR #144 / commit a3ec8fe).
+///
+/// The test does NOT require Windows: it exercises the pump-level
+/// invariant on every platform, which is exactly what regressed.
+#[test]
+fn extra_rx_ctrl_c_byte_interrupts_pump() {
+    require_pty_or_skip!("extra_rx_ctrl_c_byte_interrupts_pump");
+
+    let agent = mock_agent_path();
+    // Keep the child alive longer than the test deadline so a returning
+    // pump must be the result of the interrupt path, not a natural exit.
+    let argv = vec![
+        agent.to_string_lossy().to_string(),
+        "--mock-sleep-ms".to_string(),
+        "10000".to_string(),
+    ];
+
+    let process = NativePtyProcess::new(argv, None, None, 24, 80, None).expect("new pty");
+    process.set_echo(false);
+    process.start_impl().expect("start");
+    std::thread::sleep(Duration::from_millis(150));
+
+    let (extra_tx, extra_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(100));
+        let _ = extra_tx.send(vec![0x03]);
+    });
+
+    let interrupted = AtomicBool::new(false);
+    let mut hooks = CountingHooks::new(false);
+
+    let start = Instant::now();
+    let exit = clud::session::run_raw_pty_pump_with_extra_rx(
+        &process,
+        &interrupted,
+        &mut hooks,
+        Cursor::new(Vec::<u8>::new()),
+        Some(extra_rx),
+    );
+    let elapsed = start.elapsed();
+
+    let _ = process.close_impl();
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "pump should return promptly after extra_rx Ctrl-C; took {:?}",
+        elapsed
+    );
+    // On Windows the contract is the clean 130 returned by
+    // `interrupt_pty_process` after `close_impl`. On POSIX the value
+    // is whatever the SIGINT-killed child reports through the PTY
+    // wait path, which is currently unreliable for an unrelated
+    // running-process 4.0.x regression (see zackees/clud#159). The
+    // load-bearing invariant for this fix is that the pump returned
+    // at all — without the fix it would block on the 10s child sleep.
+    if cfg!(windows) {
+        assert_eq!(
+            exit, 130,
+            "extra_rx Ctrl-C must yield SIGINT-convention exit code 130 on Windows; got {}",
+            exit
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Detect the 0x03 byte on the pump's `extra_rx` path so Ctrl-C from a real Windows keyboard interrupts the session again. Regression introduced by #144 (`ReadConsoleInputW` reader for Shift+Enter).
- Drop the `interrupt_on_ctrl_c_byte` gate on `extra_rx` — that gate exists to ignore 0x03 in piped test fixtures, and `extra_rx` is by construction always user-driven input (keyboard or OLE drag-drop), never a piped fixture.
- Add a cross-platform pump-level integration test that injects `[0x03]` via `extra_rx` against a 10s-sleeping child and asserts prompt return + exit code 130 on Windows.

Closes #169.

## Why the existing CI didn't catch it

`test_ctrl_c_reports_pty_mode_when_forced` sends `CTRL_BREAK_EVENT` via `subprocess.send_signal` — an OS-level signal that bypasses both `ENABLE_PROCESSED_INPUT` and the new `ReadConsoleInputW` reader. The new test exercises the actual keyboard-derived path that regressed.

## Test plan

- [x] `soldr cargo fmt --check`
- [x] `soldr cargo clippy -p clud --all-targets -- -D warnings`
- [x] `ruff check`
- [x] 567 lib unit tests pass
- [x] All 10 `pty_pump` integration tests pass, including the new `extra_rx_ctrl_c_byte_interrupts_pump`
- [x] Existing `extra_rx_forwards_shift_enter_translated_bytes_to_pty` still passes (no regression in PR #144's Shift+Enter feature)
- [ ] CI matrix green across the 6 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)