### PR TITLE
ci: bump setup-soldr v0.9.44 → v0.9.46

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -70,7 +70,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.44
+        uses: zackees/setup-soldr@v0.9.46
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -60,7 +60,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.44
+        uses: zackees/setup-soldr@v0.9.46
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -55,7 +55,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.44
+        uses: zackees/setup-soldr@v0.9.46
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -55,7 +55,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.44
+        uses: zackees/setup-soldr@v0.9.46
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
## Summary

- Bumps `zackees/setup-soldr` from `v0.9.44` → `v0.9.46` across all four workflows (`_build.yml`, `_integration-test.yml`, `_lint.yml`, `_unit-test.yml`).
- v0.9.46 ships setup-soldr#343/#344, which flips the `solo-toolchain-cache` input default from `false` to `true`.
- This repo never sets that input explicitly, so the bump picks up solo-cache automatically — expected ~8–11s saved per warm CI job, zero behavior change otherwise.

## Test plan

- [ ] CI green on this PR (all four reusable workflows execute with v0.9.46)
- [ ] Spot-check one Setup soldr step in the run logs to confirm v0.9.46 is the resolved tag
- [ ] Compare Setup soldr step wall-clock against a recent `main` run — expect ~8–11s warm-job improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)