### PR TITLE
feat(daemon): clud ui local web dashboard + repo_visits tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +304,7 @@ dependencies = [
  "fs4",
  "ignore",
  "libc",
+ "open",
  "redb",
  "rodio",
  "running-process",
@@ -302,6 +315,7 @@ dependencies = [
  "sysinfo 0.37.2",
  "tempfile",
  "terminal_size",
+ "tiny_http",
  "toml_edit",
  "ureq",
  "vt100",
@@ -765,6 +779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +919,25 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -1403,6 +1442,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1480,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2110,6 +2166,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -52,6 +52,16 @@ vt100 = "0.16"
 vte = "0.15"
 wasmi = "0.40.0"
 which = "7"
+# Issue #183: in-process HTTP listener for the `clud ui` dashboard.
+# `tiny_http` is pure Rust, synchronous, and slots into the daemon's
+# existing `std::thread` model without introducing tokio. The daemon
+# binds a second loopback port alongside the JSON IPC listener and
+# serves a tiny embedded SPA + `/state.json` from it.
+tiny_http = "0.12"
+# Issue #183: cross-platform browser launch for `clud ui`. Tiny crate
+# (~50 LOC of platform glue: macOS `open`, Linux `xdg-open`, Windows
+# `cmd /c start`). One dep beats triplicate hand-rolled code.
+open = "5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/clud-bin/assets/dashboard/index.html
+++ b/crates/clud-bin/assets/dashboard/index.html
@@ -1,0 +1,352 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>clud dashboard</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #fafafa;
+      --fg: #1c1c1c;
+      --muted: #6b7280;
+      --accent: #2563eb;
+      --accent-fg: #ffffff;
+      --border: #e5e7eb;
+      --card: #ffffff;
+      --warn: #b45309;
+      --live: #15803d;
+      --gone: #9ca3af;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0e0e10;
+        --fg: #e5e7eb;
+        --muted: #9ca3af;
+        --accent: #60a5fa;
+        --accent-fg: #0e0e10;
+        --border: #27272a;
+        --card: #18181b;
+        --warn: #f59e0b;
+        --live: #22c55e;
+        --gone: #6b7280;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 24px;
+      background: var(--bg);
+      color: var(--fg);
+      font: 14px/1.45 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    }
+    h1 { font-size: 18px; margin: 0; }
+    header {
+      display: flex;
+      align-items: baseline;
+      gap: 24px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+    header .meta { color: var(--muted); font-size: 12px; font-family: ui-monospace, "Menlo", "Consolas", monospace; }
+    .tabs { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 1px solid var(--border); }
+    .tab {
+      padding: 8px 14px;
+      cursor: pointer;
+      border: 1px solid transparent;
+      border-bottom: none;
+      border-radius: 6px 6px 0 0;
+      background: transparent;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .tab.active {
+      background: var(--card);
+      color: var(--fg);
+      border-color: var(--border);
+      margin-bottom: -1px;
+    }
+    section { display: none; }
+    section.active { display: block; }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin-bottom: 12px;
+    }
+    .card h2 { font-size: 14px; margin: 0 0 8px; display: flex; justify-content: space-between; align-items: center; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th, td {
+      text-align: left;
+      padding: 6px 8px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+    th { color: var(--muted); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+    td.path, td.id { font-family: ui-monospace, "Menlo", "Consolas", monospace; font-size: 12px; word-break: break-all; }
+    .badge {
+      display: inline-block;
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 500;
+    }
+    .badge.live { background: color-mix(in srgb, var(--live) 18%, transparent); color: var(--live); }
+    .badge.gone { background: color-mix(in srgb, var(--gone) 18%, transparent); color: var(--gone); }
+    .badge.kind { background: color-mix(in srgb, var(--accent) 12%, transparent); color: var(--accent); margin-right: 6px; }
+    .button {
+      background: var(--accent);
+      color: var(--accent-fg);
+      border: 0;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 12px;
+      cursor: pointer;
+      font: inherit;
+    }
+    .button.danger { background: var(--warn); color: white; }
+    .button.subtle { background: transparent; color: var(--accent); padding: 2px 6px; border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent); }
+    .button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .empty { color: var(--muted); padding: 8px; font-style: italic; }
+    .toolbar { margin-top: 8px; display: flex; gap: 6px; flex-wrap: wrap; }
+    .footer { color: var(--muted); font-size: 12px; margin-top: 24px; }
+    .row-actions { text-align: right; white-space: nowrap; }
+    .stats {
+      display: flex;
+      gap: 16px;
+      color: var(--muted);
+      font-size: 12px;
+      flex-wrap: wrap;
+    }
+    .stats b { color: var(--fg); font-weight: 600; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>clud dashboard</h1>
+    <div class="meta" id="daemon-meta">connecting…</div>
+    <div class="stats" id="stats"></div>
+  </header>
+
+  <div class="tabs" role="tablist">
+    <button class="tab active" data-tab="sessions">Sessions</button>
+    <button class="tab" data-tab="gc">Garbage</button>
+    <button class="tab" data-tab="repos">Repos</button>
+  </div>
+
+  <section id="sessions" class="active">
+    <div class="card">
+      <h2>Sessions <span id="sessions-count" class="meta"></span></h2>
+      <div id="sessions-body"><p class="empty">loading…</p></div>
+    </div>
+  </section>
+
+  <section id="gc">
+    <div class="card">
+      <h2>Tracked garbage <span id="gc-count" class="meta"></span></h2>
+      <div class="toolbar" id="gc-toolbar"></div>
+      <div id="gc-body"><p class="empty">loading…</p></div>
+    </div>
+  </section>
+
+  <section id="repos">
+    <div class="card">
+      <h2>Repos visited <span id="repos-count" class="meta"></span></h2>
+      <div id="repos-body"><p class="empty">loading…</p></div>
+    </div>
+  </section>
+
+  <div class="footer">
+    Polling <code>/state.json</code> every 5s. Loopback only — no authentication.
+  </div>
+
+  <script>
+    const POLL_MS = 5000;
+    let lastState = null;
+
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('section').forEach(s => s.classList.remove('active'));
+        tab.classList.add('active');
+        document.getElementById(tab.dataset.tab).classList.add('active');
+      });
+    });
+
+    function fmtAge(unix) {
+      if (!unix) return '-';
+      const secs = Math.max(0, Math.floor(Date.now() / 1000) - unix);
+      if (secs < 60) return `${secs}s`;
+      if (secs < 3600) return `${Math.floor(secs / 60)}m`;
+      if (secs < 86400) return `${Math.floor(secs / 3600)}h`;
+      return `${Math.floor(secs / 86400)}d`;
+    }
+    function fmtUptime(s) {
+      const h = Math.floor(s / 3600);
+      const m = Math.floor((s % 3600) / 60);
+      const sec = s % 60;
+      if (h > 0) return `${h}h ${m}m`;
+      if (m > 0) return `${m}m ${sec}s`;
+      return `${sec}s`;
+    }
+    function esc(s) {
+      if (s === null || s === undefined) return '';
+      return String(s).replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+      })[c]);
+    }
+
+    function renderHeader(state) {
+      const d = state.daemon;
+      document.getElementById('daemon-meta').textContent =
+        `pid ${d.pid} · ipc ${d.ipc_port} · ui ${d.dashboard_port ?? '?'} · v${d.version} · up ${fmtUptime(d.uptime_secs)}`;
+      const s = state.stats;
+      document.getElementById('stats').innerHTML = `
+        <span><b>${s.live_session_count}</b> live / <b>${s.session_count}</b> sessions</span>
+        <span><b>${s.gc_count}</b> tracked</span>
+        <span><b>${s.repo_count}</b> repos</span>
+      `;
+    }
+
+    function renderSessions(state) {
+      const sessions = state.sessions || [];
+      document.getElementById('sessions-count').textContent =
+        sessions.length ? `(${sessions.length})` : '';
+      if (!sessions.length) {
+        document.getElementById('sessions-body').innerHTML =
+          '<p class="empty">no sessions recorded.</p>';
+        return;
+      }
+      const rows = sessions.map(s => `
+        <tr>
+          <td class="id">${esc(s.id)}</td>
+          <td>${esc(s.name || '-')}</td>
+          <td><span class="badge kind">${esc(s.kind)}</span></td>
+          <td>${s.live
+            ? '<span class="badge live">live</span>'
+            : `<span class="badge gone">exit ${esc(s.exit_code ?? '?')}</span>`}</td>
+          <td>${esc(fmtAge(s.created_at))}</td>
+          <td class="path">${esc(s.cwd || '-')}</td>
+        </tr>`).join('');
+      document.getElementById('sessions-body').innerHTML = `
+        <table>
+          <thead><tr>
+            <th>id</th><th>name</th><th>kind</th><th>state</th><th>age</th><th>cwd</th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table>`;
+    }
+
+    function renderGc(state) {
+      const rows = state.gc || [];
+      const kindCounts = state.stats.gc_by_kind || {};
+      document.getElementById('gc-count').textContent = rows.length ? `(${rows.length})` : '';
+
+      const toolbar = document.getElementById('gc-toolbar');
+      toolbar.innerHTML = '';
+      Object.entries(kindCounts).sort().forEach(([kind, count]) => {
+        const btn = document.createElement('button');
+        btn.className = 'button subtle';
+        btn.textContent = `Purge all ${kind} (${count})`;
+        btn.addEventListener('click', () => doPurge({ kind }, `Purge all ${count} ${kind} entries?`));
+        toolbar.appendChild(btn);
+      });
+
+      if (!rows.length) {
+        document.getElementById('gc-body').innerHTML =
+          '<p class="empty">no tracked garbage.</p>';
+        return;
+      }
+      const html = rows.map(r => `
+        <tr>
+          <td><span class="badge kind">${esc(r.kind)}</span></td>
+          <td>${esc(fmtAge(r.created_unix))}</td>
+          <td>${esc(r.agent_id || '-')}</td>
+          <td>${esc(r.branch || '-')}</td>
+          <td class="path">${esc(r.path)}</td>
+          <td class="row-actions">
+            ${r.live_locked
+              ? '<span class="badge live">locked</span>'
+              : `<button class="button danger" data-id="${r.id}">Purge</button>`}
+          </td>
+        </tr>`).join('');
+      document.getElementById('gc-body').innerHTML = `
+        <table>
+          <thead><tr>
+            <th>kind</th><th>age</th><th>agent</th><th>branch</th><th>path</th><th></th>
+          </tr></thead>
+          <tbody>${html}</tbody>
+        </table>`;
+      document.querySelectorAll('#gc-body button[data-id]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const id = Number(btn.dataset.id);
+          doPurge({ id }, `Purge tracked entry #${id}?`);
+        });
+      });
+    }
+
+    function renderRepos(state) {
+      const repos = state.repos || [];
+      document.getElementById('repos-count').textContent = repos.length ? `(${repos.length})` : '';
+      if (!repos.length) {
+        document.getElementById('repos-body').innerHTML =
+          '<p class="empty">no repo visits recorded yet.</p>';
+        return;
+      }
+      const rows = repos.map(r => `
+        <tr>
+          <td class="path">${esc(r.repo_root)}</td>
+          <td>${esc(fmtAge(r.last_visited_unix))}</td>
+          <td>${esc(r.run_count)}</td>
+          <td class="path">${esc(r.last_cwd)}</td>
+        </tr>`).join('');
+      document.getElementById('repos-body').innerHTML = `
+        <table>
+          <thead><tr>
+            <th>repo</th><th>last visited</th><th>runs</th><th>last cwd</th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table>`;
+    }
+
+    async function doPurge(body, prompt) {
+      if (!confirm(prompt)) return;
+      try {
+        const resp = await fetch('/gc/purge', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          alert(`purge failed: ${data.error || resp.statusText}`);
+          return;
+        }
+        await refresh();
+      } catch (err) {
+        alert(`purge failed: ${err}`);
+      }
+    }
+
+    async function refresh() {
+      try {
+        const resp = await fetch('/state.json');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const state = await resp.json();
+        lastState = state;
+        renderHeader(state);
+        renderSessions(state);
+        renderGc(state);
+        renderRepos(state);
+      } catch (err) {
+        document.getElementById('daemon-meta').textContent =
+          `connection lost: ${err}`;
+      }
+    }
+
+    refresh();
+    setInterval(refresh, POLL_MS);
+  </script>
+</body>
+</html>

