### PR TITLE
fix(windows): force UTF-8 codepage in cmd.exe subshells (#168)

### DIFF
--- a/crates/clud-bin/src/dnd/mod.rs
+++ b/crates/clud-bin/src/dnd/mod.rs
@@ -195,7 +195,12 @@ fn unescape_shell_spaces(s: &str) -> String {
             out.push(bytes[i]);
             i += 1;
         }
-        String::from_utf8(out).unwrap_or_default()
+        // Input is &str (valid UTF-8) and we only ever delete ASCII `\`
+        // bytes from `\ ` pairs, so `out` is guaranteed valid UTF-8 here.
+        // `from_utf8_lossy` keeps the contract obviously safe — strict
+        // `from_utf8` would otherwise need a `.expect` that nothing in
+        // the dnd flow could prove holds at a glance (issue #168 audit).
+        String::from_utf8_lossy(&out).into_owned()
     }
 }
 

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -60,17 +60,35 @@ fn merge_extra_rx(
 
 /// Build the child environment: inherit parent env + inject tracking vars.
 /// Deduplicates keys so we never pass the same var twice.
+///
+/// On Windows, also forces UTF-8 for any Python helper the agent shells
+/// out to (Codex / Claude tool scripts, MCP servers, install probes …)
+/// so output doesn't mojibake against the user's OEM codepage. Paired
+/// with the `chcp 65001` prefix in `subprocess::render_windows_batch_command`
+/// (issue #168). Node itself respects the console codepage and needs no
+/// dedicated env var.
 pub fn child_env() -> Vec<(String, String)> {
     let originator_key = running_process::ORIGINATOR_ENV_VAR;
 
+    let utf8_keys: &[&str] = if cfg!(windows) {
+        &["IN_CLUD", originator_key, "PYTHONIOENCODING", "PYTHONUTF8"]
+    } else {
+        &["IN_CLUD", originator_key]
+    };
+
     let mut env: Vec<(String, String)> = std::env::vars()
-        .filter(|(k, _)| k != "IN_CLUD" && k != originator_key)
+        .filter(|(k, _)| !utf8_keys.contains(&k.as_str()))
         .collect();
 
     env.push(("IN_CLUD".to_string(), "1".to_string()));
 
     let originator_value = format!("CLUD:{}", std::process::id());
     env.push((originator_key.to_string(), originator_value));
+
+    if cfg!(windows) {
+        env.push(("PYTHONIOENCODING".to_string(), "utf-8".to_string()));
+        env.push(("PYTHONUTF8".to_string(), "1".to_string()));
+    }
 
     env
 }
@@ -703,5 +721,27 @@ mod tests {
             "opus".to_string(),
         ];
         assert_eq!(display_verbose_command(&command), "claude --model opus");
+    }
+
+    /// Issue #168: Windows children get UTF-8 forced via Python env vars
+    /// so any Python helper the agent spawns emits and reads UTF-8.
+    /// IN_CLUD and ORIGINATOR vars must still be present, and PYTHONUTF8
+    /// must be exactly "1" (Python accepts 0/1 only).
+    #[cfg(windows)]
+    #[test]
+    fn child_env_sets_python_utf8_vars_on_windows() {
+        let env = child_env();
+        let lookup = |key: &str| -> Option<String> {
+            env.iter().find(|(k, _)| k == key).map(|(_, v)| v.clone())
+        };
+        assert_eq!(lookup("PYTHONIOENCODING").as_deref(), Some("utf-8"));
+        assert_eq!(lookup("PYTHONUTF8").as_deref(), Some("1"));
+        assert_eq!(lookup("IN_CLUD").as_deref(), Some("1"));
+        assert!(
+            lookup(running_process::ORIGINATOR_ENV_VAR).is_some(),
+            "ORIGINATOR var must still be set"
+        );
+        let pyio_count = env.iter().filter(|(k, _)| k == "PYTHONIOENCODING").count();
+        assert_eq!(pyio_count, 1, "PYTHONIOENCODING must appear exactly once");
     }
 }

