### PR TITLE
feat(gc): add low-disk cleanup watchdog

### DIFF
--- a/crates/clud-bin/src/daemon/gc_service.rs
+++ b/crates/clud-bin/src/daemon/gc_service.rs
@@ -16,8 +16,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use running_process::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
 
 use crate::gc::{
-    extract_pid_from_lock_reason, reconcile_dir, reconcile_extern_repos_dir, InsertInput, Registry,
-    TrackedEntry, EXTERN_REPO_KIND, WORKTREE_KIND,
+    extract_pid_from_lock_reason, reconcile_repo_root, InsertInput, Registry, TrackedEntry,
+    EXTERN_REPO_KIND, SIBLING_CLONE_KIND, WORKTREE_KIND,
 };
 use crate::session_registry::{LivenessProbe, OsLivenessProbe};
 use crate::subprocess;
@@ -32,9 +32,18 @@ pub(super) const WORKER_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
 
 const ENV_GC_TICK_SECS: &str = "CLUD_GC_TICK_SECS";
 const ENV_GC_EXTERN_REPO_MAX_AGE_SECS: &str = "CLUD_GC_EXTERN_REPO_MAX_AGE_SECS";
+const ENV_GC_WARN_FREE_GB: &str = "CLUD_GC_WARN_FREE_GB";
+const ENV_GC_AUTO_PURGE_FREE_GB: &str = "CLUD_GC_AUTO_PURGE_FREE_GB";
+const ENV_GC_MIN_AGE_HOURS: &str = "CLUD_GC_MIN_AGE_HOURS";
+const ENV_GC_AUTO_PURGE_ENABLED: &str = "CLUD_GC_AUTO_PURGE_ENABLED";
 const DEFAULT_GC_TICK_SECS: u64 = 3600;
 const DEFAULT_EXTERN_REPO_STALE_AFTER_SECS: u64 = 24 * 60 * 60;
+const DEFAULT_GC_WARN_FREE_GB: u64 = 10;
+const DEFAULT_GC_AUTO_PURGE_FREE_GB: u64 = 5;
+const DEFAULT_GC_MIN_AGE_HOURS: u64 = 24;
+const DEFAULT_GC_AUTO_PURGE_ENABLED: bool = true;
 const PERIODIC_GC_WORKTREE_STALE_AFTER: &str = "48h";
+const BYTES_PER_GB: u64 = 1024 * 1024 * 1024;
 
 #[cfg(test)]
 const ENV_TEST_GH_BIN: &str = "CLUD_TEST_GH_BIN";
@@ -105,6 +114,74 @@ fn gc_tick_cadence_from_raw(raw: Option<&str>) -> Option<Duration> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GcDiskWatchdogConfig {
+    warn_free_bytes: u64,
+    auto_purge_free_bytes: u64,
+    min_age: Duration,
+    auto_purge_enabled: bool,
+}
+
+impl GcDiskWatchdogConfig {
+    fn from_env() -> Self {
+        let warn_free_gb = std::env::var(ENV_GC_WARN_FREE_GB).ok();
+        let auto_purge_free_gb = std::env::var(ENV_GC_AUTO_PURGE_FREE_GB).ok();
+        let min_age_hours = std::env::var(ENV_GC_MIN_AGE_HOURS).ok();
+        let auto_purge_enabled = std::env::var(ENV_GC_AUTO_PURGE_ENABLED).ok();
+        gc_disk_watchdog_config_from_raw(
+            warn_free_gb.as_deref(),
+            auto_purge_free_gb.as_deref(),
+            min_age_hours.as_deref(),
+            auto_purge_enabled.as_deref(),
+        )
+    }
+}
+
+fn gc_disk_watchdog_config_from_raw(
+    warn_free_gb: Option<&str>,
+    auto_purge_free_gb: Option<&str>,
+    min_age_hours: Option<&str>,
+    auto_purge_enabled: Option<&str>,
+) -> GcDiskWatchdogConfig {
+    GcDiskWatchdogConfig {
+        warn_free_bytes: parse_gb_to_bytes(warn_free_gb, DEFAULT_GC_WARN_FREE_GB),
+        auto_purge_free_bytes: parse_gb_to_bytes(auto_purge_free_gb, DEFAULT_GC_AUTO_PURGE_FREE_GB),
+        min_age: parse_hours_to_duration(min_age_hours, DEFAULT_GC_MIN_AGE_HOURS),
+        auto_purge_enabled: parse_bool_setting(auto_purge_enabled, DEFAULT_GC_AUTO_PURGE_ENABLED),
+    }
+}
+
+fn parse_gb_to_bytes(raw: Option<&str>, default_gb: u64) -> u64 {
+    raw.and_then(|value| {
+        let gb = value.trim().parse::<f64>().ok()?;
+        if !gb.is_finite() || gb < 0.0 {
+            return None;
+        }
+        let bytes = gb * BYTES_PER_GB as f64;
+        if bytes >= u64::MAX as f64 {
+            Some(u64::MAX)
+        } else {
+            Some(bytes.round() as u64)
+        }
+    })
+    .unwrap_or_else(|| default_gb.saturating_mul(BYTES_PER_GB))
+}
+
+fn parse_hours_to_duration(raw: Option<&str>, default_hours: u64) -> Duration {
+    let hours = raw
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(default_hours);
+    Duration::from_secs(hours.saturating_mul(60 * 60))
+}
+
+fn parse_bool_setting(raw: Option<&str>, default: bool) -> bool {
+    match raw.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("1" | "true" | "yes" | "on") => true,
+        Some("0" | "false" | "no" | "off") => false,
+        _ => default,
+    }
+}
+
 fn run_worker_loop(
     registry: Registry,
     rx: mpsc::Receiver<GcRequestMsg>,
@@ -149,6 +226,25 @@ fn handle_worker_msg(
 }
 
 fn run_periodic_purge_tick(registry: &Registry, live_cwds_provider: &LiveCwdsProvider) {
+    let config = GcDiskWatchdogConfig::from_env();
+    run_periodic_purge_tick_with_free_space(
+        registry,
+        live_cwds_provider,
+        &config,
+        &free_space_bytes_for_path,
+    );
+}
+
+fn run_periodic_purge_tick_with_free_space<F>(
+    registry: &Registry,
+    live_cwds_provider: &LiveCwdsProvider,
+    disk_config: &GcDiskWatchdogConfig,
+    free_space: &F,
+) where
+    F: Fn(&Path) -> Result<u64, String> + ?Sized,
+{
+    run_disk_watchdog_tick(registry, live_cwds_provider, disk_config, free_space);
+
     let worktree_reply = process_op_with_live_cwds(
         registry,
         GcOp::Purge {
@@ -179,6 +275,194 @@ fn run_periodic_purge_tick(registry: &Registry, live_cwds_provider: &LiveCwdsPro
         }
         Err(message) => {
             eprintln!("[clud] gc tick: trash error: {message}");
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DiskWatchdogDecision {
+    warn: bool,
+    auto_purge: bool,
+}
+
+fn disk_watchdog_decision(config: &GcDiskWatchdogConfig, free_bytes: u64) -> DiskWatchdogDecision {
+    DiskWatchdogDecision {
+        warn: free_bytes < config.warn_free_bytes,
+        auto_purge: config.auto_purge_enabled && free_bytes < config.auto_purge_free_bytes,
+    }
+}
+
+fn run_disk_watchdog_tick<F>(
+    registry: &Registry,
+    live_cwds_provider: &LiveCwdsProvider,
+    config: &GcDiskWatchdogConfig,
+    free_space: &F,
+) where
+    F: Fn(&Path) -> Result<u64, String> + ?Sized,
+{
+    let entries = match registry.list(None) {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!("[clud] gc tick disk: failed to list tracked roots: {err}");
+            return;
+        }
+    };
+    let roots = collect_tracked_entry_roots(&entries);
+    let mut purge_roots = Vec::new();
+    for root in roots {
+        match free_space(&root) {
+            Ok(free_bytes) => {
+                let decision = disk_watchdog_decision(config, free_bytes);
+                if decision.warn {
+                    eprintln!(
+                        "[clud] gc tick disk: {} has {} GB free, below warn threshold {} GB",
+                        root.display(),
+                        format_gb(free_bytes),
+                        format_gb(config.warn_free_bytes)
+                    );
+                }
+                if decision.auto_purge {
+                    purge_roots.push(root);
+                }
+            }
+            Err(message) => {
+                eprintln!(
+                    "[clud] gc tick disk: failed to sample free space for {}: {message}",
+                    root.display()
+                );
+            }
+        }
+    }
+
+    if purge_roots.is_empty() {
+        return;
+    }
+    let purge_reply = purge_old_reclaimable_entries_for_roots(
+        registry,
+        live_cwds_provider,
+        &purge_roots,
+        config.min_age,
+    );
+    log_disk_watchdog_purge_reply(purge_roots.len(), config, purge_reply);
+}
+
+fn collect_tracked_entry_roots(entries: &[TrackedEntry]) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut roots = Vec::new();
+    for entry in entries {
+        let root = tracked_entry_root(entry);
+        let key = root.to_string_lossy().to_string();
+        if seen.insert(key) {
+            roots.push(root);
+        }
+    }
+    roots
+}
+
+fn tracked_entry_root(entry: &TrackedEntry) -> PathBuf {
+    if let Some(repo_root) = entry
+        .repo_root
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        PathBuf::from(repo_root)
+    } else {
+        PathBuf::from(&entry.path)
+    }
+}
+
+fn purge_old_reclaimable_entries_for_roots(
+    registry: &Registry,
+    live_cwds_provider: &LiveCwdsProvider,
+    roots: &[PathBuf],
+    min_age: Duration,
+) -> GcReply {
+    let cutoff = now_unix().saturating_sub(duration_secs_i64(min_age));
+    let candidates = match registry.select_older_than(cutoff, None) {
+        Ok(candidates) => candidates,
+        Err(err) => {
+            return GcReply::Error {
+                message: err.to_string(),
+            };
+        }
+    };
+    let candidates = candidates
+        .into_iter()
+        .filter(|entry| entry.kind == WORKTREE_KIND || entry.kind == SIBLING_CLONE_KIND)
+        .filter(|entry| tracked_entry_matches_any_root(entry, roots))
+        .collect();
+    purge_entries(registry, candidates, live_cwds_provider(), false)
+}
+
+fn tracked_entry_matches_any_root(entry: &TrackedEntry, roots: &[PathBuf]) -> bool {
+    let entry_root = tracked_entry_root(entry);
+    let entry_path = Path::new(&entry.path);
+    roots.iter().any(|root| {
+        path_matches_or_is_under(&entry_root, root) || path_matches_or_is_under(entry_path, root)
+    })
+}
+
+fn path_matches_or_is_under(path: &Path, root: &Path) -> bool {
+    path == root || path.starts_with(root)
+}
+
+fn duration_secs_i64(duration: Duration) -> i64 {
+    duration.as_secs().min(i64::MAX as u64) as i64
+}
+
+fn log_disk_watchdog_purge_reply(
+    low_root_count: usize,
+    config: &GcDiskWatchdogConfig,
+    reply: GcReply,
+) {
+    match reply {
+        GcReply::PurgeOk { removed, skipped } => {
+            eprintln!(
+                "[clud] gc tick disk: auto-purge checked {low_root_count} low root(s), min age {}h, removed {removed}, skipped {skipped}",
+                config.min_age.as_secs() / (60 * 60)
+            );
+        }
+        GcReply::Error { message } => {
+            eprintln!("[clud] gc tick disk: auto-purge error: {message}");
+        }
+        other => {
+            eprintln!("[clud] gc tick disk: unexpected auto-purge reply: {other:?}");
+        }
+    }
+}
+
+fn format_gb(bytes: u64) -> String {
+    format!("{:.2}", bytes as f64 / BYTES_PER_GB as f64)
+}
+
+fn free_space_bytes_for_path(path: &Path) -> Result<u64, String> {
+    let probe_path = disk_probe_path(path)?;
+    let disks = sysinfo::Disks::new_with_refreshed_list();
+    disks
+        .list()
+        .iter()
+        .filter(|disk| probe_path.starts_with(disk.mount_point()))
+        .max_by_key(|disk| disk.mount_point().components().count())
+        .map(|disk| disk.available_space())
+        .ok_or_else(|| format!("no mounted disk found for {}", probe_path.display()))
+}
+
+fn disk_probe_path(path: &Path) -> Result<PathBuf, String> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|err| format!("current_dir: {err}"))?
+            .join(path)
+    };
+    let mut probe = absolute.clone();
+    loop {
+        if probe.exists() {
+            return Ok(probe);
+        }
+        if !probe.pop() {
+            return Ok(absolute);
         }
     }
 }
