### PR TITLE
ci: bump setup-soldr v0.9.24 → v0.9.44

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -70,7 +70,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.44
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -60,7 +60,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.44
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -55,7 +55,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.44
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -55,7 +55,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.44
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` from `v0.9.24` to `v0.9.44` across all 4 reusable workflow files.
- Picks up the entire solo-toolchain-cache series (#305/#310/#313-#321/#324/#326/#328/#331/#335) plus #335 seed-isolated-cache hardlinks.
- Expected: ~13s/warm-job saved on multi-job CI workflows; toolchain phase ~17s → ~3-6s per zccache validation.

## Test plan
- [ ] `_build.yml` green on warm cache
- [ ] `_lint.yml` green on warm cache
- [ ] `_unit-test.yml` green on warm cache
- [ ] `_integration-test.yml` green on warm cache
- [ ] Toolchain phase wall-clock visibly reduced vs prior run

Generated with Claude Code