--- a/crates/clud-bin/assets/dashboard/index.html
+++ b/crates/clud-bin/assets/dashboard/index.html
@@ -268,7 +268,7 @@
           <td class="row-actions">
             ${r.live_locked
               ? '<span class="badge live">locked</span>'
-              : `<button class="button danger" data-id="${r.id}">Purge</button>`}
+              : `<button class="button danger" data-id="${r.id}" data-kind="${esc(r.kind)}" data-path="${esc(r.path)}">Delete</button>`}
           </td>
         </tr>`).join('');
       document.getElementById('gc-body').innerHTML = `
@@ -281,7 +281,12 @@
       document.querySelectorAll('#gc-body button[data-id]').forEach(btn => {
         btn.addEventListener('click', () => {
           const id = Number(btn.dataset.id);
-          doPurge({ id }, `Purge tracked entry #${id}?`);
+          const kind = btn.dataset.kind || 'entry';
+          const path = btn.dataset.path || '';
+          const prompt =
+            `Delete this ${kind}?\n\n  ${path}\n\n` +
+            `Removes the directory from disk and drops the tracking row.`;
+          doPurge({ id }, prompt);
         });
       });
     }

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -204,6 +204,18 @@ pub enum Command {
         #[command(subcommand)]
         subcommand: Option<GcSubcommand>,
     },
+    /// Issue #183: open the local web dashboard served by the always-on
+    /// clud daemon. Shows live sessions, garbage tracking, and the repos
+    /// clud has been launched in. Loopback only.
+    Ui {
+        /// Print `/state.json` to stdout and exit without launching a browser.
+        #[arg(long = "json")]
+        json: bool,
+        /// Print the dashboard URL and ensure the daemon is up, but do
+        /// not launch a browser. Handy when running on a headless host.
+        #[arg(long = "no-open")]
+        no_open: bool,
+    },
     #[command(name = "__daemon", hide = true)]
     InternalDaemon {
         #[arg(long = "state-dir")]
@@ -313,13 +325,14 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--force",
         "--no-daemon",
         "--json",
+        "--no-open",
         "--help",
         "--version",
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
-        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "__daemon",
-        "__worker",
+        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "ui",
+        "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -135,6 +135,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         | Some(Command::List)
         | Some(Command::Logs { .. })
         | Some(Command::Gc { .. })
+        | Some(Command::Ui { .. })
         | Some(Command::InternalDaemon { .. })
         | Some(Command::InternalWorker { .. }) => {}
         None => {

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -17,7 +17,7 @@ use super::paths::{
 };
 use super::process_utils::pid_is_alive;
 use super::types::{
-    DaemonInfo, DaemonRequest, DaemonResponse, GcOp, GcReply, ListRow, SessionSnapshot,
+    DaemonInfo, DaemonRequest, DaemonResponse, GcOp, GcReply, ListRow, RepoVisit, SessionSnapshot,
     WorkerClientMessage,
 };
 
@@ -290,6 +290,38 @@ pub fn gc_client_insert(state_dir: &Path, input: &InsertInput) -> io::Result<()>
         },
     )? {
         GcReply::InsertOk => Ok(()),
+        GcReply::Error { message } => Err(io::Error::other(message)),
+        other => Err(io::Error::other(format!("unexpected gc reply: {other:?}"))),
+    }
+}
+
+/// Issue #183: upsert a `repo_visits` row. Called by `clud` startup
+/// when CWD is inside a git repo. Errors are swallowed by the caller —
+/// failing to record a visit must never block a launch.
+pub fn gc_client_record_repo_visit(
+    state_dir: &Path,
+    repo_root: &Path,
+    cwd: &Path,
+) -> io::Result<()> {
+    match send_gc(
+        state_dir,
+        GcOp::RecordRepoVisit {
+            repo_root: repo_root.to_string_lossy().to_string(),
+            cwd: cwd.to_string_lossy().to_string(),
+            now_unix: None,
+        },
+    )? {
+        GcReply::RepoVisitOk => Ok(()),
+        GcReply::Error { message } => Err(io::Error::other(message)),
+        other => Err(io::Error::other(format!("unexpected gc reply: {other:?}"))),
+    }
+}
+
+/// Issue #183: enumerate the `repo_visits` table for the dashboard /
+/// `clud ui --json` payload.
+pub fn gc_client_list_repo_visits(state_dir: &Path) -> io::Result<Vec<RepoVisit>> {
+    match send_gc(state_dir, GcOp::ListRepoVisits)? {
+        GcReply::RepoVisitsOk { rows } => Ok(rows),
         GcReply::Error { message } => Err(io::Error::other(message)),
         other => Err(io::Error::other(format!("unexpected gc reply: {other:?}"))),
     }

--- a/crates/clud-bin/src/daemon/gc_service.rs
+++ b/crates/clud-bin/src/daemon/gc_service.rs
@@ -190,6 +190,40 @@ pub(super) fn process_op(registry: &Registry, op: GcOp) -> GcReply {
                 message: e.to_string(),
             },
         },
+
+        GcOp::DeleteById { id } => {
+            let entries = match registry.list(None) {
+                Ok(v) => v,
+                Err(e) => {
+                    return GcReply::Error {
+                        message: e.to_string(),
+                    };
+                }
+            };
+            let Some(target) = entries.into_iter().find(|e| e.id == id) else {
+                // Idempotent: an id that no longer exists is `removed=0,
+                // skipped=0`. The dashboard refreshes after every delete
+                // so a stale id click is silently a no-op.
+                return GcReply::PurgeOk {
+                    removed: 0,
+                    skipped: 0,
+                };
+            };
+            let live_locks = collect_live_lock_paths();
+            if target.kind == "worktree" && live_locks.contains(&target.path) {
+                return GcReply::PurgeOk {
+                    removed: 0,
+                    skipped: 1,
+                };
+            }
+            match remove_entry_and_delete_row(registry, &target) {
+                Ok(()) => GcReply::PurgeOk {
+                    removed: 1,
+                    skipped: 0,
+                },
+                Err(message) => GcReply::Error { message },
+            }
+        }
     }
 }
 
@@ -433,6 +467,95 @@ mod tests {
             GcReply::ListOk { rows } => {
                 assert_eq!(rows.len(), 1);
                 assert_eq!(rows[0].kind, "worktree");
+            }
+            other => panic!("unexpected reply: {other:?}"),
+        }
+    }
+
+    /// Issue #183: per-row Delete must target exactly the requested id
+    /// regardless of how many siblings share its kind. Earlier iterations
+    /// of the dashboard worked around the missing IPC primitive by
+    /// issuing `Purge { kind: Some(k) }` and refusing when k had >1 row,
+    /// which broke the per-row button in the common multi-row case.
+    #[test]
+    fn delete_by_id_removes_only_the_targeted_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("delete-by-id.redb");
+        let (tx, _g) = spawn_test_worker(&db_path);
+
+        // Three rows of the same kind — the bug case the workaround
+        // refused to handle.
+        let paths = [
+            dir.path().join("e1").to_string_lossy().to_string(),
+            dir.path().join("e2").to_string_lossy().to_string(),
+            dir.path().join("e3").to_string_lossy().to_string(),
+        ];
+        for p in &paths {
+            std::fs::create_dir_all(p).unwrap();
+            call(
+                &tx,
+                GcOp::Insert {
+                    kind: "cache".to_string(),
+                    path: p.clone(),
+                    repo_root: None,
+                    branch: None,
+                    agent_id: None,
+                    created_unix: Some(100),
+                },
+            );
+        }
+
+        // Snapshot the rows so we can pick the middle id by stable mapping.
+        let list = match call(&tx, GcOp::List { kind: None }) {
+            GcReply::ListOk { rows } => rows,
+            other => panic!("unexpected reply: {other:?}"),
+        };
+        assert_eq!(list.len(), 3);
+        let middle = list
+            .iter()
+            .find(|r| r.path == paths[1])
+            .expect("middle row");
+
+        let resp = call(&tx, GcOp::DeleteById { id: middle.id });
+        match resp {
+            GcReply::PurgeOk { removed, skipped } => {
+                assert_eq!(removed, 1);
+                assert_eq!(skipped, 0);
+            }
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        // The two siblings must survive.
+        let after = match call(&tx, GcOp::List { kind: None }) {
+            GcReply::ListOk { rows } => rows,
+            other => panic!("unexpected reply: {other:?}"),
+        };
+        let remaining: Vec<&str> = after.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(after.len(), 2);
+        assert!(remaining.contains(&paths[0].as_str()));
+        assert!(remaining.contains(&paths[2].as_str()));
+        assert!(!remaining.contains(&paths[1].as_str()));
+
+        // The on-disk path for the targeted row should be gone too.
+        assert!(!std::path::Path::new(&paths[1]).exists());
+        // Siblings should still be on disk.
+        assert!(std::path::Path::new(&paths[0]).exists());
+        assert!(std::path::Path::new(&paths[2]).exists());
+    }
+
+    /// Deleting a non-existent id is idempotent (`removed=0, skipped=0`).
+    /// Lets the dashboard refresh-then-click race resolve without a 500.
+    #[test]
+    fn delete_by_id_with_missing_id_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("delete-missing.redb");
+        let (tx, _g) = spawn_test_worker(&db_path);
+
+        let resp = call(&tx, GcOp::DeleteById { id: 9_999_999 });
+        match resp {
+            GcReply::PurgeOk { removed, skipped } => {
+                assert_eq!(removed, 0);
+                assert_eq!(skipped, 0);
             }
             other => panic!("unexpected reply: {other:?}"),
         }

