### PR TITLE
fix(ui): add daemon restart recovery for dashboard listener

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -216,6 +216,11 @@ pub enum Command {
         #[arg(long = "no-open")]
         no_open: bool,
     },
+    /// Control the always-on clud daemon.
+    Daemon {
+        #[command(subcommand)]
+        subcommand: DaemonSubcommand,
+    },
     #[command(name = "__daemon", hide = true)]
     InternalDaemon {
         #[arg(long = "state-dir")]
@@ -232,6 +237,13 @@ pub enum Command {
         #[arg(long = "spec-file")]
         spec_file: PathBuf,
     },
+}
+
+/// Subcommands under `clud daemon`.
+#[derive(Subcommand, Debug, Clone)]
+pub enum DaemonSubcommand {
+    /// Restart the daemon process so the next CLI call uses the current binary.
+    Restart,
 }
 
 /// Subcommands under `clud gc`. See `crates/clud-bin/src/gc.rs`.
@@ -332,7 +344,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
         "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "ui",
-        "__daemon", "__worker",
+        "daemon", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/args_tests.rs
+++ b/crates/clud-bin/src/args_tests.rs
@@ -796,3 +796,14 @@ fn test_gc_reconcile() {
         _ => panic!("expected Gc::Reconcile"),
     }
 }
+
+#[test]
+fn test_daemon_restart_subcommand_parses() {
+    let args = parse(&["clud", "daemon", "restart"]);
+    match args.command {
+        Some(Command::Daemon {
+            subcommand: DaemonSubcommand::Restart,
+        }) => {}
+        other => panic!("expected Daemon::Restart, got {other:?}"),
+    }
+}

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -136,6 +136,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         | Some(Command::Logs { .. })
         | Some(Command::Gc { .. })
         | Some(Command::Ui { .. })
+        | Some(Command::Daemon { .. })
         | Some(Command::InternalDaemon { .. })
         | Some(Command::InternalWorker { .. }) => {}
         None => {

--- a/crates/clud-bin/src/daemon/attach.rs
+++ b/crates/clud-bin/src/daemon/attach.rs
@@ -87,7 +87,8 @@ pub(super) fn run_attach(session_id: &str, state_dir: &Path, interrupted: &Atomi
         }
         DaemonResponse::Created { .. }
         | DaemonResponse::Terminated { .. }
-        | DaemonResponse::Gc { .. } => 1,
+        | DaemonResponse::Gc { .. }
+        | DaemonResponse::ShutdownAck { .. } => 1,
     }
 }
 

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -165,7 +165,13 @@ pub(super) fn send_daemon_request(
     write_json_line(&mut stream, request)?;
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
-    reader.read_line(&mut line)?;
+    let bytes = reader.read_line(&mut line)?;
+    if bytes == 0 || line.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "daemon closed connection without replying",
+        ));
+    }
     serde_json::from_str(&line).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
 }
 
@@ -186,6 +192,69 @@ pub(super) fn request_session_termination(
             format!("unexpected daemon response: {response:?}"),
         )),
     }
