### PR TITLE
feat(gc): track extern repos for safe cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage-*.xml
 .tmp/
 .tmplog/
 *.log
+.extern-repos/
 
 # clud loop state (GH issue cache, DONE/BLOCKED markers)
 .clud/

--- a/crates/clud-bin/assets/skills/clud-extern-repos/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-extern-repos/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: clud-extern-repos
+description: Coordinate dependent cross-repo changes under a repo-local .extern-repos/ checkout convention.
+triggers:
+  - When a task needs a dependent change in another repository
+  - When the user asks to use .extern-repos for cross-repo work
+---
+<!-- managed-by: clud -->
+
+# clud-extern-repos
+
+Use this workflow when the current repo needs coordinated work in a dependent repository.
+
+## Convention
+
+Place each dependent checkout at `<current-repo>/.extern-repos/<repo-name>/`. Only immediate children of `.extern-repos/` are tracked by clud GC.
+
+Before cloning, verify `.extern-repos/` is ignored by the current repo. If it is not ignored, ask before adding the ignore entry and refuse to create an unignored clone.
+
+Create feature branches in the dependent repo with the same short-name style as clud-pr, for example `feat/<short-name>`.
+
+## Coordination
+
+Keep each repo's work scoped to that repo. Do not edit the parent repo from inside the dependent checkout, and do not edit the dependent checkout from the parent repo.
+
+When opening PRs, link both directions:
+
+- Parent PR body: `Depends on <owner>/<repo>#<number>`
+- Dependent PR body: `Coordinated with <owner>/<parent-repo>#<number>`
+
+If the dependent PR must land first, make that ordering explicit in the parent PR body.
+
+## Cleanup
+
+The daemon may auto-remove `.extern-repos/<name>/` only after the tracked branch has a merged PR, the directory has been inactive for at least 24 hours, and no live clud session is rooted inside it.
+
+If `gh` is missing, rate-limited, or cannot confirm a merged PR, keep the checkout.

--- a/crates/clud-bin/src/daemon/gc_service.rs
+++ b/crates/clud-bin/src/daemon/gc_service.rs
@@ -13,8 +13,15 @@ use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::gc::{extract_pid_from_lock_reason, reconcile_dir, InsertInput, Registry, TrackedEntry};
+use running_process::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
+
+use crate::gc::{
+    extract_pid_from_lock_reason, reconcile_dir, reconcile_extern_repos_dir, InsertInput, Registry,
+    TrackedEntry, EXTERN_REPO_KIND, WORKTREE_KIND,
+};
 use crate::session_registry::{LivenessProbe, OsLivenessProbe};
+use crate::subprocess;
+use crate::win_creation_flags::invisible_helper_creationflags;
 use crate::worktrees;
 
 use super::types::{GcOp, GcReply, ListRow};
@@ -24,8 +31,13 @@ use super::types::{GcOp, GcReply, ListRow};
 pub(super) const WORKER_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
 
 const ENV_GC_TICK_SECS: &str = "CLUD_GC_TICK_SECS";
+const ENV_GC_EXTERN_REPO_MAX_AGE_SECS: &str = "CLUD_GC_EXTERN_REPO_MAX_AGE_SECS";
 const DEFAULT_GC_TICK_SECS: u64 = 3600;
+const DEFAULT_EXTERN_REPO_STALE_AFTER_SECS: u64 = 24 * 60 * 60;
 const PERIODIC_GC_WORKTREE_STALE_AFTER: &str = "48h";