--- a/crates/clud-bin/src/daemon/gc_service.rs
+++ b/crates/clud-bin/src/daemon/gc_service.rs
@@ -35,6 +35,15 @@ pub(super) struct GcRequestMsg {
 /// worker.
 pub(super) fn spawn_registry_worker() -> std::io::Result<mpsc::Sender<GcRequestMsg>> {
     let registry = Registry::open_default().map_err(std::io::Error::other)?;
+    spawn_registry_worker_with(registry)
+}
+
+/// Same as [`spawn_registry_worker`] but accepts a pre-constructed
+/// `Registry`. Tests use this to bind a worker to an isolated `redb`
+/// file without depending on the process-global `CLUD_DATA_DB` env var.
+pub(super) fn spawn_registry_worker_with(
+    registry: Registry,
+) -> std::io::Result<mpsc::Sender<GcRequestMsg>> {
     let (tx, rx) = mpsc::channel::<GcRequestMsg>();
     thread::Builder::new()
         .name("clud-gc-registry-worker".to_string())
@@ -160,6 +169,27 @@ pub(super) fn process_op(registry: &Registry, op: GcOp) -> GcReply {
                 },
             }
         }
+
+        GcOp::RecordRepoVisit {
+            repo_root,
+            cwd,
+            now_unix: provided,
+        } => {
+            let stamp = provided.unwrap_or_else(now_unix);
+            match registry.record_repo_visit(&repo_root, &cwd, stamp) {
+                Ok(()) => GcReply::RepoVisitOk,
+                Err(e) => GcReply::Error {
+                    message: e.to_string(),
+                },
+            }
+        }
+
+        GcOp::ListRepoVisits => match registry.list_repo_visits() {
+            Ok(rows) => GcReply::RepoVisitsOk { rows },
+            Err(e) => GcReply::Error {
+                message: e.to_string(),
+            },
+        },
     }
 }
 

--- a/crates/clud-bin/src/daemon/http.rs
+++ b/crates/clud-bin/src/daemon/http.rs
@@ -236,26 +236,12 @@ fn handle_purge(mut request: Request, gc_tx: Option<&mpsc::Sender<GcRequestMsg>>
         return;
     };
 
-    // Resolve the request into the GcOp::Purge call. `id` filter is
-    // performed daemon-side after we receive the full list. To keep this
-    // route a single round-trip per request we issue one Purge per filter
-    // form and rely on the kind/duration arguments already supported.
+    // Route the request: per-row delete uses the surgical `DeleteById`
+    // IPC op so the on-disk and registry-row removal target exactly the
+    // requested row regardless of how many siblings share its kind. The
+    // bulk per-kind / per-age path keeps using `Purge`.
     let op = match payload.id {
-        Some(id) => {
-            // Single-row purge: look up the matching entry by id, then
-            // purge by (kind=its kind, path=its path) using delete_by_id
-            // — issue a List first, find the row, then send a tailored op.
-            match purge_single_by_id(tx, id) {
-                Ok(reply) => {
-                    respond_purge_reply(request, reply);
-                    return;
-                }
-                Err(err) => {
-                    respond_json(request, 500, json_error_bytes(&err).as_slice());
-                    return;
-                }
-            }
-        }
+        Some(id) => GcOp::DeleteById { id },
         None => GcOp::Purge {
             duration: None,
             kind: payload.kind.clone(),
@@ -287,65 +273,6 @@ fn respond_purge_reply(request: Request, reply: GcReply) {
             );
         }
     }
-}
-
-/// Resolve `id` -> its `(kind, path)` and then issue a Purge filtered to
-/// that one row. There is no native single-row purge op so we round-trip
-/// once to enumerate, then once to purge. Acceptable because dashboard
-/// purges are user-initiated, not on the hot path.
-fn purge_single_by_id(tx: &mpsc::Sender<GcRequestMsg>, id: i64) -> Result<GcReply, String> {
-    let list_reply = send_gc_op(tx, GcOp::List { kind: None })?;
-    let rows = match list_reply {
-        GcReply::ListOk { rows } => rows,
-        GcReply::Error { message } => return Err(message),
-        other => return Err(format!("unexpected reply: {other:?}")),
-    };
-    let Some(target) = rows.into_iter().find(|r| r.id == id) else {
-        // No row with that id — return an idempotent zero-effect ack.
-        return Ok(GcReply::PurgeOk {
-            removed: 0,
-            skipped: 0,
-        });
-    };
-    if target.live_locked {
-        return Ok(GcReply::PurgeOk {
-            removed: 0,
-            skipped: 1,
-        });
-    }
-    // The existing purge op filters by kind+age but not by path. Best
-    // available primitive: filter by kind and then accept that a kind
-    // with multiple non-live-locked rows older than nothing will purge
-    // them all. To keep semantics tight we use a fresh op variant that
-    // already exists in the IPC surface — `Purge { duration: None, kind:
-    // Some(target.kind) }` — but only when there's just one row of that
-    // kind. Otherwise fall back to deleting via a future per-id IPC
-    // (tracked separately); for now we return a clear error.
-    let same_kind_count = match send_gc_op(
-        tx,
-        GcOp::List {
-            kind: Some(target.kind.clone()),
-        },
-    )? {
-        GcReply::ListOk { rows } => rows.len(),
-        GcReply::Error { message } => return Err(message),
-        other => return Err(format!("unexpected reply: {other:?}")),
-    };
-    if same_kind_count > 1 {
-        return Err(format!(
-            "per-id purge not yet supported when multiple rows share kind={} \
-             (matched id={id}); use the per-kind purge button instead",
-            target.kind
-        ));
-    }
-    send_gc_op(
-        tx,
-        GcOp::Purge {
-            duration: None,
-            kind: Some(target.kind),
-            dry_run: false,
-        },
-    )
 }
 
 // ---------- state aggregation ----------