@@ -230,7 +514,7 @@ fn process_op_with_live_cwds(registry: &Registry, op: GcOp, live_cwds: Vec<PathB
             let candidates_res = match &duration {
                 Some(d) => match worktrees::parse_duration(d) {
                     Ok(dur) => {
-                        let cutoff = now_unix().saturating_sub(dur.as_secs() as i64);
+                        let cutoff = now_unix().saturating_sub(duration_secs_i64(dur));
                         registry.select_older_than(cutoff, kind.as_deref())
                     }
                     Err(e) => {
@@ -249,44 +533,12 @@ fn process_op_with_live_cwds(registry: &Registry, op: GcOp, live_cwds: Vec<PathB
                     };
                 }
             };
-            let live_locks = collect_live_lock_paths();
-            let live_cwds = canonicalize_live_cwds(live_cwds);
-            let mut purgeable = Vec::new();
-            let mut skipped = 0usize;
-            for candidate in candidates {
-                if entry_is_live(&candidate, &live_locks, &live_cwds) {
-                    skipped += 1;
-                    continue;
-                }
-                if !entry_kind_allows_purge(&candidate) {
-                    skipped += 1;
-                    continue;
-                }
-                purgeable.push(candidate);
-            }
-            if dry_run {
-                return GcReply::PurgeOk {
-                    removed: purgeable.len(),
-                    skipped,
-                };
-            }
-            let mut removed = 0usize;
-            for entry in &purgeable {
-                if remove_entry_and_delete_row(registry, entry).is_ok() {
-                    removed += 1;
-                }
-            }
-            GcReply::PurgeOk { removed, skipped }
+            purge_entries(registry, candidates, live_cwds, dry_run)
         }
 
         GcOp::Reconcile { repo_root } => {
             let root = PathBuf::from(&repo_root);
-            let watch_dir = root.join(".claude").join("worktrees");
-            match reconcile_dir(registry, &watch_dir, Some(&root)).and_then(|worktree_res| {
-                let extern_res =
-                    reconcile_extern_repos_dir(registry, &root.join(".extern-repos"), Some(&root))?;
-                Ok(worktree_res.inserted + extern_res.inserted)
-            }) {
+            match reconcile_repo_root(registry, &root) {
                 Ok(inserted) => GcReply::ReconcileOk { inserted },
                 Err(e) => GcReply::Error {
                     message: e.to_string(),
@@ -374,6 +626,42 @@ fn process_op_with_live_cwds(registry: &Registry, op: GcOp, live_cwds: Vec<PathB
             }
         }
     }
+}
+
+fn purge_entries(
+    registry: &Registry,
+    candidates: Vec<TrackedEntry>,
+    live_cwds: Vec<PathBuf>,
+    dry_run: bool,
+) -> GcReply {
+    let live_locks = collect_live_lock_paths();
+    let live_cwds = canonicalize_live_cwds(live_cwds);
+    let mut purgeable = Vec::new();
+    let mut skipped = 0usize;
+    for candidate in candidates {
+        if entry_is_live(&candidate, &live_locks, &live_cwds) {
+            skipped += 1;
+            continue;
+        }
+        if !entry_kind_allows_purge(&candidate) {
+            skipped += 1;
+            continue;
+        }
+        purgeable.push(candidate);
+    }
+    if dry_run {
+        return GcReply::PurgeOk {
+            removed: purgeable.len(),
+            skipped,
+        };
+    }
+    let mut removed = 0usize;
+    for entry in &purgeable {
+        if remove_entry_and_delete_row(registry, entry).is_ok() {
+            removed += 1;
+        }
+    }
+    GcReply::PurgeOk { removed, skipped }
 }
 
 fn canonicalize_live_cwds(live_cwds: Vec<PathBuf>) -> Vec<PathBuf> {
@@ -634,16 +922,8 @@ fn collect_live_lock_paths() -> HashSet<String> {
 fn remove_entry_and_delete_row(registry: &Registry, entry: &TrackedEntry) -> Result<(), String> {
     if entry.kind == "worktree" {
         let main_root = entry.repo_root.clone().unwrap_or_else(|| ".".to_string());
-        let git_result = worktrees::run_git(
-            Path::new(&main_root),
-            &["worktree", "remove", "--force", &entry.path],
-        );
-        if git_result.is_err() {
-            let dir = Path::new(&entry.path);
-            if dir.exists() {
-                std::fs::remove_dir_all(dir).map_err(|e| e.to_string())?;
-            }
-        }
+        let _ =
+            worktrees::remove_worktree_path(Path::new(&main_root), Path::new(&entry.path), true)?;
     } else if entry.kind == "trash" {
         std::fs::remove_dir_all(&entry.path).map_err(|e| e.to_string())?;
     } else {
@@ -799,6 +1079,76 @@ mod tests {
         assert_eq!(
             gc_tick_cadence_from_raw(Some("1")),
             Some(Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn gc_disk_watchdog_config_parses_defaults_and_overrides() {
+        let defaults = gc_disk_watchdog_config_from_raw(None, None, None, None);
+        assert_eq!(defaults.warn_free_bytes, 10 * BYTES_PER_GB);
+        assert_eq!(defaults.auto_purge_free_bytes, 5 * BYTES_PER_GB);
+        assert_eq!(defaults.min_age, Duration::from_secs(24 * 60 * 60));
+        assert!(defaults.auto_purge_enabled);
+
+        let overrides =
+            gc_disk_watchdog_config_from_raw(Some("1.5"), Some("2"), Some("7"), Some("off"));
+        assert_eq!(overrides.warn_free_bytes, BYTES_PER_GB + BYTES_PER_GB / 2);
+        assert_eq!(overrides.auto_purge_free_bytes, 2 * BYTES_PER_GB);
+        assert_eq!(overrides.min_age, Duration::from_secs(7 * 60 * 60));
+        assert!(!overrides.auto_purge_enabled);
+    }
+
+    #[test]
+    fn gc_disk_watchdog_config_falls_back_on_invalid_values() {
+        let config =
+            gc_disk_watchdog_config_from_raw(Some("-1"), Some("nan"), Some("bad"), Some("maybe"));
+        assert_eq!(config.warn_free_bytes, 10 * BYTES_PER_GB);
+        assert_eq!(config.auto_purge_free_bytes, 5 * BYTES_PER_GB);
+        assert_eq!(config.min_age, Duration::from_secs(24 * 60 * 60));
+        assert!(config.auto_purge_enabled);
+    }
+
+    #[test]
+    fn disk_watchdog_decision_warns_and_purges_only_below_thresholds() {
+        let config = GcDiskWatchdogConfig {
+            warn_free_bytes: 10 * BYTES_PER_GB,
+            auto_purge_free_bytes: 5 * BYTES_PER_GB,
+            min_age: Duration::from_secs(24 * 60 * 60),
+            auto_purge_enabled: true,
+        };
+
+        assert_eq!(
+            disk_watchdog_decision(&config, 10 * BYTES_PER_GB),
+            DiskWatchdogDecision {
+                warn: false,
+                auto_purge: false
+            }
+        );
+        assert_eq!(
+            disk_watchdog_decision(&config, 9 * BYTES_PER_GB),
+            DiskWatchdogDecision {
+                warn: true,
+                auto_purge: false
+            }
+        );
+        assert_eq!(
+            disk_watchdog_decision(&config, 4 * BYTES_PER_GB),
+            DiskWatchdogDecision {
+                warn: true,
+                auto_purge: true
+            }
+        );
+
+        let disabled = GcDiskWatchdogConfig {
+            auto_purge_enabled: false,
+            ..config
+        };
+        assert_eq!(
+            disk_watchdog_decision(&disabled, 4 * BYTES_PER_GB),
+            DiskWatchdogDecision {
+                warn: true,
+                auto_purge: false
+            }
         );
     }
 
@@ -1042,46 +1392,85 @@ mod tests {
     }
 
     #[test]
-    fn periodic_tick_removes_old_worktree_entry() {
+    fn periodic_tick_auto_purges_old_worktree_entry_when_free_space_low() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("periodic-purge.redb");
-        let (tx, _g) = spawn_test_worker_with_tick(&db_path, "1");
+        let registry = Registry::open_at(&db_path).unwrap();
         let old_path = dir.path().join("old-worktree");
+        let old_sibling = dir.path().join("clud-pr-old");
         std::fs::create_dir_all(&old_path).unwrap();
+        std::fs::create_dir_all(&old_sibling).unwrap();
 
-        let resp = call(
-            &tx,
-            GcOp::Insert {
+        registry
+            .insert_if_new(&InsertInput {
                 kind: "worktree".to_string(),
                 path: old_path.to_string_lossy().to_string(),
                 repo_root: Some(dir.path().to_string_lossy().to_string()),
                 branch: Some("stale".to_string()),
                 agent_id: Some("agent-old".to_string()),
-                created_unix: Some(now_unix().saturating_sub(49 * 60 * 60)),
-            },
-        );
-        assert!(matches!(resp, GcReply::InsertOk));
+                now_unix: now_unix().saturating_sub(25 * 60 * 60),
+            })
+            .unwrap();
+        registry
+            .insert_if_new(&InsertInput {
+                kind: SIBLING_CLONE_KIND.to_string(),
+                path: old_sibling.to_string_lossy().to_string(),
+                repo_root: Some(dir.path().to_string_lossy().to_string()),
+                branch: Some("old".to_string()),
+                agent_id: None,
+                now_unix: now_unix().saturating_sub(25 * 60 * 60),
+            })
+            .unwrap();
 
-        let deadline = Instant::now() + Duration::from_secs(3);
-        loop {
-            let rows = match call(
-                &tx,
-                GcOp::List {
-                    kind: Some("worktree".to_string()),
-                },
-            ) {
-                GcReply::ListOk { rows } => rows,
-                other => panic!("unexpected reply: {other:?}"),
-            };
-            if rows.is_empty() {
-                assert!(!old_path.exists());
-                break;
-            }
-            if Instant::now() >= deadline {
-                panic!("periodic purge did not remove old worktree entry within 3 seconds");
-            }
-            std::thread::sleep(Duration::from_millis(100));
-        }
+        let config = GcDiskWatchdogConfig {
+            warn_free_bytes: 10 * BYTES_PER_GB,
+            auto_purge_free_bytes: 5 * BYTES_PER_GB,
+            min_age: Duration::from_secs(24 * 60 * 60),
+            auto_purge_enabled: true,
+        };
+        let live_cwds_provider: LiveCwdsProvider = Arc::new(Vec::<PathBuf>::new);
+        run_periodic_purge_tick_with_free_space(&registry, &live_cwds_provider, &config, &|_| {
+            Ok(4 * BYTES_PER_GB)
+        });
+
+        assert!(registry.list(Some(WORKTREE_KIND)).unwrap().is_empty());
+        assert!(registry.list(Some(SIBLING_CLONE_KIND)).unwrap().is_empty());
+        assert!(!old_path.exists());
+        assert!(!old_sibling.exists());
+    }
+
+    #[test]
+    fn periodic_tick_keeps_old_worktree_entry_when_free_space_is_healthy() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("periodic-healthy.redb");
+        let registry = Registry::open_at(&db_path).unwrap();
+        let old_path = dir.path().join("old-worktree");
+        std::fs::create_dir_all(&old_path).unwrap();
+
+        registry
+            .insert_if_new(&InsertInput {
+                kind: "worktree".to_string(),
+                path: old_path.to_string_lossy().to_string(),
+                repo_root: Some(dir.path().to_string_lossy().to_string()),
+                branch: Some("stale".to_string()),
+                agent_id: Some("agent-old".to_string()),
+                now_unix: now_unix().saturating_sub(25 * 60 * 60),
+            })
+            .unwrap();
+
+        let config = GcDiskWatchdogConfig {
+            warn_free_bytes: 10 * BYTES_PER_GB,
+            auto_purge_free_bytes: 5 * BYTES_PER_GB,
+            min_age: Duration::from_secs(24 * 60 * 60),
+            auto_purge_enabled: true,
+        };
+        let live_cwds_provider: LiveCwdsProvider = Arc::new(Vec::<PathBuf>::new);
+        run_periodic_purge_tick_with_free_space(&registry, &live_cwds_provider, &config, &|_| {
+            Ok(20 * BYTES_PER_GB)
+        });
+
+        assert_eq!(registry.list(Some(WORKTREE_KIND)).unwrap().len(), 1);
+        assert!(old_path.exists());
     }
 
     #[test]

--- a/crates/clud-bin/src/gc.rs
+++ b/crates/clud-bin/src/gc.rs
@@ -55,6 +55,7 @@ const META_NEXT_ID: &str = "next_id";
 
 pub const WORKTREE_KIND: &str = "worktree";
 pub const EXTERN_REPO_KIND: &str = "extern-repo";
+pub const SIBLING_CLONE_KIND: &str = "sibling-clone";
 
 /// Errors surfaced by `gc.rs`. Narrow on purpose — the CLI handlers
 /// stringify these and log; nothing branches on the variant.
@@ -444,11 +445,20 @@ pub fn extract_pid_from_lock_reason(reason: &str) -> Option<u32> {
 /// of new entries (i.e. rows that didn't previously exist).
 pub fn run_reconcile(registry: &Registry) -> Result<usize, GcError> {
     let main_root = worktrees::locate_main_repo_root().map_err(GcError::Io)?;
+    reconcile_repo_root(registry, &main_root)
+}
+
+/// Reconcile all tracked directories associated with `main_root`.
+///
+/// This scans repo-local worktrees, repo-local `.extern-repos/`, and
+/// top-level sibling temp clones adjacent to the main checkout.
+pub fn reconcile_repo_root(registry: &Registry, main_root: &Path) -> Result<usize, GcError> {
     let watch_dir = main_root.join(".claude").join("worktrees");
-    let worktree_res = reconcile_dir(registry, &watch_dir, Some(&main_root))?;
+    let worktree_res = reconcile_dir(registry, &watch_dir, Some(main_root))?;
     let extern_res =
-        reconcile_extern_repos_dir(registry, &main_root.join(".extern-repos"), Some(&main_root))?;
-    Ok(worktree_res.inserted + extern_res.inserted)
+        reconcile_extern_repos_dir(registry, &main_root.join(".extern-repos"), Some(main_root))?;
+    let sibling_res = reconcile_sibling_clones_dir(registry, main_root)?;
+    Ok(worktree_res.inserted + extern_res.inserted + sibling_res.inserted)
 }
 
 /// Result of one scan pass.
@@ -485,10 +495,30 @@ pub fn reconcile_extern_repos_dir(
     reconcile_dir_with_kind(registry, watch_dir, repo_root, ScanKind::ExternRepo)
 }
 
+/// Walk the parent of `repo_root` and insert immediate child directories
+/// that look like disposable sibling clones created by clud/soldr tooling.
+///
+/// Matching is intentionally narrow: explicit tool prefixes are accepted,
+/// and broad `*-wt-*` / `*-issue-*` examples are interpreted only as
+/// current-repo-scoped names such as `<repo>-wt-<branch>`.
+pub fn reconcile_sibling_clones_dir(
+    registry: &Registry,
+    repo_root: &Path,
+) -> Result<ScanResult, GcError> {
+    let Some(parent) = repo_root.parent() else {
+        return Ok(ScanResult::default());
+    };
+    if parent.as_os_str().is_empty() {
+        return Ok(ScanResult::default());
+    }
+    reconcile_dir_with_kind(registry, parent, Some(repo_root), ScanKind::SiblingClone)
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ScanKind {
     Worktree,
     ExternRepo,
+    SiblingClone,
 }
 
 impl ScanKind {
@@ -496,21 +526,72 @@ impl ScanKind {
         match self {
             Self::Worktree => WORKTREE_KIND,
             Self::ExternRepo => EXTERN_REPO_KIND,
+            Self::SiblingClone => SIBLING_CLONE_KIND,
         }
     }
 
-    fn accepts_dir_name(self, name: &str) -> bool {
+    fn accepts_dir_name(self, name: &str, repo_root: Option<&Path>) -> bool {
         match self {
             Self::Worktree => name.starts_with("agent-"),
             Self::ExternRepo => true,
+            Self::SiblingClone => repo_root
+                .and_then(repo_name)
+                .map(|repo| is_sibling_clone_dir_name(repo, name))
+                .unwrap_or(false),
         }
     }
 
     fn agent_id(self, name: &str) -> Option<String> {
         match self {
             Self::Worktree => Some(name.to_string()),
-            Self::ExternRepo => None,
+            Self::ExternRepo | Self::SiblingClone => None,
         }
+    }
+}
+
+fn repo_name(repo_root: &Path) -> Option<&str> {
+    repo_root.file_name().and_then(|name| name.to_str())
+}
+
+fn is_sibling_clone_dir_name(repo_name: &str, name: &str) -> bool {
+    if repo_name.is_empty() || name == repo_name {
+        return false;
+    }
+
+    // Explicit temp-clone prefixes used by clud and related tooling.
+    // The broader issue examples `*-wt-*` and `*-issue-*` are handled
+    // below only when they are scoped to the current repo name.
+    const TOOL_PREFIXES: &[&str] = &[
+        "clud-pr-",
+        "clud-release-",
+        "clud-issue-",
+        "soldr-wt-",
+        "zccache-wt-",
+    ];
+    if TOOL_PREFIXES
+        .iter()
+        .any(|prefix| has_nonempty_suffix(name, prefix))
+    {
+        return true;
+    }
+
+    has_nonempty_suffix(name, &format!("{repo_name}-wt-"))
+        || has_nonempty_suffix(name, &format!("{repo_name}-issue-"))
+}
+
+fn has_nonempty_suffix(name: &str, prefix: &str) -> bool {
+    name.strip_prefix(prefix)
+        .map(|suffix| !suffix.is_empty())
+        .unwrap_or(false)
+}
+
+fn path_matches_repo_root(path: &Path, repo_root: &Path) -> bool {
+    if path == repo_root {
+        return true;
+    }
+    match (path.canonicalize(), repo_root.canonicalize()) {
+        (Ok(path), Ok(repo_root)) => path == repo_root,
+        _ => false,
     }
 }
 
@@ -539,10 +620,17 @@ fn reconcile_dir_with_kind(
             Some(s) => s,
             None => continue,
         };
-        if !scan_kind.accepts_dir_name(name_str) {
+        if !scan_kind.accepts_dir_name(name_str, repo_root) {
             continue;
         }
         let path = entry.path();
+        if matches!(scan_kind, ScanKind::SiblingClone)
+            && repo_root
+                .map(|root| path_matches_repo_root(&path, root))
+                .unwrap_or(false)
+        {
+            continue;
+        }
         let path_str = path.to_string_lossy().to_string();
 
         let existed_before = registry_has_entry(registry, scan_kind.kind(), &path_str)?;
@@ -634,6 +722,22 @@ impl WorktreeScanner {
         ))
     }
 
+    /// Spawn a scanner watching top-level sibling temp clones next to the
+    /// current repo. Returns `None` if the repo root can't be located or
+    /// has no parent directory.
+    pub fn maybe_spawn_sibling_clones() -> Option<Self> {
+        let main_root = match worktrees::locate_main_repo_root() {
+            Ok(p) => p,
+            Err(_) => return None,
+        };
+        let parent = main_root.parent()?.to_path_buf();
+        Some(Self::spawn_with_kind(
+            parent,
+            Some(main_root),
+            ScanKind::SiblingClone,
+        ))
+    }
+
     /// Explicit spawn. Tests pass a custom watch dir. Inserts go through
     /// the GC daemon IPC; if the daemon is unreachable the scanner gives
     /// up silently.
@@ -700,10 +804,17 @@ fn scan_once_via_ipc(
             Some(s) => s.to_string(),
             None => continue,
         };
-        if !scan_kind.accepts_dir_name(&name_str) {
+        if !scan_kind.accepts_dir_name(&name_str, repo_root) {
             continue;
         }
         let path = entry.path();
+        if matches!(scan_kind, ScanKind::SiblingClone)
+            && repo_root
+                .map(|root| path_matches_repo_root(&path, root))
+                .unwrap_or(false)
+        {
+            continue;
+        }
         let path_str = path.to_string_lossy().to_string();
         let branch = best_effort_branch(&path);
         let input = InsertInput {

--- a/crates/clud-bin/src/gc_tests.rs
+++ b/crates/clud-bin/src/gc_tests.rs
@@ -260,6 +260,111 @@ fn reconcile_extern_repos_dir_inserts_immediate_child_dirs() {
 }
 
 #[test]
+fn sibling_clone_name_matching_is_conservative() {
+    for name in [
+        "clud-pr-178",
+        "clud-release-v1",
+        "clud-issue-178",
+        "clud-wt-fix",
+        "soldr-wt-task",
+        "zccache-wt-task",
+    ] {
+        assert!(
+            is_sibling_clone_dir_name("clud", name),
+            "expected {name} to match"
+        );
+    }
+
+    for name in ["myrepo-wt-fix", "myrepo-issue-178"] {
+        assert!(
+            is_sibling_clone_dir_name("myrepo", name),
+            "expected repo-scoped {name} to match"
+        );
+    }
+
+    for name in [
+        "clud",
+        "agent-abc",
+        "dep-a",
+        "random-wt-task",
+        "random-issue-178",
+        "myrepo-pr-178",
+        "clud-pr-",
+        "soldr-wt-",
+        "zccache-wt-",
+    ] {
+        assert!(
+            !is_sibling_clone_dir_name("clud", name),
+            "expected {name} to be rejected"
+        );
+    }
+}
+
+#[test]
+fn reconcile_sibling_clones_dir_inserts_only_matching_siblings() {
+    let reg = fresh_registry("reconcile-sibling-clones");
+    let dir = tempfile::tempdir().unwrap();
+    let repo_root = dir.path().join("clud");
+    std::fs::create_dir_all(&repo_root).unwrap();
+
+    for name in [
+        "clud-wt-fix",
+        "clud-issue-178",
+        "clud-pr-178",
+        "soldr-wt-task",
+        "zccache-wt-task",
+    ] {
+        std::fs::create_dir_all(dir.path().join(name)).unwrap();
+    }
+    std::fs::create_dir_all(dir.path().join("random-wt-task")).unwrap();
+    std::fs::create_dir_all(dir.path().join("random-issue-178")).unwrap();
+    std::fs::write(dir.path().join("clud-release-file"), b"hi").unwrap();
+    std::fs::create_dir_all(dir.path().join("clud-release-v1").join("nested")).unwrap();
+
+    let res = reconcile_sibling_clones_dir(&reg, &repo_root).unwrap();
+    assert_eq!(res.inserted, 6);
+    assert_eq!(res.skipped, 0);
+
+    let rows = reg.list(None).unwrap();
+    let repo_root_str = repo_root.to_string_lossy().to_string();
+    assert_eq!(rows.len(), 6);
+    assert!(rows.iter().all(|r| r.kind == SIBLING_CLONE_KIND));
+    assert!(rows.iter().all(|r| r.agent_id.is_none()));
+    assert!(rows
+        .iter()
+        .all(|r| r.repo_root.as_deref() == Some(repo_root_str.as_str())));
+    assert!(rows.iter().any(|r| r.path.ends_with("clud-wt-fix")));
+    assert!(rows.iter().any(|r| r.path.ends_with("clud-issue-178")));
+    assert!(rows.iter().any(|r| r.path.ends_with("clud-pr-178")));
+    assert!(rows.iter().any(|r| r.path.ends_with("clud-release-v1")));
+    assert!(rows.iter().any(|r| r.path.ends_with("soldr-wt-task")));
+    assert!(rows.iter().any(|r| r.path.ends_with("zccache-wt-task")));
+    assert!(!rows.iter().any(|r| r.path.ends_with("random-wt-task")));
+    assert!(!rows.iter().any(|r| r.path.ends_with("random-issue-178")));
+    assert!(!rows.iter().any(|r| r.path.ends_with("nested")));
+    assert!(!rows.iter().any(|r| r.path.ends_with("clud")));
+}
+
+#[test]
+fn reconcile_repo_root_counts_sibling_clones() {
+    let reg = fresh_registry("reconcile-repo-root-count");
+    let dir = tempfile::tempdir().unwrap();
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(repo_root.join(".claude").join("worktrees").join("agent-a")).unwrap();
+    std::fs::create_dir_all(repo_root.join(".extern-repos").join("dep-a")).unwrap();
+    std::fs::create_dir_all(dir.path().join("repo-wt-fix")).unwrap();
+
+    let inserted = reconcile_repo_root(&reg, &repo_root).unwrap();
+    assert_eq!(inserted, 3);
+
+    let rows = reg.list(None).unwrap();
+    assert_eq!(rows.len(), 3);
+    assert!(rows.iter().any(|r| r.kind == WORKTREE_KIND));
+    assert!(rows.iter().any(|r| r.kind == EXTERN_REPO_KIND));
+    assert!(rows.iter().any(|r| r.kind == SIBLING_CLONE_KIND));
+}
+
+#[test]
 fn reconcile_dir_handles_missing_watch_dir() {
     let reg = fresh_registry("reconcile-missing");
     let dir = tempfile::tempdir().unwrap();

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -304,9 +304,10 @@ fn main() {
     }
     let _session_guard = startup::enforce_session_cap();
 
-    // Issue #110/#181: spawn background GC scanners. They poll the current
-    // repo's `.claude/worktrees/` and `.extern-repos/` directories every
-    // ~2s and insert newly-detected tracked entries.
+    // Issue #110/#181/#178: spawn background GC scanners. They poll the
+    // current repo's `.claude/worktrees/`, `.extern-repos/`, and sibling
+    // temp-clone directories every ~2s and insert newly-detected tracked
+    // entries.
     // Existing rows are left alone — the scanner is insert-only, no
     // write churn. `Drop` joins the worker thread; explicit `drop` below
     // sequences cancellation before the session-registry guard.
@@ -315,6 +316,7 @@ fn main() {
     }
     let _scanner_guard = gc::WorktreeScanner::maybe_spawn();
     let _extern_repo_scanner_guard = gc::WorktreeScanner::maybe_spawn_extern_repos();
+    let _sibling_clone_scanner_guard = gc::WorktreeScanner::maybe_spawn_sibling_clones();
 
     // Clear stale DONE/BLOCKED markers from a prior run so that loops don't
     // short-circuit on iteration 1. See loop_spec for semantics.
@@ -384,6 +386,7 @@ fn main() {
         let (summary, err) = runner::summarize_loop_outcome(exit_code);
         session.on_loop_end(summary, err);
     }
+    drop(_sibling_clone_scanner_guard);
     drop(_extern_repo_scanner_guard);
     drop(_scanner_guard);
     drop(_session_guard);

--- a/crates/clud-bin/src/worktrees.rs
+++ b/crates/clud-bin/src/worktrees.rs
@@ -19,8 +19,14 @@ use std::time::{Duration, SystemTime};
 
 use running_process::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
 
+use crate::gc::extract_pid_from_lock_reason;
+use crate::session_registry::{LivenessProbe, OsLivenessProbe};
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;
+
+pub const ENV_GC_LOCKED_HARD_AGE_DAYS: &str = "CLUD_GC_LOCKED_HARD_AGE_DAYS";
+const DEFAULT_GC_LOCKED_HARD_AGE_DAYS: u64 = 7;
+const SECS_PER_DAY: u64 = 86_400;
 
 /// One row of the porcelain output from `git worktree list --porcelain`.
 ///
@@ -34,8 +40,8 @@ pub struct WorktreeEntry {
     pub bare: bool,
     pub detached: bool,
     /// True when the porcelain block ends with a `locked` line.
-    /// Per `git-worktree(1)` docs we must never remove these even with
-    /// `--force`.
+    /// Live locks are skipped; stale dead/no-PID locks pass through a
+    /// hard-age gate before normal removal rules are applied.
     pub locked: bool,
     /// Optional human-readable reason that accompanies a `locked` line.
     /// Claude Code emits `locked claude agent agent-<id> (pid <pid>)`
@@ -75,6 +81,18 @@ impl WorktreeStatus {
     }
 }
 
+/// Liveness of a git-worktree lock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockStatus {
+    Unlocked,
+    /// Locked, but the lock reason did not contain a parseable PID.
+    NoPid,
+    /// Locked by a PID that is still alive.
+    LivePid(u32),
+    /// Locked by a PID that is no longer alive.
+    DeadPid(u32),
+}
+
 /// Inputs to the stale-detection predicate. Kept as a plain struct so the
 /// logic is trivial to unit-test without touching disk or `git`.
 #[derive(Debug, Clone, Copy)]
@@ -82,8 +100,11 @@ pub struct StalenessInputs {
     pub status: WorktreeStatus,
     /// Age of the worktree's working directory (mtime delta).
     pub age: Duration,
-    /// Locked worktrees are never stale (skipped from removal entirely).
-    pub locked: bool,
+    /// Liveness of any git-worktree lock.
+    pub lock_status: LockStatus,
+    /// Locked worktrees are presumed orphaned after this age, even if the
+    /// lock PID still appears live.
+    pub locked_hard_age: Duration,
 }
 
 /// Options gathered from the CLI flags.
@@ -172,15 +193,9 @@ pub fn run(opts: &CleanOptions) -> i32 {
     let mut removed = 0usize;
     let mut failed = 0usize;
     for c in &plan.candidates {
-        let mut args: Vec<&str> = vec!["worktree", "remove"];
-        if opts.force {
-            args.push("--force");
-        }
-        let path_str = c.entry.path.to_string_lossy().to_string();
-        args.push(&path_str);
-        match run_git(&main_repo, &args) {
-            Ok(_) => {
-                println!("removed {}", c.entry.path.display());
+        match remove_worktree_path(&main_repo, &c.entry.path, opts.force) {
+            Ok(note) => {
+                println!("removed {}{}", c.entry.path.display(), note);
                 removed += 1;
             }
             Err(e) => {
@@ -225,22 +240,26 @@ struct Plan {
 }
 
 fn build_plan(rows: &[Classified], opts: &CleanOptions) -> Plan {
+    let probe = OsLivenessProbe;
+    build_plan_with_liveness(rows, opts, &probe, locked_hard_age_from_env())
+}
+
+fn build_plan_with_liveness(
+    rows: &[Classified],
+    opts: &CleanOptions,
+    probe: &dyn LivenessProbe,
+    locked_hard_age: Duration,
+) -> Plan {
     let mut plan = Plan::default();
     for row in rows {
         if row.is_main {
             continue;
         }
-        if row.entry.locked {
-            plan.skipped.push(Candidate {
-                entry: row.entry.clone(),
-                reason: "locked".to_string(),
-            });
-            continue;
-        }
         let inputs = StalenessInputs {
             status: row.status,
             age: row.age,
-            locked: row.entry.locked,
+            lock_status: lock_status_for_entry(&row.entry, probe),
+            locked_hard_age,
         };
         match decide_action(inputs, opts) {
             Action::Remove(reason) => plan.candidates.push(Candidate {
@@ -257,6 +276,23 @@ fn build_plan(rows: &[Classified], opts: &CleanOptions) -> Plan {
     plan
 }
 
+fn lock_status_for_entry(entry: &WorktreeEntry, probe: &dyn LivenessProbe) -> LockStatus {
+    if !entry.locked {
+        return LockStatus::Unlocked;
+    }
+    let Some(reason) = entry.locked_reason.as_deref() else {
+        return LockStatus::NoPid;
+    };
+    let Some(pid) = extract_pid_from_lock_reason(reason) else {
+        return LockStatus::NoPid;
+    };
+    if probe.is_alive(pid) {
+        LockStatus::LivePid(pid)
+    } else {
+        LockStatus::DeadPid(pid)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Action {
     Remove(String),
@@ -266,11 +302,12 @@ enum Action {
 }
 
 fn decide_action(inputs: StalenessInputs, opts: &CleanOptions) -> Action {
-    if inputs.locked {
-        return Action::Skip("locked".to_string());
-    }
+    let lock_prefix = match locked_removal_prefix(inputs) {
+        Ok(prefix) => prefix,
+        Err(reason) => return Action::Skip(reason),
+    };
     let is_old = inputs.age >= opts.stale_after;
-    match inputs.status {
+    let action = match inputs.status {
         WorktreeStatus::Clean => {
             if is_old {
                 Action::Remove(format!("clean + stale ({})", fmt_age(inputs.age)))
@@ -313,7 +350,69 @@ fn decide_action(inputs: StalenessInputs, opts: &CleanOptions) -> Action {
                 Action::Skip("unpushed commits (use --force to remove)".to_string())
             }
         }
+    };
+    apply_lock_prefix(action, lock_prefix)
+}
+
+fn locked_removal_prefix(inputs: StalenessInputs) -> Result<Option<String>, String> {
+    match inputs.lock_status {
+        LockStatus::Unlocked => Ok(None),
+        LockStatus::LivePid(pid) => {
+            if inputs.age > inputs.locked_hard_age {
+                Ok(Some(format!(
+                    "stale lock (pid {pid} still alive; hard age exceeded)"
+                )))
+            } else {
+                Err(format!("locked (live pid {pid})"))
+            }
+        }
+        LockStatus::NoPid => {
+            if inputs.age > inputs.locked_hard_age {
+                Ok(Some("stale lock (no pid)".to_string()))
+            } else {
+                Err(format!(
+                    "locked (no pid; hard age not reached: {} <= {})",
+                    fmt_age(inputs.age),
+                    fmt_age(inputs.locked_hard_age)
+                ))
+            }
+        }
+        LockStatus::DeadPid(pid) => {
+            if inputs.age > inputs.locked_hard_age {
+                Ok(Some(format!("stale lock (dead pid {pid})")))
+            } else {
+                Err(format!(
+                    "locked (dead pid {pid}; hard age not reached: {} <= {})",
+                    fmt_age(inputs.age),
+                    fmt_age(inputs.locked_hard_age)
+                ))
+            }
+        }
     }
+}
+
+fn apply_lock_prefix(action: Action, lock_prefix: Option<String>) -> Action {
+    let Some(prefix) = lock_prefix else {
+        return action;
+    };
+    match action {
+        Action::Remove(reason) => Action::Remove(format!("{prefix}; {reason}")),
+        Action::Skip(reason) => Action::Skip(format!("{prefix}; {reason}")),
+        Action::Ignore => Action::Ignore,
+    }
+}
+
+fn locked_hard_age_from_env() -> Duration {
+    let raw = std::env::var(ENV_GC_LOCKED_HARD_AGE_DAYS).ok();
+    locked_hard_age_from_raw(raw.as_deref())
+}
+
+fn locked_hard_age_from_raw(raw: Option<&str>) -> Duration {
+    let days = raw
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_GC_LOCKED_HARD_AGE_DAYS);
+    let secs = days.saturating_mul(SECS_PER_DAY);
+    Duration::from_secs(secs)
 }
 
 pub(crate) fn fmt_age(d: Duration) -> String {
@@ -377,6 +476,115 @@ fn confirm_interactive(n: usize) -> bool {
         return false;
     }
     matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemovalOutcome {
+    GitRemove,
+    FallbackAfterGitSuccess,
+    FallbackAfterGitFailure,
+    PrunedAfterGitFailure,
+}
+
+impl RemovalOutcome {
+    fn note(self) -> &'static str {
+        match self {
+            Self::GitRemove => "",
+            Self::FallbackAfterGitSuccess => " (direct fallback after git reported success)",
+            Self::FallbackAfterGitFailure => " (direct fallback after git remove failed)",
+            Self::PrunedAfterGitFailure => " (path already gone; pruned stale git metadata)",
+        }
+    }
+}
+
+pub(crate) fn remove_worktree_path(
+    main_repo: &Path,
+    path: &Path,
+    force: bool,
+) -> Result<&'static str, String> {
+    remove_worktree_path_with_git(main_repo, path, force, run_git).map(RemovalOutcome::note)
+}
+
+fn remove_worktree_path_with_git<F>(
+    main_repo: &Path,
+    path: &Path,
+    force: bool,
+    git: F,
+) -> Result<RemovalOutcome, String>
+where
+    F: Fn(&Path, &[&str]) -> Result<String, String>,
+{
+    let mut args: Vec<&str> = vec!["worktree", "remove"];
+    if force {
+        args.push("--force");
+    }
+    let path_str = path.to_string_lossy().to_string();
+    args.push(&path_str);
+
+    match git(main_repo, &args) {
+        Ok(_) => {
+            if !path_try_exists(path)? {
+                return Ok(RemovalOutcome::GitRemove);
+            }
+            fallback_remove_and_prune(main_repo, path, &git).map_err(|fallback_err| {
+                format!(
+                    "git worktree remove reported success but {} still exists; fallback failed: {fallback_err}",
+                    path.display()
+                )
+            })?;
+            Ok(RemovalOutcome::FallbackAfterGitSuccess)
+        }
+        Err(git_err) => {
+            if path_try_exists(path)? {
+                fallback_remove_and_prune(main_repo, path, &git).map_err(|fallback_err| {
+                    format!(
+                        "git worktree remove failed: {git_err}; fallback failed: {fallback_err}"
+                    )
+                })?;
+                Ok(RemovalOutcome::FallbackAfterGitFailure)
+            } else {
+                best_effort_unlock_and_prune_worktree(main_repo, path, &git);
+                Ok(RemovalOutcome::PrunedAfterGitFailure)
+            }
+        }
+    }
+}
+
+fn fallback_remove_and_prune<F>(main_repo: &Path, path: &Path, git: &F) -> Result<(), String>
+where
+    F: Fn(&Path, &[&str]) -> Result<String, String>,
+{
+    if path_try_exists(path)? {
+        match std::fs::remove_dir_all(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(format!("remove_dir_all({}): {e}", path.display()));
+            }
+        }
+    }
+    if path_try_exists(path)? {
+        return Err(format!(
+            "{} still exists after remove_dir_all",
+            path.display()
+        ));
+    }
+    best_effort_unlock_and_prune_worktree(main_repo, path, git);
+    Ok(())
+}
+
+fn best_effort_unlock_and_prune_worktree<F>(main_repo: &Path, path: &Path, git: &F)
+where
+    F: Fn(&Path, &[&str]) -> Result<String, String>,
+{
+    let path_str = path.to_string_lossy().to_string();
+    let _ = git(main_repo, &["worktree", "unlock", &path_str]);
+    let _ = git(main_repo, &["worktree", "prune", "--expire=now"]);
+}
+
+fn path_try_exists(path: &Path) -> Result<bool, String> {
+    path.try_exists()
+        .map_err(|e| format!("checking whether {} exists: {e}", path.display()))
 }
 
 // ---------- git-side helpers ----------

--- a/crates/clud-bin/src/worktrees_tests.rs
+++ b/crates/clud-bin/src/worktrees_tests.rs
@@ -243,121 +243,125 @@ fn opts(stale_after: Duration, force: bool) -> CleanOptions {
     }
 }
 
+fn days(n: u64) -> Duration {
+    Duration::from_secs(86_400 * n)
+}
+
+fn inputs(status: WorktreeStatus, age: Duration) -> StalenessInputs {
+    StalenessInputs {
+        status,
+        age,
+        lock_status: LockStatus::Unlocked,
+        locked_hard_age: days(7),
+    }
+}
+
+fn locked_inputs(
+    status: WorktreeStatus,
+    age: Duration,
+    lock_status: LockStatus,
+) -> StalenessInputs {
+    StalenessInputs {
+        status,
+        age,
+        lock_status,
+        locked_hard_age: days(7),
+    }
+}
+
 #[test]
 fn decide_clean_and_old_is_removed() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::Clean,
-        age: Duration::from_secs(86_400 * 2),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), false));
+    let act = decide_action(
+        inputs(WorktreeStatus::Clean, days(2)),
+        &opts(Duration::from_secs(86_400), false),
+    );
     assert!(matches!(act, Action::Remove(_)));
 }
 
 #[test]
 fn decide_clean_but_fresh_is_ignored() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::Clean,
-        age: Duration::from_secs(60),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), false));
+    let act = decide_action(
+        inputs(WorktreeStatus::Clean, Duration::from_secs(60)),
+        &opts(Duration::from_secs(86_400), false),
+    );
     assert_eq!(act, Action::Ignore);
 }
 
 #[test]
 fn decide_branch_gone_is_always_removed() {
     // Even when fresh, a [gone] upstream → remove.
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::BranchGone,
-        age: Duration::from_secs(1),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), false));
+    let act = decide_action(
+        inputs(WorktreeStatus::BranchGone, Duration::from_secs(1)),
+        &opts(Duration::from_secs(86_400), false),
+    );
     assert!(matches!(act, Action::Remove(_)));
 }
 
 #[test]
 fn decide_dirty_without_force_is_skipped() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::Dirty,
-        age: Duration::from_secs(86_400 * 30),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), false));
+    let act = decide_action(
+        inputs(WorktreeStatus::Dirty, days(30)),
+        &opts(Duration::from_secs(86_400), false),
+    );
     assert!(matches!(act, Action::Skip(_)));
 }
 
 #[test]
 fn decide_dirty_with_force_is_removed() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::Dirty,
-        age: Duration::from_secs(86_400 * 30),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), true));
+    let act = decide_action(
+        inputs(WorktreeStatus::Dirty, days(30)),
+        &opts(Duration::from_secs(86_400), true),
+    );
     assert!(matches!(act, Action::Remove(_)));
 }
 
 #[test]
 fn decide_unpushed_without_force_is_skipped() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::Unpushed,
-        age: Duration::from_secs(86_400 * 30),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), false));
+    let act = decide_action(
+        inputs(WorktreeStatus::Unpushed, days(30)),
+        &opts(Duration::from_secs(86_400), false),
+    );
     assert!(matches!(act, Action::Skip(_)));
 }
 
 #[test]
 fn decide_unpushed_with_force_is_removed() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::Unpushed,
-        age: Duration::from_secs(86_400 * 30),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), true));
+    let act = decide_action(
+        inputs(WorktreeStatus::Unpushed, days(30)),
+        &opts(Duration::from_secs(86_400), true),
+    );
     assert!(matches!(act, Action::Remove(_)));
 }
 
 #[test]
 fn decide_no_upstream_fresh_is_ignored() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::NoUpstream,
