### PR TITLE
test: validate bundled skill frontmatter yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,10 @@ See [`docs/DESIGN_DECISIONS.md`](docs/DESIGN_DECISIONS.md) for full rationale.
 
 After **any** code edit you **must** run `bash lint` (runs `cargo fmt --check`, `cargo clippy -D warnings`, and `ruff check`).
 
+### Bundled Skill Imports
+
+When adding or renaming any imported/bundled skill, update the relevant `BUNDLED_SKILLS` registry and make sure the `SKILL.md` frontmatter parses with a real YAML parser. The guardrail tests live in `crates/clud-bin/src/skills.rs` for `crates/clud-bin/assets/skills/*/SKILL.md` imports and `crates/clud-bin/src/skill_install.rs` for root `skills/*/SKILL.md` imports. Run `soldr cargo test -p clud --lib skills::` and `soldr cargo test -p clud --lib skill_install::` after changing skill imports or frontmatter.
+
 ## Test Coverage
 
 - ~104 Rust unit tests across arg parsing, command building, backend resolution, loop-spec (URL classification, GH-JSON parsing, marker files).

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,5 @@
+# CODEX.md
+
+Codex uses the same repository instructions as Claude Code.
+
+Read and follow [CLAUDE.md](CLAUDE.md) for all AI-agent guidance, including build/test commands, documentation rules, and bundled skill import validation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "running-process",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "signal-hook",
  "sysinfo 0.37.2",
@@ -1870,6 +1871,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,6 +1938,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2262,6 +2282,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -64,6 +64,7 @@ tiny_http = "0.12"
 open = "5"
 
 [dev-dependencies]
+serde_yaml = "0.9"
 tempfile = "3"
 
 [lib]

--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -158,8 +158,17 @@ fn update_diverges(path: &Path, skill: &Skill) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::Deserialize;
     use std::fs;
     use tempfile::TempDir;
+
+    #[derive(Debug, Deserialize)]
+    struct SkillFrontmatter {
+        name: String,
+        description: String,
+        #[serde(default)]
+        triggers: Vec<String>,
+    }
 
     /// Embedded copy of the canonical clud-pr skill — used as the
     /// embedded-content reference in the install state-transition tests.
@@ -168,6 +177,25 @@ mod tests {
     /// here too.
     fn ref_skill() -> &'static Skill {
         &BUNDLED_SKILLS[0]
+    }
+
+    fn frontmatter_yaml<'a>(skill_name: &str, skill_md: &'a str) -> &'a str {
+        let Some(after_open) = skill_md
+            .strip_prefix("---\r\n")
+            .or_else(|| skill_md.strip_prefix("---\n"))
+        else {
+            panic!("skill {skill_name} must start with YAML frontmatter");
+        };
+        let Some(end) = after_open.find("\n---") else {
+            panic!("skill {skill_name} missing closing YAML frontmatter marker");
+        };
+        &after_open[..end]
+    }
+
+    fn parse_frontmatter(skill: &Skill) -> SkillFrontmatter {
+        serde_yaml::from_str(frontmatter_yaml(skill.name, skill.content)).unwrap_or_else(|err| {
+            panic!("skill {} has invalid YAML frontmatter: {err}", skill.name)
+        })
     }
 
     /// Mirror of [`ensure_skill_installed`] but routed at a caller-supplied
@@ -293,10 +321,10 @@ mod tests {
     }
 
     #[test]
-    fn every_bundled_skill_has_real_content() {
+    fn every_bundled_skill_has_real_content_and_valid_frontmatter() {
         // Compile-time + content guard: if someone deletes a skill file
         // the include_str! still compiles to "" — assert every entry has
-        // real frontmatter so a missing file is caught here, not by the
+        // real YAML frontmatter so a missing file is caught here, not by the
         // user reading an empty SKILL.md from their home dir.
         assert!(!BUNDLED_SKILLS.is_empty(), "no bundled skills?");
         for skill in BUNDLED_SKILLS {
@@ -306,11 +334,20 @@ mod tests {
                 skill.name,
                 skill.content.len()
             );
-            let frontmatter_marker = format!("name: {}", skill.name);
+            let frontmatter = parse_frontmatter(skill);
+            assert_eq!(
+                frontmatter.name, skill.name,
+                "skill {} frontmatter name must match BUNDLED_SKILLS entry",
+                skill.name
+            );
             assert!(
-                skill.content.contains(&frontmatter_marker),
-                "skill {} content missing 'name: {}' frontmatter — bad include_str path?",
-                skill.name,
+                !frontmatter.description.trim().is_empty(),
+                "skill {} missing frontmatter description",
+                skill.name
+            );
+            assert!(
+                !frontmatter.triggers.is_empty(),
+                "skill {} missing frontmatter triggers",
                 skill.name
             );
         }

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -194,7 +194,35 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::Deserialize;
     use tempfile::tempdir;
+
+    #[derive(Debug, Deserialize)]
+    struct SkillFrontmatter {
+        name: String,
+        description: String,
+        #[serde(default)]
+        triggers: Vec<String>,
+    }
+
+    fn frontmatter_yaml<'a>(skill_name: &str, skill_md: &'a str) -> &'a str {
+        let Some(after_open) = skill_md
+            .strip_prefix("---\r\n")
+            .or_else(|| skill_md.strip_prefix("---\n"))
+        else {
+            panic!("skill {skill_name} must start with YAML frontmatter");
+        };
+        let Some(end) = after_open.find("\n---") else {
+            panic!("skill {skill_name} missing closing YAML frontmatter marker");
+        };
+        &after_open[..end]
+    }
+
+    fn parse_frontmatter(skill: &BundledSkill) -> SkillFrontmatter {
+        serde_yaml::from_str(frontmatter_yaml(skill.name, skill.skill_md)).unwrap_or_else(|err| {
+            panic!("skill {} has invalid YAML frontmatter: {err}", skill.name)
+        })
+    }
 
     fn fake_skills() -> Vec<BundledSkill> {
         vec![
@@ -272,6 +300,29 @@ mod tests {
                 s.skill_md.contains("managed-by: clud"),
                 "skill {} missing managed-by marker",
                 s.name
+            );
+        }
+    }
+
+    #[test]
+    fn bundled_skill_frontmatter_is_valid_yaml() {
+        assert!(!BUNDLED_SKILLS.is_empty());
+        for skill in BUNDLED_SKILLS {
+            let frontmatter = parse_frontmatter(skill);
+            assert_eq!(
+                frontmatter.name, skill.name,
+                "skill {} frontmatter name must match BUNDLED_SKILLS entry",
+                skill.name
+            );
+            assert!(
+                !frontmatter.description.trim().is_empty(),
+                "skill {} missing frontmatter description",
+                skill.name
+            );
+            assert!(
+                !frontmatter.triggers.is_empty(),
+                "skill {} missing frontmatter triggers",
+                skill.name
             );
         }
     }


### PR DESCRIPTION
## Summary

- add real YAML parser validation for bundled/imported skill `SKILL.md` frontmatter
- cover both skill registries: `crates/clud-bin/src/skills.rs` and `crates/clud-bin/src/skill_install.rs`
- document the rule in `CLAUDE.md` and make `CODEX.md` point to `CLAUDE.md` for AI-agent instructions

## Validation

- `soldr cargo test -p clud --lib skills::`
- `soldr cargo test -p clud --lib skill_install::`
- `bash lint`