+}
+
+/// Ask the daemon to terminate and wait for its pid to exit. Returns the
+/// daemon pid that was stopped. If the running daemon predates the shutdown
+/// IPC and drops the connection on the unknown request, fall back to killing
+/// the recorded pid tree directly; that is the version-skew state this
+/// recovery path is meant to repair.
+pub(super) fn request_daemon_shutdown(state_dir: &Path) -> io::Result<u32> {
+    let info = read_json_file::<DaemonInfo>(&daemon_info_path(state_dir))?;
+    let recorded_pid = info.pid;
+    if !pid_is_alive(recorded_pid) {
+        let _ = fs::remove_file(daemon_info_path(state_dir));
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("daemon pid {recorded_pid} is not running"),
+        ));
+    }
+
+    let pid = match send_daemon_request(state_dir, &DaemonRequest::Shutdown) {
+        Ok(DaemonResponse::ShutdownAck { pid }) => pid,
+        Ok(DaemonResponse::Error { message }) => return Err(io::Error::other(message)),
+        Ok(response) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected daemon response: {response:?}"),
+            ));
+        }
+        Err(err) if is_old_daemon_signature(&err) => {
+            eprintln!(
+                "[clud] daemon pid {recorded_pid} does not support shutdown IPC; terminating it directly"
+            );
+            signal_process_tree(recorded_pid, Signal::Term);
+            thread::sleep(Duration::from_millis(150));
+            if pid_is_alive(recorded_pid) {
+                signal_process_tree(recorded_pid, Signal::Kill);
+            }
+            recorded_pid
+        }
+        Err(err) => return Err(err),
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while pid_is_alive(pid) {
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("daemon pid {pid} did not exit within 10s after shutdown"),
+            ));
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let _ = fs::remove_file(daemon_info_path(state_dir));
+    Ok(pid)
+}
+
+fn is_old_daemon_signature(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::UnexpectedEof
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionAborted
+    )
 }
 
 pub(super) fn send_worker_message(
@@ -389,6 +458,8 @@ pub fn gc_client_list_repo_visits(state_dir: &Path) -> io::Result<Vec<RepoVisit>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     /// Issue #192: a daemon whose `daemon.json` reports the same version
     /// as the spawning binary must NOT be restarted. This is the steady-
@@ -431,5 +502,100 @@ mod tests {
             version: None,
         };
         assert!(!daemon_version_matches(&info));
+    }
+
+    fn write_daemon_info(state_dir: &Path, pid: u32, port: u16) {
+        fs::create_dir_all(state_dir).unwrap();
+        let info = DaemonInfo {
+            pid,
+            port,
+            dashboard_port: None,
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        };
+        super::super::io_helpers::write_json_file(&daemon_info_path(state_dir), &info).unwrap();
+    }
+
+    fn spawn_silent_peer() -> (u16, Arc<AtomicBool>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let saw_request = Arc::new(AtomicBool::new(false));
+        let saw_request_thread = Arc::clone(&saw_request);
+
+        thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                let mut reader = BufReader::new(stream);
+                let mut line = String::new();
+                let _ = reader.read_line(&mut line);
+                if !line.is_empty() {
+                    saw_request_thread.store(true, Ordering::SeqCst);
+                }
+            }
+        });
+
+        (port, saw_request)
+    }
+
+    #[test]
+    fn send_daemon_request_translates_silent_peer_to_unexpected_eof() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (port, saw_request) = spawn_silent_peer();
+        write_daemon_info(tmp.path(), std::process::id(), port);
+
+        let err = send_daemon_request(tmp.path(), &DaemonRequest::Shutdown)
+            .expect_err("silent peer must not produce a daemon response");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            !err.to_string().contains("EOF while parsing a value"),
+            "must not surface the raw serde_json EOF message: {err}"
+        );
+
+        for _ in 0..20 {
+            if saw_request.load(Ordering::SeqCst) {
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert!(
+            saw_request.load(Ordering::SeqCst),
+            "stub peer should have observed the request before closing"
+        );
+    }
+
+    #[test]
+    fn is_old_daemon_signature_recognizes_connection_drop_variants() {
+        assert!(is_old_daemon_signature(&io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "x"
+        )));
+        assert!(is_old_daemon_signature(&io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "x"
+        )));
+        assert!(is_old_daemon_signature(&io::Error::new(
+            io::ErrorKind::ConnectionAborted,
+            "x"
+        )));
+        assert!(!is_old_daemon_signature(&io::Error::new(
+            io::ErrorKind::NotFound,
+            "x"
+        )));
+        assert!(!is_old_daemon_signature(&io::Error::new(
+            io::ErrorKind::TimedOut,
+            "x"
+        )));
+    }
+
+    #[test]
+    fn request_daemon_shutdown_treats_dead_pid_as_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_daemon_info(tmp.path(), u32::MAX, 9);
+
+        let err = request_daemon_shutdown(tmp.path())
+            .expect_err("dead daemon pid should be treated as absent");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(
+            !daemon_info_path(tmp.path()).exists(),
+            "stale daemon.json should be removed"
+        );
     }
 }

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -3,13 +3,13 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-use crate::args::{Args, Command};
+use crate::args::{Args, Command, DaemonSubcommand};
 use crate::backend::LaunchMode;
 use crate::command::{has_noninteractive_prompt, LaunchPlan};
 use crate::verbose_log;
 
 use super::attach::{attach_to_session, run_attach};