@@ -814,6 +741,84 @@ mod tests {
         let state_body = fetch_state_json(port).expect("re-fetch state");
         let state: DashboardState = serde_json::from_str(&state_body).expect("parse state");
         assert_eq!(state.stats.gc_count, 0);
+    }
+
+    /// Per-row Delete button on the dashboard: `POST /gc/purge {id: N}`
+    /// must remove exactly the targeted row even when other rows share
+    /// its `kind`. Replaces the earlier "single row of a kind" workaround
+    /// that returned a 500 in this case.
+    #[test]
+    fn end_to_end_per_row_delete_only_targets_requested_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("delete-by-id.redb");
+
+        let registry = Registry::open_at(&db_path).expect("open registry");
+        let gc_tx = spawn_registry_worker_with(registry).expect("worker");
+
+        // Three siblings of the same kind in a tempdir.
+        let paths: Vec<String> = ["e1", "e2", "e3"]
+            .iter()
+            .map(|name| {
+                let p = dir.path().join(name);
+                std::fs::create_dir_all(&p).unwrap();
+                p.to_string_lossy().to_string()
+            })
+            .collect();
+        for p in &paths {
+            let (rx_t, rx) = mpsc::sync_channel::<GcReply>(1);
+            gc_tx
+                .send(GcRequestMsg {
+                    op: GcOp::Insert {
+                        kind: "cache".to_string(),
+                        path: p.clone(),
+                        repo_root: None,
+                        branch: None,
+                        agent_id: None,
+                        created_unix: Some(1000),
+                    },
+                    reply_tx: rx_t,
+                })
+                .unwrap();
+            let _ = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        }
+
+        let port = spawn_dashboard(dir.path().to_path_buf(), Some(gc_tx.clone()), 9999, 100)
+            .expect("dashboard spawned");
+
+        // Fetch /state.json to get the assigned ids.
+        let state_body = fetch_state_json(port).expect("fetch state");
+        let state: DashboardState = serde_json::from_str(&state_body).expect("parse");
+        let middle = state
+            .gc
+            .iter()
+            .find(|r| r.path == paths[1])
+            .expect("middle row");
+
+        // POST /gc/purge {"id": <middle.id>}
+        let body = fetch_path(
+            port,
+            "POST",
+            "/gc/purge",
+            Some(format!(r#"{{"id":{}}}"#, middle.id)),
+        )
+        .expect("delete");
+        let resp: PurgeResponse = serde_json::from_str(&body).expect("parse");
+        assert_eq!(resp.removed, 1);
+        assert_eq!(resp.skipped, 0);
+
+        // The two siblings must survive.
+        let after = fetch_state_json(port).expect("re-fetch state");
+        let after_state: DashboardState = serde_json::from_str(&after).expect("parse");
+        let surviving: Vec<&str> = after_state.gc.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(after_state.gc.len(), 2);
+        assert!(surviving.contains(&paths[0].as_str()));
+        assert!(surviving.contains(&paths[2].as_str()));
+        assert!(!surviving.contains(&paths[1].as_str()));
+
+        // On-disk deletion happened for the targeted row only.
+        assert!(!std::path::Path::new(&paths[1]).exists());
+        assert!(std::path::Path::new(&paths[0]).exists());
+        assert!(std::path::Path::new(&paths[2]).exists());
     }
 
     /// Tiny HTTP/1.0 client for tests. Connect, send a request, read the

--- a/crates/clud-bin/src/daemon/http.rs
+++ b/crates/clud-bin/src/daemon/http.rs
@@ -1,0 +1,845 @@
+//! Issue #183: in-process HTTP dashboard.
+//!
+//! Binds a second loopback `tiny_http::Server` alongside the IPC TCP
+//! listener (`daemon/server.rs`). Serves three routes:
+//!
+//! - `GET /` / `GET /index.html` — the embedded single-page dashboard.
+//! - `GET /state.json` — one consolidated JSON document with daemon meta,
+//!   live sessions, GC tracked entries, repo visits, and aggregate stats.
+//! - `POST /gc/purge` — body `{id?, kind?}`; delegates to the existing
+//!   `GcOp::Purge` IPC op and returns `{removed, skipped}`.
+//!
+//! Loopback-only, no authentication — matches the trust model of the
+//! existing JSON IPC listener.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{self, Read};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tiny_http::{Header, Method, Request, Response, Server};
+
+use super::gc_service::{GcRequestMsg, WORKER_REPLY_TIMEOUT};
+use super::io_helpers::read_json_file;
+use super::paths::{daemon_info_path, sessions_dir};
+use super::process_utils::pid_is_alive;
+use super::types::{DaemonInfo, GcOp, GcReply, ListRow, RepoVisit, SessionKind, SessionSnapshot};
+
+/// Bundled single-page dashboard. Vanilla JS, no build step. Polls
+/// `/state.json` every 5s and renders the three tabs (Sessions / GC /
+/// Repos) plus per-row and per-kind purge controls.
+const DASHBOARD_HTML: &str = include_str!("../../assets/dashboard/index.html");
+
+/// Hard cap on a POST request body so a misbehaving client can't OOM the
+/// daemon. The purge payload is two short JSON fields; 16 KiB is generous.
+const MAX_REQUEST_BODY_BYTES: usize = 16 * 1024;
+
+/// Aggregate document returned by `GET /state.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DashboardState {
+    pub daemon: DaemonStateView,
+    pub sessions: Vec<SessionView>,
+    pub gc: Vec<ListRow>,
+    pub repos: Vec<RepoVisit>,
+    pub stats: Stats,
+}
+
+/// Meta about the daemon serving this dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonStateView {
+    pub pid: u32,
+    pub ipc_port: u16,
+    pub dashboard_port: Option<u16>,
+    pub started_at_unix: i64,
+    pub now_unix: i64,
+    pub uptime_secs: u64,
+    pub version: String,
+}
+
+/// Public-safe projection of `SessionSnapshot` — drops the *_pid fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionView {
+    pub id: String,
+    pub kind: String,
+    pub name: Option<String>,
+    pub cwd: Option<String>,
+    pub created_at: Option<u64>,
+    pub detachable: bool,
+    pub background: bool,
+    pub attachable: bool,
+    pub repeat_interval_secs: Option<u64>,
+    pub repeat_next_run_at: Option<u64>,
+    pub repeat_running: bool,
+    pub exit_code: Option<i32>,
+    pub worker_port: u16,
+    pub live: bool,
+}
+
+/// Counts derived from the rest of the document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Stats {
+    pub session_count: usize,
+    pub live_session_count: usize,
+    pub gc_count: usize,
+    pub gc_by_kind: HashMap<String, usize>,
+    pub repo_count: usize,
+}
+
+/// Body of `POST /gc/purge`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PurgeRequest {
+    #[serde(default)]
+    pub id: Option<i64>,
+    #[serde(default)]
+    pub kind: Option<String>,
+}
+
+/// Response body of `POST /gc/purge`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PurgeResponse {
+    pub removed: usize,
+    pub skipped: usize,
+}
+
+/// Spawn the dashboard's HTTP listener in a background thread.
+/// Returns the bound port (or `None` if the listener could not be brought
+/// up — logged once and the daemon continues without a dashboard).
+pub(super) fn spawn_dashboard(
+    state_dir: PathBuf,
+    gc_tx: Option<mpsc::Sender<GcRequestMsg>>,
+    ipc_port: u16,
+    started_at_unix: i64,
+) -> Option<u16> {
+    let server = match Server::http("127.0.0.1:0") {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("[clud] note: dashboard listener failed to bind: {err}");
+            return None;
+        }
+    };
+    let port = match server.server_addr().to_ip() {
+        Some(addr) => addr.port(),
+        None => {
+            eprintln!("[clud] note: dashboard listener has no IPv4 address");
+            return None;
+        }
+    };
+    let res = thread::Builder::new()
+        .name("clud-dashboard-http".to_string())
+        .spawn(move || run_dashboard_loop(server, state_dir, gc_tx, ipc_port, started_at_unix));
+    match res {
+        Ok(_) => Some(port),
+        Err(err) => {
+            eprintln!("[clud] note: dashboard thread spawn failed: {err}");
+            None
+        }
+    }
+}
+
+fn run_dashboard_loop(
+    server: Server,
+    state_dir: PathBuf,
+    gc_tx: Option<mpsc::Sender<GcRequestMsg>>,
+    ipc_port: u16,
+    started_at_unix: i64,
+) {
+    for request in server.incoming_requests() {
+        let method = request.method().clone();
+        let url = request.url().to_string();
+        let path = url.split('?').next().unwrap_or(&url).to_string();
+        match (method, path.as_str()) {
+            (Method::Get, "/") | (Method::Get, "/index.html") => {
+                respond_html(request, 200, DASHBOARD_HTML.as_bytes());
+            }
+            (Method::Get, "/state.json") => {
+                handle_state(
+                    request,
+                    &state_dir,
+                    gc_tx.as_ref(),
+                    ipc_port,
+                    started_at_unix,
+                );
+            }
+            (Method::Post, "/gc/purge") => {
+                handle_purge(request, gc_tx.as_ref());
+            }
+            _ => {
+                respond_text(request, 404, b"not found");
+            }
+        }
+    }
+}
+
+// ---------- route handlers ----------
+
+fn handle_state(
+    request: Request,
+    state_dir: &Path,
+    gc_tx: Option<&mpsc::Sender<GcRequestMsg>>,
+    ipc_port: u16,
+    started_at_unix: i64,
+) {
+    match build_dashboard_state(state_dir, gc_tx, ipc_port, started_at_unix) {
+        Ok(state) => match serde_json::to_vec(&state) {
+            Ok(bytes) => respond_json(request, 200, &bytes),
+            Err(err) => respond_json(
+                request,
+                500,
+                json_error_bytes(&format!("serialize state failed: {err}")).as_slice(),
+            ),
+        },
+        Err(err) => {
+            respond_json(request, 500, json_error_bytes(&err.to_string()).as_slice());
+        }
+    }
+}
+
+fn handle_purge(mut request: Request, gc_tx: Option<&mpsc::Sender<GcRequestMsg>>) {
+    let body = match read_body(&mut request) {
+        Ok(b) => b,
+        Err(err) => {
+            respond_json(
+                request,
+                400,
+                json_error_bytes(&format!("read body failed: {err}")).as_slice(),
+            );
+            return;
+        }
+    };
+    let payload: PurgeRequest = if body.is_empty() {
+        PurgeRequest::default()
+    } else {
+        match serde_json::from_slice(&body) {
+            Ok(p) => p,
+            Err(err) => {
+                respond_json(
+                    request,
+                    400,
+                    json_error_bytes(&format!("invalid JSON: {err}")).as_slice(),
+                );
+                return;
+            }
+        }
+    };
+
+    let Some(tx) = gc_tx else {
+        respond_json(
+            request,
+            503,
+            json_error_bytes("gc registry unavailable").as_slice(),
+        );
+        return;
+    };
+
+    // Resolve the request into the GcOp::Purge call. `id` filter is
+    // performed daemon-side after we receive the full list. To keep this
+    // route a single round-trip per request we issue one Purge per filter
+    // form and rely on the kind/duration arguments already supported.
+    let op = match payload.id {
+        Some(id) => {
+            // Single-row purge: look up the matching entry by id, then
+            // purge by (kind=its kind, path=its path) using delete_by_id
+            // — issue a List first, find the row, then send a tailored op.
+            match purge_single_by_id(tx, id) {
+                Ok(reply) => {
+                    respond_purge_reply(request, reply);
+                    return;
+                }
+                Err(err) => {
+                    respond_json(request, 500, json_error_bytes(&err).as_slice());
+                    return;
+                }
+            }
+        }
+        None => GcOp::Purge {
+            duration: None,
+            kind: payload.kind.clone(),
+            dry_run: false,
+        },
+    };
+
+    match send_gc_op(tx, op) {
+        Ok(reply) => respond_purge_reply(request, reply),
+        Err(err) => respond_json(request, 500, json_error_bytes(&err).as_slice()),
+    }
+}
+
+fn respond_purge_reply(request: Request, reply: GcReply) {
+    match reply {
+        GcReply::PurgeOk { removed, skipped } => {
+            let body = serde_json::to_vec(&PurgeResponse { removed, skipped })
+                .unwrap_or_else(|_| b"{}".to_vec());
+            respond_json(request, 200, &body);
+        }
+        GcReply::Error { message } => {
+            respond_json(request, 500, json_error_bytes(&message).as_slice());
+        }
+        other => {
+            respond_json(
+                request,
+                500,
+                json_error_bytes(&format!("unexpected reply: {other:?}")).as_slice(),
+            );
+        }
+    }
+}
+
+/// Resolve `id` -> its `(kind, path)` and then issue a Purge filtered to
+/// that one row. There is no native single-row purge op so we round-trip
+/// once to enumerate, then once to purge. Acceptable because dashboard
+/// purges are user-initiated, not on the hot path.
+fn purge_single_by_id(tx: &mpsc::Sender<GcRequestMsg>, id: i64) -> Result<GcReply, String> {
+    let list_reply = send_gc_op(tx, GcOp::List { kind: None })?;
+    let rows = match list_reply {
+        GcReply::ListOk { rows } => rows,
+        GcReply::Error { message } => return Err(message),
+        other => return Err(format!("unexpected reply: {other:?}")),
+    };
+    let Some(target) = rows.into_iter().find(|r| r.id == id) else {
+        // No row with that id — return an idempotent zero-effect ack.
+        return Ok(GcReply::PurgeOk {
+            removed: 0,
+            skipped: 0,
+        });
+    };
+    if target.live_locked {
+        return Ok(GcReply::PurgeOk {
+            removed: 0,
+            skipped: 1,
+        });
+    }
+    // The existing purge op filters by kind+age but not by path. Best
+    // available primitive: filter by kind and then accept that a kind
+    // with multiple non-live-locked rows older than nothing will purge
+    // them all. To keep semantics tight we use a fresh op variant that
+    // already exists in the IPC surface — `Purge { duration: None, kind:
+    // Some(target.kind) }` — but only when there's just one row of that
+    // kind. Otherwise fall back to deleting via a future per-id IPC
+    // (tracked separately); for now we return a clear error.
+    let same_kind_count = match send_gc_op(
+        tx,
+        GcOp::List {
+            kind: Some(target.kind.clone()),
+        },
+    )? {
+        GcReply::ListOk { rows } => rows.len(),
+        GcReply::Error { message } => return Err(message),
+        other => return Err(format!("unexpected reply: {other:?}")),
+    };
+    if same_kind_count > 1 {
+        return Err(format!(
+            "per-id purge not yet supported when multiple rows share kind={} \
+             (matched id={id}); use the per-kind purge button instead",
+            target.kind
+        ));
+    }
+    send_gc_op(
+        tx,
+        GcOp::Purge {
+            duration: None,
+            kind: Some(target.kind),
+            dry_run: false,
+        },
+    )
+}
+
+// ---------- state aggregation ----------
+
+fn build_dashboard_state(
+    state_dir: &Path,
+    gc_tx: Option<&mpsc::Sender<GcRequestMsg>>,
+    ipc_port: u16,
+    started_at_unix: i64,
+) -> Result<DashboardState, String> {
+    let now_unix = current_unix();
+
+    let sessions = read_session_views(state_dir).unwrap_or_default();
+    let live_session_count = sessions.iter().filter(|s| s.live).count();
+
+    let gc_rows = match gc_tx {
+        Some(tx) => match send_gc_op(tx, GcOp::List { kind: None }) {
+            Ok(GcReply::ListOk { rows }) => rows,
+            Ok(GcReply::Error { message }) => return Err(format!("gc.list failed: {message}")),
+            Ok(other) => return Err(format!("gc.list unexpected reply: {other:?}")),
+            Err(err) => return Err(err),
+        },
+        None => Vec::new(),
+    };
+
+    let repos = match gc_tx {
+        Some(tx) => match send_gc_op(tx, GcOp::ListRepoVisits) {
+            Ok(GcReply::RepoVisitsOk { rows }) => rows,
+            Ok(GcReply::Error { message }) => {
+                return Err(format!("gc.list_repo_visits failed: {message}"));
+            }
+            Ok(other) => {
+                return Err(format!("gc.list_repo_visits unexpected reply: {other:?}"));
+            }
+            Err(err) => return Err(err),
+        },
+        None => Vec::new(),
+    };
+
+    let mut gc_by_kind: HashMap<String, usize> = HashMap::new();
+    for row in &gc_rows {
+        *gc_by_kind.entry(row.kind.clone()).or_insert(0) += 1;
+    }
+
+    let stats = Stats {
+        session_count: sessions.len(),
+        live_session_count,
+        gc_count: gc_rows.len(),
+        gc_by_kind,
+        repo_count: repos.len(),
+    };
+
+    Ok(DashboardState {
+        daemon: DaemonStateView {
+            pid: std::process::id(),
+            ipc_port,
+            dashboard_port: read_dashboard_port(state_dir).ok().flatten(),
+            started_at_unix,
+            now_unix,
+            uptime_secs: (now_unix - started_at_unix).max(0) as u64,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        sessions,
+        gc: gc_rows,
+        repos,
+        stats,
+    })
+}
+
+fn read_session_views(state_dir: &Path) -> io::Result<Vec<SessionView>> {
+    let mut out = Vec::new();
+    let dir = sessions_dir(state_dir);
+    let entries = match fs::read_dir(&dir) {
+        Ok(it) => it,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(out),
+        Err(err) => return Err(err),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(snap) = read_json_file::<SessionSnapshot>(&path) else {
+            continue;
+        };
+        let live = snap.exit_code.is_none() && pid_is_alive(snap.worker_pid);
+        out.push(SessionView {
+            id: snap.id,
+            kind: match snap.kind {
+                SessionKind::Subprocess => "subprocess".to_string(),
+                SessionKind::Pty => "pty".to_string(),
+            },
+            name: snap.name,
+            cwd: snap.cwd,
+            created_at: snap.created_at,
+            detachable: snap.detachable,
+            background: snap.background,
+            attachable: snap.attachable,
+            repeat_interval_secs: snap.repeat_interval_secs,
+            repeat_next_run_at: snap.repeat_next_run_at,
+            repeat_running: snap.repeat_running,
+            exit_code: snap.exit_code,
+            worker_port: snap.worker_port,
+            live,
+        });
+    }
+    // Newest first.
+    out.sort_by(|a, b| b.created_at.unwrap_or(0).cmp(&a.created_at.unwrap_or(0)));
+    Ok(out)
+}
+
+// ---------- IPC plumbing ----------
+
+fn send_gc_op(tx: &mpsc::Sender<GcRequestMsg>, op: GcOp) -> Result<GcReply, String> {
+    let (reply_tx, reply_rx) = mpsc::sync_channel::<GcReply>(1);
+    tx.send(GcRequestMsg { op, reply_tx })
+        .map_err(|_| "gc registry worker stopped".to_string())?;
+    reply_rx
+        .recv_timeout(WORKER_REPLY_TIMEOUT)
+        .map_err(|_| "gc registry worker timed out".to_string())
+}
+
+// ---------- public helpers for the `clud ui` CLI ----------
+
+/// Read the daemon-info file and return its dashboard port, if present.
+/// `Ok(None)` distinguishes "daemon is up but the dashboard listener
+/// didn't bind on this run" from "daemon hasn't even been started".
+pub fn read_dashboard_port(state_dir: &Path) -> io::Result<Option<u16>> {
+    let info = read_json_file::<DaemonInfo>(&daemon_info_path(state_dir))?;
+    Ok(info.dashboard_port)
+}
+
+/// Re-export the typed info read by the `clud ui` CLI. Kept narrow so the
+/// CLI layer doesn't depend on the (internal) `DaemonInfo` struct.
+pub fn read_dashboard_info(state_dir: &Path) -> io::Result<DashboardInfo> {
+    let info = read_json_file::<DaemonInfo>(&daemon_info_path(state_dir))?;
+    Ok(DashboardInfo {
+        pid: info.pid,
+        ipc_port: info.port,
+        dashboard_port: info.dashboard_port,
+    })
+}
+
+/// Public view of `daemon.json` used by the `clud ui` CLI.
+#[derive(Debug, Clone)]
+pub struct DashboardInfo {
+    pub pid: u32,
+    pub ipc_port: u16,
+    pub dashboard_port: Option<u16>,
+}
+
+pub fn dashboard_url_from_info(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/")
+}
+
+/// Fetch `/state.json` from the running dashboard. Used by `clud ui --json`.
+pub fn fetch_state_json(port: u16) -> io::Result<String> {
+    use std::io::Write;
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    let req = "GET /state.json HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    stream.write_all(req.as_bytes())?;
+    stream.flush()?;
+    let mut buf = Vec::with_capacity(4096);
+    stream.read_to_end(&mut buf)?;
+    // Split off the HTTP headers; we only return the body.
+    let body_start = find_body_start(&buf).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "dashboard response had no headers terminator",
+        )
+    })?;
+    let body = &buf[body_start..];
+    String::from_utf8(body.to_vec())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}
+
+fn find_body_start(buf: &[u8]) -> Option<usize> {
+    buf.windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|i| i + 4)
+        .or_else(|| buf.windows(2).position(|w| w == b"\n\n").map(|i| i + 2))
+}
+
+// ---------- tiny_http helpers ----------
+
+fn respond_html(request: Request, status: u16, body: &[u8]) {
+    let response = Response::from_data(body.to_vec())
+        .with_status_code(status)
+        .with_header(html_content_type())
+        .with_header(no_cache_header());
+    let _ = request.respond(response);
+}
+
+fn respond_json(request: Request, status: u16, body: &[u8]) {
+    let response = Response::from_data(body.to_vec())
+        .with_status_code(status)
+        .with_header(json_content_type())
+        .with_header(no_cache_header());
+    let _ = request.respond(response);
+}
+
+fn respond_text(request: Request, status: u16, body: &[u8]) {
+    let response = Response::from_data(body.to_vec())
+        .with_status_code(status)
+        .with_header(text_content_type())
+        .with_header(no_cache_header());
+    let _ = request.respond(response);
+}
+
+fn html_content_type() -> Header {
+    Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
+        .expect("static content-type header")
+}
+
+fn json_content_type() -> Header {
+    Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+        .expect("static content-type header")
+}
+
+fn text_content_type() -> Header {
+    Header::from_bytes(&b"Content-Type"[..], &b"text/plain; charset=utf-8"[..])
+        .expect("static content-type header")
+}
+
+fn no_cache_header() -> Header {
+    Header::from_bytes(&b"Cache-Control"[..], &b"no-store"[..]).expect("static cache header")
+}
+
+fn read_body(request: &mut Request) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    request
+        .as_reader()
+        .take(MAX_REQUEST_BODY_BYTES as u64)
+        .read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+fn json_error_bytes(message: &str) -> Vec<u8> {
+    let payload = serde_json::json!({ "error": message });
+    serde_json::to_vec(&payload).unwrap_or_else(|_| b"{\"error\":\"unknown\"}".to_vec())
+}
+
+fn current_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::gc_service::spawn_registry_worker_with;
+    use crate::daemon::types::{SessionKind, SessionSnapshot};
+    use crate::gc::Registry;
+    use std::io::Write;
+
+    fn write_fake_session(state_dir: &Path, id: &str, snap: SessionSnapshot) {
+        let dir = state_dir.join("sessions");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{id}.json"));
+        std::fs::write(&path, serde_json::to_vec_pretty(&snap).unwrap()).unwrap();
+    }
+
+    fn fake_snapshot(id: &str, name: &str, cwd: &str) -> SessionSnapshot {
+        SessionSnapshot {
+            id: id.to_string(),
+            kind: SessionKind::Pty,
+            cwd: Some(cwd.to_string()),
+            name: Some(name.to_string()),
+            created_at: Some(500),
+            detachable: false,
+            background: false,
+            attachable: true,
+            repeat_interval_secs: None,
+            repeat_next_run_at: None,
+            repeat_running: false,
+            // Sensitive fields — the SessionView should drop these.
+            daemon_pid: 1,
+            // A PID this unlikely to be alive forces live=false in tests.
+            worker_pid: 4_000_000_000,
+            worker_port: 12345,
+            root_pid: None,
+            exit_code: None,
+        }
+    }
+
+    #[test]
+    fn dashboard_url_format() {
+        assert_eq!(dashboard_url_from_info(54321), "http://127.0.0.1:54321/");
+    }
+
+    #[test]
+    fn purge_request_defaults_when_body_is_empty() {
+        let parsed: PurgeRequest = serde_json::from_str("{}").unwrap();
+        assert!(parsed.id.is_none());
+        assert!(parsed.kind.is_none());
+    }
+
+    #[test]
+    fn purge_request_round_trips_kind_filter() {
+        let json = r#"{"kind":"worktree"}"#;
+        let parsed: PurgeRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.kind.as_deref(), Some("worktree"));
+    }
+
+    #[test]
+    fn dashboard_html_asset_loads() {
+        // Sanity check: the embedded asset compiled in. Tests pulled from
+        // disk would mask a missing `include_str!`.
+        assert!(DASHBOARD_HTML.contains("clud"));
+    }
+
+    #[test]
+    fn find_body_start_after_crlf_crlf() {
+        let raw = b"HTTP/1.0 200 OK\r\nContent-Type: application/json\r\n\r\n{\"x\":1}";
+        let idx = find_body_start(raw).unwrap();
+        assert_eq!(&raw[idx..], b"{\"x\":1}");
+    }
+
+    #[test]
+    fn build_state_with_empty_state_dir_returns_zeros() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = build_dashboard_state(dir.path(), None, 9999, 100).expect("build");
+        assert_eq!(state.stats.session_count, 0);
+        assert_eq!(state.stats.live_session_count, 0);
+        assert_eq!(state.stats.gc_count, 0);
+        assert_eq!(state.stats.repo_count, 0);
+        assert_eq!(state.daemon.ipc_port, 9999);
+        assert_eq!(state.daemon.started_at_unix, 100);
+        assert_eq!(state.daemon.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn build_state_includes_session_snapshots() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fake_session(
+            dir.path(),
+            "sess-a",
+            fake_snapshot("sess-a", "test", "/dev/foo"),
+        );
+
+        let state = build_dashboard_state(dir.path(), None, 9999, 100).expect("build");
+        assert_eq!(state.sessions.len(), 1);
+        assert_eq!(state.sessions[0].id, "sess-a");
+        assert_eq!(state.sessions[0].name.as_deref(), Some("test"));
+        assert_eq!(state.sessions[0].cwd.as_deref(), Some("/dev/foo"));
+        assert_eq!(state.sessions[0].kind, "pty");
+        // Unlikely-PID worker should be reported as not live.
+        assert!(!state.sessions[0].live);
+
+        // SessionView must not expose `daemon_pid` / `worker_pid` / `root_pid`.
+        let json = serde_json::to_value(&state.sessions[0]).unwrap();
+        assert!(json.get("daemon_pid").is_none());
+        assert!(json.get("worker_pid").is_none());
+        assert!(json.get("root_pid").is_none());
+    }
+
+    #[test]
+    fn end_to_end_state_endpoint_returns_all_three_kinds() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("e2e.redb");
+
+        // Seed: one session.
+        write_fake_session(
+            dir.path(),
+            "sess-x",
+            fake_snapshot("sess-x", "fix", "/dev/repo"),
+        );
+
+        // Seed: one GC row + one repo visit.
+        let registry = Registry::open_at(&db_path).expect("open registry");
+        let gc_tx = spawn_registry_worker_with(registry).expect("worker");
+        let (rx_t, rx) = mpsc::sync_channel::<GcReply>(1);
+        gc_tx
+            .send(GcRequestMsg {
+                op: GcOp::Insert {
+                    kind: "worktree".to_string(),
+                    path: "/tmp/wt-x".to_string(),
+                    repo_root: Some("/dev/repo".to_string()),
+                    branch: Some("feat/x".to_string()),
+                    agent_id: Some("agent-x".to_string()),
+                    created_unix: Some(1000),
+                },
+                reply_tx: rx_t,
+            })
+            .unwrap();
+        let _ = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+
+        let (rx_t, rx) = mpsc::sync_channel::<GcReply>(1);
+        gc_tx
+            .send(GcRequestMsg {
+                op: GcOp::RecordRepoVisit {
+                    repo_root: "/dev/repo".to_string(),
+                    cwd: "/dev/repo".to_string(),
+                    now_unix: Some(2000),
+                },
+                reply_tx: rx_t,
+            })
+            .unwrap();
+        let _ = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+
+        // Spawn the actual HTTP server.
+        let port = spawn_dashboard(dir.path().to_path_buf(), Some(gc_tx.clone()), 9999, 100)
+            .expect("dashboard spawned");
+
+        // Hit /state.json.
+        let body = fetch_state_json(port).expect("fetch state");
+        let state: DashboardState = serde_json::from_str(&body).expect("parse");
+        assert_eq!(state.stats.session_count, 1);
+        assert_eq!(state.stats.gc_count, 1);
+        assert_eq!(state.stats.repo_count, 1);
+        assert_eq!(state.sessions[0].name.as_deref(), Some("fix"));
+        assert_eq!(state.gc[0].kind, "worktree");
+        assert_eq!(state.repos[0].repo_root, "/dev/repo");
+        assert_eq!(state.repos[0].run_count, 1);
+
+        // Hit GET / and confirm the HTML asset is served.
+        let html_body = fetch_path(port, "GET", "/", None).expect("fetch root");
+        assert!(html_body.contains("clud dashboard"));
+    }
+
+    #[test]
+    fn end_to_end_purge_kind_round_trip_mutates_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("purge.redb");
+
+        let registry = Registry::open_at(&db_path).expect("open registry");
+        let gc_tx = spawn_registry_worker_with(registry).expect("worker");
+        for p in ["/tmp/p-a", "/tmp/p-b"] {
+            let (rx_t, rx) = mpsc::sync_channel::<GcReply>(1);
+            gc_tx
+                .send(GcRequestMsg {
+                    op: GcOp::Insert {
+                        kind: "cache".to_string(),
+                        path: p.to_string(),
+                        repo_root: None,
+                        branch: None,
+                        agent_id: None,
+                        created_unix: Some(1000),
+                    },
+                    reply_tx: rx_t,
+                })
+                .unwrap();
+            let _ = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        }
+
+        let port = spawn_dashboard(dir.path().to_path_buf(), Some(gc_tx.clone()), 9999, 100)
+            .expect("dashboard spawned");
+
+        // POST /gc/purge {"kind":"cache"}
+        let body = fetch_path(
+            port,
+            "POST",
+            "/gc/purge",
+            Some(r#"{"kind":"cache"}"#.to_string()),
+        )
+        .expect("purge");
+        let resp: PurgeResponse = serde_json::from_str(&body).expect("parse");
+        assert_eq!(resp.removed, 2);
+        assert_eq!(resp.skipped, 0);
+
+        // Verify the registry is now empty for that kind.
+        let state_body = fetch_state_json(port).expect("re-fetch state");
+        let state: DashboardState = serde_json::from_str(&state_body).expect("parse state");
+        assert_eq!(state.stats.gc_count, 0);
+    }
+
+    /// Tiny HTTP/1.0 client for tests. Connect, send a request, read the
+    /// body. Avoids pulling in a real HTTP client dep just for tests.
+    fn fetch_path(port: u16, method: &str, path: &str, body: Option<String>) -> io::Result<String> {
+        let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+        stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+        let mut req =
+            format!("{method} {path} HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n",);
+        if let Some(b) = &body {
+            req.push_str(&format!(
+                "Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                b.len(),
+                b
+            ));
+        } else {
+            req.push_str("\r\n");
+        }
+        stream.write_all(req.as_bytes())?;
+        stream.flush()?;
+        let mut buf = Vec::with_capacity(4096);
+        stream.read_to_end(&mut buf)?;
+        let body_start = find_body_start(&buf)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no header terminator"))?;
+        String::from_utf8(buf[body_start..].to_vec())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+    }
+}

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -3,6 +3,7 @@ mod client;
 mod commands;
 mod entry;
 mod gc_service;
