### PR TITLE
Fix Linux release wheel linking with cargo-zigbuild

### DIFF
--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -18,6 +18,16 @@ DIST = ROOT / "dist"
 BuildMode = Literal["dev", "release"]
 
 
+def build_environment(mode: BuildMode, env: dict[str, str]) -> dict[str, str]:
+    if mode == "release" and platform.system() == "Linux":
+        env = env.copy()
+        # maturin --zig delegates final linking to cargo-zigbuild's target
+        # linker. setup-soldr's fast linker shim forces host clang/mold, which
+        # cannot see Zig's Linux C++ runtime during manylinux wheel builds.
+        env["SOLDR_LINKER"] = "default"
+    return env
+
+
 def build_command(mode: BuildMode, env: dict[str, str] | None = None) -> list[str]:
     from ci.env import maturin_argv
 
@@ -82,7 +92,7 @@ def install_wheel(wheel: Path, *, env: dict[str, str]) -> int:
 def run_build(mode: BuildMode) -> int:
     from ci.env import build_env
 
-    env = build_env()
+    env = build_environment(mode, build_env())
     DIST.mkdir(parents=True, exist_ok=True)
     before = {path.name for path in built_wheels()}
     cmd = build_command(mode, env=env)

--- a/tests/test_build_wheel.py
+++ b/tests/test_build_wheel.py
@@ -1,0 +1,25 @@
+from ci import build_wheel
+
+
+def test_linux_release_uses_zigbuild_linker(monkeypatch):
+    monkeypatch.setattr(build_wheel.platform, "system", lambda: "Linux")
+
+    env = build_wheel.build_environment("release", {"SOLDR_LINKER": "fast"})
+
+    assert env["SOLDR_LINKER"] == "default"
+
+
+def test_linux_dev_keeps_existing_linker(monkeypatch):
+    monkeypatch.setattr(build_wheel.platform, "system", lambda: "Linux")
+
+    env = build_wheel.build_environment("dev", {"SOLDR_LINKER": "fast"})
+
+    assert env["SOLDR_LINKER"] == "fast"
+
+
+def test_non_linux_release_keeps_existing_linker(monkeypatch):
+    monkeypatch.setattr(build_wheel.platform, "system", lambda: "Darwin")
+
+    env = build_wheel.build_environment("release", {"SOLDR_LINKER": "fast"})
+
+    assert env["SOLDR_LINKER"] == "fast"

--- a/vendor/whisper-rs-sys/build.rs
+++ b/vendor/whisper-rs-sys/build.rs
@@ -5,12 +5,20 @@ extern crate semver;
 
 use cmake::Config;
 use std::env;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
+    println!("cargo:rerun-if-env-changed=CARGO_ZIGBUILD_RUSTC_VERSION");
+    println!("cargo:rerun-if-env-changed=ZIG_COMMAND");
+    println!("cargo:rerun-if-env-changed=CXX");
+    println!(
+        "cargo:rerun-if-env-changed={}",
+        target_env_key("CXX", &target)
+    );
     // Link C++ standard library
     if let Some(cpp_stdlib) = get_cpp_link_stdlib(&target) {
         println!("cargo:rustc-link-lib=dylib={}", cpp_stdlib);
@@ -374,13 +382,47 @@ fn main() {
 fn get_cpp_link_stdlib(target: &str) -> Option<&'static str> {
     if target.contains("msvc") {
         None
-    } else if target.contains("apple") || target.contains("freebsd") || target.contains("openbsd") {
+    } else if target.contains("apple")
+        || target.contains("freebsd")
+        || target.contains("openbsd")
+    {
         Some("c++")
     } else if target.contains("android") {
         Some("c++_shared")
+    } else if linux_zig_cxx_toolchain(target) {
+        Some("c++")
     } else {
         Some("stdc++")
     }
+}
+
+fn linux_zig_cxx_toolchain(target: &str) -> bool {
+    if !target.contains("linux") {
+        return false;
+    }
+
+    // cargo-zigbuild uses Zig's C++ runtime on Linux; those objects carry
+    // std::__1 symbols, so linking libstdc++ leaves whisper.cpp unresolved.
+    env::var_os("CARGO_ZIGBUILD_RUSTC_VERSION").is_some()
+        || env::var_os("ZIG_COMMAND").is_some()
+        || env_value_mentions_zigcxx("CXX")
+        || env_value_mentions_zigcxx(&target_env_key("CXX", target))
+}
+
+fn target_env_key(prefix: &str, target: &str) -> String {
+    format!("{}_{}", prefix, target.replace('-', "_"))
+}
+
+fn env_value_mentions_zigcxx(key: &str) -> bool {
+    match env::var_os(key) {
+        Some(value) => os_str_mentions_zigcxx(&value),
+        None => false,
+    }
+}
+
+fn os_str_mentions_zigcxx(value: &OsStr) -> bool {
+    let value = value.to_string_lossy().to_ascii_lowercase();
+    value.contains("zigcxx") || value.contains("zig c++")
 }
 
 fn configure_windows_gnu_toolchain(config: &mut Config) {


### PR DESCRIPTION
## Summary
- Link vendored `whisper-rs-sys` against libc++ when Linux builds are using cargo-zigbuild/Zig C++ tooling.
- Set `SOLDR_LINKER=default` for Linux release wheel builds so cargo-zigbuild's target `zigcc` linker wins over soldr's host fast-linker shim.
- Add tests for the Linux release wheel linker override.

## Verification
- `cargo fmt --all --check`
- `cargo check -p clud --locked`
- `uv run python -m pytest tests/test_build_wheel.py tests/test_ci_env.py tests/test_packaging_metadata.py`
- Linux x86 Build release workflow: https://github.com/zackees/clud/actions/runs/26774428258
- Linux ARM Build release workflow: https://github.com/zackees/clud/actions/runs/26774430094