-use super::client::{ensure_daemon, send_daemon_request};
+use super::client::{ensure_daemon, request_daemon_shutdown, send_daemon_request};
 use super::commands::{run_kill, run_list, run_logs};
 use super::io_helpers::{resolve_backlog_bytes, terminal_dimensions};
 use super::paths::state_dir;
@@ -68,6 +68,34 @@ fn env_truthy(name: &str) -> bool {
     std::env::var(name)
         .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
         .unwrap_or(false)
+}
+
+fn run_daemon_subcommand(state_dir: &Path, subcommand: &DaemonSubcommand) -> i32 {
+    match subcommand {
+        DaemonSubcommand::Restart => match request_daemon_shutdown(state_dir) {
+            Ok(pid) => {
+                eprintln!("[clud] daemon pid {pid} stopped");
+                if let Err(err) = ensure_daemon(state_dir) {
+                    eprintln!("[clud] failed to start replacement daemon: {err}");
+                    return 1;
+                }
+                eprintln!("[clud] new daemon started");
+                0
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                eprintln!("[clud] no running daemon; starting one");
+                if let Err(err) = ensure_daemon(state_dir) {
+                    eprintln!("[clud] failed to start daemon: {err}");
+                    return 1;
+                }
+                0
+            }
+            Err(err) => {
+                eprintln!("[clud] daemon restart failed: {err}");
+                1
+            }
+        },
+    }
 }
 
 pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i32> {
@@ -164,6 +192,10 @@ pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i
                 *lines,
                 interrupted,
             ))
+        }
+        Some(Command::Daemon { subcommand }) => {
+            let state_dir = state_dir(args);
+            Some(run_daemon_subcommand(&state_dir, subcommand))
         }
         Some(Command::InternalDaemon { state_dir }) => Some(run_daemon(state_dir)),
         Some(Command::InternalWorker {
@@ -328,7 +360,8 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         }
         DaemonResponse::Session { .. }
         | DaemonResponse::Terminated { .. }
-        | DaemonResponse::Gc { .. } => 1,
+        | DaemonResponse::Gc { .. }
+        | DaemonResponse::ShutdownAck { .. } => 1,
     }
 }
 

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::{self, BufRead, BufReader};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -88,17 +89,46 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
     }
 
     let workers = Arc::new(Mutex::new(HashMap::<String, Arc<NativeProcess>>::new()));