+mod http;
 mod io_helpers;
 mod keys;
 mod paths;
@@ -14,8 +15,13 @@ mod worker;
 mod worker_shared;
 
 pub use client::{
-    ensure_daemon, gc_client_insert, gc_client_list, gc_client_purge, gc_client_reconcile,
+    ensure_daemon, gc_client_insert, gc_client_list, gc_client_list_repo_visits, gc_client_purge,
+    gc_client_reconcile, gc_client_record_repo_visit,
 };
 pub use entry::{experimental_enabled, handle_special_command, run_centralized_session};
+pub use http::{
+    dashboard_url_from_info, fetch_state_json, read_dashboard_info, read_dashboard_port,
+    DashboardInfo,
+};
 pub use paths::default_state_dir;
-pub use types::{ListRow, ENV_NO_DAEMON};
+pub use types::{ListRow, RepoVisit, ENV_NO_DAEMON};

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -5,7 +5,7 @@ use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use running_process::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
 use sysinfo::Signal;
@@ -14,12 +14,20 @@ use crate::win_creation_flags::invisible_helper_creationflags;
 
 use super::client::cleanup_stale_state;
 use super::gc_service::{spawn_registry_worker, GcRequestMsg, WORKER_REPLY_TIMEOUT};
+use super::http::spawn_dashboard;
 use super::io_helpers::{new_session_id, read_json_file, write_json_file, write_json_line};
 use super::paths::{daemon_info_path, session_snapshot_path, sessions_dir, spec_path, specs_dir};
 use super::process_utils::{pid_is_alive, signal_process_tree};
 use super::types::{
     DaemonInfo, DaemonRequest, DaemonResponse, GcReply, SessionSnapshot, WorkerLaunchSpec,
 };
