### PR TITLE
fix(clud-pr-merge): handle long CI, PR-only checks, harness quirks

### DIFF
--- a/skills/clud-pr-merge/SKILL.md
+++ b/skills/clud-pr-merge/SKILL.md
@@ -26,10 +26,15 @@ If the gates fail in fixable ways, dispatch a sub-agent to fix; up to 3 rounds t
    - **Default cap: 45 minutes** (the FastLED repo and similar embedded projects routinely hit 25–30 min platform builds). Tighten the cap to `max(15, p90 + 5min)` for repos with faster CI; never go below 15 minutes.
    - **Announce upfront** with one user-facing line: `[clud-pr-merge] polling CI for up to <N> min; slowest recent build was <P90> min.` Silent polling reads as a hung shell — never skip this announcement.
    - Then loop with **30-second sleeps**. Each iteration fetches:
+     - `gh pr view <num> --json state --jq .state` — **first** check every iteration. If the PR became MERGED or CLOSED, **break the loop immediately** (success for MERGED, abort for CLOSED). See "Early-exit on PR state change" below.
      - `gh pr checks <num> --json name,state,bucket` — every required check has a non-PENDING state.
      - `gh api repos/{owner}/{repo}/pulls/{num}/reviews --jq '.[] | select(.user.login=="coderabbitai[bot]")'` — at least one CodeRabbit review has been posted (or CodeRabbit explicitly "skipped" the review, which counts as reported).
 
-   Both must report at least once. If the cap elapses with neither reporting, **give up and warn the user**: `[clud-pr-merge] timed out waiting for CI/CodeRabbit after <N> minutes. Re-run when checks have reported.` Do NOT merge.
+   Both signals must report at least once *or* the PR state must change to MERGED/CLOSED. If the cap elapses with no signal, **give up and warn the user**: `[clud-pr-merge] timed out waiting for CI/CodeRabbit after <N> minutes. Re-run when checks have reported.` Do NOT merge.
+
+   **Early-exit on PR state change (CRITICAL — prevents the "stuck shell" bug).** GitHub Actions jobs do NOT cancel when a PR is merged out from under them. If a maintainer merges (or auto-merge fires) while the poll is waiting, the slow platform-build jobs on the original SHA keep running for another ~20 min. The poll's "no PENDING checks" condition stays false the whole time, so the loop keeps spawning sleeps and never exits — from the user's perspective the shell is hung. Two preventions, both mandatory:
+   1. Check `gh pr view <num> --json state` FIRST in every poll iteration and break the loop the moment state ≠ OPEN. The poll's exit reason is "PR merged/closed," not "all checks finished."
+   2. For polls started via `run_in_background: true`, the bash loop runs OUT of band from the conversation. The moment merge is confirmed externally (manual `gh pr view`, the `<task-notification>` payload of the bg task, or any other signal), kill the background task via the runtime's stop mechanism. Do NOT rely on "it'll self-terminate" — the loop's purpose is moot but the loop body doesn't know that.
 
    **Polling pattern.** Use Bash with `until <condition>; do sleep 30; done` (sleep *inside* the body). Do not chain `sleep N; <cmd>` — the Claude Code harness blocks leading sleeps. For waits longer than ~5 minutes consider `ScheduleWakeup` instead so the conversation isn't held open by an active poll.
 
@@ -74,6 +79,8 @@ If the gates fail in fixable ways, dispatch a sub-agent to fix; up to 3 rounds t
 - **Treating "check missing from main" as "passing on main"** — PR-only workflows (e.g. `pull_request_target`) never run on `push` events, so they're invisible in main's check-runs. Cross-reference recent PRs before classifying.
 - **Trusting `gh pr checks` exit code** — it returns 1 whenever any check failed, even with `--json`. Always read the output and ignore `$?`.
 - **Leading `sleep N; <cmd>` chains** — the Claude Code harness blocks these. Use `until <check>; do sleep N; done` (sleep inside the body), or `run_in_background: true` for fire-and-forget waits, or `ScheduleWakeup` for >5min waits.
+- **CI poll that doesn't watch PR state** — if `gh pr view <num> --json state` is not checked every iteration, the loop will keep spinning for 20+ minutes after a merge (GitHub Actions jobs do not cancel on merge, so PENDING checks remain PENDING). Always poll PR state first; break on MERGED/CLOSED.
+- **Background poll left running after merge confirmation** — once you see `state: MERGED` from any source, kill the background poll task explicitly. Do NOT rely on "it'll self-terminate" — the loop's exit condition is moot but the loop body doesn't know that, and respawned `sleep 30` processes will continue to spam the host until the cap is hit.
 - **Letting the fix-agent expand scope** — pass a tight scope; if the agent finds an unrelated bug, it gets noted, not fixed in this PR.
 
 ## When NOT to use this

