### PR TITLE
test(daemon): re-enable named-session list test on Windows (closes #160)

### DIFF
--- a/tests/integration/test_daemon_cleanup.py
+++ b/tests/integration/test_daemon_cleanup.py
@@ -286,10 +286,6 @@ class TestDaemonSessionHardening:
         finally:
             kill_daemon_for_session(state_dir, session_id)
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="Regression on Windows after running-process 4.0.x migration — see zackees/clud#160",
-    )
     def test_named_session_shows_in_list(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- Removes the `skipif(sys.platform == 'win32')` from `test_named_session_shows_in_list` in `tests/integration/test_daemon_cleanup.py`.
- Issue #160 reported that this test failed on `windows-2025` after the running-process 4.0.1 migration (#158). Local repro on Windows now passes 5/5 against the current main + the running-process 4.0.2 bump from #162 + Windows-side fixes from #170 / #171.
- The full `TestDaemonSessionHardening` class (11 tests) also passes locally.

## Test plan

- [ ] CI windows-2025 integration job passes the re-enabled test.
- [ ] CI windows-11-arm integration job still passes (was previously green).
- [ ] No new flake on Linux/macOS for the same test (it was already running there).

Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)