### PR TITLE
fix(clud-pr-merge): probe CodeRabbit presence; drop CR gate on repos without it

### DIFF
--- a/skills/clud-pr-merge/SKILL.md
+++ b/skills/clud-pr-merge/SKILL.md
@@ -21,16 +21,36 @@ If the gates fail in fixable ways, dispatch a sub-agent to fix; up to 3 rounds t
 
 1. **Resolve the PR.** `gh pr view --json number,headRefName,baseRefName,state,mergeable,statusCheckRollup,url` against the current branch. Refuse if state ≠ OPEN or mergeable ≠ MERGEABLE/UNKNOWN.
 
-2. **Estimate the wait, announce it, then poll.** Before sleeping:
+2. **Estimate the wait, probe CodeRabbit presence, announce both, then poll.** Before sleeping:
+   - **Probe whether CodeRabbit is installed on this repo (issue #194).** Sample the 5 most-recent *merged* PRs for any `coderabbitai[bot]` review:
+     ```
+     CR_REVIEW_COUNT=$(gh pr list --repo <owner/repo> --state merged --limit 5 --json number \
+       | jq -r '.[].number' \
+       | while read n; do
+           gh api repos/<owner/repo>/pulls/$n/reviews \
+             --jq '[.[] | select(.user.login=="coderabbitai[bot]")] | length'
+         done | awk '{s+=$1} END {print s+0}')
+     if [ "$CR_REVIEW_COUNT" -eq 0 ]; then CR_REQUIRED=false; else CR_REQUIRED=true; fi
+     ```
+     - Sample "merged" not "any state" — open PRs may legitimately predate CR's review window and would yield a false negative.
+     - Sample size 5 — robust against one slipped PR, cheap (one cluster of API calls), no caching across runs (CR may be installed mid-session and caching would shadow that).
+     - "Drop" not "warn and continue" — when CR is provably absent, requiring a CR review is a *category* error, not a relaxed gate.
    - Probe the repo's *recent* CI duration: `gh run list --repo <owner/repo> --branch main --limit 10 --json conclusion,startedAt,updatedAt`. Take the p90 wall-clock; round up to the nearest 5 min. This is your expected wait.
    - **Default cap: 45 minutes** (the FastLED repo and similar embedded projects routinely hit 25–30 min platform builds). Tighten the cap to `max(15, p90 + 5min)` for repos with faster CI; never go below 15 minutes.
-   - **Announce upfront** with one user-facing line: `[clud-pr-merge] polling CI for up to <N> min; slowest recent build was <P90> min.` Silent polling reads as a hung shell — never skip this announcement.
+   - **Announce upfront** with one user-facing line that names both the cap and the CodeRabbit decision. Silent polling reads as a hung shell — never skip this announcement.
+     - CR detected: `[clud-pr-merge] polling CI for up to <N> min; slowest recent build was <P90> min; CodeRabbit detected — gating on CI + CR review.`
+     - CR not detected: `[clud-pr-merge] polling CI for up to <N> min; slowest recent build was <P90> min; CodeRabbit not detected on this repo (sampled 5 recent merged PRs) — gating on CI only.`
    - Then loop with **30-second sleeps**. Each iteration fetches:
      - `gh pr view <num> --json state --jq .state` — **first** check every iteration. If the PR became MERGED or CLOSED, **break the loop immediately** (success for MERGED, abort for CLOSED). See "Early-exit on PR state change" below.
      - `gh pr checks <num> --json name,state,bucket` — every required check has a non-PENDING state.
-     - `gh api repos/{owner}/{repo}/pulls/{num}/reviews --jq '.[] | select(.user.login=="coderabbitai[bot]")'` — at least one CodeRabbit review has been posted (or CodeRabbit explicitly "skipped" the review, which counts as reported).
+     - **Only if `CR_REQUIRED=true`:** `gh api repos/{owner}/{repo}/pulls/{num}/reviews --jq '.[] | select(.user.login=="coderabbitai[bot]")'` — at least one CodeRabbit review has been posted (or CodeRabbit explicitly "skipped" the review, which counts as reported). When `CR_REQUIRED=false`, skip this check entirely — the exit condition collapses to `pending == 0`.
 
-   Both signals must report at least once *or* the PR state must change to MERGED/CLOSED. If the cap elapses with no signal, **give up and warn the user**: `[clud-pr-merge] timed out waiting for CI/CodeRabbit after <N> minutes. Re-run when checks have reported.` Do NOT merge.
+   Exit condition:
+   - `CR_REQUIRED=true` → `pending == 0 AND coderabbit_reviews != 0` (current behavior; if CR was sampled-present but never reviews this specific PR within the cap, the skill times out — that's correct, an installed-but-slow CR is still a real gate).
+   - `CR_REQUIRED=false` → `pending == 0` alone.
+   - In either case, a PR state change to MERGED/CLOSED also breaks the loop.
+
+   If the cap elapses with no signal, **give up and warn the user**: `[clud-pr-merge] timed out waiting for CI/CodeRabbit after <N> minutes. Re-run when checks have reported.` Do NOT merge.
 
    **Early-exit on PR state change (CRITICAL — prevents the "stuck shell" bug).** GitHub Actions jobs do NOT cancel when a PR is merged out from under them. If a maintainer merges (or auto-merge fires) while the poll is waiting, the slow platform-build jobs on the original SHA keep running for another ~20 min. The poll's "no PENDING checks" condition stays false the whole time, so the loop keeps spawning sleeps and never exits — from the user's perspective the shell is hung. Two preventions, both mandatory:
    1. Check `gh pr view <num> --json state` FIRST in every poll iteration and break the loop the moment state ≠ OPEN. The poll's exit reason is "PR merged/closed," not "all checks finished."
@@ -74,6 +94,7 @@ If the gates fail in fixable ways, dispatch a sub-agent to fix; up to 3 rounds t
 
 - **Poll loop without a cap** — always stop at the announced cap (default 45 min, adjusted per repo); better to warn-and-stop than burn forever.
 - **Silent polling** — without an upfront "polling for up to N min" announcement, the user reads the silent wait as a hung shell. Always announce.
+- **CodeRabbit-not-installed deadlock — probe before polling.** On a repo without CodeRabbit, the `coderabbit_reviews != 0` clause never satisfies, so the loop spins until the cap fires (issue #194; observed: ~20 min silent stall on `zackees/zccache#523`). Always run the 5-merged-PR `coderabbitai[bot]` review-presence probe in step 2 and drop the CR clause when the sample is zero. Do not "warn and continue" — a category-error gate is not a relaxed gate.
 - **Treating timeout as merge-eligible** — no signal ≠ green signal. Refuse to merge in the timeout case.
 - **Conflating "passing on main" with "not a regression"** — only the *same check name* on main counts. Renamed/added checks are new regressions until proven otherwise.
 - **Treating "check missing from main" as "passing on main"** — PR-only workflows (e.g. `pull_request_target`) never run on `push` events, so they're invisible in main's check-runs. Cross-reference recent PRs before classifying.


### PR DESCRIPTION
## Summary

- Adds a one-shot CodeRabbit-presence probe to `clud-pr-merge` step 2: samples the 5 most-recent **merged** PRs for any `coderabbitai[bot]` review.
- When the sample sums to zero, drops the `coderabbit_reviews != 0` clause from the poll's exit condition — gate collapses to `pending == 0` only.
- When the sample is non-zero, behavior is unchanged: the skill still waits for CR on the current PR and times out if CR is installed-but-slow. (Acceptance criterion: "installed-but-slow case preserved.")
- Announcement line now states the gate in effect — `CodeRabbit detected — gating on CI + CR review` vs `CodeRabbit not detected on this repo (sampled 5 recent merged PRs) — gating on CI only`.
- Adds a Failure-modes-to-avoid bullet pointing to issue #194 + the repro PR (`zackees/zccache#523`).

The fix lives in `skills/clud-pr-merge/SKILL.md` — `skill_install.rs` overwrites the user's installed copy on every `clud` launch when the embedded copy diverges, so users pick up the new behavior on the next `clud` invocation after the next release.

Closes #194

## Test plan

- [x] `bash lint` — clean
- [x] `soldr cargo test --lib skill_install::` — all 11 tests pass (skill bundle name + content checks)
- [ ] Real-world validation on a CR-less repo (e.g. `zackees/zccache`): run `/clud-pr-merge` on an open PR; verify the announcement reports `CodeRabbit not detected` and the loop exits as soon as `pending == 0` (no extra ~20 min stall).
- [ ] Real-world validation on a CR-enabled repo (e.g. `zackees/clud`): verify the announcement reports `CodeRabbit detected` and the loop still waits for the CR review on the current PR.

## Design notes

The decisions section of the issue is reflected in inline comments under step 2 of the skill: sample-of-merged not any-state, sample size 5, per-run not cached, "drop" not "warn and continue." These are exposed in the skill text so a reader can judge edge cases without going back to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)