-        age: Duration::from_secs(60),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), false));
+    let act = decide_action(
+        inputs(WorktreeStatus::NoUpstream, Duration::from_secs(60)),
+        &opts(Duration::from_secs(86_400), false),
+    );
     assert_eq!(act, Action::Ignore);
 }
 
 #[test]
 fn decide_no_upstream_stale_skipped_without_force() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::NoUpstream,
-        age: Duration::from_secs(86_400 * 30),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), false));
+    let act = decide_action(
+        inputs(WorktreeStatus::NoUpstream, days(30)),
+        &opts(Duration::from_secs(86_400), false),
+    );
     assert!(matches!(act, Action::Skip(_)));
 }
 
 #[test]
 fn decide_no_upstream_stale_removed_with_force() {
-    let inputs = StalenessInputs {
-        status: WorktreeStatus::NoUpstream,
-        age: Duration::from_secs(86_400 * 30),
-        locked: false,
-    };
-    let act = decide_action(inputs, &opts(Duration::from_secs(86_400), true));
+    let act = decide_action(
+        inputs(WorktreeStatus::NoUpstream, days(30)),
+        &opts(Duration::from_secs(86_400), true),
+    );
     assert!(matches!(act, Action::Remove(_)));
 }
 
-/// Locked worktrees must NEVER be removed — not even with `--force`.
-/// This is the critical safety invariant the issue calls out.
 #[test]