+
+#[cfg(test)]
+const ENV_TEST_GH_BIN: &str = "CLUD_TEST_GH_BIN";
 
 /// One request handed from a connection thread to the registry worker.
 pub(super) struct GcRequestMsg {
@@ -141,22 +153,23 @@ fn run_periodic_purge_tick(registry: &Registry, live_cwds_provider: &LiveCwdsPro
         registry,
         GcOp::Purge {
             duration: Some(PERIODIC_GC_WORKTREE_STALE_AFTER.to_string()),
-            kind: Some("worktree".to_string()),
+            kind: Some(WORKTREE_KIND.to_string()),
             dry_run: false,
         },
         live_cwds_provider(),
     );
-    match worktree_reply {
-        GcReply::PurgeOk { removed, skipped } => {
-            eprintln!("[clud] gc tick: removed {removed}, skipped {skipped}");
-        }
-        GcReply::Error { message } => {
-            eprintln!("[clud] gc tick: error: {message}");
-        }
-        other => {
-            eprintln!("[clud] gc tick: unexpected reply: {other:?}");
-        }
-    }
+    log_periodic_purge_reply(WORKTREE_KIND, worktree_reply);
+
+    let extern_reply = process_op_with_live_cwds(
+        registry,
+        GcOp::Purge {
+            duration: None,
+            kind: Some(EXTERN_REPO_KIND.to_string()),
+            dry_run: false,
+        },
+        live_cwds_provider(),
+    );
+    log_periodic_purge_reply(EXTERN_REPO_KIND, extern_reply);
 
     match reap_trash_entries(registry) {
         Ok((removed, failed)) => {
@@ -166,6 +179,20 @@ fn run_periodic_purge_tick(registry: &Registry, live_cwds_provider: &LiveCwdsPro
         }
         Err(message) => {
             eprintln!("[clud] gc tick: trash error: {message}");
+        }
+    }
+}
+
+fn log_periodic_purge_reply(kind: &str, reply: GcReply) {
+    match reply {
+        GcReply::PurgeOk { removed, skipped } => {
+            eprintln!("[clud] gc tick {kind}: removed {removed}, skipped {skipped}");
+        }
+        GcReply::Error { message } => {
+            eprintln!("[clud] gc tick {kind}: error: {message}");
+        }
+        other => {
+            eprintln!("[clud] gc tick {kind}: unexpected reply: {other:?}");
         }
     }
 }
@@ -224,13 +251,23 @@ fn process_op_with_live_cwds(registry: &Registry, op: GcOp, live_cwds: Vec<PathB
             };
             let live_locks = collect_live_lock_paths();
             let live_cwds = canonicalize_live_cwds(live_cwds);
-            let (purgeable, skipped): (Vec<_>, Vec<_>) = candidates
-                .into_iter()
-                .partition(|c| !entry_is_live(c, &live_locks, &live_cwds));
+            let mut purgeable = Vec::new();
+            let mut skipped = 0usize;
+            for candidate in candidates {
+                if entry_is_live(&candidate, &live_locks, &live_cwds) {
+                    skipped += 1;
+                    continue;
+                }
+                if !entry_kind_allows_purge(&candidate) {
+                    skipped += 1;
+                    continue;
+                }
+                purgeable.push(candidate);
+            }
             if dry_run {
                 return GcReply::PurgeOk {
                     removed: purgeable.len(),
-                    skipped: skipped.len(),
+                    skipped,
                 };
             }
             let mut removed = 0usize;
@@ -239,19 +276,18 @@ fn process_op_with_live_cwds(registry: &Registry, op: GcOp, live_cwds: Vec<PathB
                     removed += 1;
                 }
             }
