### PR TITLE
ci: bump setup-soldr v0.9.46 → v0.9.47

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -70,7 +70,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.46
+        uses: zackees/setup-soldr@v0.9.47
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -60,7 +60,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.46
+        uses: zackees/setup-soldr@v0.9.47
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -55,7 +55,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.46
+        uses: zackees/setup-soldr@v0.9.47
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -55,7 +55,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.46
+        uses: zackees/setup-soldr@v0.9.47
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
## Summary
- Bumps `zackees/setup-soldr` from v0.9.46 → v0.9.47 across all 4 workflow files.
- Picks up setup-soldr#347/#348 — new `cache-eviction-policy` input (defaults to disabled; behavior unchanged for this repo).

## Test plan
- [ ] CI green on _build, _lint, _unit-test, _integration-test workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)