### PR TITLE
Bump version to 2.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "base64",
  "clap",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.15"
+version = "2.0.16"
 dependencies = [
  "libc",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.15"
+version = "2.0.16"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.15"
+version = "2.0.16"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clud/__init__.py
+++ b/src/clud/__init__.py
@@ -1,3 +1,3 @@
 """clud — Fast Rust CLI for running Claude Code and Codex in YOLO mode."""
 
-__version__ = "2.0.15"
+__version__ = "2.0.16"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.15"
+version = "2.0.16"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Bump clud from 2.0.15 to 2.0.16 after the Linux release-wheel fix landed.
- Keep Rust, Python, and lockfile metadata aligned for the auto-release preflight.

## Verification
- `uv run python -m pytest tests/test_packaging_metadata.py tests/test_build_wheel.py`
- `cargo metadata --locked --no-deps --format-version 1`