### PR TITLE
feat: add clud trash quarantine

### DIFF
--- a/crates/clud-bin/assets/skills/clud-windows-trash/README.md
+++ b/crates/clud-bin/assets/skills/clud-windows-trash/README.md
@@ -1,0 +1,3 @@
+# clud-windows-trash
+
+Use `clud trash` for Windows-locked DLL/EXE/PYD artifacts instead of retrying deletion or killing processes. The daemon retries cleanup from `~/.clud/trash/`.

--- a/crates/clud-bin/assets/skills/clud-windows-trash/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-windows-trash/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: clud-windows-trash
+description: Quarantine Windows-locked DLL/EXE/PYD artifacts with clud trash instead of retrying deletes or killing processes.
+triggers:
+  - "When deleting *.dll, *.pyd, or *.exe on Windows fails with os error 32 or being used by another process"
+  - "When a build fails because an output DLL, PYD, or EXE is locked"
+  - "When a directory containing Windows build artifacts cannot be removed"
+---
+<!-- managed-by: clud -->
+
+# /clud-windows-trash
+
+Use `clud trash` when Windows refuses to delete freshly built native artifacts.
+
+## Triggers
+
+- A delete of `*.dll`, `*.pyd`, or `*.exe` fails with `os error 32`, `being used by another process`, `Access is denied`, or similar loader/Defender lock symptoms.
+- A build script cannot overwrite an output file because the previous artifact is still locked.
+- A directory removal fails and the tree contains Windows native build outputs.
+
+## Rules
+
+1. Do not retry `del`, `Remove-Item`, or `rm` in a loop.
+2. Do not run `taskkill` for guessed parent processes.
+3. Run `clud trash <path>` for the locked file or containing directory, then continue the build or cleanup.
+4. If `clud trash` reports a source/trash volume mismatch, pass `--cross-volume` only when the copy cost is acceptable: `clud trash --cross-volume <path>`.
+
+## Workflow
+
+1. Identify the smallest locked path that unblocks the build. Prefer the exact file; use the containing build-output directory when many siblings are blocked.
+2. Run `clud trash <path>`.
+3. If the command succeeds, proceed immediately. The clud daemon will retry deletion from `~/.clud/trash/` until Windows releases the lock.
+4. If cross-volume copy is required and acceptable, rerun with `--cross-volume`. Source removal after the copy is best-effort.
+5. To inspect pending cleanup, run `clud gc list --kind trash`.
+
+## Exit Guidance
+
+After a successful trash, keep going. Do not wait for the daemon to reap the quarantined path unless the user explicitly asks to verify cleanup.

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -216,6 +216,15 @@ pub enum Command {
         #[arg(long = "no-open")]
         no_open: bool,
     },
+    /// Quarantine paths under ~/.clud/trash and let daemon GC reap them.
+    Trash {
+        /// Allow copy + best-effort source removal when source and trash
+        /// live on different volumes.
+        #[arg(long = "cross-volume")]
+        cross_volume: bool,
+        #[arg(required = true, value_name = "PATH")]
+        paths: Vec<PathBuf>,
+    },
     /// Control the always-on clud daemon.
     Daemon {
         #[command(subcommand)]
@@ -254,6 +263,9 @@ pub enum GcSubcommand {
         /// Issue #135: emit a JSON array instead of the human-readable table.
         #[arg(long = "json")]
         json: bool,
+        /// Restrict to a single entry kind (e.g. `worktree`, `trash`).
+        #[arg(long = "kind")]
+        kind: Option<String>,
     },
     /// Remove tracked entries older than `<duration>`. When `<duration>`
     /// is omitted, purge ALL tracked entries that are not live-locked.
@@ -344,7 +356,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
         "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "ui",
-        "daemon", "__daemon", "__worker",
+        "trash", "daemon", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/args_tests.rs
+++ b/crates/clud-bin/src/args_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::path::PathBuf;
 
 fn parse(args: &[&str]) -> Args {
     let raw: Vec<String> = args.iter().map(|s| s.to_string()).collect();
@@ -694,8 +695,11 @@ fn test_gc_list() {
     let args = parse(&["clud", "gc", "list"]);
     match args.command {
         Some(Command::Gc {
-            subcommand: Some(GcSubcommand::List { json }),
-        }) => assert!(!json),
+            subcommand: Some(GcSubcommand::List { json, kind }),
+        }) => {
+            assert!(!json);
+            assert!(kind.is_none());
+        }
         _ => panic!("expected Gc::List"),
     }
 }