-    for stream in listener.incoming() {
-        let Ok(stream) = stream else {
-            continue;
-        };
-        let workers = Arc::clone(&workers);
-        let state_dir = state_dir.to_path_buf();
-        let gc_tx = gc_tx.clone();
-        thread::spawn(move || {
-            let _ = handle_daemon_connection(stream, &state_dir, &workers, gc_tx);
-        });
+    let shutdown_requested = Arc::new(AtomicBool::new(false));
+    if let Err(err) = listener.set_nonblocking(true) {
+        eprintln!("[clud] failed to configure daemon listener: {}", err);
+        return 1;
     }
+
+    loop {
+        match listener.accept() {
+            Ok((stream, _addr)) => {
+                let workers = Arc::clone(&workers);
+                let state_dir = state_dir.to_path_buf();
+                let gc_tx = gc_tx.clone();
+                let shutdown_requested = Arc::clone(&shutdown_requested);
+                thread::spawn(move || {
+                    let _ = handle_daemon_connection(
+                        stream,
+                        &state_dir,
+                        &workers,
+                        gc_tx,
+                        &shutdown_requested,
+                    );
+                });
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                if shutdown_requested.load(Ordering::SeqCst) {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+            Err(err) => {
+                if shutdown_requested.load(Ordering::SeqCst) {
+                    break;
+                }
+                eprintln!("[clud] daemon listener accept failed: {}", err);
+                thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+
+    let _ = fs::remove_file(daemon_info_path(state_dir));
     0
 }
 
@@ -107,6 +137,7 @@ fn handle_daemon_connection(
     state_dir: &Path,
     workers: &Arc<Mutex<HashMap<String, Arc<NativeProcess>>>>,
     gc_tx: Option<mpsc::Sender<GcRequestMsg>>,
+    shutdown_requested: &Arc<AtomicBool>,
 ) -> io::Result<()> {
     let mut reader = BufReader::new(stream.try_clone()?);
     let mut line = String::new();
@@ -143,8 +174,17 @@ fn handle_daemon_connection(
             let reply = dispatch_gc_op(gc_tx.as_ref(), payload);
             DaemonResponse::Gc { reply }
         }
+        DaemonRequest::Shutdown => DaemonResponse::ShutdownAck {
+            pid: std::process::id(),
+        },
     };
-    write_json_line(&mut stream, &response)
+    let is_shutdown = matches!(response, DaemonResponse::ShutdownAck { .. });
+    let result = write_json_line(&mut stream, &response);
+    if is_shutdown {
+        let _ = stream.shutdown(std::net::Shutdown::Write);
+        shutdown_requested.store(true, Ordering::SeqCst);
+    }
+    result
 }
 
 /// Hand a GC op to the registry worker and await the reply. Returns a

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -141,16 +141,32 @@ pub(super) enum DaemonRequest {
     Gc {
         payload: GcOp,
     },
+    /// Ask the daemon to exit after replying. Used by `clud daemon restart`.
+    Shutdown,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub(super) enum DaemonResponse {
-    Created { session: SessionSnapshot },
-    Session { session: SessionSnapshot },
-    Terminated { session: SessionSnapshot },
-    Gc { reply: GcReply },
-    Error { message: String },
+    Created {
+        session: SessionSnapshot,
+    },
+    Session {
+        session: SessionSnapshot,
+    },
+    Terminated {
+        session: SessionSnapshot,
+    },
+    Gc {
+        reply: GcReply,
+    },
+    /// Acknowledgement for `DaemonRequest::Shutdown`.
+    ShutdownAck {
+        pid: u32,
+    },
+    Error {
+        message: String,
+    },
 }
 
 /// Issue #135: payload carried by `DaemonRequest::Gc`. Identical in
@@ -386,4 +402,36 @@ pub(super) struct AttachedClient {
 pub(super) struct BacklogState {
     pub(super) chunks: std::collections::VecDeque<Vec<u8>>,
     pub(super) total_bytes: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shutdown_request_serializes_as_tagged_op() {
+        let wire = serde_json::to_string(&DaemonRequest::Shutdown).unwrap();
+        assert_eq!(wire, r#"{"op":"shutdown"}"#);
+    }
+
+    #[test]
+    fn shutdown_request_roundtrips() {
+        let wire = serde_json::to_string(&DaemonRequest::Shutdown).unwrap();
+        let parsed: DaemonRequest = serde_json::from_str(&wire).unwrap();
+        assert!(matches!(parsed, DaemonRequest::Shutdown));
+    }
+
+    #[test]
+    fn shutdown_ack_response_roundtrips_with_pid() {
+        let response = DaemonResponse::ShutdownAck { pid: 142500 };
+        let wire = serde_json::to_string(&response).unwrap();
+        assert!(wire.contains(r#""op":"shutdown_ack""#));
+        assert!(wire.contains(r#""pid":142500"#));
+
+        let parsed: DaemonResponse = serde_json::from_str(&wire).unwrap();
+        match parsed {
+            DaemonResponse::ShutdownAck { pid } => assert_eq!(pid, 142500),
+            other => panic!("expected ShutdownAck, got {other:?}"),
+        }
+    }
 }

--- a/crates/clud-bin/src/ui.rs
+++ b/crates/clud-bin/src/ui.rs
@@ -14,6 +14,13 @@ use crate::daemon::{
     DashboardInfo,
 };
 
+pub(crate) fn dashboard_listener_missing_message(pid: u32) -> String {
+    format!(
+        "error: this daemon (pid {pid}) was started without a dashboard listener. \
+         Restart it with `clud daemon restart`, then re-run `clud ui`."
+    )
+}
+
 pub fn run(json: bool, no_open: bool) -> i32 {
     let state_dir = match daemon::default_state_dir() {
         Ok(p) => p,
@@ -37,12 +44,7 @@ pub fn run(json: bool, no_open: bool) -> i32 {
     };
 
     let Some(port) = info.dashboard_port else {
-        eprintln!(
-            "error: this daemon ({}) was started without a dashboard listener. \
-             Stop it (e.g. via `clud kill --all` for sessions; the daemon will respawn) \
-             and retry.",
-            info.pid
-        );
+        eprintln!("{}", dashboard_listener_missing_message(info.pid));
         return 1;
     };
 
@@ -95,9 +97,21 @@ mod tests {
     //! pinning here are the surface the CLI promises.
 
     #[test]
-    fn module_compiles() {
-        // Trivial check: forces the module to be exercised under
-        // `cargo test`. Real behavioral tests live in `daemon/http.rs`
-        // alongside the routes this CLI consumes.
+    fn dashboard_listener_missing_message_includes_pid() {
+        let msg = super::dashboard_listener_missing_message(142500);
+        assert!(msg.contains("142500"));
+    }
+
+    #[test]
+    fn dashboard_listener_missing_message_does_not_recommend_kill_all() {
+        let msg = super::dashboard_listener_missing_message(1);
+        assert!(!msg.contains("kill --all"));
+        assert!(!msg.contains("will respawn"));
+    }
+
+    #[test]
+    fn dashboard_listener_missing_message_points_at_daemon_restart() {
+        let msg = super::dashboard_listener_missing_message(1);
+        assert!(msg.contains("clud daemon restart"));
     }
 }

--- a/tests/integration/test_daemon_restart.py
+++ b/tests/integration/test_daemon_restart.py
@@ -1,0 +1,90 @@
+"""Integration coverage for issue #186: `clud daemon restart`."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from ._daemon_helpers import (
+    kill_process,
+    managed_env,
+    pid_is_alive,
+    wait_for_pids_to_exit,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _read_daemon_info(state_dir: Path, timeout: float = 10.0) -> dict:
+    info_path = state_dir / "daemon.json"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if info_path.is_file():
+            try:
+                return json.loads(info_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                pass
+        time.sleep(0.05)
+    raise AssertionError(f"timed out waiting for {info_path}")
+
+
+def _run_restart(clud_binary: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(clud_binary), "daemon", "restart"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def _cleanup_daemon(state_dir: Path) -> None:
+    info_path = state_dir / "daemon.json"
+    if not info_path.is_file():
+        return
+    try:
+        pid = int(json.loads(info_path.read_text(encoding="utf-8"))["pid"])
+    except (json.JSONDecodeError, KeyError, ValueError):
+        return
+    if pid_is_alive(pid):
+        kill_process(pid)
+        wait_for_pids_to_exit([pid], timeout=15)
+
+
+def test_daemon_restart_replaces_pid_and_restores_dashboard_listener(
+    clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+) -> None:
+    state_dir = tmp_path / "daemon-state"
+    env = managed_env(mock_env, state_dir)
+
+    try:
+        first = _run_restart(clud_binary, env)
+        assert first.returncode == 0, (
+            f"cold-start daemon restart failed: {first.returncode}\n"
+            f"stdout: {first.stdout!r}\nstderr: {first.stderr!r}"
+        )
+        original_info = _read_daemon_info(state_dir)
+        original_pid = int(original_info["pid"])
+        assert pid_is_alive(original_pid)
+
+        second = _run_restart(clud_binary, env)
+        assert second.returncode == 0, (
+            f"daemon restart failed: {second.returncode}\n"
+            f"stdout: {second.stdout!r}\nstderr: {second.stderr!r}"
+        )
+
+        wait_for_pids_to_exit([original_pid], timeout=15)
+        new_info = _read_daemon_info(state_dir)
+        new_pid = int(new_info["pid"])
+
+        assert new_pid != original_pid
+        assert pid_is_alive(new_pid)
+        assert new_info.get("dashboard_port"), (
+            f"replacement daemon must have a dashboard listener; got {new_info!r}"
+        )
+    finally:
+        _cleanup_daemon(state_dir)


### PR DESCRIPTION
Summary:
- add a daemon shutdown IPC and clud daemon restart recovery command
- update clud ui to point users at daemon restart instead of clud kill --all when no dashboard listener is present
- cover restart wire format, stale daemon shutdown fallback, UI messaging, and integration restart behavior

Tests:
- cargo fmt -p clud -- --check
- git diff --check
- soldr cargo test -p clud --lib daemon::types::tests
- soldr cargo test -p clud --lib daemon::client::tests
- soldr cargo test -p clud --lib ui::tests::dashboard_listener_missing_message
- soldr cargo test -p clud --lib args::tests::test_daemon_restart_subcommand_parses
- CLUD_INTEGRATION_TESTS=1 python -m pytest tests/integration/test_daemon_restart.py -q

Closes #186