-fn decide_locked_never_removed_even_with_force() {
+fn decide_fresh_live_locks_are_skipped_even_with_force() {
     for status in [
         WorktreeStatus::Clean,
         WorktreeStatus::Dirty,
@@ -365,17 +369,240 @@ fn decide_locked_never_removed_even_with_force() {
         WorktreeStatus::NoUpstream,
         WorktreeStatus::BranchGone,
     ] {
-        let inputs = StalenessInputs {
-            status,
-            age: Duration::from_secs(86_400 * 365),
-            locked: true,
-        };
-        let act = decide_action(inputs, &opts(Duration::from_secs(86_400), true));
+        let act = decide_action(
+            locked_inputs(status, days(7), LockStatus::LivePid(12345)),
+            &opts(Duration::from_secs(86_400), true),
+        );
         assert!(
             matches!(act, Action::Skip(_)),
-            "locked + {status:?} must be Skip, got {act:?}"
+            "live locked + {status:?} must be Skip, got {act:?}"
         );
     }
+}
+
+#[test]
+fn decide_stale_live_lock_can_remove_clean_worktree_after_hard_age() {
+    let act = decide_action(
+        locked_inputs(WorktreeStatus::Clean, days(8), LockStatus::LivePid(12345)),
+        &opts(Duration::from_secs(86_400), false),
+    );
+    let Action::Remove(reason) = act else {
+        panic!("expected hard-aged live lock to be removable when clean, got {act:?}");
+    };
+    assert!(reason.contains("stale lock (pid 12345 still alive; hard age exceeded)"));
+    assert!(reason.contains("clean + stale"));
+}
+
+#[test]
+fn decide_fresh_dead_or_unknown_locks_are_skipped() {
+    for lock_status in [LockStatus::DeadPid(12345), LockStatus::NoPid] {
+        let act = decide_action(
+            locked_inputs(WorktreeStatus::BranchGone, days(7), lock_status),
+            &opts(Duration::from_secs(86_400), true),
+        );
+        assert!(
+            matches!(act, Action::Skip(_)),
+            "{lock_status:?} at hard-age boundary must be skipped, got {act:?}"
+        );
+    }
+}
+
+#[test]
+fn decide_stale_dead_lock_can_remove_clean_worktree() {
+    let act = decide_action(
+        locked_inputs(WorktreeStatus::Clean, days(8), LockStatus::DeadPid(12345)),
+        &opts(Duration::from_secs(86_400), false),
+    );
+    let Action::Remove(reason) = act else {
+        panic!("expected stale dead lock to be removable when clean, got {act:?}");
+    };
+    assert!(reason.contains("stale lock (dead pid 12345)"));
+    assert!(reason.contains("clean + stale"));
+}
+
+#[test]
+fn decide_stale_no_pid_lock_can_remove_branch_gone_worktree() {
+    let act = decide_action(
+        locked_inputs(WorktreeStatus::BranchGone, days(8), LockStatus::NoPid),
+        &opts(Duration::from_secs(86_400), false),
+    );
+    let Action::Remove(reason) = act else {
+        panic!("expected stale no-pid lock to be removable when branch is gone, got {act:?}");
+    };
+    assert!(reason.contains("stale lock (no pid)"));
+    assert!(reason.contains("upstream branch gone"));
+}
+
+#[test]
+fn decide_stale_dead_lock_still_requires_force_for_dirty_worktree() {
+    let without_force = decide_action(
+        locked_inputs(WorktreeStatus::Dirty, days(8), LockStatus::DeadPid(12345)),
+        &opts(Duration::from_secs(86_400), false),
+    );
+    assert!(matches!(without_force, Action::Skip(_)));
+
+    let with_force = decide_action(
+        locked_inputs(WorktreeStatus::Dirty, days(8), LockStatus::DeadPid(12345)),
+        &opts(Duration::from_secs(86_400), true),
+    );
+    assert!(matches!(with_force, Action::Remove(_)));
+}
+
+#[test]
+fn locked_hard_age_defaults_to_seven_days() {
+    assert_eq!(locked_hard_age_from_raw(None), days(7));
+    assert_eq!(locked_hard_age_from_raw(Some("3")), days(3));
+    assert_eq!(locked_hard_age_from_raw(Some("not-a-number")), days(7));
+}
+
+fn classified_locked(
+    name: &str,
+    status: WorktreeStatus,
+    age: Duration,
+    reason: Option<&str>,
+) -> Classified {
+    Classified {
+        entry: WorktreeEntry {
+            path: PathBuf::from(format!("/tmp/{name}")),
+            head: None,
+            branch: None,
+            bare: false,
+            detached: false,
+            locked: true,
+            locked_reason: reason.map(str::to_string),
+            prunable: false,
+        },
+        status,
+        age,
+        is_main: false,
+    }
+}
+
+#[test]
+fn build_plan_uses_lock_reason_pid_liveness() {
+    let rows = vec![
+        classified_locked(
+            "live",
+            WorktreeStatus::Clean,
+            days(6),
+            Some("claude agent agent-live (pid 111)"),
+        ),
+        classified_locked(
+            "dead",
+            WorktreeStatus::Clean,
+            days(8),
+            Some("claude agent agent-dead (pid 222)"),
+        ),
+    ];
+    let probe = crate::session_registry::MockLivenessProbe::with_alive([111]);
+    let plan = build_plan_with_liveness(&rows, &opts(days(1), false), &probe, days(7));
+
+    assert_eq!(plan.candidates.len(), 1);
+    assert!(plan.candidates[0].entry.path.ends_with("dead"));
+    assert!(plan.candidates[0].reason.contains("dead pid 222"));
+    assert_eq!(plan.skipped.len(), 1);
+    assert!(plan.skipped[0].entry.path.ends_with("live"));
+    assert!(plan.skipped[0].reason.contains("live pid 111"));
+}
+
+#[test]
+fn remove_worktree_path_falls_back_when_git_success_leaves_dir() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    let wt = tmp.path().join("wt");
+    std::fs::create_dir_all(&repo).expect("repo dir");
+    std::fs::create_dir_all(&wt).expect("worktree dir");
+    std::fs::write(wt.join("file.txt"), "content").expect("worktree file");
+
+    let calls = std::cell::RefCell::new(Vec::<Vec<String>>::new());
+    let outcome = remove_worktree_path_with_git(&repo, &wt, false, |cwd, args| {
+        assert_eq!(cwd, repo.as_path());
+        calls
+            .borrow_mut()
+            .push(args.iter().map(|s| s.to_string()).collect());
+        Ok(String::new())
+    })
+    .expect("fallback should remove directory and prune");
+
+    assert_eq!(outcome, RemovalOutcome::FallbackAfterGitSuccess);
+    assert!(!wt.exists());
+    let calls = calls.into_inner();
+    assert_eq!(
+        calls[0],
+        vec![
+            "worktree".to_string(),
+            "remove".to_string(),
+            wt.to_string_lossy().to_string()
+        ]
+    );
+    assert_eq!(
+        calls[1],
+        vec![
+            "worktree".to_string(),
+            "unlock".to_string(),
+            wt.to_string_lossy().to_string()
+        ]
+    );
+    assert_eq!(
+        calls[2],
+        vec![
+            "worktree".to_string(),
+            "prune".to_string(),
+            "--expire=now".to_string()
+        ]
+    );
+}
+
+#[test]
+fn remove_worktree_path_falls_back_when_git_remove_fails_and_dir_remains() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    let wt = tmp.path().join("wt");
+    std::fs::create_dir_all(&repo).expect("repo dir");
+    std::fs::create_dir_all(&wt).expect("worktree dir");
+
+    let wt_arg = wt.to_string_lossy().to_string();
+    let calls = std::cell::RefCell::new(Vec::<Vec<String>>::new());
+    let outcome = remove_worktree_path_with_git(&repo, &wt, true, |_, args| {
+        calls
+            .borrow_mut()
+            .push(args.iter().map(|s| s.to_string()).collect());
+        if args == ["worktree", "remove", "--force", wt_arg.as_str()] {
+            Err("locked worktree".to_string())
+        } else {
+            Ok(String::new())
+        }
+    })
+    .expect("fallback should remove directory and prune");
+
+    assert_eq!(outcome, RemovalOutcome::FallbackAfterGitFailure);
+    assert!(!wt.exists());
+    let calls = calls.into_inner();
+    assert_eq!(
+        calls[0],
+        vec![
+            "worktree".to_string(),
+            "remove".to_string(),
+            "--force".to_string(),
+            wt.to_string_lossy().to_string()
+        ]
+    );
+    assert_eq!(
+        calls[1],
+        vec![
+            "worktree".to_string(),
+            "unlock".to_string(),
+            wt.to_string_lossy().to_string()
+        ]
+    );
+    assert_eq!(
+        calls[2],
+        vec![
+            "worktree".to_string(),
+            "prune".to_string(),
+            "--expire=now".to_string()
+        ]
+    );
 }
 
 #[test]