@@ -706,9 +710,26 @@ fn test_gc_list_json() {
     let args = parse(&["clud", "gc", "list", "--json"]);
     match args.command {
         Some(Command::Gc {
-            subcommand: Some(GcSubcommand::List { json }),
-        }) => assert!(json),
+            subcommand: Some(GcSubcommand::List { json, kind }),
+        }) => {
+            assert!(json);
+            assert!(kind.is_none());
+        }
         _ => panic!("expected Gc::List --json"),
+    }
+}
+
+#[test]
+fn test_gc_list_kind_filter() {
+    let args = parse(&["clud", "gc", "list", "--kind", "trash"]);
+    match args.command {
+        Some(Command::Gc {
+            subcommand: Some(GcSubcommand::List { json, kind }),
+        }) => {
+            assert!(!json);
+            assert_eq!(kind.as_deref(), Some("trash"));
+        }
+        _ => panic!("expected Gc::List --kind trash"),
     }
 }
 
@@ -794,6 +815,30 @@ fn test_gc_reconcile() {
             subcommand: Some(GcSubcommand::Reconcile),
         }) => {}
         _ => panic!("expected Gc::Reconcile"),
+    }
+}
+
+#[test]
+fn test_trash_command_parses_paths_and_cross_volume() {
+    let args = parse(&[
+        "clud",
+        "trash",
+        "--cross-volume",
+        "target/foo.dll",
+        "bar.exe",
+    ]);
+    match args.command {
+        Some(Command::Trash {
+            cross_volume,
+            paths,
+        }) => {
+            assert!(cross_volume);
+            assert_eq!(
+                paths,
+                vec![PathBuf::from("target/foo.dll"), PathBuf::from("bar.exe")]
+            );
+        }
+        _ => panic!("expected Trash command"),
     }
 }
 

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -136,6 +136,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         | Some(Command::Logs { .. })
         | Some(Command::Gc { .. })
         | Some(Command::Ui { .. })
+        | Some(Command::Trash { .. })
         | Some(Command::Daemon { .. })
         | Some(Command::InternalDaemon { .. })
         | Some(Command::InternalWorker { .. }) => {}

--- a/crates/clud-bin/src/daemon/gc_service.rs
+++ b/crates/clud-bin/src/daemon/gc_service.rs
@@ -137,7 +137,7 @@ fn handle_worker_msg(
 }
 
 fn run_periodic_purge_tick(registry: &Registry, live_cwds_provider: &LiveCwdsProvider) {
-    let reply = process_op_with_live_cwds(
+    let worktree_reply = process_op_with_live_cwds(
         registry,
         GcOp::Purge {
             duration: Some(PERIODIC_GC_WORKTREE_STALE_AFTER.to_string()),
@@ -146,7 +146,7 @@ fn run_periodic_purge_tick(registry: &Registry, live_cwds_provider: &LiveCwdsPro
         },
         live_cwds_provider(),
     );
-    match reply {
+    match worktree_reply {
         GcReply::PurgeOk { removed, skipped } => {
             eprintln!("[clud] gc tick: removed {removed}, skipped {skipped}");
         }
@@ -155,6 +155,17 @@ fn run_periodic_purge_tick(registry: &Registry, live_cwds_provider: &LiveCwdsPro
         }
         other => {
             eprintln!("[clud] gc tick: unexpected reply: {other:?}");
+        }
+    }
+
+    match reap_trash_entries(registry) {
+        Ok((removed, failed)) => {
+            if removed > 0 || failed > 0 {
+                eprintln!("[clud] gc tick: trash removed {removed}, failed {failed}");
+            }
+        }
+        Err(message) => {
+            eprintln!("[clud] gc tick: trash error: {message}");
         }
     }
 }
@@ -344,6 +355,9 @@ fn entry_is_live(
     live_locks: &HashSet<String>,
     live_cwds: &[PathBuf],
 ) -> bool {
+    if entry.kind == "trash" {
+        return false;
+    }
     if entry.kind == "worktree" && live_locks.contains(&entry.path) {
         return true;
     }
@@ -411,6 +425,8 @@ fn remove_entry_and_delete_row(registry: &Registry, entry: &TrackedEntry) -> Res
                 std::fs::remove_dir_all(dir).map_err(|e| e.to_string())?;
             }
         }
+    } else if entry.kind == "trash" {
+        std::fs::remove_dir_all(&entry.path).map_err(|e| e.to_string())?;
     } else {
         let p = Path::new(&entry.path);
         if p.exists() {
@@ -418,6 +434,27 @@ fn remove_entry_and_delete_row(registry: &Registry, entry: &TrackedEntry) -> Res
         }
     }
     registry.delete(entry.id).map_err(|e| e.to_string())
+}
+
+fn reap_trash_entries(registry: &Registry) -> Result<(usize, usize), String> {
+    let entries = registry
+        .list(Some("trash"))
+        .map_err(|err| err.to_string())?;
+    let mut removed = 0usize;
+    let mut failed = 0usize;
+    for entry in entries {
+        match std::fs::remove_dir_all(&entry.path) {
+            Ok(()) => {
+                registry.delete(entry.id).map_err(|err| err.to_string())?;
+                eprintln!("[gc] trash: reaped {}", entry.path);
+                removed += 1;
+            }
+            Err(_) => {
+                failed += 1;
+            }
+        }
+    }
+    Ok((removed, failed))
 }
 
 #[cfg(test)]
