### PR TITLE
fix(windows): skip Ctrl-Break for batch wrappers

### DIFF
--- a/crates/clud-bin/src/process_tree.rs
+++ b/crates/clud-bin/src/process_tree.rs
@@ -92,6 +92,17 @@ fn descendant_pids(system: &System, root: Pid) -> Vec<Pid> {
     descendants
 }
 
+/// Whether Ctrl+C teardown should start with a cooperative Ctrl+Break.
+///
+/// Native backend executables can receive this best-effort signal before the
+/// hard kill. Windows batch wrappers cannot: their direct child is `cmd.exe`,
+/// and Ctrl+Break makes cmd's batch interpreter print `Terminate batch job
+/// (Y/N)?` and wait on stdin. For those wrappers we skip straight to
+/// `kill_tree`, which still terminates the cmd.exe child and its descendants.
+pub fn should_cooperative_break(direct_child_is_batch_wrapper: bool) -> bool {
+    !direct_child_is_batch_wrapper
+}
+
 /// Best-effort cooperative shutdown of a Windows console process group.
 ///
 /// When clud spawns the backend with `CREATE_NEW_PROCESS_GROUP`, the
@@ -106,6 +117,9 @@ fn descendant_pids(system: &System, root: Pid) -> Vec<Pid> {
 /// event was queued), `false` otherwise. Failures are silent and
 /// non-fatal: the caller is expected to fall through to `kill_tree` after
 /// a short grace window regardless.
+///
+/// Do not call this when the direct child is a `cmd.exe` batch wrapper; see
+/// [`should_cooperative_break`] for the user-visible prompt it avoids.
 ///
 /// No-op on non-Windows targets — POSIX has no `CREATE_NEW_PROCESS_GROUP`
 /// concept and clud's foreground process group already receives the
@@ -133,6 +147,16 @@ pub fn try_break_group(pid: u32) -> bool {
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    #[test]
+    fn cooperative_break_skipped_for_batch_wrapper() {
+        assert!(!super::should_cooperative_break(true));
+    }
+
+    #[test]
+    fn cooperative_break_sent_for_native_executable() {
+        assert!(super::should_cooperative_break(false));
+    }
 
     #[test]
     fn kill_tree_of_dead_pid_does_not_panic() {

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -201,6 +201,7 @@ pub fn run_plan_subprocess(
             ));
         }
 
+        let batch_wrapped = subprocess::argv_is_batch_wrapped(&plan.command);
         let config = ProcessConfig {
             command: subprocess::command_spec_for_subprocess(plan.command.clone()),
             cwd: plan.cwd.as_ref().map(PathBuf::from),
@@ -261,9 +262,14 @@ pub fn run_plan_subprocess(
         // fallback is unavailable there.
         let mut captured_output = String::new();
         let exit_code = if plan.stream_json_progress {
-            run_with_stream_json_renderer(&process, interrupted, &mut captured_output)
+            run_with_stream_json_renderer(
+                &process,
+                interrupted,
+                &mut captured_output,
+                batch_wrapped,
+            )
         } else {
-            run_with_inherited_stdio(&process, interrupted)
+            run_with_inherited_stdio(&process, interrupted, batch_wrapped)
         };
         match exit_code {
             ProcessOutcome::Exited(code) => {
@@ -328,8 +334,9 @@ enum ProcessOutcome {
 ///
 /// Sequence:
 ///
-/// 1. Windows-only: send `CTRL_BREAK_EVENT` to the child's console
-///    process group. The backend is spawned with
+/// 1. Windows-only, when the direct child is a native executable: send
+///    `CTRL_BREAK_EVENT` to the child's console process group. The
+///    backend is spawned with
 ///    `CREATE_NEW_PROCESS_GROUP` so the OS does *not* deliver the
 ///    user's `CTRL_C_EVENT` to it — that prevents stray
 ///    `KeyboardInterrupt` tracebacks from blocking `subprocess` waits
@@ -338,6 +345,11 @@ enum ProcessOutcome {
 ///    backend that *does* install a Ctrl+Break handler. Failures and
 ///    non-Windows targets short-circuit silently and we proceed to the
 ///    hard kill.
+///
+///    When the direct child is `cmd.exe` running a `.cmd` / `.bat`
+///    backend wrapper, skip this step. Ctrl+Break makes cmd's batch
+///    interpreter display `Terminate batch job (Y/N)?` and wait on
+///    stdin, so the clean interrupt path must go straight to `kill_tree`.
 /// 2. `kill_tree`: snapshot the PID *before* killing the direct child
 ///    so we can walk descendants. On Windows the direct child is
 ///    cmd.exe (BatBadBat wrapper, see `subprocess.rs`) and the real
@@ -348,12 +360,14 @@ enum ProcessOutcome {
 /// 3. `process.kill()` + `process.wait(2s)`: final TerminateProcess on
 ///    the direct handle and a bounded wait so we don't return while
 ///    the child is still draining.
-fn teardown_interrupted_child(process: &running_process::NativeProcess) {
+fn teardown_interrupted_child(process: &running_process::NativeProcess, batch_wrapped: bool) {
     if let Some(pid) = process.pid() {
-        // Cooperative Ctrl+Break first. No-op on POSIX (returns false)
-        // and any failure on Windows is non-fatal — the hard kill below
-        // is always run regardless.
-        let _ = process_tree::try_break_group(pid);
+        // Cooperative Ctrl+Break first when it is safe. No-op on POSIX
+        // (returns false), and any Windows failure is non-fatal because
+        // the hard kill below always runs.
+        if process_tree::should_cooperative_break(batch_wrapped) {
+            let _ = process_tree::try_break_group(pid);
+        }
         process_tree::kill_tree(pid);
     }
     let _ = process.kill();
@@ -367,6 +381,7 @@ fn teardown_interrupted_child(process: &running_process::NativeProcess) {
 fn run_with_inherited_stdio(
     process: &running_process::NativeProcess,
     interrupted: &AtomicBool,
+    batch_wrapped: bool,
 ) -> ProcessOutcome {
     loop {
         match process.poll() {
@@ -378,7 +393,7 @@ fn run_with_inherited_stdio(
             }
             Ok(None) => {
                 if interrupted.load(Ordering::SeqCst) {
-                    teardown_interrupted_child(process);
+                    teardown_interrupted_child(process, batch_wrapped);
                     return ProcessOutcome::Interrupted;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(50));
@@ -406,6 +421,7 @@ fn run_with_stream_json_renderer(
     process: &running_process::NativeProcess,
     interrupted: &AtomicBool,
     captured_output: &mut String,
+    batch_wrapped: bool,
 ) -> ProcessOutcome {
     use running_process::{ReadStatus, StreamKind};
     use std::time::Duration;
@@ -413,7 +429,7 @@ fn run_with_stream_json_renderer(
     let timeout = Duration::from_millis(100);
     loop {
         if interrupted.load(Ordering::SeqCst) {
-            teardown_interrupted_child(process);
+            teardown_interrupted_child(process, batch_wrapped);
             return ProcessOutcome::Interrupted;
         }
         match process.read_stream(StreamKind::Stdout, Some(timeout)) {

--- a/crates/clud-bin/src/subprocess.rs
+++ b/crates/clud-bin/src/subprocess.rs
@@ -40,6 +40,25 @@ pub fn command_spec_for_subprocess(argv: Vec<String>) -> CommandSpec {
     CommandSpec::Argv(argv)
 }
 
+/// Return whether this argv will be launched through `cmd.exe` on Windows.
+///
+/// Callers use this to distinguish native backend processes from BatBadBat
+/// `.cmd` / `.bat` wrappers. The distinction matters during Ctrl+C teardown:
+/// sending Ctrl+Break to a batch-wrapper `cmd.exe` can leave the user at the
+/// blocking `Terminate batch job (Y/N)?` prompt, while native executables can
+/// still use the cooperative break before the hard tree kill.
+pub fn argv_is_batch_wrapped(argv: &[String]) -> bool {
+    #[cfg(windows)]
+    {
+        is_windows_batch_wrapper(argv.first().map(String::as_str))
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = argv;
+        false
+    }
+}
+
 /// True when `program` ends in `.cmd` or `.bat` (case-insensitive). Always
 /// false on non-Windows targets — POSIX never has to special-case batch
 /// wrappers.
@@ -131,7 +150,33 @@ fn quote_for_cmd(arg: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::command_spec_for_subprocess;
+    use super::{argv_is_batch_wrapped, command_spec_for_subprocess};
+
+    #[test]
+    fn argv_is_batch_wrapped_false_for_native_and_empty_argv() {
+        assert!(!argv_is_batch_wrapped(&["claude.exe".into()]));
+        assert!(!argv_is_batch_wrapped(&["claude".into()]));
+        assert!(!argv_is_batch_wrapped(&[]));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn argv_is_batch_wrapped_true_for_cmd_and_bat_on_windows() {
+        assert!(argv_is_batch_wrapped(&[
+            r"C:\Users\me\AppData\Roaming\npm\claude.cmd".into()
+        ]));
+        assert!(argv_is_batch_wrapped(&[
+            r"C:\tools\thing.BAT".into(),
+            "go".into()
+        ]));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn argv_is_batch_wrapped_always_false_off_windows() {
+        assert!(!argv_is_batch_wrapped(&["something.cmd".into()]));
+        assert!(!argv_is_batch_wrapped(&["something.bat".into()]));
+    }
 
     #[test]
     fn native_executable_stays_argv() {

--- a/docs/architecture/windows-quirks.md
+++ b/docs/architecture/windows-quirks.md
@@ -11,9 +11,9 @@ overwrite it, an OLE `IDropTarget` adapter so dragging a file onto the
 console window actually drops paths into the prompt, `CREATE_NO_WINDOW` for
 daemon-helper subprocesses that would otherwise flash a conhost window, a
 `whisper-rs` carve-out on `aarch64-pc-windows-msvc` where the sys-crate
-doesn't build, and a descendant-tree killer to reap orphaned `node.exe`
-grandchildren when the user hits Ctrl+C on `clud --codex`. All nine degrade
-to no-ops (or different mechanisms entirely) on POSIX.
+doesn't build, and a Ctrl+C descendant-tree teardown that reaps orphaned
+backend grandchildren without tripping cmd.exe's batch-job prompt. All nine
+degrade to no-ops (or different mechanisms entirely) on POSIX.
 
 ## Why so many?
 
@@ -82,11 +82,14 @@ the codebase stays portable.
   thanks to the outer quotes. The `/D` flag suppresses any user-installed
   `AutoRun` registry key; `/S` makes cmd's quote handling predictable
   (outermost `"..."` stripped verbatim); `/C` runs and exits.
+  `subprocess::argv_is_batch_wrapped` exposes the same `.cmd` / `.bat`
+  decision to the Ctrl+C teardown path so clud can treat the intermediate
+  `cmd.exe` differently from a native backend executable.
 
 - **File**: `crates/clud-bin/src/subprocess.rs:34`
   (`command_spec_for_subprocess`); the case-insensitive `.cmd`/`.bat` check
   at `:47` (`is_windows_batch_wrapper`); per-arg quoting at `:106`
-  (`quote_for_cmd`).
+  (`quote_for_cmd`); `argv_is_batch_wrapped` for Ctrl+C teardown gating.
 
 - **POSIX behavior**: No-op. `is_windows_batch_wrapper` is gated
   `#[cfg(windows)]`; on POSIX every argv stays as `CommandSpec::Argv` and a
@@ -303,11 +306,12 @@ the codebase stays portable.
   is compiled. Only `aarch64-pc-windows-msvc` is carved out; Linux ARM
   and macOS ARM build `whisper-rs` normally.
 
-### (i) `process_tree::kill_tree` for `--codex` Ctrl+C orphan reap
+### (i) `process_tree::kill_tree` for Ctrl+C backend-tree reap
 
-- **Symptom**: User hits Ctrl+C in `clud --codex` and the prompt takes
-  several seconds to come back; in the meantime an orphaned `node.exe`
-  (the real Codex) keeps writing garbage to the inherited console. The
+- **Symptom**: User hits Ctrl+C in a subprocess-mode backend session and
+  the prompt takes several seconds to come back; in the meantime an
+  orphaned `node.exe` (the real Claude/Codex backend) keeps writing
+  garbage to the inherited console. The
   cause is structural: because of quirk (b) the real process tree at
   runtime is `clud.exe → cmd.exe → node.exe`, and `process.kill()` on
   the direct child reaps only the cmd.exe — the node.exe survives until
@@ -320,11 +324,17 @@ the codebase stays portable.
   deepest-first, ending with the root. The cooperative companion
   `try_break_group` calls
   `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)` so a well-behaved
-  agent with a `SetConsoleCtrlHandler` for `CTRL_BREAK_EVENT` can flush
-  state during the short grace window before the hard kill follows.
+  native agent with a `SetConsoleCtrlHandler` for `CTRL_BREAK_EVENT` can
+  flush state during the short grace window before the hard kill follows.
+  That cooperative break is skipped when the direct child is the BatBadBat
+  `cmd.exe` wrapper from quirk (b): cmd's batch interpreter responds by
+  printing `Terminate batch job (Y/N)?` and waiting on stdin. The hard
+  `kill_tree` step still runs for both Claude and Codex, so the wrapper and
+  backend descendants are reaped without prompting.
 
 - **File**: `crates/clud-bin/src/process_tree.rs:46` (`kill_tree`); `:75`
-  (`descendant_pids`); `:113` (`try_break_group`).
+  (`descendant_pids`); `should_cooperative_break`; `:113`
+  (`try_break_group`).
 
 - **POSIX behavior**: Same `kill_tree` code path runs (`sysinfo` is
   cross-platform; `Signal::Kill` is SIGKILL on Unix; `process.kill()`

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -283,6 +283,33 @@ def mock_env_codex_cmd(mock_agent_binary: Path, tmp_path: Path) -> dict[str, str
     env["PATH"] = str(tmp_path) + os.pathsep + env.get("PATH", "")
     env.pop("VIRTUAL_ENV", None)
     env["RUNNING_PROCESS_CHILD_PID_LOG_PATH"] = str(tmp_path / "child_pids.log")
+    env["CLUD_NO_DAEMON"] = "1"
+    env["CLUD_NO_UNLOCK"] = "1"
+    return env
+
+
+@pytest.fixture
+def mock_env_cmd_wrappers(mock_agent_binary: Path, tmp_path: Path) -> dict[str, str]:
+    """Windows-only env where both backends resolve to `.cmd` wrappers."""
+    if sys.platform != "win32":
+        pytest.skip("Windows-only .cmd wrapper fixture")
+
+    mock_agent_path = tmp_path / "mock-agent.exe"
+    shutil.copy2(mock_agent_binary, mock_agent_path)
+
+    for backend in ("claude", "codex"):
+        wrapper = tmp_path / f"{backend}.cmd"
+        wrapper.write_text(
+            "@echo off\r\n"
+            "\"%~dp0mock-agent.exe\" %*\r\n",
+            encoding="utf-8",
+        )
+
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path) + os.pathsep + env.get("PATH", "")
+    env.pop("VIRTUAL_ENV", None)
+    env["RUNNING_PROCESS_CHILD_PID_LOG_PATH"] = str(tmp_path / "child_pids.log")
+    env["CLUD_NO_DAEMON"] = "1"
     env["CLUD_NO_UNLOCK"] = "1"
     return env
 

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import pytest
 
+from ._daemon_helpers import kill_process, wait_for_pids_to_exit, wait_for_tree_pids
+
 pytestmark = pytest.mark.integration
 
 _TIMEOUT = 15
@@ -58,6 +60,21 @@ def _parse_agent_report(result: subprocess.CompletedProcess[str]) -> dict:
         if line.startswith("{"):
             return json.loads(line)
     return json.loads(cleaned)
+
+
+def _wait_for_pid_log(path: Path, minimum: int, timeout: float = 10.0) -> list[int]:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if path.is_file():
+            pids = [
+                int(line)
+                for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip().isdigit()
+            ]
+            if len(pids) >= minimum:
+                return pids
+        time.sleep(0.05)
+    raise AssertionError(f"timed out waiting for {minimum} child pids in {path}")
 
 
 class TestBackendSelection:
@@ -491,6 +508,65 @@ class TestLoopMode:
 
 class TestInterruptReporting:
     """Verify Ctrl+C reports how clud was launched."""
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only cmd.exe prompt repro")
+    @pytest.mark.parametrize(
+        ("backend_args", "backend_name"),
+        [
+            ([], "claude"),
+            (["--codex"], "codex"),
+        ],
+    )
+    def test_cmd_wrapper_ctrl_break_exit_does_not_prompt_or_orphan_children(
+        self,
+        clud_binary: Path,
+        mock_env_cmd_wrappers: dict[str, str],
+        tmp_path: Path,
+        backend_args: list[str],
+        backend_name: str,
+    ) -> None:
+        pid_log = Path(mock_env_cmd_wrappers["RUNNING_PROCESS_CHILD_PID_LOG_PATH"])
+        tree_log = tmp_path / f"{backend_name}-tree.jsonl"
+        proc = subprocess.Popen(
+            [
+                str(clud_binary),
+                *backend_args,
+                "-p",
+                f"{backend_name} clean interrupt",
+                "--",
+                "--mock-sleep-ms",
+                "15000",
+                "--mock-spawn-tree-log",
+                str(tree_log),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=mock_env_cmd_wrappers,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
+
+        child_pids: list[int] = []
+        tree_pids: list[int] = []
+        try:
+            child_pids = _wait_for_pid_log(pid_log, minimum=1)
+            tree_pids = wait_for_tree_pids(tree_log, minimum=3)
+
+            proc.send_signal(signal.CTRL_BREAK_EVENT)
+            time.sleep(0.1)
+            if proc.poll() is None:
+                proc.send_signal(signal.CTRL_BREAK_EVENT)
+            stdout, stderr = proc.communicate(timeout=10)
+        finally:
+            if proc.poll() is None:
+                kill_process(proc.pid)
+                proc.wait(timeout=5)
+
+        combined = f"{stdout}\n{stderr}"
+        wait_for_pids_to_exit(child_pids + tree_pids, timeout=10)
+        assert proc.returncode == 130, combined
+        assert "Terminate batch job" not in combined
 
     def test_ctrl_c_reports_pty_mode_when_forced(
         self, clud_binary: Path, mock_env: dict[str, str]


### PR DESCRIPTION
Summary:
- detect backend argv that clud wraps through cmd.exe for .cmd/.bat launchers
- skip cooperative Ctrl-Break only for batch-wrapper children to avoid the Terminate batch job prompt
- keep hard process-tree cleanup for both Claude and Codex wrapper paths
- document the Windows Ctrl-C behavior and add Windows integration coverage

Tests:
- soldr cargo fmt --check
- soldr cargo test -p clud --lib subprocess::
- soldr cargo test -p clud --lib process_tree::
- soldr cargo test -p clud --lib runner::
- CLUD_INTEGRATION_TESTS=1 python -m pytest tests/integration/test_mock_agents.py::TestInterruptReporting::test_cmd_wrapper_ctrl_break_exit_does_not_prompt_or_orphan_children -q
- git diff --check
- bash lint

Closes #185