### PR TITLE
feat(daemon): skip GC entries under live session CWDs

### DIFF
--- a/crates/clud-bin/src/daemon/attach.rs
+++ b/crates/clud-bin/src/daemon/attach.rs
@@ -88,6 +88,7 @@ pub(super) fn run_attach(session_id: &str, state_dir: &Path, interrupted: &Atomi
         DaemonResponse::Created { .. }
         | DaemonResponse::Terminated { .. }
         | DaemonResponse::Gc { .. }
+        | DaemonResponse::LiveCwds { .. }
         | DaemonResponse::ShutdownAck { .. } => 1,
     }
 }

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -361,6 +361,7 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         DaemonResponse::Session { .. }
         | DaemonResponse::Terminated { .. }
         | DaemonResponse::Gc { .. }
+        | DaemonResponse::LiveCwds { .. }
         | DaemonResponse::ShutdownAck { .. } => 1,
     }
 }

--- a/crates/clud-bin/src/daemon/gc_service.rs
+++ b/crates/clud-bin/src/daemon/gc_service.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -33,26 +33,47 @@ pub(super) struct GcRequestMsg {
     pub(super) reply_tx: mpsc::SyncSender<GcReply>,
 }
 
+type LiveCwdsProvider = Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync + 'static>;
+
 /// Open the registry and spawn the single worker thread. Returns the
 /// sender every connection thread uses to dispatch GC ops. Caller keeps
 /// the sender alive for the daemon's lifetime; dropping it stops the
 /// worker.
+#[cfg(test)]
 pub(super) fn spawn_registry_worker() -> std::io::Result<mpsc::Sender<GcRequestMsg>> {
     let registry = Registry::open_default().map_err(std::io::Error::other)?;
     spawn_registry_worker_with(registry)
 }
 
+pub(super) fn spawn_registry_worker_for_state(
+    state_dir: PathBuf,
+) -> std::io::Result<mpsc::Sender<GcRequestMsg>> {
+    let registry = Registry::open_default().map_err(std::io::Error::other)?;
+    spawn_registry_worker_with_live_cwds(
+        registry,
+        Arc::new(move || super::sessions::list_live_session_cwds(&state_dir)),
+    )
+}
+
 /// Same as [`spawn_registry_worker`] but accepts a pre-constructed
 /// `Registry`. Tests use this to bind a worker to an isolated `redb`
 /// file without depending on the process-global `CLUD_DATA_DB` env var.
+#[cfg(test)]
 pub(super) fn spawn_registry_worker_with(
     registry: Registry,
+) -> std::io::Result<mpsc::Sender<GcRequestMsg>> {
+    spawn_registry_worker_with_live_cwds(registry, Arc::new(Vec::<PathBuf>::new))
+}
+
+fn spawn_registry_worker_with_live_cwds(
+    registry: Registry,
+    live_cwds_provider: LiveCwdsProvider,
 ) -> std::io::Result<mpsc::Sender<GcRequestMsg>> {
     let (tx, rx) = mpsc::channel::<GcRequestMsg>();
     let tick_cadence = gc_tick_cadence_from_env();
     thread::Builder::new()
         .name("clud-gc-registry-worker".to_string())
-        .spawn(move || run_worker_loop(registry, rx, tick_cadence))?;
+        .spawn(move || run_worker_loop(registry, rx, tick_cadence, live_cwds_provider))?;
     Ok(tx)
 }
 