+
+fn current_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
 
 pub(super) fn run_daemon(state_dir: &Path) -> i32 {
     if let Err(err) = fs::create_dir_all(state_dir) {
@@ -43,15 +51,6 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
             return 1;
         }
     };
-    let info = DaemonInfo {
-        pid: std::process::id(),
-        port,
-    };
-    if let Err(err) = write_json_file(&daemon_info_path(state_dir), &info) {
-        eprintln!("[clud] failed to persist daemon info: {}", err);
-        return 1;
-    }
-
     // Issue #135: GC registry worker is in-process now. Failing to open
     // the registry is non-fatal — session ops still work; only GC ops
     // will error back to the CLI. Log once and continue.
@@ -62,6 +61,29 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
             None
         }
     };
+
+    // Issue #183: in-process HTTP dashboard. Bind a second loopback port
+    // alongside the IPC listener and run a `tiny_http` server on a worker
+    // thread. The port is recorded in `daemon.json` so `clud ui` can
+    // discover it. Bind failures are non-fatal — IPC keeps working;
+    // `dashboard_port` is just `None` on this daemon instance.
+    let started_at_unix = current_unix();
+    let dashboard_port = spawn_dashboard(
+        state_dir.to_path_buf(),
+        gc_tx.clone(),
+        port,
+        started_at_unix,
+    );
+
+    let info = DaemonInfo {
+        pid: std::process::id(),
+        port,
+        dashboard_port,
+    };
+    if let Err(err) = write_json_file(&daemon_info_path(state_dir), &info) {
+        eprintln!("[clud] failed to persist daemon info: {}", err);
+        return 1;
+    }
 
     let workers = Arc::new(Mutex::new(HashMap::<String, Arc<NativeProcess>>::new()));
     for stream in listener.incoming() {

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use sysinfo::Signal;
 
 use crate::command::LaunchPlan;
+pub use crate::gc::RepoVisit;
 
 use super::process_utils::signal_process_tree;
 
@@ -46,6 +47,12 @@ pub(super) enum SessionKind {
 pub(super) struct DaemonInfo {
     pub(super) pid: u32,
     pub(super) port: u16,
+    /// Issue #183: loopback port for the in-process HTTP dashboard. `None`
+    /// when the dashboard listener failed to bind (logged once at daemon
+    /// start; IPC keeps working). Older clud versions wrote this file
+    /// without the field, so reads tolerate its absence.
+    #[serde(default)]
+    pub(super) dashboard_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -173,6 +180,18 @@ pub(crate) enum GcOp {
         #[serde(default)]
         created_unix: Option<i64>,
     },
+    /// Issue #183: upsert a `repo_visits` row, called by every clud
+    /// startup from inside a git repo. The daemon increments the
+    /// per-repo run counter and records the current cwd.
+    RecordRepoVisit {
+        repo_root: String,
+        cwd: String,
+        #[serde(default)]
+        now_unix: Option<i64>,
+    },
+    /// Issue #183: enumerate the `repo_visits` table, newest first.
+    /// Powers the `repos` array in `clud ui` / `/state.json`.
+    ListRepoVisits,
 }
 
 /// Issue #135: payload carried by `DaemonResponse::Gc`. Mirrors what the
@@ -180,11 +199,26 @@ pub(crate) enum GcOp {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "gc_op", rename_all = "snake_case")]
 pub(crate) enum GcReply {
-    ListOk { rows: Vec<ListRow> },
-    PurgeOk { removed: usize, skipped: usize },
-    ReconcileOk { inserted: usize },
+    ListOk {
+        rows: Vec<ListRow>,
+    },
+    PurgeOk {
+        removed: usize,
+        skipped: usize,
+    },
+    ReconcileOk {
+        inserted: usize,
+    },
     InsertOk,
-    Error { message: String },
+    /// Issue #183: ack for a successful `GcOp::RecordRepoVisit` upsert.
+    RepoVisitOk,
+    /// Issue #183: payload for `GcOp::ListRepoVisits`.
+    RepoVisitsOk {
+        rows: Vec<RepoVisit>,
+    },
+    Error {
+        message: String,
+    },
 }
 
 /// Row shape returned by `gc.list`. Stable JSON schema for the CLI; the

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -192,6 +192,13 @@ pub(crate) enum GcOp {
     /// Issue #183: enumerate the `repo_visits` table, newest first.
     /// Powers the `repos` array in `clud ui` / `/state.json`.
     ListRepoVisits,
+    /// Issue #183: surgically delete a single tracked entry by its
+    /// `id`. Used by the dashboard's per-row Delete button. Runs the
+    /// same on-disk removal as `Purge` (worktree-aware) but targets
+    /// exactly one row regardless of how many siblings share its kind.
+    DeleteById {
+        id: i64,
+    },
 }
 
 /// Issue #135: payload carried by `DaemonResponse::Gc`. Mirrors what the

--- a/crates/clud-bin/src/gc.rs
+++ b/crates/clud-bin/src/gc.rs
@@ -44,6 +44,12 @@ const TRACKED: TableDefinition<(&str, &str), &[u8]> = TableDefinition::new("trac
 /// monotonic `next_id` counter used to mint `TrackedEntry.id` values.
 const META: TableDefinition<&str, u64> = TableDefinition::new("meta");
 
+/// redb table (issue #183): `repo_root -> serde_json::to_vec(&RepoVisitRow)`.
+/// One row per unique git repo `clud` has been launched in. Upserted on
+/// every startup; powers the `Repos` tab of `clud ui` and the
+/// `repos[]` array in `/state.json`.
+const REPO_VISITS: TableDefinition<&str, &[u8]> = TableDefinition::new("repo_visits");
+
 const META_SCHEMA_VERSION: &str = "schema_version";
 const META_NEXT_ID: &str = "next_id";
 
@@ -139,6 +145,27 @@ pub struct InsertInput {
     pub now_unix: i64,
 }
 
+/// On-disk row for `REPO_VISITS`. Stored as serde_json bytes keyed by
+/// `repo_root`. `run_count` increments on every upsert; `last_cwd` is the
+/// CWD of the most recent invocation (may differ from `repo_root` when
+/// `clud` was run from a subdirectory of the repo).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RepoVisitRow {
+    last_visited_unix: i64,
+    run_count: u64,
+    last_cwd: String,
+}
+
+/// One row from the `repo_visits` table. Public so the daemon HTTP
+/// handler and `clud ui` JSON output can serialize it directly.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoVisit {
+    pub repo_root: String,
+    pub last_visited_unix: i64,
+    pub run_count: u64,
+    pub last_cwd: String,
+}
+
 /// `redb`-backed registry of tracked entries.
 ///
 /// `redb::Database` serializes writers at the file level, so we hold a
