### PR TITLE
ci: disable setup-uv cache post-step

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -46,8 +46,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          enable-cache: false
 
       - name: Cache venv
         uses: actions/cache@v4

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -36,8 +36,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          enable-cache: false
 
       - name: Cache venv
         uses: actions/cache@v4

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -31,8 +31,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          enable-cache: false
 
       - name: Cache venv
         uses: actions/cache@v4

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -31,8 +31,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          enable-cache: false
 
       - name: Cache venv
         uses: actions/cache@v4


### PR DESCRIPTION
Summary:
- disable setup-uv's built-in cache in all shared workflow templates
- keep the explicit .venv cache in place for Python dependencies
- avoid Windows post-job failures from uv cache prune after tests have already passed

Tests:
- git diff --check

Unblocks #201, #202, #203, and #204.