### PR TITLE
feat: one-line cross-platform install scripts (closes #163)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -194,12 +194,26 @@ jobs:
           body: |
             ## Install
 
+            **macOS / Linux:**
+
             ```bash
-            pip install clud==${{ needs.preflight.outputs.version }}
+            curl -fsSL https://raw.githubusercontent.com/zackees/clud/main/install.sh | sh
             ```
+
+            **Windows (PowerShell):**
+
+            ```powershell
+            irm https://raw.githubusercontent.com/zackees/clud/main/install.ps1 | iex
+            ```
+
+            Pin this exact version with `CLUD_VERSION=${{ needs.preflight.outputs.version }}` (POSIX) or `$env:CLUD_VERSION = '${{ needs.preflight.outputs.version }}'` (PowerShell) before piping into `sh` / `iex`.
+
+            Already managing Python tools? Equivalent:
 
             ```bash
             uv tool install clud==${{ needs.preflight.outputs.version }}
+            pipx install clud==${{ needs.preflight.outputs.version }}
+            pip install clud==${{ needs.preflight.outputs.version }}
             ```
 
             Pre-built wheels for Linux (x86/ARM), Windows (x86/ARM), and macOS (x86/ARM) are attached below and available on PyPI.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,26 @@ The name `clud` is simply a shorter, easier-to-type version of `claude`.
 
 ## Installation
 
+**macOS / Linux**
+
 ```bash
-pip install clud
+curl -fsSL https://raw.githubusercontent.com/zackees/clud/main/install.sh | sh
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://raw.githubusercontent.com/zackees/clud/main/install.ps1 | iex
+```
+
+Both scripts install [`uv`](https://docs.astral.sh/uv) if needed, then `uv tool install clud`, and put `clud` on PATH for new shells. Pin a version with `CLUD_VERSION=2.0.11 curl ... | sh` (POSIX) or `$env:CLUD_VERSION = '2.0.11'; irm ... | iex` (PowerShell). Re-run to upgrade.
+
+Already have a Python package manager? Any of these works equivalently:
+
+```bash
+uv tool install clud   # recommended — isolated, fast
+pipx install clud      # equivalent if you already use pipx
+pip install clud       # plain pip; you must ensure the install bin dir is on PATH
 ```
 
 ## Usage

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,129 @@
+# One-line installer for clud — the fast Rust CLI for Claude Code and Codex.
+#
+#   irm https://raw.githubusercontent.com/zackees/clud/main/install.ps1 | iex
+#
+# What this does:
+#   1. Ensures `uv` (https://docs.astral.sh/uv) is installed (idempotent;
+#      bootstraps it via Astral's official one-line installer if missing).
+#   2. Runs `uv tool install clud[==VERSION]`, which drops the `clud.exe`
+#      executable into uv's tool bin directory.
+#   3. Adds uv's tool bin directory to the User PATH (HKCU\Environment)
+#      so new terminals find `clud` without manual intervention.
+#   4. Prints the exact `Set-Item Env:PATH` line for the current session.
+#
+# Environment:
+#   $env:CLUD_VERSION   Pin a specific clud version (e.g. "2.0.10"). Unset → latest.
+#   $env:CLUD_NO_PATH   Set to "1" to skip the User PATH mutation.
+#
+# Re-running this script upgrades or reinstalls cleanly
+# (`uv tool install --force`).
+#
+# This is the END-USER installer for clud. The repo's `./install` script
+# (no extension) is a DEVELOPER helper that installs `soldr` for building
+# clud from source — unrelated.
+
+#Requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+
+function Write-Info($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Warn($msg) { Write-Host "warn: $msg" -ForegroundColor Yellow }
+function Write-ErrLine($msg) { Write-Host "error: $msg" -ForegroundColor Red }
+
+function Test-Command($name) {
+    return [bool](Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+function Ensure-Uv {
+    if (Test-Command 'uv') { return }
+    Write-Info "uv not found — installing via https://astral.sh/uv/install.ps1"
+    # Astral's official one-line PowerShell installer. It lands uv.exe in
+    # %USERPROFILE%\.local\bin and adds that dir to the User PATH for new
+    # shells; we surface it on PATH for the CURRENT session below.
+    Invoke-RestMethod -Uri 'https://astral.sh/uv/install.ps1' | Invoke-Expression
+
+    foreach ($candidate in @(
+            (Join-Path $env:USERPROFILE '.local\bin'),
+            (Join-Path $env:USERPROFILE '.cargo\bin'))) {
+        if ((Test-Path $candidate) -and -not ($env:PATH -split ';' -contains $candidate)) {
+            $env:PATH = "$candidate;$env:PATH"
+        }
+    }
+    if (-not (Test-Command 'uv')) {
+        Write-ErrLine "uv install did not put uv.exe on PATH — open a new terminal and re-run, or install uv manually from https://docs.astral.sh/uv"
+        exit 1
+    }
+}
+
+function Install-Clud {
+    $spec = 'clud'
+    if ($env:CLUD_VERSION) {
+        $spec = "clud==$($env:CLUD_VERSION)"
+    }
+    Write-Info "installing $spec via uv tool"
+    # --force replaces any prior install cleanly so re-running this
+    # script upgrades or repairs without manual `uv tool uninstall`.
+    & uv tool install --force $spec
+    if ($LASTEXITCODE -ne 0) {
+        Write-ErrLine "uv tool install failed with exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
+}
+
+function Get-UvToolBinDir {
+    try {
+        $dir = (& uv tool dir --bin 2>$null | Out-String).Trim()
+        if ($LASTEXITCODE -eq 0 -and $dir) { return $dir }
+    } catch {}
+    return $null
+}
+
+function Add-UserPath($dir) {
+    # Idempotent User PATH mutation via the registry to avoid duplicate
+    # entries that setx + repeated runs would otherwise pile up.
+    $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    if (-not $userPath) { $userPath = '' }
+    $entries = $userPath -split ';' | Where-Object { $_ -ne '' }
+    if ($entries -contains $dir) { return $false }
+    $newPath = if ($userPath) { "$userPath;$dir" } else { $dir }
+    [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+    return $true
+}
+
+function Setup-Path {
+    $toolBin = Get-UvToolBinDir
+    if (-not $toolBin) {
+        Write-Warn "could not determine uv tool bin dir — skipping PATH setup"
+        return
+    }
+    if ($env:CLUD_NO_PATH -eq '1') {
+        Write-Info "CLUD_NO_PATH=1 — skipping User PATH update"
+        Write-Host ""
+        Write-Host "clud installed at: $toolBin\clud.exe"
+        Write-Host "Add this directory to your current shell with:"
+        Write-Host "  `$env:PATH = `"$toolBin;`$env:PATH`""
+        return
+    }
+    $added = Add-UserPath $toolBin
+    # Surface on PATH for the CURRENT session too, since registry-level
+    # changes don't apply to the running process.
+    if (-not ($env:PATH -split ';' -contains $toolBin)) {
+        $env:PATH = "$toolBin;$env:PATH"
+    }
+    Write-Host ""
+    if ($added) {
+        Write-Info "added $toolBin to User PATH — new terminals will find clud automatically"
+    } else {
+        Write-Info "$toolBin already on User PATH"
+    }
+    Write-Host "For the current session run:"
+    Write-Host "  `$env:PATH = `"$toolBin;`$env:PATH`""
+    Write-Host "Then verify with:  clud --version"
+}
+
+function Main {
+    Ensure-Uv
+    Install-Clud
+    Setup-Path
+}
+
+Main

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env sh
+# One-line installer for clud — the fast Rust CLI for Claude Code and Codex.
+#
+#   curl -fsSL https://raw.githubusercontent.com/zackees/clud/main/install.sh | sh
+#
+# What this does:
+#   1. Ensures `uv` (https://docs.astral.sh/uv) is installed (idempotent;
+#      bootstraps it via Astral's official one-line installer if missing).
+#   2. Runs `uv tool install clud[==VERSION]`, which drops the `clud`
+#      executable into uv's tool bin directory.
+#   3. Calls `uv tool update-shell` so the bin directory lands on PATH for
+#      future shells.
+#   4. Prints the explicit PATH line if your current shell needs reloading.
+#
+# Environment:
+#   CLUD_VERSION   Pin a specific clud version (e.g. CLUD_VERSION=2.0.10).
+#                  Unset → install latest.
+#   CLUD_NO_PATH   Set to skip `uv tool update-shell` (script still prints
+#                  the directory you'd need to add).
+#
+# Re-running this script upgrades or reinstalls cleanly (`uv tool install
+# --reinstall`).
+#
+# This is the END-USER installer for clud. The repo's `./install` script
+# (no extension) is a DEVELOPER helper that installs `soldr` for building
+# clud from source — unrelated.
+
+set -eu
+
+CLUD_VERSION="${CLUD_VERSION:-}"
+
+log() { printf '%s\n' "$*" >&2; }
+err() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        err "required command '$1' is not on PATH"
+    fi
+}
+
+ensure_uv() {
+    if command -v uv >/dev/null 2>&1; then
+        return 0
+    fi
+    log "uv not found — installing via https://astral.sh/uv/install.sh"
+    require_cmd curl
+    require_cmd sh
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # Astral's installer drops uv into ~/.local/bin (default) or
+    # $CARGO_HOME/bin — surface that on PATH for this shell so the
+    # subsequent `uv tool install` resolves.
+    for d in "$HOME/.local/bin" "$HOME/.cargo/bin"; do
+        case ":$PATH:" in
+            *":$d:"*) ;;
+            *) PATH="$d:$PATH"; export PATH ;;
+        esac
+    done
+    if ! command -v uv >/dev/null 2>&1; then
+        err "uv install did not put uv on PATH — open a new shell and re-run, or install uv manually from https://docs.astral.sh/uv"
+    fi
+}
+
+install_clud() {
+    spec="clud"
+    if [ -n "$CLUD_VERSION" ]; then
+        spec="clud==$CLUD_VERSION"
+    fi
+    log "installing $spec via uv tool"
+    # --force replaces any prior install cleanly so re-running this
+    # script upgrades or repairs without manual `uv tool uninstall`.
+    uv tool install --force "$spec"
+}
+
+setup_path() {
+    if [ -n "${CLUD_NO_PATH:-}" ]; then
+        log "CLUD_NO_PATH set — skipping shell PATH update"
+    else
+        # `uv tool update-shell` edits the user's shell profile to add
+        # uv's tool bin dir to PATH for future shells. It is idempotent.
+        if ! uv tool update-shell >/dev/null 2>&1; then
+            log "warning: 'uv tool update-shell' failed; you may need to add uv's tool bin dir to PATH manually"
+        fi
+    fi
+    # Resolve the bin dir uv used so we can tell the user the exact path.
+    tool_bin=""
+    if command -v uv >/dev/null 2>&1; then
+        tool_bin=$(uv tool dir --bin 2>/dev/null || true)
+    fi
+    if [ -n "$tool_bin" ]; then
+        case ":$PATH:" in
+            *":$tool_bin:"*)
+                log "clud is on PATH — try 'clud --version'"
+                ;;
+            *)
+                log ""
+                log "clud installed at: $tool_bin/clud"
+                log "Add this directory to your current shell with:"
+                log "  export PATH=\"$tool_bin:\$PATH\""
+                log "Future shells should pick it up automatically (uv tool update-shell)."
+                ;;
+        esac
+    fi
+}
+
+main() {
+    ensure_uv
+    install_clud
+    setup_path
+}
+
+main "$@"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,0 +1,144 @@
+"""Sanity checks for the user-facing install scripts (issue #163).
+
+Covers what the AC calls out:
+- URL construction (the install URL the script bootstraps points at uv
+  via the Astral domain, not an arbitrary third party).
+- Version pinning (CLUD_VERSION → ``clud==<ver>`` spec, otherwise plain
+  ``clud``).
+- PATH mutation logic (POSIX surfaces the tool dir; PowerShell mutates
+  the User-scope PATH idempotently).
+
+These are static-content tests because the scripts shell out to network
+installers we can't exercise inline. The point is to guard the contract
+that a copy/paste install line keeps working after refactors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SH = (ROOT / "install.sh").read_text(encoding="utf-8")
+PS1 = (ROOT / "install.ps1").read_text(encoding="utf-8")
+
+
+# ---- POSIX (install.sh) ---------------------------------------------------
+
+
+def test_sh_has_posix_shebang() -> None:
+    # `/usr/bin/env sh` keeps the script portable across distros where
+    # /bin/sh may be a dash → bash → ksh symlink.
+    assert SH.startswith("#!/usr/bin/env sh\n")
+
+
+def test_sh_bootstraps_uv_from_astral() -> None:
+    # The uv installer URL is the single network dependency. Pin it to
+    # the official Astral domain so a refactor can't redirect it through
+    # a malicious mirror.
+    assert "https://astral.sh/uv/install.sh" in SH
+
+
+def test_sh_supports_version_pin() -> None:
+    # Default (latest) install path.
+    assert 'spec="clud"' in SH
+    # CLUD_VERSION env var produces an `==` spec.
+    assert 'spec="clud==$CLUD_VERSION"' in SH
+    assert 'CLUD_VERSION="${CLUD_VERSION:-}"' in SH
+
+
+def test_sh_installs_via_uv_tool_with_force() -> None:
+    # --force makes re-running the script upgrade in place, which the
+    # issue's AC requires ("Re-running the installer upgrades or
+    # confirms the existing install without leaving duplicate PATH
+    # entries").
+    assert 'uv tool install --force "$spec"' in SH
+
+
+def test_sh_updates_shell_path() -> None:
+    # POSIX hand-off to uv's own shell-profile editor.
+    assert "uv tool update-shell" in SH
+
+
+def test_sh_has_clud_no_path_escape_hatch() -> None:
+    # Users in CI / containers should be able to skip the profile edit
+    # but still get clud installed.
+    assert 'CLUD_NO_PATH' in SH
+
+
+# ---- Windows (install.ps1) ------------------------------------------------
+
+
+def test_ps1_has_requires_directive() -> None:
+    # Pin a minimum PowerShell version so users hit a clear error rather
+    # than a parser failure on 2.x / nano server.
+    assert "#Requires -Version 5.1" in PS1
+
+
+def test_ps1_bootstraps_uv_from_astral() -> None:
+    assert "https://astral.sh/uv/install.ps1" in PS1
+
+
+def test_ps1_supports_version_pin() -> None:
+    # Default (latest) install path.
+    assert "$spec = 'clud'" in PS1
+    # CLUD_VERSION env var produces an `==` spec.
+    assert '"clud==$($env:CLUD_VERSION)"' in PS1
+
+
+def test_ps1_installs_via_uv_tool_with_force() -> None:
+    assert "uv tool install --force $spec" in PS1
+
+
+def test_ps1_path_mutation_is_idempotent() -> None:
+    # The User PATH update reads the existing entries, checks membership,
+    # and only writes when missing. Without this gate, every re-run
+    # would append the same dir, growing PATH unbounded.
+    assert "GetEnvironmentVariable('PATH', 'User')" in PS1
+    assert "if ($entries -contains $dir)" in PS1
+    assert "SetEnvironmentVariable('PATH', $newPath, 'User')" in PS1
+
+
+def test_ps1_has_clud_no_path_escape_hatch() -> None:
+    assert "CLUD_NO_PATH" in PS1
+
+
+# ---- Cross-script invariants ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("script", "label"),
+    [(SH, "install.sh"), (PS1, "install.ps1")],
+    ids=["install.sh", "install.ps1"],
+)
+def test_script_does_not_call_pipx_or_pip(script: str, label: str) -> None:
+    # Both AC-mandated installers route through uv, not pipx/pip, because
+    # uv's tool-install path has the most reliable cross-platform PATH
+    # behavior. If a future change adds a pipx/pip fallback, the test
+    # should be relaxed deliberately rather than slipping in unnoticed.
+    assert "pipx install" not in script, f"{label} unexpectedly calls pipx"
+    assert "pip install" not in script, f"{label} unexpectedly calls pip"
+
+
+@pytest.mark.parametrize(
+    ("script", "label"),
+    [(SH, "install.sh"), (PS1, "install.ps1")],
+    ids=["install.sh", "install.ps1"],
+)
+def test_script_references_only_official_uv_origin(script: str, label: str) -> None:
+    # Both scripts must source uv from astral.sh — nothing else. A bare
+    # `curl ... | sh` from an attacker-controlled host would be the most
+    # severe regression possible here, so make it loud if it changes.
+    import re
+
+    urls = re.findall(r"https?://[^\s'\")]+", script)
+    third_party = [
+        u
+        for u in urls
+        if u.startswith(("http://", "https://"))
+        and "astral.sh/uv/install" not in u
+        and "docs.astral.sh" not in u
+        and "raw.githubusercontent.com/zackees/clud" not in u
+    ]
+    assert not third_party, f"{label} references unexpected URLs: {third_party}"


### PR DESCRIPTION
## Summary

- Adds `install.sh` (POSIX) and `install.ps1` (Windows PowerShell) — copy/paste one-liners that bootstrap `uv` if needed, then `uv tool install --force clud[==VERSION]` so `clud` lands on PATH for new shells.
- `CLUD_VERSION` pins a release; `CLUD_NO_PATH=1` skips the PATH mutation for CI/container use.
- Re-running the script upgrades cleanly. Windows PATH update is idempotent (reads existing User PATH before appending; no duplicates).
- Distinct from the existing developer-only `./install` script (which installs `soldr` for building from source); both new scripts call this out in their header comments.
- README leads with the one-liners. The auto-release workflow body now includes both as well, alongside the underlying `uv tool` / `pipx` / `pip` alternatives.
- 16 static-content sanity checks (`tests/test_install_scripts.py`) guard the URL, version pinning, and PATH mutation logic.

## Test plan

- [ ] `tests/test_install_scripts.py` passes on Linux/Windows/macOS CI (16 tests, all static — no network).
- [ ] Manual smoke on a clean Windows VM: `irm https://raw.githubusercontent.com/zackees/clud/feat/issue-163-install-scripts/install.ps1 | iex` then `clud --version` from a NEW PowerShell.
- [ ] Manual smoke on a clean macOS / Linux shell: `curl -fsSL https://raw.githubusercontent.com/zackees/clud/feat/issue-163-install-scripts/install.sh | sh` then `clud --version` from a NEW shell.
- [ ] Re-run the same install line; verify no duplicate PATH entries and that the script reports the existing install.
- [ ] `CLUD_VERSION=2.0.11 curl ... | sh` pins to that exact version.

Closes #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)