### PR TITLE
chore(ci): pin setup-soldr to v0.9.24 (force upgrade)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -70,7 +70,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0
+        uses: zackees/setup-soldr@v0.9.24
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -60,7 +60,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0
+        uses: zackees/setup-soldr@v0.9.24
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -55,7 +55,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0
+        uses: zackees/setup-soldr@v0.9.24
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -55,7 +55,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0
+        uses: zackees/setup-soldr@v0.9.24
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
Pin all `zackees/setup-soldr@v0` references to `zackees/setup-soldr@v0.9.24` so this repo explicitly carries the v0.9.21–v0.9.24 perf-fix cascade:

- **v0.9.21** — implicit `cargo-registry-cache=true` pairing when `prebuild-deps: soldr-cook` (closes the "cook is on, why is it still downloading?" trap).
- **v0.9.22** — pre-compress race probe avoids the 19-minute wall-clock waste pattern when a sibling job wins the cache reservation race (setup-soldr#268 Fix A).
- **v0.9.23** — soldr 0.7.48 (zccache 1.11.8 cross-clone .obj fix) + ncc side-chunk `dist/` copy hotfix.
- **v0.9.24** — raise `cache-payload-max-bytes` default 2GiB → 6GiB. Unblocks build-cache save on medium-large Rust workspaces that were chronic-skipping every run.

Validated end-to-end on zccache CI: post-step wall-clock dropped from **18m 8s → ~27s** and compile-cache `hit_rate` jumped from **0.7% → 100%** across the cascade.

Pinned (vs. `@v0` floating) for reproducibility — `v0` already points at this commit, so behavior is identical today, but future v0-tag moves can't accidentally regress this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)