@@ -178,6 +205,11 @@ impl Registry {
         let txn = db.begin_write()?;
         {
             let _ = txn.open_table(TRACKED)?;
+            // Issue #183: opens (or creates) the `repo_visits` table on every
+            // daemon start. Existing data.redb files predate this table and
+            // will auto-migrate on first open — redb's `open_table` is
+            // create-if-missing.
+            let _ = txn.open_table(REPO_VISITS)?;
             let mut meta = txn.open_table(META)?;
             if meta.get(META_SCHEMA_VERSION)?.is_none() {
                 meta.insert(META_SCHEMA_VERSION, 1u64)?;
@@ -188,6 +220,57 @@ impl Registry {
         }
         txn.commit()?;
         Ok(())
+    }
+
+    /// Issue #183: upsert one `repo_visits` row. `repo_root` is the key.
+    /// On first call inserts `{last_visited_unix, run_count: 1, last_cwd}`;
+    /// subsequent calls bump `run_count` and overwrite `last_visited_unix`
+    /// and `last_cwd`.
+    pub fn record_repo_visit(
+        &self,
+        repo_root: &str,
+        cwd: &str,
+        now_unix: i64,
+    ) -> Result<(), GcError> {
+        let wtxn = self.db.begin_write()?;
+        {
+            let mut table = wtxn.open_table(REPO_VISITS)?;
+            let prior = table.get(repo_root)?;
+            let prior_count: u64 = match prior.as_ref() {
+                Some(g) => serde_json::from_slice::<RepoVisitRow>(g.value())?.run_count,
+                None => 0,
+            };
+            // Drop the read guard before re-borrowing `table` mutably.
+            drop(prior);
+            let row = RepoVisitRow {
+                last_visited_unix: now_unix,
+                run_count: prior_count + 1,
+                last_cwd: cwd.to_string(),
+            };
+            let bytes = serde_json::to_vec(&row)?;
+            table.insert(repo_root, bytes.as_slice())?;
+        }
+        wtxn.commit()?;
+        Ok(())
+    }
+
+    /// Issue #183: return every `repo_visits` row, newest first.
+    pub fn list_repo_visits(&self) -> Result<Vec<RepoVisit>, GcError> {
+        let rtxn = self.db.begin_read()?;
+        let table = rtxn.open_table(REPO_VISITS)?;
+        let mut out = Vec::new();
+        for entry in table.iter()? {
+            let (k, v) = entry?;
+            let row: RepoVisitRow = serde_json::from_slice(v.value())?;
+            out.push(RepoVisit {
+                repo_root: k.value().to_string(),
+                last_visited_unix: row.last_visited_unix,
+                run_count: row.run_count,
+                last_cwd: row.last_cwd,
+            });
+        }
+        out.sort_by(|a, b| b.last_visited_unix.cmp(&a.last_visited_unix));
+        Ok(out)
     }
 
     /// Insert a new entry keyed by `(kind, path)`. **No-op if a row with

--- a/crates/clud-bin/src/gc_tests.rs
+++ b/crates/clud-bin/src/gc_tests.rs
@@ -33,6 +33,58 @@ fn schema_bootstraps_on_first_open() {
     // Reopening on a populated db must not error out.
 }
 
+// ---------- Issue #183: repo_visits table ----------
+
+#[test]
+fn record_repo_visit_inserts_first_row() {
+    let reg = fresh_registry("repo-visit-insert");
+    reg.record_repo_visit("/dev/foo", "/dev/foo", 1000)
+        .expect("record");
+    let rows = reg.list_repo_visits().expect("list");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].repo_root, "/dev/foo");
+    assert_eq!(rows[0].last_cwd, "/dev/foo");
+    assert_eq!(rows[0].last_visited_unix, 1000);
+    assert_eq!(rows[0].run_count, 1);
+}
+
+#[test]
+fn record_repo_visit_increments_run_count() {
+    let reg = fresh_registry("repo-visit-incr");
+    reg.record_repo_visit("/dev/foo", "/dev/foo", 1000).unwrap();
+    reg.record_repo_visit("/dev/foo", "/dev/foo/sub", 1100)
+        .unwrap();
+    reg.record_repo_visit("/dev/foo", "/dev/foo", 1200).unwrap();
+    let rows = reg.list_repo_visits().expect("list");
+    assert_eq!(rows.len(), 1, "second/third visits upsert, never duplicate");
+    assert_eq!(rows[0].run_count, 3);
+    // last_visited and last_cwd reflect the most recent call.
+    assert_eq!(rows[0].last_visited_unix, 1200);
+    assert_eq!(rows[0].last_cwd, "/dev/foo");
+}
+
+#[test]
+fn list_repo_visits_orders_newest_first() {
+    let reg = fresh_registry("repo-visit-order");
+    reg.record_repo_visit("/dev/old", "/dev/old", 100).unwrap();
+    reg.record_repo_visit("/dev/newest", "/dev/newest", 9000)
+        .unwrap();
+    reg.record_repo_visit("/dev/mid", "/dev/mid", 500).unwrap();
+    let rows = reg.list_repo_visits().expect("list");
+    let repos: Vec<&str> = rows.iter().map(|r| r.repo_root.as_str()).collect();
+    assert_eq!(repos, vec!["/dev/newest", "/dev/mid", "/dev/old"]);
+}
+
+#[test]
+fn record_repo_visit_distinguishes_keys() {
+    let reg = fresh_registry("repo-visit-distinct");
+    reg.record_repo_visit("/dev/a", "/dev/a", 100).unwrap();
+    reg.record_repo_visit("/dev/b", "/dev/b", 200).unwrap();
+    let rows = reg.list_repo_visits().expect("list");
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|r| r.run_count == 1));
+}
+
 #[test]
 fn insert_then_list_round_trips() {
     let reg = fresh_registry("rt");

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -30,6 +30,7 @@ pub mod startup;
 pub mod stream_json;
 pub mod subprocess;
 pub mod trampoline;
+pub mod ui;
 pub mod verbose_log;
 pub mod voice;
 pub mod wasm;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,7 @@
 use clud::{
     args, backend, backend_bootstrap, command, console_setup, console_title, daemon, gc,
     hook_health, large_file_guard, loop_artifacts, loop_spec, runner, skill_install, skills,
-    startup, trampoline, verbose_log, wasm, worktrees,
+    startup, trampoline, ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -65,6 +65,12 @@ fn main() {
     // so a registry-less host can still run `clud gc reconcile`.
     if let Some(args::Command::Gc { subcommand }) = &args.command {
         std::process::exit(gc::run(&args, subcommand.clone()));
+    }
+
+    // Issue #183: `clud ui` opens the local dashboard. Self-contained;
+    // never launches a backend.
+    if let Some(args::Command::Ui { json, no_open }) = &args.command {
+        std::process::exit(ui::run(*json, *no_open));
     }
 
     // Issue #83: `--clean-worktrees` is a self-contained maintenance path.
@@ -182,6 +188,11 @@ fn main() {
                     if args.verbose {
                         verbose_log::log(format_args!("[clud] daemon: unavailable: {e}"));
                     }
+                } else {
+                    // Issue #183: record one row in the `repo_visits` table
+                    // per (repo_root, current launch). Errors are non-fatal:
+                    // failing to record a visit must never block a launch.
+                    record_repo_visit_best_effort(&state_dir, args.verbose);
                 }
             }
             Err(e) => {
@@ -368,4 +379,27 @@ fn main() {
         verbose_log::log(format_args!("[clud] exit: code {exit_code}"));
     }
     std::process::exit(exit_code);
+}
+
+/// Issue #183: best-effort upsert of `(repo_root, cwd)` into the daemon's
+/// `repo_visits` table. Resolves the current git root; if there isn't one,
+/// this is a no-op (we don't track scratch-dir launches). All errors are
+/// swallowed — recording a repo visit must never block a launch.
+fn record_repo_visit_best_effort(state_dir: &std::path::Path, verbose: bool) {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    // `git_root_from` returns its input verbatim when no `.git` is found
+    // anywhere up the tree. We treat that as "not in a repo" and skip,
+    // so we don't accumulate one row per random scratch directory.
+    let repo_root = loop_spec::git_root_from(&cwd);
+    if !repo_root.join(".git").exists() {
+        return;
+    }
+    if let Err(e) = daemon::gc_client_record_repo_visit(state_dir, &repo_root, &cwd) {
+        if verbose {
+            verbose_log::log(format_args!("[clud] repo_visit: {e}"));
+        }
+    }
 }

--- a/crates/clud-bin/src/ui.rs
+++ b/crates/clud-bin/src/ui.rs
@@ -1,0 +1,103 @@
+//! Issue #183: `clud ui` subcommand — open the local web dashboard.
+//!
+//! Three modes, all gated through the same `run` entry point so the
+//! daemon-up / port-discovery preamble is shared:
+//!
+//! 1. Default (`clud ui`) — ensure the daemon is up, then launch the
+//!    user's default browser at the dashboard URL.
+//! 2. `--no-open` — same preamble but only print the URL.
+//! 3. `--json` — fetch `/state.json` from the dashboard and dump it to
+//!    stdout, no browser. Mirrors the `clud gc list --json` convention.
+
+use crate::daemon::{
+    self, dashboard_url_from_info, ensure_daemon, fetch_state_json, read_dashboard_info,
+    DashboardInfo,
+};
+
+pub fn run(json: bool, no_open: bool) -> i32 {
+    let state_dir = match daemon::default_state_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: cannot resolve clud state dir: {e}");
+            return 1;
+        }
+    };
+
+    if let Err(e) = ensure_daemon(&state_dir) {
+        eprintln!("error: daemon unavailable: {e}");
+        return 1;
+    }
+
+    let info = match read_dashboard_info(&state_dir) {
+        Ok(info) => info,
+        Err(e) => {
+            eprintln!("error: cannot read daemon info: {e}");
+            return 1;
+        }
+    };
+
+    let Some(port) = info.dashboard_port else {
+        eprintln!(
+            "error: this daemon ({}) was started without a dashboard listener. \
+             Stop it (e.g. via `clud kill --all` for sessions; the daemon will respawn) \
+             and retry.",
+            info.pid
+        );
+        return 1;
+    };
+
+    if json {
+        return print_state_json(port);
+    }
+
+    let url = dashboard_url_from_info(port);
+    println!("{}", url);
+
+    if no_open {
+        return 0;
+    }
+
+    open_browser(&url, &info)
+}
+
+fn print_state_json(port: u16) -> i32 {
+    match fetch_state_json(port) {
+        Ok(body) => {
+            println!("{}", body);
+            0
+        }
+        Err(e) => {
+            eprintln!("error: fetch /state.json failed: {e}");
+            1
+        }
+    }
+}
+
+fn open_browser(url: &str, info: &DashboardInfo) -> i32 {
+    // The `open` crate handles macOS `open`, Linux `xdg-open`, and
+    // Windows `cmd /c start` under the hood. Failures are non-fatal — we
+    // still printed the URL above and the user can paste it manually.
+    if let Err(e) = open::that_detached(url) {
+        eprintln!(
+            "note: could not auto-open browser ({e}); paste the URL above. \
+             (daemon pid {})",
+            info.pid
+        );
+        return 1;
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    //! Most of `ui.rs` is wrapper plumbing around the daemon HTTP layer
+    //! that is exercised by `daemon/http.rs` tests; the bits worth
+    //! pinning here are the surface the CLI promises.
+
+    #[test]
+    fn module_compiles() {
+        // Trivial check: forces the module to be exercised under
+        // `cargo test`. Real behavioral tests live in `daemon/http.rs`
+        // alongside the routes this CLI consumes.
+    }
+}


### PR DESCRIPTION
Closes #183.

## Summary

Adds an in-process HTTP dashboard served by the always-on `clud` daemon, plus a `repo_visits` redb table that records every git repo clud has been launched in. New `clud ui` CLI launches the browser at the dashboard URL.

- **Transport.** Embeds `tiny_http` (sync, ~3K LOC, zero transitive deps — fits the daemon's existing `std::thread` model with no tokio drag). Bound to `127.0.0.1:0` alongside the IPC listener; the OS-assigned port is published in `~/.clud/state/daemon.json` next to the existing `pid`/`port` fields. Loopback-only, no authentication (matches existing IPC trust model).
- **Routes.**
  - `GET /` / `GET /index.html` — embedded single-page dashboard (vanilla JS, no build step, polls `/state.json` every 5s).
  - `GET /state.json` — one consolidated JSON document with daemon meta, live sessions (public-safe `SessionView` that drops the `*_pid` fields), GC tracked entries, repo visits, and aggregate stats grouped by kind.
  - `POST /gc/purge` — body `{id?, kind?}`; delegates to the existing `GcOp::Purge` IPC op and returns `{removed, skipped}`.
- **`repo_visits` table.** Tiny new redb table (`repo_root -> {last_visited_unix, run_count, last_cwd}`). Upserted on every `clud` startup from inside a git repo via a new `GcOp::RecordRepoVisit` IPC op. Skipped when no `.git` is found anywhere up the tree — we don't accumulate one row per scratch directory. Errors are swallowed: failing to record a visit never blocks a launch.
- **`clud ui` subcommand.**
  - `clud ui` — ensure daemon up, print URL, launch the default browser via the cross-platform `open` crate (macOS `open`, Linux `xdg-open`, Windows `cmd /c start`).
  - `clud ui --json` — fetch `/state.json` and print to stdout (mirrors the existing `clud gc list --json` convention).
  - `clud ui --no-open` — print URL only, no browser.

## Files changed

| | |
|---|---|
| `crates/clud-bin/Cargo.toml` | add `tiny_http = "0.12"`, `open = "5"` |
| `crates/clud-bin/src/daemon/http.rs` | NEW — HTTP server, routes, state aggregation, CLI client helpers |
| `crates/clud-bin/assets/dashboard/index.html` | NEW — embedded SPA |
| `crates/clud-bin/src/ui.rs` | NEW — `clud ui` CLI handler |
| `crates/clud-bin/src/gc.rs` | add `REPO_VISITS` redb table, `record_repo_visit`, `list_repo_visits`, `RepoVisit` |
| `crates/clud-bin/src/gc_tests.rs` | 4 new tests for the repo_visits table |
| `crates/clud-bin/src/daemon/types.rs` | add `dashboard_port` field to `DaemonInfo`; new `GcOp::RecordRepoVisit` / `ListRepoVisits` and corresponding replies |
| `crates/clud-bin/src/daemon/server.rs` | spawn the HTTP listener alongside IPC; write `dashboard_port` into `daemon.json` |
| `crates/clud-bin/src/daemon/gc_service.rs` | handle the new ops; new `spawn_registry_worker_with` (registry injection for tests) |
| `crates/clud-bin/src/daemon/client.rs` | `gc_client_record_repo_visit`, `gc_client_list_repo_visits` |
| `crates/clud-bin/src/daemon/mod.rs` | re-exports for the new public surface |
| `crates/clud-bin/src/args.rs` | new `Command::Ui { json, no_open }` and arg-splitter wiring |
| `crates/clud-bin/src/command/builder.rs` | add `Ui` to the launch-plan no-op arm |
| `crates/clud-bin/src/main.rs` | dispatch `clud ui`; record repo visit after `ensure_daemon` |
| `crates/clud-bin/src/lib.rs` | export the new `ui` module |

## Test plan

- [x] `bash lint` — all checks pass (`cargo fmt --check`, `cargo clippy -D warnings`, `ruff`).
- [x] Library tests pass (601 + 9 new dashboard tests + 4 new repo_visits tests = 614 unit tests). One pre-existing flaky test under parallel load (`process_tree::tests::kill_tree_terminates_real_descendant_on_windows`) passes on retry.
- [x] New tests (9 dashboard + 4 repo_visits) all pass on Windows:
  - `daemon::http::tests::build_state_with_empty_state_dir_returns_zeros`
  - `daemon::http::tests::build_state_includes_session_snapshots` (also asserts `daemon_pid`/`worker_pid`/`root_pid` are NOT serialized)
  - `daemon::http::tests::end_to_end_state_endpoint_returns_all_three_kinds` (spawns a real `tiny_http::Server`, hits `GET /state.json`, asserts sessions + gc + repos all present; also fetches `GET /` and asserts the HTML asset renders)
  - `daemon::http::tests::end_to_end_purge_kind_round_trip_mutates_registry` (`POST /gc/purge {"kind":"cache"}` → confirms registry shrinks to zero on next `/state.json` poll)
  - `gc::tests::record_repo_visit_*` × 4 (insert, upsert, ordering, distinct keys).
- [ ] CI to confirm cross-platform (Linux + macOS).

## Decisions / non-obvious choices

- **`tiny_http` over `axum`** — the daemon is 100% sync today; pulling in tokio for a tiny dashboard would drag ~30 transitive crates and ~2 MB of binary for no real ergonomic gain.
- **Two listeners, one process** — IPC port stays JSON-over-TCP. The HTTP dashboard binds a separate port published in `daemon.json`. Keeps the protocols cleanly separated; old clients ignore the new field thanks to `#[serde(default)]`.
- **No auth** — matches the existing IPC posture. Documented inline at the bind site so a future "expose off loopback" change knows to revisit this.
- **`repo_visits` is a new redb table, not a new `kind` in `tracked_entries`** — different semantics (upsert with counter vs. insert-only), and a separate table keeps the existing scanner contract intact.
- **Per-id purge limitation surfaced honestly** — the existing `GcOp::Purge` filters by `(kind, age)` but not by `id`/`path`. The dashboard's per-row purge currently works only when the row is the only one of its kind; otherwise it returns a 500 with a clear message pointing the user at the per-kind button. A native per-id purge op is the right follow-up (small additive IPC change) but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)