--- a/skills/clud-pr-merge/SKILL.md
+++ b/skills/clud-pr-merge/SKILL.md
@@ -21,30 +21,41 @@ If the gates fail in fixable ways, dispatch a sub-agent to fix; up to 3 rounds t
 
 1. **Resolve the PR.** `gh pr view --json number,headRefName,baseRefName,state,mergeable,statusCheckRollup,url` against the current branch. Refuse if state ≠ OPEN or mergeable ≠ MERGEABLE/UNKNOWN.
 
-2. **Poll until CI + CodeRabbit have reported.** Loop with **30-second sleeps**, capped at **12 minutes total** (24 iterations). Each iteration fetches:
-   - `gh pr checks <num> --json name,state,bucket` — every required check has a non-PENDING state.
-   - `gh api repos/{owner}/{repo}/pulls/{num}/reviews --jq '.[] | select(.user.login=="coderabbitai")'` — at least one CodeRabbit review (or comment) has been posted.
+2. **Estimate the wait, announce it, then poll.** Before sleeping:
+   - Probe the repo's *recent* CI duration: `gh run list --repo <owner/repo> --branch main --limit 10 --json conclusion,startedAt,updatedAt`. Take the p90 wall-clock; round up to the nearest 5 min. This is your expected wait.
+   - **Default cap: 45 minutes** (the FastLED repo and similar embedded projects routinely hit 25–30 min platform builds). Tighten the cap to `max(15, p90 + 5min)` for repos with faster CI; never go below 15 minutes.
+   - **Announce upfront** with one user-facing line: `[clud-pr-merge] polling CI for up to <N> min; slowest recent build was <P90> min.` Silent polling reads as a hung shell — never skip this announcement.
+   - Then loop with **30-second sleeps**. Each iteration fetches:
+     - `gh pr checks <num> --json name,state,bucket` — every required check has a non-PENDING state.
+     - `gh api repos/{owner}/{repo}/pulls/{num}/reviews --jq '.[] | select(.user.login=="coderabbitai[bot]")'` — at least one CodeRabbit review has been posted (or CodeRabbit explicitly "skipped" the review, which counts as reported).
 
-   Both must report at least once. If 12 minutes pass with neither reporting, **give up and warn the user**: `[clud-pr-merge] timed out waiting for CI/CodeRabbit after 12 minutes. Re-run when checks have reported.` Do NOT merge.
+   Both must report at least once. If the cap elapses with neither reporting, **give up and warn the user**: `[clud-pr-merge] timed out waiting for CI/CodeRabbit after <N> minutes. Re-run when checks have reported.` Do NOT merge.
 
-3. **Diff CI failures vs main.** For every failing check on the PR:
+   **Polling pattern.** Use Bash with `until <condition>; do sleep 30; done` (sleep *inside* the body). Do not chain `sleep N; <cmd>` — the Claude Code harness blocks leading sleeps. For waits longer than ~5 minutes consider `ScheduleWakeup` instead so the conversation isn't held open by an active poll.
+
+   **`gh pr checks` exit-code gotcha.** `gh pr checks` exits non-zero whenever ANY check has failed, even with `--json`. A backgrounded poll that finishes with exit 1 may still have produced complete output — always read the output, never gate on `$?`.
+
+3. **Diff CI failures vs main (with PR-only-workflow handling).** For every failing check on the PR:
    - Fetch the same check name on `main`'s latest commit: `gh api repos/{owner}/{repo}/commits/main/check-runs`.
-   - If the same check is also failing on main → **pre-existing failure**, not a regression. Mark and skip.
-   - If the check is passing on main but failing on the PR → **regression**. Add to the fix queue.
+   - **Same check failing on main** → **pre-existing failure**, not a regression. Mark and skip.
+   - **Same check passing on main** → **regression**. Add to the fix queue.
+   - **Same check absent from main's check-runs** → the workflow is PR-only (e.g. `pull_request_target` or `pull_request` event triggers don't run on `push` to main). Classify by sampling recent PRs: `gh pr list --state all --limit 10 --json number` then `gh pr checks <n>` for each. If the same check fails on every recent PR, treat as **pre-existing infrastructure failure** and skip. If failures are sporadic, treat as **inconclusive** and surface to the user for judgment — do NOT silently merge.
 
-4. **Collect CodeRabbit findings.** `gh api repos/{owner}/{repo}/pulls/{num}/comments` filtered to `user.login == "coderabbitai"`. Also pull review-level comments. Resolved threads are skipped.
+4. **Collect CodeRabbit findings.** `gh api repos/{owner}/{repo}/pulls/{num}/comments` filtered to `user.login == "coderabbitai[bot]"`. Also pull review-level comments. Resolved threads are skipped.
 
 5. **Round-based fix loop, max 3 rounds.** For each round:
    - If fix queue (regressions + CodeRabbit comments) is empty → break, proceed to merge.
    - Dispatch a sub-agent with: the regression list, the CodeRabbit comments, the relevant file paths, and the constraint to keep changes minimal (only fix what's flagged, don't refactor unrelated code).
    - After the agent finishes: `bash lint` + `bash test`, commit, push.