@@ -746,6 +783,56 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(100));
         }
+    }
+
+    #[test]
+    fn trash_reaper_deletes_successful_entry_and_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("trash-reap.redb");
+        let registry = Registry::open_at(&db_path).unwrap();
+        let trash_dir = dir.path().join("trash-item");
+        std::fs::create_dir_all(&trash_dir).unwrap();
+        registry
+            .insert_if_new(&InsertInput {
+                kind: "trash".to_string(),
+                path: trash_dir.to_string_lossy().to_string(),
+                repo_root: None,
+                branch: None,
+                agent_id: Some("C:/repo/target/debug/foo.dll".to_string()),
+                now_unix: 100,
+            })
+            .unwrap();
+
+        let (removed, failed) = reap_trash_entries(&registry).unwrap();
+
+        assert_eq!((removed, failed), (1, 0));
+        assert!(!trash_dir.exists());
+        assert!(registry.list(Some("trash")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn trash_reaper_keeps_row_when_delete_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("trash-reap-fail.redb");
+        let registry = Registry::open_at(&db_path).unwrap();
+        let not_a_dir = dir.path().join("still-locked.dll");
+        std::fs::write(&not_a_dir, b"locked").unwrap();
+        registry
+            .insert_if_new(&InsertInput {
+                kind: "trash".to_string(),
+                path: not_a_dir.to_string_lossy().to_string(),
+                repo_root: None,
+                branch: None,
+                agent_id: Some("C:/repo/target/debug/still-locked.dll".to_string()),
+                now_unix: 100,
+            })
+            .unwrap();
+
+        let (removed, failed) = reap_trash_entries(&registry).unwrap();
+
+        assert_eq!((removed, failed), (0, 1));
+        assert!(not_a_dir.exists());
+        assert_eq!(registry.list(Some("trash")).unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -23,5 +23,5 @@ pub use http::{
     dashboard_url_from_info, fetch_state_json, read_dashboard_info, read_dashboard_port,
     DashboardInfo,
 };
-pub use paths::default_state_dir;
+pub use paths::{default_state_dir, default_trash_dir};
 pub use types::{ListRow, RepoVisit, ENV_NO_DAEMON};

--- a/crates/clud-bin/src/daemon/paths.rs
+++ b/crates/clud-bin/src/daemon/paths.rs
@@ -22,6 +22,16 @@ pub fn default_state_dir() -> std::io::Result<PathBuf> {
     Ok(home.join(".clud").join("state"))
 }
 
+/// Per-user quarantine root for `clud trash`.
+///
+/// Lives next to `data.redb` at `~/.clud/trash/` so the always-on daemon
+/// can reap entries across all repos and shells.
+pub fn default_trash_dir() -> std::io::Result<PathBuf> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| std::io::Error::other("no home directory; cannot resolve clud trash dir"))?;
+    Ok(home.join(".clud").join("trash"))
+}
+
 pub(super) fn state_dir(args: &Args) -> PathBuf {
     if let Some(path) = &args.daemon_state_dir {
         return path.clone();

--- a/crates/clud-bin/src/gc.rs
+++ b/crates/clud-bin/src/gc.rs
@@ -685,7 +685,7 @@ pub fn run(args: &Args, sub: Option<GcSubcommand>) -> i32 {
         }
     };
     match sub.unwrap() {
-        GcSubcommand::List { json } => cmd_list(&state_dir, json),
+        GcSubcommand::List { json, kind } => cmd_list(&state_dir, json, kind.as_deref()),
         GcSubcommand::Purge {
             duration,
             dry_run,
@@ -723,8 +723,8 @@ fn print_help_and_exit_zero() -> i32 {
     }
 }
 
-fn cmd_list(state_dir: &Path, json: bool) -> i32 {
-    let rows = match crate::daemon::gc_client_list(state_dir, None) {
+fn cmd_list(state_dir: &Path, json: bool, kind_filter: Option<&str>) -> i32 {
+    let rows = match crate::daemon::gc_client_list(state_dir, kind_filter) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("error: list failed: {e}");

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -30,6 +30,7 @@ pub mod startup;
 pub mod stream_json;
 pub mod subprocess;
 pub mod trampoline;
+pub mod trash;
 pub mod ui;
 pub mod verbose_log;
 pub mod voice;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,7 @@
 use clud::{
     args, backend, backend_bootstrap, command, console_setup, console_title, daemon, gc,
     hook_health, large_file_guard, loop_artifacts, loop_spec, runner, skill_install, skills,
-    startup, trampoline, ui, verbose_log, wasm, worktrees,
+    startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -71,6 +71,17 @@ fn main() {
     // never launches a backend.
     if let Some(args::Command::Ui { json, no_open }) = &args.command {
         std::process::exit(ui::run(*json, *no_open));
+    }
+
+    // Issue #182: `clud trash` is self-contained maintenance. Dispatch
+    // before backend resolution so quarantining a locked artifact never
+    // launches an agent process.
+    if let Some(args::Command::Trash {
+        cross_volume,
+        paths,
+    }) = &args.command
+    {
+        std::process::exit(trash::run(&args, paths, *cross_volume));
     }
 
     // Issue #83: `--clean-worktrees` is a self-contained maintenance path.

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -555,7 +555,7 @@ pub fn run_plan_pty(
         // the matching guard in `run_plan_subprocess` — same rationale.
         if interrupted.load(Ordering::SeqCst) {
             if verbose {
-                verbose_log::log("[clud] interrupted via Ctrl+C");
+                verbose_log::log("[clud] interrupted via Ctrl+C (pty)");
             }
             return 130;
         }

--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -42,6 +42,10 @@ const BUNDLED_SKILLS: &[Skill] = &[
         name: "clud-issue",
         content: include_str!("../../../skills/clud-issue/SKILL.md"),
     },
+    Skill {
+        name: "clud-windows-trash",
+        content: include_str!("../../../skills/clud-windows-trash/SKILL.md"),
+    },
 ];
 
 /// Run the install/check for every bundled skill on launch. Cheap on the
@@ -366,6 +370,10 @@ mod tests {
         assert!(
             names.contains(&"clud-issue"),
             "clud-issue missing from bundle"
+        );
+        assert!(
+            names.contains(&"clud-windows-trash"),
+            "clud-windows-trash missing from bundle"
         );
     }
 

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -50,6 +50,10 @@ pub const BUNDLED_SKILLS: &[BundledSkill] = &[
         name: "clud-docker-rust-app-dev",
         skill_md: include_str!("../assets/skills/clud-docker-rust-app-dev/SKILL.md"),
     },
+    BundledSkill {
+        name: "clud-windows-trash",
+        skill_md: include_str!("../assets/skills/clud-windows-trash/SKILL.md"),
+    },
 ];
 
 /// One CLI backend that consumes `SKILL.md` files. Adding support for a
@@ -335,6 +339,7 @@ mod tests {
         assert!(names.contains(&"clud-pr"));
         assert!(names.contains(&"clud-tag-release"));
         assert!(names.contains(&"clud-docker-rust-app-dev"));
+        assert!(names.contains(&"clud-windows-trash"));
     }
 
     #[test]

--- a/crates/clud-bin/src/trash.rs
+++ b/crates/clud-bin/src/trash.rs
@@ -1,0 +1,478 @@
+//! `clud trash` quarantine command.
+//!
+//! Moves paths into a per-user trash root and records a `kind = "trash"`
+//! GC row so the daemon can retry deletion until locked DLL/EXE/PYD files
+//! become removable.
+
+use std::ffi::OsStr;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::args::Args;
+use crate::gc::InsertInput;
+
+static SUFFIX_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+#[derive(Debug, Clone)]
+pub struct TrashRecord {
+    pub origin_path: String,
+    pub quarantine_dir: PathBuf,
+    pub quarantined_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub enum TrashError {
+    InvalidPath(PathBuf),
+    Io {
+        action: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    CrossVolume {
+        source: PathBuf,
+        trash_root: PathBuf,
+        source_volume: String,
+        trash_volume: String,
+    },
+}
+
+impl std::fmt::Display for TrashError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPath(path) => write!(f, "{} has no basename to trash", path.display()),
+            Self::Io {
+                action,
+                path,
+                source,
+            } => {
+                write!(f, "{action} {}: {source}", path.display())
+            }
+            Self::CrossVolume {
+                source,
+                trash_root,
+                source_volume,
+                trash_volume,
+            } => write!(
+                f,
+                "{} is on volume {source_volume}, trash root {} is on {trash_volume}. Pass --cross-volume to copy + best-effort remove instead.",
+                source.display(),
+                trash_root.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TrashError {}
+
+/// Dispatch a `clud trash` invocation. Returns the process exit code.
+pub fn run(args: &Args, paths: &[PathBuf], cross_volume: bool) -> i32 {
+    if args.no_daemon || daemon_disabled_via_env() {
+        eprintln!("error: trash operations require the clud daemon; remove --no-daemon");
+        return 2;
+    }
+    let trash_root = match crate::daemon::default_trash_dir() {
+        Ok(path) => path,
+        Err(err) => {
+            eprintln!("error: cannot resolve clud trash dir: {err}");
+            return 1;
+        }
+    };
+    let state_dir = match crate::daemon::default_state_dir() {
+        Ok(path) => path,
+        Err(err) => {
+            eprintln!("error: cannot resolve clud state dir: {err}");
+            return 1;
+        }
+    };
+
+    let mut failed = false;
+    for path in paths {
+        match trash_one_path(path, &trash_root, cross_volume) {
+            Ok(record) => {
+                let input = insert_input_for_record(&record, now_unix());
+                match crate::daemon::gc_client_insert(&state_dir, &input) {
+                    Ok(()) => {
+                        println!(
+                            "trashed {} -> {}",
+                            record.origin_path,
+                            record.quarantined_path.display()
+                        );
+                    }
+                    Err(err) => {
+                        failed = true;
+                        eprintln!(
+                            "error: trashed {} -> {}, but failed to register GC row: {err}",
+                            record.origin_path,
+                            record.quarantined_path.display()
+                        );
+                    }
+                }
+            }
+            Err(err) => {
+                failed = true;
+                eprintln!("error: {err}");
+            }
+        }
+    }
+
+    if failed {
+        1
+    } else {
+        0
+    }
+}
+
+pub fn insert_input_for_record(record: &TrashRecord, now_unix: i64) -> InsertInput {
+    InsertInput {
+        kind: "trash".to_string(),
+        path: record.quarantine_dir.to_string_lossy().to_string(),
+        repo_root: None,
+        branch: None,
+        agent_id: Some(record.origin_path.clone()),
+        now_unix,
+    }
+}
+
+pub fn trash_one_path(
+    path: &Path,
+    trash_root: &Path,
+    cross_volume: bool,
+) -> Result<TrashRecord, TrashError> {
+    let source = absolute_path(path).map_err(|source| TrashError::Io {
+        action: "resolve",
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let source_meta = std::fs::symlink_metadata(&source).map_err(|source_err| TrashError::Io {
+        action: "stat",
+        path: source.clone(),
+        source: source_err,
+    })?;
+    let basename = source
+        .file_name()
+        .map(OsStr::to_os_string)
+        .ok_or_else(|| TrashError::InvalidPath(source.clone()))?;
+
+    std::fs::create_dir_all(trash_root).map_err(|source| TrashError::Io {
+        action: "create_dir_all",
+        path: trash_root.to_path_buf(),
+        source,
+    })?;
+    let trash_root_abs = absolute_path(trash_root).map_err(|source| TrashError::Io {
+        action: "resolve",
+        path: trash_root.to_path_buf(),
+        source,
+    })?;
+
+    if !cross_volume && volumes_differ(&source, &trash_root_abs) {
+        let source_volume = volume_label(&source);
+        let trash_volume = volume_label(&trash_root_abs);
+        return Err(TrashError::CrossVolume {
+            source,
+            trash_root: trash_root_abs,
+            source_volume,
+            trash_volume,
+        });
+    }
+
+    let quarantine_dir = create_unique_quarantine_dir(&trash_root_abs)?;
+    let quarantined_path = quarantine_dir.join(basename);
+    let move_result = if cross_volume {
+        copy_path(&source, &quarantined_path, &source_meta)
+            .map(|_| remove_source_best_effort(&source, &source_meta))
+    } else {
+        std::fs::rename(&source, &quarantined_path).map_err(|source_err| {
+            if is_cross_volume_error(&source_err) {
+                TrashError::CrossVolume {
+                    source: source.clone(),
+                    trash_root: trash_root_abs.clone(),
+                    source_volume: volume_label(&source),
+                    trash_volume: volume_label(&trash_root_abs),
+                }
+            } else {
+                TrashError::Io {
+                    action: "rename",
+                    path: source.clone(),
+                    source: source_err,
+                }
+            }
+        })
+    };
+
+    if let Err(err) = move_result {
+        let _ = std::fs::remove_dir_all(&quarantine_dir);
+        return Err(err);
+    }
+
+    Ok(TrashRecord {
+        origin_path: source.to_string_lossy().to_string(),
+        quarantine_dir,
+        quarantined_path,
+    })
+}
+
+fn daemon_disabled_via_env() -> bool {
+    std::env::var_os(crate::daemon::ENV_NO_DAEMON)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn absolute_path(path: &Path) -> io::Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn create_unique_quarantine_dir(trash_root: &Path) -> Result<PathBuf, TrashError> {
+    for _ in 0..32 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        let name = format!(
+            "{}-{}",
+            timestamp_utcish(now.as_secs() as i64),
+            randomish_hex(now)
+        );
+        let dir = trash_root.join(name);
+        match std::fs::create_dir(&dir) {
+            Ok(()) => return Ok(dir),
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(source) => {
+                return Err(TrashError::Io {
+                    action: "create_dir",
+                    path: dir,
+                    source,
+                });
+            }
+        }
+    }
+    Err(TrashError::Io {
+        action: "create unique trash dir",
+        path: trash_root.to_path_buf(),
+        source: io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a unique trash directory",
+        ),
+    })
+}
+
+fn randomish_hex(now: std::time::Duration) -> String {
+    let counter = SUFFIX_COUNTER.fetch_add(1, Ordering::Relaxed) as u64;
+    let mut x =
+        now.as_nanos() as u64 ^ ((std::process::id() as u64) << 24) ^ counter.rotate_left(17);
+    x = x.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^= x >> 31;
+    format!("{:06x}", x & 0x00ff_ffff)
+}
+
+fn timestamp_utcish(unix_secs: i64) -> String {
+    let days = unix_secs.div_euclid(86_400);
+    let seconds_of_day = unix_secs.rem_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    let hour = seconds_of_day / 3_600;
+    let minute = (seconds_of_day % 3_600) / 60;
+    let second = seconds_of_day % 60;
+    format!("{year:04}{month:02}{day:02}T{hour:02}{minute:02}{second:02}Z")
+}
+
+fn civil_from_days(days_since_epoch: i64) -> (i64, i64, i64) {
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let mut year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = mp + if mp < 10 { 3 } else { -9 };
+    if month <= 2 {
+        year += 1;
+    }
+    (year, month, day)
+}
+
+fn copy_path(source: &Path, dest: &Path, metadata: &std::fs::Metadata) -> Result<(), TrashError> {
+    if metadata.is_dir() {
+        copy_dir_all(source, dest)
+    } else {
+        std::fs::copy(source, dest)
+            .map(|_| ())
+            .map_err(|source_err| TrashError::Io {
+                action: "copy",
+                path: source.to_path_buf(),
+                source: source_err,
+            })
+    }
+}
+
+fn copy_dir_all(source: &Path, dest: &Path) -> Result<(), TrashError> {
+    std::fs::create_dir_all(dest).map_err(|source_err| TrashError::Io {
+        action: "create_dir_all",
+        path: dest.to_path_buf(),
+        source: source_err,
+    })?;
+    for entry in std::fs::read_dir(source).map_err(|source_err| TrashError::Io {
+        action: "read_dir",
+        path: source.to_path_buf(),
+        source: source_err,
+    })? {
+        let entry = entry.map_err(|source_err| TrashError::Io {
+            action: "read_dir entry",
+            path: source.to_path_buf(),
+            source: source_err,
+        })?;
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        let metadata = entry.metadata().map_err(|source_err| TrashError::Io {
+            action: "stat",
+            path: from.clone(),
+            source: source_err,
+        })?;
+        copy_path(&from, &to, &metadata)?;
+    }
+    Ok(())
+}
+
+fn remove_source_best_effort(source: &Path, metadata: &std::fs::Metadata) {
+    let _ = if metadata.is_dir() {
+        std::fs::remove_dir_all(source)
+    } else {
+        std::fs::remove_file(source)
+    };
+}
+
+fn is_cross_volume_error(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::CrossesDevices || matches!(err.raw_os_error(), Some(17 | 18))
+}
+
+fn volumes_differ(source: &Path, trash_root: &Path) -> bool {
+    match (volume_key(source), volume_key(trash_root)) {
+        (Some(a), Some(b)) => a != b,
+        _ => false,
+    }
+}
+
+#[cfg(windows)]
+fn volume_key(path: &Path) -> Option<String> {
+    use std::path::{Component, Prefix};
+
+    let Component::Prefix(prefix) = path.components().next()? else {
+        return None;
+    };
+    match prefix.kind() {
+        Prefix::Disk(disk) | Prefix::VerbatimDisk(disk) => {
+            Some(format!("{}:", (disk as char).to_ascii_uppercase()))
+        }
+        Prefix::UNC(server, share) | Prefix::VerbatimUNC(server, share) => Some(format!(
+            "\\\\{}\\{}",
+            server.to_string_lossy().to_ascii_lowercase(),
+            share.to_string_lossy().to_ascii_lowercase()
+        )),
+        _ => Some(prefix.as_os_str().to_string_lossy().to_string()),
+    }
+}
+
+#[cfg(not(windows))]
+fn volume_key(_path: &Path) -> Option<String> {
+    None
+}
+
+fn volume_label(path: &Path) -> String {
+    volume_key(path).unwrap_or_else(|| {
+        path.components()
+            .next()
+            .map(|c| c.as_os_str().to_string_lossy().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "unknown".to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn timestamp_formats_epoch_as_utcish() {
+        assert_eq!(timestamp_utcish(0), "19700101T000000Z");
+        assert_eq!(timestamp_utcish(86_400), "19700102T000000Z");
+    }
+
+    #[test]
+    fn random_suffix_is_six_hex_chars() {
+        let value = randomish_hex(Duration::from_nanos(123));
+        assert_eq!(value.len(), 6);
+        assert!(value.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn same_volume_trash_renames_file_into_quarantine_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("artifact.dll");
+        let trash_root = dir.path().join("trash");
+        std::fs::write(&source, b"locked-ish").unwrap();
+
+        let record = trash_one_path(&source, &trash_root, false).unwrap();
+
+        assert!(!source.exists());
+        assert_eq!(record.quarantine_dir.parent(), Some(trash_root.as_path()));
+        assert_eq!(
+            record.quarantined_path.file_name().and_then(OsStr::to_str),
+            Some("artifact.dll")
+        );
+        assert_eq!(
+            std::fs::read(&record.quarantined_path).unwrap(),
+            b"locked-ish"
+        );
+        assert_eq!(record.origin_path, source.to_string_lossy());
+    }
+
+    #[test]
+    fn cross_volume_mode_copies_then_best_effort_removes_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("artifact.exe");
+        let trash_root = dir.path().join("trash");
+        std::fs::write(&source, b"copy me").unwrap();
+
+        let record = trash_one_path(&source, &trash_root, true).unwrap();
+
+        assert!(!source.exists(), "best-effort remove should succeed here");
+        assert_eq!(std::fs::read(&record.quarantined_path).unwrap(), b"copy me");
+    }
+
+    #[test]
+    fn insert_input_tracks_quarantine_dir_and_origin_agent_id() {
+        let record = TrashRecord {
+            origin_path: "C:/repo/target/debug/foo.dll".to_string(),
+            quarantine_dir: PathBuf::from("C:/Users/me/.clud/trash/20260101T000000Z-abcdef"),
+            quarantined_path: PathBuf::from(
+                "C:/Users/me/.clud/trash/20260101T000000Z-abcdef/foo.dll",
+            ),
+        };
+
+        let input = insert_input_for_record(&record, 123);
+        assert_eq!(input.kind, "trash");
+        assert_eq!(
+            input.path,
+            "C:/Users/me/.clud/trash/20260101T000000Z-abcdef"
+        );
+        assert_eq!(
+            input.agent_id.as_deref(),
+            Some("C:/repo/target/debug/foo.dll")
+        );
+        assert_eq!(input.now_unix, 123);
+    }
+}

--- a/skills/clud-windows-trash/SKILL.md
+++ b/skills/clud-windows-trash/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: clud-windows-trash
+description: Quarantine Windows-locked DLL/EXE/PYD artifacts with clud trash instead of retrying deletes or killing processes.
+triggers:
+  - "When deleting *.dll, *.pyd, or *.exe on Windows fails with os error 32 or being used by another process"
+  - "When a build fails because an output DLL, PYD, or EXE is locked"
+  - "When a directory containing Windows build artifacts cannot be removed"
+---
+<!-- managed-by: clud -->
+
+# /clud-windows-trash
+
+Use `clud trash` when Windows refuses to delete freshly built native artifacts.
+
+## Triggers
+
+- A delete of `*.dll`, `*.pyd`, or `*.exe` fails with `os error 32`, `being used by another process`, `Access is denied`, or similar loader/Defender lock symptoms.
+- A build script cannot overwrite an output file because the previous artifact is still locked.
+- A directory removal fails and the tree contains Windows native build outputs.
+
+## Rules
+
+1. Do not retry `del`, `Remove-Item`, or `rm` in a loop.
+2. Do not run `taskkill` for guessed parent processes.
+3. Run `clud trash <path>` for the locked file or containing directory, then continue the build or cleanup.
+4. If `clud trash` reports a source/trash volume mismatch, pass `--cross-volume` only when the copy cost is acceptable: `clud trash --cross-volume <path>`.
+
+## Workflow
+
+1. Identify the smallest locked path that unblocks the build. Prefer the exact file; use the containing build-output directory when many siblings are blocked.
+2. Run `clud trash <path>`.
+3. If the command succeeds, proceed immediately. The clud daemon will retry deletion from `~/.clud/trash/` until Windows releases the lock.
+4. If cross-volume copy is required and acceptable, rerun with `--cross-volume`. Source removal after the copy is best-effort.
+5. To inspect pending cleanup, run `clud gc list --kind trash`.
+
+## Exit Guidance
+
+After a successful trash, keep going. Do not wait for the daemon to reap the quarantined path unless the user explicitly asks to verify cleanup.


### PR DESCRIPTION
## Summary
- add `clud trash <path>...` with same-volume quarantine and `--cross-volume` copy fallback
- track quarantines as `kind = trash` GC rows with the original path in `agent_id`, and support `clud gc list --kind trash`
- reap trash rows on daemon GC ticks and add the bundled `clud-windows-trash` skill

Closes #182

## Validation
- `soldr cargo fmt --check`
- `soldr cargo test -p clud trash`
- `soldr cargo test -p clud skill`
- `git diff --check origin/main..HEAD`