### PR TITLE
fix(windows): suppress byte-stream stdin reader when console_input is active (#188)

### DIFF
--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -567,10 +567,21 @@ where
     let normalize_console_stdin =
         should_normalize_interactive_console_stdin(interactive_real_stdin);
     let interrupt_on_ctrl_c_byte = interactive_real_stdin;
+    // Issue #188: when an `extra_rx` is wired and we're on Windows with
+    // an interactive real-stdin console, the `console_input`
+    // `ReadConsoleInputW` reader is feeding that channel and is the
+    // authoritative source of console bytes (including Shift+Enter →
+    // `\n`). Spawning the byte-stream stdin reader below would race
+    // with it on the same STDIN console queue — `ReadFile` strips
+    // modifier state, so a stolen Shift+Enter surfaces as `\r`. Skip
+    // it in that exact case so `console_input` is the sole consumer.
+    let spawn_byte_stream_stdin_reader =
+        should_spawn_byte_stream_stdin_reader(interactive_real_stdin, extra_rx.is_some());
     if verbose {
         verbose_log::log(format_args!(
-            "[clud] pty pump: start interactive_stdin={} normalize_console_stdin={}",
-            interactive_real_stdin, normalize_console_stdin
+            "[clud] pty pump: start interactive_stdin={} normalize_console_stdin={} \
+             spawn_byte_stream_stdin_reader={}",
+            interactive_real_stdin, normalize_console_stdin, spawn_byte_stream_stdin_reader
         ));
     }
 
@@ -578,25 +589,34 @@ where
     // Detached (not joined) so a blocked `read()` on real stdin doesn't
     // wedge shutdown when the child exits — the process is terminating
     // anyway. See Step 12.
-    std::thread::spawn(move || {
-        let mut reader = stdin_source;
-        let mut buf = [0u8; 4096];
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    let mut chunk = buf[..n].to_vec();
-                    if normalize_console_stdin {
-                        normalize_interactive_console_stdin_chunk(&mut chunk);
+    if spawn_byte_stream_stdin_reader {
+        std::thread::spawn(move || {
+            let mut reader = stdin_source;
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break, // EOF
+                    Ok(n) => {
+                        let mut chunk = buf[..n].to_vec();
+                        if normalize_console_stdin {
+                            normalize_interactive_console_stdin_chunk(&mut chunk);
+                        }
+                        if stdin_tx.send(chunk).is_err() {
+                            break; // Main thread dropped the receiver → exit.
+                        }
                     }
-                    if stdin_tx.send(chunk).is_err() {
-                        break; // Main thread dropped the receiver → exit.
-                    }
+                    Err(_) => break,
                 }
-                Err(_) => break,
             }
-        }
-    });
+        });
+    } else {
+        // `console_input` is the sole consumer via `extra_rx`. Drop the
+        // unused stdin source and channel sender so the corresponding
+        // `stdin_rx.try_recv()` in the main loop returns `Empty`
+        // immediately (no thread will ever send on it).
+        drop(stdin_source);
+        drop(stdin_tx);
+    }
 
     let mut observer = F3Observer::new();
     // Issue #63 / #79: bracketed-paste passes through the PTY pump as
