### PR TITLE
ci: bump setup-soldr v0.9.48 -> v0.9.49

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -69,7 +69,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -59,7 +59,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -54,7 +54,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -54,7 +54,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.48` to `v0.9.49`.

## What's in v0.9.49
- `cache-eviction-policy: protect-foundations` thresholds raised from 9 GB / 8 GB to 9.5 GB / 9.0 GB.
- Reason: v0.9.48 was leaving ~2 GB of usable cache budget on the table. New thresholds keep 0.5 GB headroom under GitHub's 10 GB cap and fire eviction less eagerly while still beating GitHub's own non-deterministic LRU. The 6h age floor from v0.9.48 is unchanged.

No action input changes; this is a pure threshold tuning that takes effect for repos already using `cache-eviction-policy: protect-foundations`.

## Test plan
- [ ] CI green (warm restore + post-step eviction logs)
- [ ] Post-step eviction log shows new thresholds (`evicting toward 9 GB` when usage > 9.5 GB) — or no eviction at all if usage stays under 9.5 GB