-   - Wait for CI to re-run (poll with the 30s/12min budget again, this round only).
+   - Wait for CI to re-run (poll with the same announce-and-cap procedure from step 2, this round only).
    - Re-evaluate gates. If both clear → break. Otherwise → next round.
    - After round 3 with gates still failing → **give up**. Print remaining blockers and exit without merging.
 
 6. **Clean tree gate.** Same as `/clud-pr`: every modified/untracked file gets a deliberate commit-or-delete decision. No stash-and-merge tricks.
 
 7. **Merge.** `gh pr merge <num> --squash --delete-branch` (or `--merge` if the repo prefers full history — check repo conventions first). Confirm with `gh pr view <num> --json state,mergedAt`.
+
+   **"Already merged" is success.** If `gh pr merge` returns `pull request <num> was already merged`, treat it as success (a maintainer merged it while we were polling). Skip straight to the post-merge confirmation.
 
 ## Hard rules
 
@@ -56,9 +67,13 @@ If the gates fail in fixable ways, dispatch a sub-agent to fix; up to 3 rounds t
 
 ## Failure modes to avoid
 
-- **Poll loop without a cap** — always stop at 12 minutes; better to warn-and-stop than burn forever.
+- **Poll loop without a cap** — always stop at the announced cap (default 45 min, adjusted per repo); better to warn-and-stop than burn forever.
+- **Silent polling** — without an upfront "polling for up to N min" announcement, the user reads the silent wait as a hung shell. Always announce.
 - **Treating timeout as merge-eligible** — no signal ≠ green signal. Refuse to merge in the timeout case.
 - **Conflating "passing on main" with "not a regression"** — only the *same check name* on main counts. Renamed/added checks are new regressions until proven otherwise.
+- **Treating "check missing from main" as "passing on main"** — PR-only workflows (e.g. `pull_request_target`) never run on `push` events, so they're invisible in main's check-runs. Cross-reference recent PRs before classifying.
+- **Trusting `gh pr checks` exit code** — it returns 1 whenever any check failed, even with `--json`. Always read the output and ignore `$?`.
+- **Leading `sleep N; <cmd>` chains** — the Claude Code harness blocks these. Use `until <check>; do sleep N; done` (sleep inside the body), or `run_in_background: true` for fire-and-forget waits, or `ScheduleWakeup` for >5min waits.
 - **Letting the fix-agent expand scope** — pass a tight scope; if the agent finds an unrelated bug, it gets noted, not fixed in this PR.
 
 ## When NOT to use this


### PR DESCRIPTION
## Summary

Tightens `/clud-pr-merge` against four failure modes observed during a live run against FastLED PRs #2552 / #2554 (where one platform build hit 26m7s wall-clock).

### 1. Bump default poll cap 12 → 45 min, with per-repo p90 sizing
The old 12-min cap timed out on FastLED's slowest GHA platform builds before they could finish. The skill now probes `gh run list` for the repo's recent p90 wall-clock and sizes the cap to `max(15, p90 + 5min)`, defaulting to 45 min when no probe is available. Crucially, it now **announces the expected wait upfront** with a user-facing one-liner so users don't read the silent poll as a hung shell.

### 2. Document the polling pattern
The Claude Code harness blocks leading `sleep N; <cmd>` chains. The skill now mandates `until <check>; do sleep 30; done` (sleep inside the loop body) and suggests `ScheduleWakeup` for waits longer than ~5 min.

### 3. Handle PR-only workflows
`pull_request_target` checks never run on `push` events, so they're invisible in main's check-runs. The old "same check on main" comparison silently mis-classified them. The skill now adds a third branch: if a failing check is missing from main's check-runs, sample the last 10 PRs; consistent failure across them ⇒ pre-existing infrastructure, sporadic ⇒ inconclusive, surface to user.

### 4. `gh` CLI exit-code gotcha + "already merged"
- `gh pr checks` exits non-zero whenever any check failed (even with `--json`), so a backgrounded poll can finish exit-1 with complete valid output. Skill now says to read output, never gate on `$?`.
- If `gh pr merge` reports `pull request <num> was already merged`, treat as success — a maintainer merged the PR while we were polling.

## Test plan
- [x] No code changes outside `skills/clud-pr-merge/SKILL.md`
- [ ] Validate against a real PR with long CI (manual; the FastLED instance that surfaced these issues already merged)