-            GcReply::PurgeOk {
-                removed,
-                skipped: skipped.len(),
-            }
+            GcReply::PurgeOk { removed, skipped }
         }
 
         GcOp::Reconcile { repo_root } => {
             let root = PathBuf::from(&repo_root);
             let watch_dir = root.join(".claude").join("worktrees");
-            match reconcile_dir(registry, &watch_dir, Some(&root)) {
-                Ok(res) => GcReply::ReconcileOk {
-                    inserted: res.inserted,
-                },
+            match reconcile_dir(registry, &watch_dir, Some(&root)).and_then(|worktree_res| {
+                let extern_res =
+                    reconcile_extern_repos_dir(registry, &root.join(".extern-repos"), Some(&root))?;
+                Ok(worktree_res.inserted + extern_res.inserted)
+            }) {
+                Ok(inserted) => GcReply::ReconcileOk { inserted },
                 Err(e) => GcReply::Error {
                     message: e.to_string(),
                 },
@@ -373,6 +409,189 @@ fn entry_path_contains_live_cwd(entry: &TrackedEntry, live_cwds: &[PathBuf]) -> 
         .any(|cwd| cwd == &entry_path || cwd.starts_with(&entry_path))
 }
 
+fn entry_kind_allows_purge(entry: &TrackedEntry) -> bool {
+    if entry.kind == EXTERN_REPO_KIND {
+        return extern_repo_is_purgeable(entry, extern_repo_stale_after());
+    }
+    true
+}
+
+fn extern_repo_stale_after() -> Duration {
+    let secs = std::env::var(ENV_GC_EXTERN_REPO_MAX_AGE_SECS)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_EXTERN_REPO_STALE_AFTER_SECS);
+    Duration::from_secs(secs)
+}
+
+fn extern_repo_is_purgeable(entry: &TrackedEntry, stale_after: Duration) -> bool {
+    let path = Path::new(&entry.path);
+    if !path.is_dir() {
+        return false;
+    }
+    let Some(mtime) = most_recent_mtime(path) else {
+        return false;
+    };
+    let Ok(age) = SystemTime::now().duration_since(mtime) else {
+        return false;
+    };
+    if age < stale_after {
+        return false;
+    }
+    let Some(branch) = entry
+        .branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| crate::gc::best_effort_branch(path))
+    else {
+        return false;
+    };
+    let Some(slug) = repo_slug_for_extern_repo(path) else {
+        return false;
+    };
+    gh_pr_list_reports_merged(&branch, &slug)
+}
+
+fn most_recent_mtime(path: &Path) -> Option<SystemTime> {
+    let metadata = std::fs::symlink_metadata(path).ok()?;
+    let mut latest = metadata.modified().ok()?;
+    if metadata.is_dir() {
+        let entries = std::fs::read_dir(path).ok()?;
+        for entry in entries.flatten() {
+            if let Some(child_mtime) = most_recent_mtime(&entry.path()) {
+                if child_mtime > latest {
+                    latest = child_mtime;
+                }
+            }
+        }
+    }
+    Some(latest)
+}
+
+fn repo_slug_for_extern_repo(path: &Path) -> Option<String> {
+    let remote = worktrees::run_git(path, &["remote", "get-url", "origin"]).ok()?;
+    parse_github_slug_from_remote_url(&remote)
+}
+
+fn parse_github_slug_from_remote_url(remote: &str) -> Option<String> {
+    let s = remote.trim().trim_end_matches('/');
+    if let Some(rest) = s.strip_prefix("git@github.com:") {
+        return slug_from_github_path(rest);
+    }
+    for prefix in [
+        "https://github.com/",
+        "http://github.com/",
+        "ssh://git@github.com/",
+        "git://github.com/",
+    ] {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            return slug_from_github_path(rest);
+        }
+    }
+    None
+}
+
+fn slug_from_github_path(path: &str) -> Option<String> {
+    let clean = path.trim().trim_matches('/').trim_end_matches(".git");
+    let mut parts = clean.split('/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim().trim_end_matches(".git");
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+fn gh_pr_list_reports_merged(branch: &str, slug: &str) -> bool {
+    let args = vec![
+        "pr".to_string(),
+        "list".to_string(),
+        "--head".to_string(),
+        branch.to_string(),
+        "--state".to_string(),
+        "all".to_string(),
+        "--json".to_string(),
+        "mergedAt,url".to_string(),
+        "--repo".to_string(),
+        slug.to_string(),
+    ];
+    let Ok((exit_code, stdout)) = run_gh_capture(&args) else {
+        return false;
+    };
+    exit_code == 0 && gh_pr_list_json_has_merged(&stdout)
+}
+
+fn gh_pr_list_json_has_merged(stdout: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout) else {
+        return false;
+    };
+    value
+        .as_array()
+        .map(|items| {
+            items.iter().any(|item| {
+                item.get("mergedAt")
+                    .and_then(|merged_at| merged_at.as_str())
+                    .map(|s| !s.trim().is_empty())
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn run_gh_capture(args: &[String]) -> Result<(i32, String), String> {
+    let mut argv = vec![gh_program()];
+    argv.extend(args.iter().cloned());
+    let config = ProcessConfig {
+        command: subprocess::command_spec_for_subprocess(argv),
+        cwd: None,
+        env: None,
+        capture: true,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: invisible_helper_creationflags(),
+        create_process_group: false,
+        stdin_mode: StdinMode::Null,
+        nice: None,
+    };
+    let process = NativeProcess::new(config);
+    process
+        .start()
+        .map_err(|e| format!("failed to start gh: {e}"))?;
+
+    let mut buf = Vec::<u8>::new();
+    loop {
+        match process.read_combined(Some(Duration::from_millis(100))) {
+            ReadStatus::Line(event) => {
+                buf.extend_from_slice(&event.line);
+                buf.push(b'\n');
+            }
+            ReadStatus::Timeout => {
+                if process.returncode().is_some() {
+                    break;
+                }
+            }
+            ReadStatus::Eof => break,
+        }
+    }
+    let exit_code = process
+        .wait(Some(Duration::from_secs(30)))
+        .map_err(|e| format!("waiting for gh: {e}"))?;
+    Ok((exit_code, String::from_utf8_lossy(&buf).to_string()))
+}
+
+fn gh_program() -> String {
+    #[cfg(test)]
+    {
+        if let Some(path) = std::env::var_os(ENV_TEST_GH_BIN) {
+            if !path.is_empty() {
+                return path.to_string_lossy().to_string();
+            }
+        }
+    }
+    "gh".to_string()
+}
+
 fn now_unix() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -461,7 +680,12 @@ fn reap_trash_entries(registry: &Registry) -> Result<(usize, usize), String> {
 mod tests {
     use super::*;
     use crate::gc::ENV_DATA_DB;
+    use std::ffi::OsString;
+    use std::fs;
     use std::sync::Mutex;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     // ENV_DATA_DB is process-global; serialize so two test threads
     // never race to open the same redb file concurrently.
@@ -515,10 +739,54 @@ mod tests {
         }
     }
 
+    struct ScopedEnv {
+        key: &'static str,
+        prior: Option<OsString>,
+    }
+
+    impl ScopedEnv {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let prior = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, prior }
+        }
+    }
+
+    impl Drop for ScopedEnv {
+        fn drop(&mut self) {
+            restore_env_var(self.key, self.prior.take());
+        }
+    }
+
     fn call(tx: &mpsc::Sender<GcRequestMsg>, op: GcOp) -> GcReply {
         let (reply_tx, reply_rx) = mpsc::sync_channel::<GcReply>(1);
         tx.send(GcRequestMsg { op, reply_tx }).unwrap();
         reply_rx.recv_timeout(Duration::from_secs(5)).unwrap()
+    }
+
+    fn write_mock_gh(dir: &Path, json: &str) -> PathBuf {
+        #[cfg(windows)]
+        {
+            let path = dir.join("gh.cmd");
+            fs::write(&path, format!("@echo off\r\necho {json}\r\nexit /b 0\r\n")).unwrap();
+            path
+        }
+        #[cfg(not(windows))]
+        {
+            let path = dir.join("gh");
+            fs::write(
+                &path,
+                format!("#!/bin/sh\ncat <<'JSON'\n{json}\nJSON\nexit 0\n"),
+            )
+            .unwrap();
+            #[cfg(unix)]
+            {
+                let mut perms = fs::metadata(&path).unwrap().permissions();
+                perms.set_mode(0o755);
+                fs::set_permissions(&path, perms).unwrap();
+            }
+            path
+        }
     }
 
     #[test]
@@ -532,6 +800,37 @@ mod tests {
             gc_tick_cadence_from_raw(Some("1")),
             Some(Duration::from_secs(1))
         );
+    }
+
+    #[test]
+    fn github_remote_slug_parser_accepts_common_origin_urls() {
+        assert_eq!(
+            parse_github_slug_from_remote_url("git@github.com:zackees/dep.git"),
+            Some("zackees/dep".to_string())
+        );
+        assert_eq!(
+            parse_github_slug_from_remote_url("https://github.com/zackees/dep.git\n"),
+            Some("zackees/dep".to_string())
+        );
+        assert_eq!(
+            parse_github_slug_from_remote_url("ssh://git@github.com/zackees/dep"),
+            Some("zackees/dep".to_string())
+        );
+        assert_eq!(
+            parse_github_slug_from_remote_url("https://example.com/x/y"),
+            None
+        );
+    }
+
+    #[test]
+    fn gh_pr_list_json_requires_non_empty_merged_at() {
+        assert!(gh_pr_list_json_has_merged(
+            r#"[{"mergedAt":"2026-01-01T00:00:00Z","url":"https://github.com/a/b/pull/1"}]"#
+        ));
+        assert!(!gh_pr_list_json_has_merged(
+            r#"[{"mergedAt":null,"url":"https://github.com/a/b/pull/1"}]"#
+        ));
+        assert!(!gh_pr_list_json_has_merged("not json"));
     }
 
     #[test]
@@ -833,6 +1132,53 @@ mod tests {
         assert_eq!((removed, failed), (0, 1));
         assert!(not_a_dir.exists());
         assert_eq!(registry.list(Some("trash")).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn periodic_tick_removes_merged_stale_extern_repo_entry() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("extern-purge.redb");
+        let repo = dir.path().join("extern");
+        fs::create_dir_all(&repo).unwrap();
+        worktrees::run_git(&repo, &["init"]).expect("git init");
+        worktrees::run_git(&repo, &["checkout", "-b", "feat/test"]).expect("git branch");
+        worktrees::run_git(
+            &repo,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/zackees/dependency.git",
+            ],
+        )
+        .expect("git remote");
+
+        let mock_gh = write_mock_gh(
+            dir.path(),
+            r#"[{"mergedAt":"2026-01-01T00:00:00Z","url":"https://github.com/zackees/dependency/pull/1"}]"#,
+        );
+        let _age = ScopedEnv::set(ENV_GC_EXTERN_REPO_MAX_AGE_SECS, "0");
+        let _gh = ScopedEnv::set(ENV_TEST_GH_BIN, mock_gh.as_os_str());
+
+        let registry = Registry::open_at(&db_path).expect("open registry");
+        registry
+            .insert_if_new(&InsertInput {
+                kind: EXTERN_REPO_KIND.to_string(),
+                path: repo.to_string_lossy().to_string(),
+                repo_root: Some(dir.path().to_string_lossy().to_string()),
+                branch: Some("feat/test".to_string()),
+                agent_id: None,
+                now_unix: now_unix(),
+            })
+            .expect("insert extern repo");
+
+        let live_cwds_provider: LiveCwdsProvider = Arc::new(Vec::<PathBuf>::new);
+        run_periodic_purge_tick(&registry, &live_cwds_provider);
+
+        let rows = registry.list(Some(EXTERN_REPO_KIND)).expect("list");
+        assert!(rows.is_empty(), "merged extern-repo row should be deleted");
+        assert!(!repo.exists(), "merged extern-repo dir should be deleted");
     }
 
     #[test]

--- a/crates/clud-bin/src/gc.rs
+++ b/crates/clud-bin/src/gc.rs
@@ -53,6 +53,9 @@ const REPO_VISITS: TableDefinition<&str, &[u8]> = TableDefinition::new("repo_vis
 const META_SCHEMA_VERSION: &str = "schema_version";
 const META_NEXT_ID: &str = "next_id";
 
+pub const WORKTREE_KIND: &str = "worktree";
+pub const EXTERN_REPO_KIND: &str = "extern-repo";
+
 /// Errors surfaced by `gc.rs`. Narrow on purpose — the CLI handlers
 /// stringify these and log; nothing branches on the variant.
 #[derive(Debug)]
@@ -442,7 +445,10 @@ pub fn extract_pid_from_lock_reason(reason: &str) -> Option<u32> {
 pub fn run_reconcile(registry: &Registry) -> Result<usize, GcError> {
     let main_root = worktrees::locate_main_repo_root().map_err(GcError::Io)?;
     let watch_dir = main_root.join(".claude").join("worktrees");
-    reconcile_dir(registry, &watch_dir, Some(&main_root)).map(|res| res.inserted)
+    let worktree_res = reconcile_dir(registry, &watch_dir, Some(&main_root))?;
+    let extern_res =
+        reconcile_extern_repos_dir(registry, &main_root.join(".extern-repos"), Some(&main_root))?;
+    Ok(worktree_res.inserted + extern_res.inserted)
 }
 
 /// Result of one scan pass.
@@ -466,6 +472,54 @@ pub fn reconcile_dir(
     watch_dir: &Path,
     repo_root: Option<&Path>,
 ) -> Result<ScanResult, GcError> {
+    reconcile_dir_with_kind(registry, watch_dir, repo_root, ScanKind::Worktree)
+}
+
+/// Walk `<repo>/.extern-repos/` and insert each immediate child directory
+/// as an `extern-repo` row. Nested directories are intentionally ignored.
+pub fn reconcile_extern_repos_dir(
+    registry: &Registry,
+    watch_dir: &Path,
+    repo_root: Option<&Path>,
+) -> Result<ScanResult, GcError> {
+    reconcile_dir_with_kind(registry, watch_dir, repo_root, ScanKind::ExternRepo)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ScanKind {
+    Worktree,
+    ExternRepo,
+}
+
+impl ScanKind {
+    fn kind(self) -> &'static str {
+        match self {
+            Self::Worktree => WORKTREE_KIND,
+            Self::ExternRepo => EXTERN_REPO_KIND,
+        }
+    }
+
+    fn accepts_dir_name(self, name: &str) -> bool {
+        match self {
+            Self::Worktree => name.starts_with("agent-"),
+            Self::ExternRepo => true,
+        }
+    }
+
+    fn agent_id(self, name: &str) -> Option<String> {
+        match self {
+            Self::Worktree => Some(name.to_string()),
+            Self::ExternRepo => None,
+        }
+    }
+}
+
+fn reconcile_dir_with_kind(
+    registry: &Registry,
+    watch_dir: &Path,
+    repo_root: Option<&Path>,
+    scan_kind: ScanKind,
+) -> Result<ScanResult, GcError> {
     let mut res = ScanResult::default();
     let entries = match std::fs::read_dir(watch_dir) {
         Ok(it) => it,
@@ -485,13 +539,13 @@ pub fn reconcile_dir(
             Some(s) => s,
             None => continue,
         };
-        if !name_str.starts_with("agent-") {
+        if !scan_kind.accepts_dir_name(name_str) {
             continue;
         }
         let path = entry.path();
         let path_str = path.to_string_lossy().to_string();
 
-        let existed_before = registry_has_entry(registry, "worktree", &path_str)?;
+        let existed_before = registry_has_entry(registry, scan_kind.kind(), &path_str)?;
 
         if existed_before {
             // No-op insert; just bump the skipped counter.
@@ -501,11 +555,11 @@ pub fn reconcile_dir(
 
         let branch = best_effort_branch(&path);
         let input = InsertInput {
-            kind: "worktree".to_string(),
+            kind: scan_kind.kind().to_string(),
             path: path_str,
             repo_root: repo_root.map(|p| p.to_string_lossy().to_string()),
             branch,
-            agent_id: Some(name_str.to_string()),
+            agent_id: scan_kind.agent_id(name_str),
             now_unix: now_unix(),
         };
         registry.insert_if_new(&input)?;
@@ -520,7 +574,7 @@ fn registry_has_entry(registry: &Registry, kind: &str, path: &str) -> Result<boo
     Ok(table.get((kind, path))?.is_some())
 }
 
-fn best_effort_branch(path: &Path) -> Option<String> {
+pub(crate) fn best_effort_branch(path: &Path) -> Option<String> {
     worktrees::run_git(path, &["rev-parse", "--abbrev-ref", "HEAD"])
         .ok()
         .map(|s| s.trim().to_string())
@@ -558,18 +612,46 @@ impl WorktreeScanner {
             }
         };
         let watch_dir = main_root.join(".claude").join("worktrees");
-        Some(Self::spawn(watch_dir, Some(main_root)))
+        Some(Self::spawn_with_kind(
+            watch_dir,
+            Some(main_root),
+            ScanKind::Worktree,
+        ))
+    }
+
+    /// Spawn a scanner watching the current repo's `.extern-repos/`.
+    /// Returns `None` if the repo root can't be located.
+    pub fn maybe_spawn_extern_repos() -> Option<Self> {
+        let main_root = match worktrees::locate_main_repo_root() {
+            Ok(p) => p,
+            Err(_) => return None,
+        };
+        let watch_dir = main_root.join(".extern-repos");
+        Some(Self::spawn_with_kind(
+            watch_dir,
+            Some(main_root),
+            ScanKind::ExternRepo,
+        ))
     }
 
     /// Explicit spawn. Tests pass a custom watch dir. Inserts go through
     /// the GC daemon IPC; if the daemon is unreachable the scanner gives
     /// up silently.
     pub fn spawn(watch_dir: PathBuf, repo_root: Option<PathBuf>) -> Self {
+        Self::spawn_with_kind(watch_dir, repo_root, ScanKind::Worktree)
+    }
+
+    fn spawn_with_kind(
+        watch_dir: PathBuf,
+        repo_root: Option<PathBuf>,
+        scan_kind: ScanKind,
+    ) -> Self {
         let cancel = Arc::new(AtomicBool::new(false));
         let cancel_t = cancel.clone();
+        let thread_name = format!("clud-gc-scanner-{}", scan_kind.kind());
         let handle = std::thread::Builder::new()
-            .name("clud-gc-scanner".to_string())
-            .spawn(move || run_scanner_loop(watch_dir, repo_root, cancel_t))
+            .name(thread_name)
+            .spawn(move || run_scanner_loop(watch_dir, repo_root, scan_kind, cancel_t))
             .expect("spawn scanner thread");
         Self {
             cancel,
@@ -592,10 +674,14 @@ impl Drop for WorktreeScanner {
     }
 }
 
-/// Walk `watch_dir` once, sending `gc.insert` IPC ops for each agent-*
-/// subdir found. Returns `Err` on the first IPC failure so the caller
+/// Walk `watch_dir` once, sending `gc.insert` IPC ops for each matching
+/// immediate subdir. Returns `Err` on the first IPC failure so the caller
 /// can stop retrying.
-fn scan_once_via_ipc(watch_dir: &Path, repo_root: Option<&Path>) -> Result<(), String> {
+fn scan_once_via_ipc(
+    watch_dir: &Path,
+    repo_root: Option<&Path>,
+    scan_kind: ScanKind,
+) -> Result<(), String> {
     let entries = match std::fs::read_dir(watch_dir) {
         Ok(it) => it,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -614,18 +700,18 @@ fn scan_once_via_ipc(watch_dir: &Path, repo_root: Option<&Path>) -> Result<(), S
             Some(s) => s.to_string(),
             None => continue,
         };
-        if !name_str.starts_with("agent-") {
+        if !scan_kind.accepts_dir_name(&name_str) {
             continue;
         }
         let path = entry.path();
         let path_str = path.to_string_lossy().to_string();
         let branch = best_effort_branch(&path);
         let input = InsertInput {
-            kind: "worktree".to_string(),
+            kind: scan_kind.kind().to_string(),
             path: path_str,
             repo_root: repo_root.map(|p| p.to_string_lossy().to_string()),
             branch,
-            agent_id: Some(name_str),
+            agent_id: scan_kind.agent_id(&name_str),
             now_unix: now_unix(),
         };
         let state_dir = crate::daemon::default_state_dir().map_err(|e| e.to_string())?;
@@ -634,12 +720,17 @@ fn scan_once_via_ipc(watch_dir: &Path, repo_root: Option<&Path>) -> Result<(), S
     Ok(())
 }
 
-fn run_scanner_loop(watch_dir: PathBuf, repo_root: Option<PathBuf>, cancel: Arc<AtomicBool>) {
+fn run_scanner_loop(
+    watch_dir: PathBuf,
+    repo_root: Option<PathBuf>,
+    scan_kind: ScanKind,
+    cancel: Arc<AtomicBool>,
+) {
     let repo_root_ref = repo_root.as_deref();
     let mut ipc_failed = false;
     while !cancel.load(Ordering::SeqCst) {
         if !ipc_failed {
-            if let Err(e) = scan_once_via_ipc(&watch_dir, repo_root_ref) {
+            if let Err(e) = scan_once_via_ipc(&watch_dir, repo_root_ref, scan_kind) {
                 // Best-effort: log once, then stop trying.
                 if std::env::var_os("CLUD_GC_SCANNER_VERBOSE").is_some() {
                     eprintln!("[clud] debug: gc scanner: daemon ipc failed: {e}");

--- a/crates/clud-bin/src/gc_tests.rs
+++ b/crates/clud-bin/src/gc_tests.rs
@@ -233,6 +233,33 @@ fn reconcile_dir_inserts_agent_subdirs() {
 }
 
 #[test]
+fn reconcile_extern_repos_dir_inserts_immediate_child_dirs() {
+    let reg = fresh_registry("reconcile-extern-repos");
+    let dir = tempfile::tempdir().unwrap();
+    let repo_root = dir.path().join("repo");
+    let watch = repo_root.join(".extern-repos");
+    std::fs::create_dir_all(watch.join("dep-a")).unwrap();
+    std::fs::create_dir_all(watch.join("dep-b").join("nested")).unwrap();
+    std::fs::write(watch.join("README"), b"hi").unwrap();
+
+    let res = reconcile_extern_repos_dir(&reg, &watch, Some(&repo_root)).unwrap();
+    assert_eq!(res.inserted, 2);
+    assert_eq!(res.skipped, 0);
+
+    let rows = reg.list(None).unwrap();
+    let repo_root_str = repo_root.to_string_lossy().to_string();
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|r| r.kind == EXTERN_REPO_KIND));
+    assert!(rows.iter().all(|r| r.agent_id.is_none()));
+    assert!(rows
+        .iter()
+        .all(|r| r.repo_root.as_deref() == Some(repo_root_str.as_str())));
+    assert!(rows.iter().any(|r| r.path.ends_with("dep-a")));
+    assert!(rows.iter().any(|r| r.path.ends_with("dep-b")));
+    assert!(!rows.iter().any(|r| r.path.ends_with("nested")));
+}
+
+#[test]
 fn reconcile_dir_handles_missing_watch_dir() {
     let reg = fresh_registry("reconcile-missing");
     let dir = tempfile::tempdir().unwrap();

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -304,9 +304,9 @@ fn main() {
     }
     let _session_guard = startup::enforce_session_cap();
 
-    // Issue #110: spawn the background worktree scanner. Polls the
-    // current repo's `.claude/worktrees/` every ~2s and inserts any
-    // newly-detected agent-<id> dir into the tracked-entries table.
+    // Issue #110/#181: spawn background GC scanners. They poll the current
+    // repo's `.claude/worktrees/` and `.extern-repos/` directories every
+    // ~2s and insert newly-detected tracked entries.
     // Existing rows are left alone — the scanner is insert-only, no
     // write churn. `Drop` joins the worker thread; explicit `drop` below
     // sequences cancellation before the session-registry guard.
@@ -314,6 +314,7 @@ fn main() {
         verbose_log::log("[clud] worktree scanner: starting");
     }
     let _scanner_guard = gc::WorktreeScanner::maybe_spawn();
+    let _extern_repo_scanner_guard = gc::WorktreeScanner::maybe_spawn_extern_repos();
 
     // Clear stale DONE/BLOCKED markers from a prior run so that loops don't
     // short-circuit on iteration 1. See loop_spec for semantics.
@@ -383,6 +384,7 @@ fn main() {
         let (summary, err) = runner::summarize_loop_outcome(exit_code);
         session.on_loop_end(summary, err);
     }
+    drop(_extern_repo_scanner_guard);
     drop(_scanner_guard);
     drop(_session_guard);
     drop(_dnd_subprocess_guard);

--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -46,6 +46,10 @@ const BUNDLED_SKILLS: &[Skill] = &[
         name: "clud-windows-trash",
         content: include_str!("../../../skills/clud-windows-trash/SKILL.md"),
     },
+    Skill {
+        name: "clud-extern-repos",
+        content: include_str!("../../../skills/clud-extern-repos/SKILL.md"),
+    },
 ];
 
 /// Run the install/check for every bundled skill on launch. Cheap on the
@@ -374,6 +378,10 @@ mod tests {
         assert!(
             names.contains(&"clud-windows-trash"),
             "clud-windows-trash missing from bundle"
+        );
+        assert!(
+            names.contains(&"clud-extern-repos"),
+            "clud-extern-repos missing from bundle"
         );
     }
 

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -54,6 +54,10 @@ pub const BUNDLED_SKILLS: &[BundledSkill] = &[
         name: "clud-windows-trash",
         skill_md: include_str!("../assets/skills/clud-windows-trash/SKILL.md"),
     },
+    BundledSkill {
+        name: "clud-extern-repos",
+        skill_md: include_str!("../assets/skills/clud-extern-repos/SKILL.md"),
+    },
 ];
 
 /// One CLI backend that consumes `SKILL.md` files. Adding support for a
@@ -340,6 +344,7 @@ mod tests {
         assert!(names.contains(&"clud-tag-release"));
         assert!(names.contains(&"clud-docker-rust-app-dev"));
         assert!(names.contains(&"clud-windows-trash"));
+        assert!(names.contains(&"clud-extern-repos"));
     }
 
     #[test]

--- a/skills/clud-extern-repos/SKILL.md
+++ b/skills/clud-extern-repos/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: clud-extern-repos
+description: Coordinate dependent cross-repo changes under a repo-local .extern-repos/ checkout convention.
+triggers:
+  - When a task needs a dependent change in another repository
+  - When the user asks to use .extern-repos for cross-repo work
+---
+<!-- managed-by: clud -->
+
+# clud-extern-repos
+
+Use this workflow when the current repo needs coordinated work in a dependent repository.
+
+## Convention
+
+Place each dependent checkout at `<current-repo>/.extern-repos/<repo-name>/`. Only immediate children of `.extern-repos/` are tracked by clud GC.
+
+Before cloning, verify `.extern-repos/` is ignored by the current repo. If it is not ignored, ask before adding the ignore entry and refuse to create an unignored clone.
+
+Create feature branches in the dependent repo with the same short-name style as clud-pr, for example `feat/<short-name>`.
+
+## Coordination
+
+Keep each repo's work scoped to that repo. Do not edit the parent repo from inside the dependent checkout, and do not edit the dependent checkout from the parent repo.
+
+When opening PRs, link both directions:
+
+- Parent PR body: `Depends on <owner>/<repo>#<number>`
+- Dependent PR body: `Coordinated with <owner>/<parent-repo>#<number>`
+
+If the dependent PR must land first, make that ordering explicit in the parent PR body.
+
+## Cleanup
+
+The daemon may auto-remove `.extern-repos/<name>/` only after the tracked branch has a merged PR, the directory has been inactive for at least 24 hours, and no live clud session is rooted inside it.
+
+If `gh` is missing, rate-limited, or cannot confirm a merged PR, keep the checkout.


### PR DESCRIPTION
Summary:
- add repo-local `.extern-repos/` tracking alongside `.claude/worktrees/`
- register `extern-repo` GC entries for immediate child checkouts and list them through existing GC commands
- purge stale extern repos only after `gh pr list` confirms the branch PR is merged, the checkout is inactive long enough, and no live session CWD is rooted inside it
- bundle a `clud-extern-repos` skill and ignore `.extern-repos/`

Validation:
- `soldr cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `soldr cargo test -p clud gc::tests`
- `soldr cargo test -p clud daemon::gc_service::tests`
- `soldr cargo test -p clud skills::tests`
- `soldr cargo test -p clud skill_install::tests`
- `bash lint`

Closes #181