@@ -753,6 +773,26 @@ fn stdin_source_is_real_stdin<R: 'static>() -> bool {
 
 fn should_normalize_interactive_console_stdin(interactive_real_stdin: bool) -> bool {
     cfg!(windows) && interactive_real_stdin
+}
+
+/// Decide whether the PTY pump should spawn its byte-stream stdin
+/// reader thread (the one that calls `io::stdin().read(...)`).
+///
+/// Issue #188: On Windows with an interactive real-stdin console and an
+/// `extra_rx` already wired, the `console_input::ReadConsoleInputW`
+/// worker is the authoritative source of console bytes — including the
+/// modifier-aware Shift+Enter → `\n` translation. Spawning the
+/// byte-stream reader in that case would race with `ReadConsoleInputW`
+/// on the same STDIN console queue. `ReadFile` strips modifier state
+/// before producing bytes, so a stolen Shift+Enter surfaces as `\r`
+/// instead of `\n`. Returning `false` keeps `console_input` as the
+/// sole consumer.
+///
+/// Every other configuration — POSIX, piped stdin, no `extra_rx` —
+/// keeps the byte-stream reader so existing behavior (including
+/// `echo "prompt" | clud` and POSIX interactive use) is unchanged.
+fn should_spawn_byte_stream_stdin_reader(interactive_real_stdin: bool, has_extra_rx: bool) -> bool {
+    !(cfg!(windows) && interactive_real_stdin && has_extra_rx)
 }
 
 fn normalize_interactive_console_stdin_chunk(chunk: &mut [u8]) {

--- a/crates/clud-bin/src/session_tests.rs
+++ b/crates/clud-bin/src/session_tests.rs
@@ -226,6 +226,48 @@ fn only_real_stdin_gets_interactive_console_policy() {
     assert!(!stdin_source_is_real_stdin::<std::io::Cursor<Vec<u8>>>());
 }
 
+// ─── should_spawn_byte_stream_stdin_reader (issue #188) ─────────────
+
+/// Issue #188 GREEN: Windows + interactive console + extra_rx wired
+/// suppresses the byte-stream stdin reader so the `console_input`
+/// `ReadConsoleInputW` worker is the sole consumer of the STDIN
+/// console queue. Without this gate, the byte-stream reader's
+/// `ReadFile` call races with `ReadConsoleInputW` on the same queue
+/// and Shift+Enter events surface as `\r` instead of `\n`.
+#[cfg(windows)]
+#[test]
+fn windows_interactive_with_extra_rx_suppresses_byte_stream_reader() {
+    assert!(!should_spawn_byte_stream_stdin_reader(true, true));
+}
+
+/// Issue #188: without an `extra_rx`, nothing else is consuming the
+/// console queue, so the byte-stream reader must run — otherwise no
+/// keystrokes reach the child at all.
+#[test]
+fn no_extra_rx_keeps_byte_stream_reader() {
+    assert!(should_spawn_byte_stream_stdin_reader(true, false));
+    assert!(should_spawn_byte_stream_stdin_reader(false, false));
+}
+
+/// Issue #188: piped stdin (`echo "..." | clud`) is not a console
+/// queue at all — `ReadConsoleInputW` can't function on a pipe handle
+/// — so the byte-stream reader must run even when an `extra_rx` is
+/// supplied. The `interactive_real_stdin` gate keys on
+/// `terminals_are_interactive()`.
+#[test]
+fn piped_stdin_keeps_byte_stream_reader_even_with_extra_rx() {
+    assert!(should_spawn_byte_stream_stdin_reader(false, true));
+}
+
+/// Issue #188: POSIX has no conhost / `ReadFile` modifier-stripping
+/// race, so the suppression must not apply there — the gate is
+/// `cfg!(windows)`-scoped.
+#[cfg(not(windows))]
+#[test]
+fn posix_keeps_byte_stream_reader_even_with_extra_rx() {
+    assert!(should_spawn_byte_stream_stdin_reader(true, true));
+}
+
 // ─── BracketedPasteNormalizer (issue #63 / #79) ────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #188.

`runner::run_plan_pty` (`runner.rs:534`) spawns
`console_input::spawn_console_input_reader()` — the
`ReadConsoleInputW` worker added in #141 that knows about the Shift
modifier and translates `VK_RETURN + SHIFT_PRESSED` -> `\n`. But
`session::run_raw_pty_pump_full_verbose` (`session.rs:581`) also
unconditionally spawned a detached `io::stdin().read(...)` thread —
i.e. `ReadFile` on the same `STD_INPUT_HANDLE`. Both calls drain the
same console input queue. Conhost strips modifier state before the
byte-stream view is produced, so when `ReadFile` won a Shift+Enter
event the user saw `\r` instead of `\n`. The translator was correct;
the wiring around it raced.

This PR adds `should_spawn_byte_stream_stdin_reader(interactive_real_stdin,
has_extra_rx)` and gates the stdin reader spawn on it. On Windows with
an interactive real-stdin console and an `extra_rx` already wired,
`console_input` becomes the sole consumer of the console queue. POSIX,
piped stdin (`echo "..." | clud`), and Windows-without-extra_rx paths
keep the byte-stream reader so their behavior is unchanged.

## Files

- `crates/clud-bin/src/session.rs` — new gate function + spawn-time
  conditional + `drop(stdin_source); drop(stdin_tx)` in the suppress
  branch so the existing `stdin_rx.try_recv()` in the main loop is a
  silent no-op when nothing will ever send.
- `crates/clud-bin/src/session_tests.rs` — four unit tests pinning
  the decision matrix:
  - Windows + interactive + `extra_rx` → suppress (the fix invariant)
  - No `extra_rx` (any platform) → keep
  - Piped stdin + `extra_rx` → keep (`ReadConsoleInputW` can't run on
    a pipe handle)
  - POSIX + interactive + `extra_rx` → keep (no conhost race)

## TDD trail

- **RED:** the integration test in #188's body
  (`shift_enter_dual_reader.rs`) demonstrates the race on a real
  console. It is not shipped in this PR because, by design, it
  recreates the dual-consumer wiring the fix prevents — so it stays
  RED on purpose as documentation of the underlying hazard.
- **GREEN:** the four new unit tests on `should_spawn_byte_stream_stdin_reader`
  (`session_tests.rs:223-265`) are RED without this PR (the function
  doesn't exist) and GREEN after it.

## Test plan

- [x] `bash lint` — clean.
- [x] `bash test` — 608 Rust unit tests pass (up from 605), 77 Python
  unit tests pass.
- [x] `soldr cargo test -p clud --lib -- should_spawn_byte_stream_stdin_reader windows_interactive_with_extra_rx no_extra_rx_keeps piped_stdin_keeps` — all 3 newly-added gated tests pass.
- [ ] Manual on real Windows console: launch `clud --pty` against
  Claude / codex, press Shift+Enter at the prompt, confirm a literal
  newline is inserted (no submit) — under both bare `cmd.exe` and
  Windows Terminal.
- [ ] Manual: plain Enter still submits (sends `\r`).
- [ ] Manual: Ctrl-C still interrupts via the 0x03 byte path in
  `extra_rx` (already covered by the existing
  `extra_rx_ctrl_c_byte_interrupts_pump` regression test, which still
  passes).
- [ ] Manual: drag-drop, F3 voice key, bracketed paste still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