--- a/crates/clud-bin/src/subprocess.rs
+++ b/crates/clud-bin/src/subprocess.rs
@@ -75,12 +75,24 @@ fn is_windows_batch_wrapper(program: Option<&str>) -> bool {
 ///   command line. Without `/S`, cmd applies a different "first-and-last
 ///   quote on the line" rule that breaks on paths with spaces.
 /// * `/C` runs the command and exits.
+///
+/// The rendered command is prefixed with `chcp 65001 > nul &` so the
+/// shim and its descendants run under codepage 65001 (UTF-8). Without
+/// this, cmd.exe inherits the user's OEM/ANSI codepage (CP437 / CP1252
+/// / CP932 / …) and any non-ASCII bytes written by Node-based agents
+/// (Claude, Codex) get mojibaked on the way out. `> nul` swallows the
+/// "Active code page: 65001" banner so the user's session stays clean.
+/// `&` (not `&&`) keeps the launch going even if a hardened
+/// configuration refuses the codepage switch — the worst case is then
+/// the same as before this change, not a hard failure (issue #168).
 #[cfg(windows)]
 fn render_windows_batch_command(argv: &[String]) -> String {
-    argv.iter()
+    let cmd = argv
+        .iter()
         .map(|arg| quote_for_cmd(arg))
         .collect::<Vec<_>>()
-        .join(" ")
+        .join(" ");
+    format!("chcp 65001 > nul & {cmd}")
 }
 
 /// Quote one argv token for cmd.exe.
@@ -142,12 +154,15 @@ mod tests {
     #[test]
     fn cmd_wrapper_with_no_args_routes_through_shell() {
         // Just the `.cmd` path with no extra args: the rendered command is
-        // simply the quoted exe path, which still has to go through cmd.exe.
+        // the UTF-8 codepage prefix followed by the quoted exe path.
         let spec =
             command_spec_for_subprocess(vec![r"C:\Users\me\AppData\Roaming\npm\codex.cmd".into()]);
         match spec {
             running_process::CommandSpec::Shell(command) => {
-                assert_eq!(command, r#""C:\Users\me\AppData\Roaming\npm\codex.cmd""#);
+                assert_eq!(
+                    command,
+                    r#"chcp 65001 > nul & "C:\Users\me\AppData\Roaming\npm\codex.cmd""#
+                );
             }
             other => panic!("expected Shell for .cmd wrapper, got {other:?}"),
         }
@@ -166,8 +181,29 @@ mod tests {
             other => panic!("expected Shell, got {other:?}"),
         };
         assert!(
-            rendered.starts_with(r#""C:\path with spaces\codex.cmd" "exec" "hello world""#),
+            rendered.contains(r#""C:\path with spaces\codex.cmd" "exec" "hello world""#),
             "spaces in exe path and arg must each be wrapped in quotes: {rendered}"
+        );
+    }
+
+    /// Issue #168: every cmd.exe wrapping must force codepage 65001 so
+    /// Node-based agents (Claude / Codex) emit and consume UTF-8 instead
+    /// of mojibaking under the user's OEM/ANSI codepage.
+    #[cfg(windows)]
+    #[test]
+    fn cmd_wrapper_prepends_utf8_codepage_switch() {
+        let spec = command_spec_for_subprocess(vec![
+            r"C:\Users\me\AppData\Roaming\npm\codex.cmd".into(),
+            "exec".into(),
+            "hello".into(),
+        ]);
+        let rendered = match spec {
+            running_process::CommandSpec::Shell(s) => s,
+            other => panic!("expected Shell, got {other:?}"),
+        };
+        assert!(
+            rendered.starts_with("chcp 65001 > nul & "),
+            "every cmd.exe shim must start with the UTF-8 codepage switch: {rendered}"
         );
     }
 

--- a/crates/clud-bin/tests/utf8_codepage.rs
+++ b/crates/clud-bin/tests/utf8_codepage.rs
@@ -1,0 +1,109 @@
+//! UTF-8 codepage round-trip for the Windows cmd.exe wrapper (issue #168).
+//!
+//! Real bug being pinned: on Windows the cmd.exe shim that wraps a `.cmd` /
+//! `.bat` agent runs under the user's OEM/ANSI codepage (CP437 in US-EN,
+//! CP1252 in WEU, CP932 / CP949 / CP936 / CP1251 elsewhere). Anything the
+//! shim's tree writes that isn't pure ASCII gets mojibaked on the way to
+//! clud's stdout capture. PR for this issue prepends `chcp 65001 > nul &`
+//! to the rendered command so the whole shim subtree runs under UTF-8.
+//!
+//! This test pins the codepage behavior end-to-end by:
+//!
+//! 1. Writing a UTF-8 byte string (CJK + emoji + accented Latin) to a tempfile.
+//! 2. Authoring a one-line `.cmd` file that `type`s that tempfile to stdout.
+//! 3. Routing the launch through `subprocess::command_spec_for_subprocess`,
+//!    which is the single decision point that owns the cmd.exe wrap.
+//! 4. Spawning the resulting `CommandSpec::Shell` via `NativeProcess`
+//!    with capture on, draining stdout, and asserting the captured
+//!    bytes equal the original UTF-8 payload (modulo a trailing CRLF
+//!    `type` may append).
+//!
+//! Windows-only because the cmd.exe wrap path is `#[cfg(windows)]` in
+//! `subprocess.rs`; POSIX never reaches it.
+
+#![cfg(windows)]
+
+use std::time::Duration;
+
+use clud::subprocess::command_spec_for_subprocess;
+use running_process::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
+
+/// The codepage prefix should let a `.cmd` shim emit non-ASCII UTF-8
+/// bytes that survive the round trip back through clud's capture.
+#[test]
+fn cmd_wrapper_round_trips_utf8_bytes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Mix of CJK, accented Latin, emoji — bytes that would mojibake under
+    // every common non-UTF-8 Windows codepage.
+    let payload: &[u8] = "你好 — café — 🦀".as_bytes();
+    let payload_path = tmp.path().join("payload.txt");
+    std::fs::write(&payload_path, payload).expect("write payload");
+
+    // `@type` echoes the file's bytes verbatim; `@echo off` keeps the
+    // shim from printing the command itself. The path is quoted so spaces
+    // in the tempdir don't break parsing.
+    let shim_path = tmp.path().join("emit.cmd");
+    let shim_body = format!("@echo off\r\n@type \"{}\"\r\n", payload_path.display());
+    std::fs::write(&shim_path, shim_body).expect("write shim");
+
+    // This is the seam under test: command_spec_for_subprocess is what
+    // injects the chcp 65001 prefix on Windows .cmd / .bat invocations.
+    let command = command_spec_for_subprocess(vec![shim_path.to_string_lossy().into_owned()]);
+    match &command {
+        running_process::CommandSpec::Shell(s) => {
+            assert!(
+                s.starts_with("chcp 65001 > nul & "),
+                "expected UTF-8 codepage prefix; got: {s}"
+            );
+        }
+        other => panic!("expected Shell variant for .cmd shim, got {other:?}"),
+    }
+
+    let process = NativeProcess::new(ProcessConfig {
+        command,
+        cwd: None,
+        env: None,
+        capture: true,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Null,
+        nice: None,
+    });
+    process.start().expect("start cmd shim");
+
+    let mut buf = Vec::<u8>::new();
+    loop {
+        match process.read_combined(Some(Duration::from_millis(100))) {
+            ReadStatus::Line(event) => {
+                buf.extend_from_slice(&event.line);
+                buf.push(b'\n');
+            }
+            ReadStatus::Timeout => {
+                if process.returncode().is_some() {
+                    break;
+                }
+            }
+            ReadStatus::Eof => break,
+        }
+    }
+    let exit = process
+        .wait(Some(Duration::from_secs(10)))
+        .expect("wait cmd shim");
+    assert_eq!(exit, 0, "cmd shim exited non-zero: {exit}");
+
+    // `type` may emit a trailing CRLF that ReadStatus::Line replaces with
+    // `\n`; trim trailing whitespace before comparison.
+    let captured = String::from_utf8_lossy(&buf).into_owned();
+    let trimmed = captured.trim_end_matches(['\r', '\n']);
+    let expected = std::str::from_utf8(payload).expect("payload is utf-8");
+    assert_eq!(
+        trimmed,
+        expected,
+        "UTF-8 bytes mojibaked through the cmd.exe wrapper. \
+         captured={trimmed:?} (len={}, raw_bytes={:?}); expected={expected:?}",
+        trimmed.len(),
+        buf
+    );
+}


### PR DESCRIPTION
Closes #168.

## Summary

- `subprocess::render_windows_batch_command` prepends `chcp 65001 > /dev/null &` to every cmd.exe shim invocation, so the shim and its descendants run under codepage 65001 (UTF-8). Without this, the shim inherits the user's OEM/ANSI codepage (CP437 / CP1252 / CP932 / CP949 / CP936 / CP1251 / …) and any non-ASCII UTF-8 bytes from Node-based agents (Claude, Codex) — CJK names, emoji, accented filenames, code-fence box drawing — get mojibaked on the way back through clud's stdout capture.
- `runner::child_env` injects `PYTHONIOENCODING=utf-8` + `PYTHONUTF8=1` on Windows so any Python helper the agent shells out to (MCP servers, install probes, Codex/Claude tool scripts) emits and reads UTF-8 too. Node respects the console codepage and needs no dedicated env var.
- `dnd::unescape_shell_spaces`: switch from `from_utf8(...).unwrap_or_default()` to `from_utf8_lossy(...).into_owned()`. The transform is infallible by construction, but the lossy form removes a footgun that could silently return an empty string.

## Why `&` and not `&&`

`&` runs the next command unconditionally; `&&` runs it only on success. If a hardened configuration refuses the codepage switch, `&` keeps the launch going — the worst case is the prior (pre-#168) behavior, never a hard failure.

## Audit summary (strict `from_utf8` callsites)

| Site | Status |
| --- | --- |
| `runner.rs::emit_rendered_line`, `capture.rs::snap`, `loop_spec.rs`, `daemon/commands.rs`, `worktrees.rs`, `dnd/dropfiles.rs`, `backend_bootstrap.rs::run_captured_command`, `voice/linux_capture.rs`, `wasm.rs` | Already `from_utf8_lossy` — primary capture surface |
| `session.rs::parse_f3_csi` (line 211) | Strict `from_utf8`, but `.ok()?` falls through on failure → caller treats as "not a recognized OSC". Safe by design. |
| `session.rs::emit_paste_block` (line 892) | Strict `from_utf8` with explicit `Err` arm that forwards bytes verbatim. Safe by design. |
| `backend_bootstrap.rs:619`, `session_tests.rs:255` | Test-only helpers; producers are clud's own UTF-8 constants. |
| `dnd/mod.rs:198` | Switched to lossy in this PR |
| `dnd/mod.rs:164` | Already lossy on the failure path |

## Test plan

- [x] `soldr cargo fmt --check`
- [x] `soldr cargo clippy -p clud --all-targets -- -D warnings`
- [x] `ruff check`
- [x] `soldr cargo test -p clud --lib` — 588 passed
  - includes new `subprocess::tests::cmd_wrapper_prepends_utf8_codepage_switch`
  - includes new `runner::tests::child_env_sets_python_utf8_vars_on_windows` (Windows-only)
- [x] `soldr cargo test -p clud --test utf8_codepage` — 1 passed (Windows end-to-end round-trip with CJK + emoji + accented Latin)
- [ ] CI matrix green across the 6 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)