### PR TITLE
chore(ci): bump soldr 0.7.32 → 0.7.45 + canonicalize prebuild-deps

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -73,14 +73,14 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           toolchain: "1.94.1"
-          version: "0.7.32"
+          version: "0.7.45"
           cache: true
           build-cache-mode: thin
           shims: true
           linker: ${{ runner.os == 'macOS' && 'platform-default' || 'fast' }}
           preserve-source-mtimes: true
           solo-toolchain-cache: true
-          prebuild-deps: cargo-chef
+          prebuild-deps: soldr-cook
           prebuild-deps-flags: ${{ inputs.build-mode == 'release' && '--release --workspace' || '--workspace' }}
 
       - name: Restore source checkout

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -63,14 +63,14 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           toolchain: "1.94.1"
-          version: "0.7.32"
+          version: "0.7.45"
           cache: true
           build-cache-mode: thin
           shims: true
           linker: ${{ runner.os == 'macOS' && 'platform-default' || 'fast' }}
           preserve-source-mtimes: true
           solo-toolchain-cache: true
-          prebuild-deps: cargo-chef
+          prebuild-deps: soldr-cook
           prebuild-deps-flags: "--workspace"
 
       - name: Restore source checkout

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -58,14 +58,14 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           toolchain: "1.94.1"
-          version: "0.7.32"
+          version: "0.7.45"
           cache: true
           build-cache-mode: thin
           shims: true
           linker: ${{ runner.os == 'macOS' && 'platform-default' || 'fast' }}
           preserve-source-mtimes: true
           solo-toolchain-cache: true
-          prebuild-deps: cargo-chef
+          prebuild-deps: soldr-cook
           prebuild-deps-flags: "--workspace"
 
       - name: Restore source checkout

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -58,14 +58,14 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           toolchain: "1.94.1"
-          version: "0.7.32"
+          version: "0.7.45"
           cache: true
           build-cache-mode: thin
           shims: true
           linker: ${{ runner.os == 'macOS' && 'platform-default' || 'fast' }}
           preserve-source-mtimes: true
           solo-toolchain-cache: true
-          prebuild-deps: cargo-chef
+          prebuild-deps: soldr-cook
           prebuild-deps-flags: "--workspace"
 
       - name: Restore source checkout


### PR DESCRIPTION
Bumps `version:` from soldr `0.7.32` → `0.7.45` across all 4 reusable workflows. Strict-superset version bump.

## Why

- **soldr 0.7.44** (zackees/soldr#566) — `cargo chef cook` no longer leaves the workspace in its stubbed `0.0.1` skeleton state; stabilizes first-party compile-cache keys across cold→warm runs.
- **soldr 0.7.45** — bundles **zccache 1.11.7** (zackees/zccache#449 → [PR #450](https://github.com/zackees/zccache/pull/450)) with depgraph drift detection; prevents stale-artifact link errors when transitive `.cpp.hpp` headers change in C++ unity builds.
- Plus 11 additional release-train fixes between 0.7.32 and 0.7.45 (compile-journal robustness, isolated-seed support, cache-mode benchmark hardening, etc.).

Also normalizes `prebuild-deps: cargo-chef` (deprecated alias) → `prebuild-deps: soldr-cook` (canonical, identical behavior, per setup-soldr v0.9.11+).

## Test plan

- [ ] Full CI runs green across all 4 reusable workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)