--- a/docs/architecture/gc-and-registry.md
+++ b/docs/architecture/gc-and-registry.md
@@ -2,8 +2,9 @@
 
 `clud` maintains two separate `redb` databases for two separate concerns: a per-launch
 **session cap** that bounds how many sibling `clud` processes may run concurrently, and a
-**tracked-entry GC** that owns the lifecycle of `.claude/worktrees/agent-*` directories across
-repos and across invocations. The two stores live in different files, on different code paths,
+**tracked-entry GC** that owns the lifecycle of `.claude/worktrees/agent-*`, `.extern-repos/*`,
+and known sibling temp-clone directories across repos and across invocations. The two stores live
+in different files, on different code paths,
 with different ownership models — they have nothing to do with each other besides both being
 `redb`-backed, and confusing them is the single fastest way to wedge the system. This doc covers
 both, plus the worktree scanner that feeds the GC store and the unrelated `--clean-worktrees`
@@ -14,7 +15,7 @@ subcommand.
 | File | Concern | Ownership | Lifetime |
 |---|---|---|---|
 | `sessions.redb` (POSIX: `$XDG_STATE_HOME/clud/`; Windows: `%LOCALAPPDATA%\clud\`) | Per-launch session cap | File-lock serialized via `sessions.lock` | Opened for ms at startup and again at shutdown; never across the session |
-| `~/.clud/data.redb` | Tracked-entry GC (`agent-*` worktrees) | Single-owner: the always-on `clud __daemon` process owns it via the in-process `daemon/gc_service.rs` registry-worker thread; everyone else uses JSON-over-TCP | Opened once at daemon startup; lives until the daemon idle-shuts |
+| `~/.clud/data.redb` | Tracked-entry GC (`agent-*` worktrees, extern repos, sibling temp clones) | Single-owner: the always-on `clud __daemon` process owns it via the in-process `daemon/gc_service.rs` registry-worker thread; everyone else uses JSON-over-TCP | Opened once at daemon startup; lives until the daemon idle-shuts |
 
 Why two files? The session cap is a *guardrail* — it needs the simplest possible "open, decide,
 close" semantics so a crashed `clud` can never deadlock the next one. The tracked-entry GC is a
@@ -127,22 +128,25 @@ All three subcommands are thin IPC clients against the daemon. `--no-daemon` (or
 - **`clud gc purge [--duration 7d] [--kind worktree] [--dry-run] [--yes]`** — `cmd_purge`
   pre-validates the duration string locally, then calls `daemon::gc_client_purge`. The daemon
   selects candidates (all rows, or rows older than `now - duration`), partitions out
-  live-locked worktrees, and either reports the count (dry-run) or runs `git worktree remove
-  --force` (falling back to `remove_dir_all` if git refuses) and deletes the row. Bare
+  live-locked worktrees or live session CWD ancestors, and either reports the count (dry-run) or
+  runs verified removal. Worktree rows use `git worktree remove --force`; if git fails or reports
+  success while the directory survives, clud falls back to direct removal plus `git worktree prune`.
+  Bare
   `clud gc purge` (no `--duration`) is interactive and asks for `y/N` confirmation unless
   `--yes`.
 - **`clud gc reconcile`** — `cmd_reconcile` calls `daemon::gc_client_reconcile` with the
-  current repo root. The daemon walks `<repo>/.claude/worktrees/` and inserts any agent-*
-  subdir that isn't already tracked. Returns the count of new rows.
+  current repo root. The daemon walks `<repo>/.claude/worktrees/`, `<repo>/.extern-repos/`, and
+  conservative sibling temp-clone names next to the repo. Returns the count of new rows.
 
 Bare `clud gc` (no subcommand) prints help and exits 0 without contacting the daemon
 (`crates/clud-bin/src/gc.rs:591`).
 
 ## Worktree scanner
 
-`WorktreeScanner` (`crates/clud-bin/src/gc.rs:459`) is a polling thread spawned at clud startup
-from `main.rs:296` via `WorktreeScanner::maybe_spawn()`. It walks `<repo>/.claude/worktrees/`
-every ~2 seconds and sends `gc.insert` IPC ops for any `agent-*` subdir it sees. The scanner is
+`WorktreeScanner` (`crates/clud-bin/src/gc.rs`) is a polling thread spawned at clud startup
+from `main.rs` via `WorktreeScanner::maybe_spawn*()`. It walks `<repo>/.claude/worktrees/`,
+`<repo>/.extern-repos/`, and conservative sibling temp-clone names every ~2 seconds and sends
+`gc.insert` IPC ops for matching immediate subdirs it sees. The scanner is
 **insert-only**: rows that already exist are no-ops (`Registry::insert_if_new` at
 `crates/clud-bin/src/gc.rs:198`), so there is no per-cycle write churn.
 
@@ -169,9 +173,11 @@ It enumerates via `git worktree list --porcelain`, classifies each entry as
 and removes those that are *safe* — clean AND (older than `--stale-after` OR upstream `[gone]`).
 `--force` widens the safe set to include `dirty` and `unpushed`.
 
-**Locked worktrees are never removed, even with `--force`**
-(`crates/clud-bin/src/worktrees.rs:268`). `--dry-run` is a faithful preview: nothing is mutated
-until the actual `git worktree remove` invocation.
+Locked worktrees with fresh live/unknown/dead lock reasons are skipped. Once a lock exceeds
+`CLUD_GC_LOCKED_HARD_AGE_DAYS` (default 7), `--clean-worktrees` presumes it is orphaned and lets
+the entry pass through the same clean/dirty/unpushed/no-upstream/force rules as an unlocked
+worktree. `--dry-run` is a faithful preview: nothing is mutated until the actual verified
+worktree removal path.
 
 The GC daemon does borrow `parse_worktree_porcelain` and the "extract pid from locked-reason"
 helper from this module to compute the `live_locked` flag on `gc.list` output, but the two flows


### PR DESCRIPTION
﻿## Summary
- add daemon low-disk watchdog thresholds and auto-purge for old tracked worktrees/sibling clones
- add PID-aware hard-age handling for locked worktrees plus verified worktree removal fallback
- track conservative sibling temp clone directories in reconcile/scanners and document the updated GC model

Closes #178

## Validation
- soldr cargo fmt --check
- git diff --check origin/main..HEAD
- soldr cargo test -p clud gc::tests --lib
- soldr cargo test -p clud worktrees --lib
- soldr cargo test -p clud daemon::gc_service --lib
- bash lint