@@ -76,10 +97,11 @@ fn run_worker_loop(
     registry: Registry,
     rx: mpsc::Receiver<GcRequestMsg>,
     tick_cadence: Option<Duration>,
+    live_cwds_provider: LiveCwdsProvider,
 ) {
     let Some(tick_cadence) = tick_cadence else {
         while let Ok(msg) = rx.recv() {
-            handle_worker_msg(&registry, msg);
+            handle_worker_msg(&registry, msg, &live_cwds_provider);
         }
         return;
     };
@@ -89,14 +111,14 @@ fn run_worker_loop(
         let timeout = next_tick.saturating_duration_since(Instant::now());
         match rx.recv_timeout(timeout) {
             Ok(msg) => {
-                handle_worker_msg(&registry, msg);
+                handle_worker_msg(&registry, msg, &live_cwds_provider);
                 if Instant::now() >= next_tick {
-                    run_periodic_purge_tick(&registry);
+                    run_periodic_purge_tick(&registry, &live_cwds_provider);
                     next_tick = Instant::now() + tick_cadence;
                 }
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                run_periodic_purge_tick(&registry);
+                run_periodic_purge_tick(&registry, &live_cwds_provider);
                 next_tick = Instant::now() + tick_cadence;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
@@ -104,20 +126,25 @@ fn run_worker_loop(
     }
 }
 
-fn handle_worker_msg(registry: &Registry, msg: GcRequestMsg) {
-    let reply = process_op(registry, msg.op);
+fn handle_worker_msg(
+    registry: &Registry,
+    msg: GcRequestMsg,
+    live_cwds_provider: &LiveCwdsProvider,
+) {
+    let reply = process_op_with_live_cwds(registry, msg.op, live_cwds_provider());
     // Hung-up callers are fine — the worker keeps serving the rest.
     let _ = msg.reply_tx.send(reply);
 }
 
-fn run_periodic_purge_tick(registry: &Registry) {
-    let reply = process_op(
+fn run_periodic_purge_tick(registry: &Registry, live_cwds_provider: &LiveCwdsProvider) {
+    let reply = process_op_with_live_cwds(
         registry,
         GcOp::Purge {
             duration: Some(PERIODIC_GC_WORKTREE_STALE_AFTER.to_string()),
             kind: Some("worktree".to_string()),
             dry_run: false,
         },
+        live_cwds_provider(),
     );
     match reply {
         GcReply::PurgeOk { removed, skipped } => {
@@ -132,7 +159,7 @@ fn run_periodic_purge_tick(registry: &Registry) {
     }
 }
 
-pub(super) fn process_op(registry: &Registry, op: GcOp) -> GcReply {
+fn process_op_with_live_cwds(registry: &Registry, op: GcOp, live_cwds: Vec<PathBuf>) -> GcReply {
     match op {
         GcOp::List { kind } => match registry.list(kind.as_deref()) {
             Ok(rows) => {
@@ -185,9 +212,10 @@ pub(super) fn process_op(registry: &Registry, op: GcOp) -> GcReply {
                 }
             };
             let live_locks = collect_live_lock_paths();
+            let live_cwds = canonicalize_live_cwds(live_cwds);
             let (purgeable, skipped): (Vec<_>, Vec<_>) = candidates
                 .into_iter()
-                .partition(|c| !(c.kind == "worktree" && live_locks.contains(&c.path)));
+                .partition(|c| !entry_is_live(c, &live_locks, &live_cwds));
             if dry_run {
                 return GcReply::PurgeOk {
                     removed: purgeable.len(),
@@ -283,7 +311,8 @@ pub(super) fn process_op(registry: &Registry, op: GcOp) -> GcReply {
                 };
             };
             let live_locks = collect_live_lock_paths();
-            if target.kind == "worktree" && live_locks.contains(&target.path) {
+            let live_cwds = canonicalize_live_cwds(live_cwds);
+            if entry_is_live(&target, &live_locks, &live_cwds) {
                 return GcReply::PurgeOk {
                     removed: 0,
                     skipped: 1,
@@ -298,6 +327,36 @@ pub(super) fn process_op(registry: &Registry, op: GcOp) -> GcReply {
             }
         }
     }
+}
+
+fn canonicalize_live_cwds(live_cwds: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = live_cwds
+        .into_iter()
+        .filter_map(|path| std::fs::canonicalize(path).ok())
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn entry_is_live(
+    entry: &TrackedEntry,
+    live_locks: &HashSet<String>,
+    live_cwds: &[PathBuf],
+) -> bool {
+    if entry.kind == "worktree" && live_locks.contains(&entry.path) {
+        return true;
+    }
+    entry_path_contains_live_cwd(entry, live_cwds)
+}
+
+fn entry_path_contains_live_cwd(entry: &TrackedEntry, live_cwds: &[PathBuf]) -> bool {
+    let Ok(entry_path) = std::fs::canonicalize(&entry.path) else {
+        return false;
+    };
+    live_cwds
+        .iter()
+        .any(|cwd| cwd == &entry_path || cwd.starts_with(&entry_path))
 }
 
 fn now_unix() -> i64 {
@@ -401,6 +460,15 @@ mod tests {
         restore_env_var(ENV_DATA_DB, prior_db);
         let tx = tx.unwrap();
         (tx, guard)
+    }
+
+    fn spawn_test_worker_with_live_cwds(
+        db_path: &Path,
+        live_cwds: Vec<PathBuf>,
+    ) -> mpsc::Sender<GcRequestMsg> {
+        let registry = Registry::open_at(db_path).expect("open registry");
+        spawn_registry_worker_with_live_cwds(registry, Arc::new(move || live_cwds.clone()))
+            .expect("spawn registry worker")
     }
 
     fn restore_env_var(key: &str, prior: Option<std::ffi::OsString>) {
@@ -536,6 +604,105 @@ mod tests {
             GcReply::ListOk { rows } => assert_eq!(rows.len(), 1),
             other => panic!("unexpected reply: {other:?}"),
         }
+    }
+
+    #[test]
+    fn purge_skips_entry_equal_to_live_session_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("live-cwd-direct.redb");
+        let path_a = dir.path().join("A");
+        let path_b = dir.path().join("B");
+        std::fs::create_dir_all(&path_a).unwrap();
+        std::fs::create_dir_all(&path_b).unwrap();
+        let tx = spawn_test_worker_with_live_cwds(&db_path, vec![path_a.clone()]);
+
+        for path in [&path_a, &path_b] {
+            call(
+                &tx,
+                GcOp::Insert {
+                    kind: "cache".to_string(),
+                    path: path.to_string_lossy().to_string(),
+                    repo_root: None,
+                    branch: None,
+                    agent_id: None,
+                    created_unix: Some(100),
+                },
+            );
+        }
+
+        let resp = call(
+            &tx,
+            GcOp::Purge {
+                duration: None,
+                kind: None,
+                dry_run: false,
+            },
+        );
+        match resp {
+            GcReply::PurgeOk { removed, skipped } => {
+                assert_eq!(removed, 1);
+                assert_eq!(skipped, 1);
+            }
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        assert!(path_a.exists(), "live cwd entry should remain on disk");
+        assert!(!path_b.exists(), "non-live entry should be deleted");
+        let rows = match call(&tx, GcOp::List { kind: None }) {
+            GcReply::ListOk { rows } => rows,
+            other => panic!("unexpected reply: {other:?}"),
+        };
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].path, path_a.to_string_lossy().to_string());
+    }
+
+    #[test]
+    fn purge_skips_entry_that_is_ancestor_of_live_session_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("live-cwd-ancestor.redb");
+        let path_a = dir.path().join("A");
+        let live_subdir = path_a.join("sub");
+        std::fs::create_dir_all(&live_subdir).unwrap();
+        let tx = spawn_test_worker_with_live_cwds(&db_path, vec![live_subdir]);
+
+        call(
+            &tx,
+            GcOp::Insert {
+                kind: "cache".to_string(),
+                path: path_a.to_string_lossy().to_string(),
+                repo_root: None,
+                branch: None,
+                agent_id: None,
+                created_unix: Some(100),
+            },
+        );
+
+        let resp = call(
+            &tx,
+            GcOp::Purge {
+                duration: None,
+                kind: None,
+                dry_run: false,
+            },
+        );
+        match resp {
+            GcReply::PurgeOk { removed, skipped } => {
+                assert_eq!(removed, 0);
+                assert_eq!(skipped, 1);
+            }
+            other => panic!("unexpected reply: {other:?}"),
+        }
+
+        assert!(
+            path_a.exists(),
+            "ancestor of live cwd should remain on disk"
+        );
+        let rows = match call(&tx, GcOp::List { kind: None }) {
+            GcReply::ListOk { rows } => rows,
+            other => panic!("unexpected reply: {other:?}"),
+        };
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].path, path_a.to_string_lossy().to_string());
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -14,11 +14,12 @@ use sysinfo::Signal;
 use crate::win_creation_flags::invisible_helper_creationflags;
 
 use super::client::cleanup_stale_state;
-use super::gc_service::{spawn_registry_worker, GcRequestMsg, WORKER_REPLY_TIMEOUT};
+use super::gc_service::{spawn_registry_worker_for_state, GcRequestMsg, WORKER_REPLY_TIMEOUT};
 use super::http::{default_live_sessions_provider, spawn_dashboard};
 use super::io_helpers::{new_session_id, read_json_file, write_json_file, write_json_line};
 use super::paths::{daemon_info_path, session_snapshot_path, sessions_dir, spec_path, specs_dir};
 use super::process_utils::{pid_is_alive, signal_process_tree};
+use super::sessions::list_live_session_cwds;
 use super::types::{
     DaemonInfo, DaemonRequest, DaemonResponse, GcReply, SessionSnapshot, WorkerLaunchSpec,
 };
@@ -55,7 +56,7 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
     // Issue #135: GC registry worker is in-process now. Failing to open
     // the registry is non-fatal — session ops still work; only GC ops
     // will error back to the CLI. Log once and continue.
-    let gc_tx = match spawn_registry_worker() {
+    let gc_tx = match spawn_registry_worker_for_state(state_dir.to_path_buf()) {
         Ok(tx) => Some(tx),
         Err(err) => {
             eprintln!("[clud] note: gc registry unavailable: {}", err);
@@ -162,6 +163,9 @@ fn handle_daemon_connection(
                 },
             }
         }
+        DaemonRequest::ListLiveCwds => DaemonResponse::LiveCwds {
+            paths: list_live_session_cwds(state_dir),
+        },
         DaemonRequest::Terminate { session_id } => {
             match daemon_terminate_session(state_dir, workers, &session_id) {
                 Ok(session) => DaemonResponse::Terminated { session },

--- a/crates/clud-bin/src/daemon/sessions.rs
+++ b/crates/clud-bin/src/daemon/sessions.rs
@@ -97,16 +97,11 @@ pub(super) fn list_background_sessions(state_dir: &Path) -> Vec<SessionSnapshot>
         let Ok(session) = read_json_file::<SessionSnapshot>(&path) else {
             continue;
         };
-        if session.exit_code.is_some() || !session.background {
+        if !session.background {
             continue;
         }
-        if !pid_is_alive(session.worker_pid) {
+        if !session_is_live(&session) {
             continue;
-        }
-        if let Some(root_pid) = session.root_pid {
-            if !pid_is_alive(root_pid) {
-                continue;
-            }
         }
         sessions.push(session);
     }
@@ -114,11 +109,55 @@ pub(super) fn list_background_sessions(state_dir: &Path) -> Vec<SessionSnapshot>
     sessions
 }
 
+pub(super) fn list_live_session_cwds(state_dir: &Path) -> Vec<std::path::PathBuf> {
+    let Ok(entries) = fs::read_dir(sessions_dir(state_dir)) else {
+        return Vec::new();
+    };
+    let mut paths = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(session) = read_json_file::<SessionSnapshot>(&path) else {
+            continue;
+        };
+        if !session_is_live(&session) {
+            continue;
+        }
+        let Some(cwd) = session.cwd.as_deref() else {
+            continue;
+        };
+        let Ok(canonical) = fs::canonicalize(cwd) else {
+            continue;
+        };
+        paths.push(canonical);
+    }
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
 pub(super) fn list_attachable_sessions(state_dir: &Path) -> Vec<SessionSnapshot> {
     list_background_sessions(state_dir)
         .into_iter()
         .filter(|session| session.attachable)
         .collect()
+}
+
+fn session_is_live(session: &SessionSnapshot) -> bool {
+    if session.exit_code.is_some() {
+        return false;
+    }
+    if !pid_is_alive(session.worker_pid) {
+        return false;
+    }
+    if let Some(root_pid) = session.root_pid {
+        if !pid_is_alive(root_pid) {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -129,10 +168,21 @@ mod tests {
     use tempfile::TempDir;
 
     fn write_snapshot(state_dir: &Path, id: &str, created_at: u64, exit_code: Option<i32>) {
+        write_snapshot_with_cwd_and_pid(state_dir, id, created_at, exit_code, None, 0);
+    }
+
+    fn write_snapshot_with_cwd_and_pid(
+        state_dir: &Path,
+        id: &str,
+        created_at: u64,
+        exit_code: Option<i32>,
+        cwd: Option<String>,
+        worker_pid: u32,
+    ) {
         let snap = SessionSnapshot {
             id: id.into(),
             kind: SessionKind::Subprocess,
-            cwd: None,
+            cwd,
             name: None,
             created_at: Some(created_at),
             detachable: false,
@@ -142,7 +192,7 @@ mod tests {
             repeat_next_run_at: None,
             repeat_running: false,
             daemon_pid: 0,
-            worker_pid: 0,
+            worker_pid,
             worker_port: 0,
             root_pid: None,
             exit_code,
@@ -168,5 +218,42 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let nonexistent = tmp.path().join("does-not-exist");
         assert!(most_recent_session_any(&nonexistent).is_none());
+    }
+
+    #[test]
+    fn list_live_session_cwds_returns_canonical_live_cwds() {
+        let tmp = TempDir::new().unwrap();
+        let live_cwd = tmp.path().join("live");
+        let exited_cwd = tmp.path().join("exited");
+        std::fs::create_dir_all(&live_cwd).unwrap();
+        std::fs::create_dir_all(&exited_cwd).unwrap();
+
+        write_snapshot_with_cwd_and_pid(
+            tmp.path(),
+            "sess-live",
+            1,
+            None,
+            Some(live_cwd.to_string_lossy().to_string()),
+            std::process::id(),
+        );
+        write_snapshot_with_cwd_and_pid(
+            tmp.path(),
+            "sess-exited",
+            2,
+            Some(0),
+            Some(exited_cwd.to_string_lossy().to_string()),
+            std::process::id(),
+        );
+        write_snapshot_with_cwd_and_pid(
+            tmp.path(),
+            "sess-dead-worker",
+            3,
+            None,
+            Some(exited_cwd.to_string_lossy().to_string()),
+            u32::MAX,
+        );
+
+        let paths = list_live_session_cwds(tmp.path());
+        assert_eq!(paths, vec![std::fs::canonicalize(live_cwd).unwrap()]);
     }
 }

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -130,6 +130,8 @@ pub(super) enum DaemonRequest {
     Session {
         session_id: String,
     },
+    /// Return canonicalized CWDs for every live session snapshot.
+    ListLiveCwds,
     Terminate {
         session_id: String,
     },
@@ -153,6 +155,9 @@ pub(super) enum DaemonResponse {
     },
     Session {
         session: SessionSnapshot,
+    },
+    LiveCwds {
+        paths: Vec<PathBuf>,
     },
     Terminated {
         session: SessionSnapshot,
@@ -419,6 +424,33 @@ mod tests {
         let wire = serde_json::to_string(&DaemonRequest::Shutdown).unwrap();
         let parsed: DaemonRequest = serde_json::from_str(&wire).unwrap();
         assert!(matches!(parsed, DaemonRequest::Shutdown));
+    }
+
+    #[test]
+    fn list_live_cwds_request_serializes_as_tagged_op() {
+        let wire = serde_json::to_string(&DaemonRequest::ListLiveCwds).unwrap();
+        assert_eq!(wire, r#"{"op":"list_live_cwds"}"#);
+    }
+
+    #[test]
+    fn live_cwds_response_roundtrips_with_paths() {
+        let response = DaemonResponse::LiveCwds {
+            paths: vec![PathBuf::from("/tmp/live-a"), PathBuf::from("/tmp/live-b")],
+        };
+        let wire = serde_json::to_string(&response).unwrap();
+        assert!(wire.contains(r#""op":"live_cwds""#));
+        assert!(wire.contains(r#"/tmp/live-a"#));
+
+        let parsed: DaemonResponse = serde_json::from_str(&wire).unwrap();
+        match parsed {
+            DaemonResponse::LiveCwds { paths } => {
+                assert_eq!(
+                    paths,
+                    vec![PathBuf::from("/tmp/live-a"), PathBuf::from("/tmp/live-b")]
+                );
+            }
+            other => panic!("expected LiveCwds, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a daemon `list_live_cwds` IPC request/response that returns canonical live session CWDs
- feed live CWDs into the GC registry worker so purge/delete skips entries equal to or ancestors of active sessions
- keep existing git worktree lock PID protection as the worktree-specific stronger signal

Closes #180

## Validation
- `soldr cargo fmt --check`
- `soldr cargo test -p clud live_cwd`
- `soldr cargo test -p clud purge_skips_entry`
- `git diff --check`