### PR TITLE
[codex] Lower free license cutoff

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -29,10 +29,10 @@ consultants, and other staff, whether full-time or part-time.
 "Qualified Free User" means either:
 
 - an individual using the Software for that individual's own benefit; or
-- an Organization with a People Count of fewer than 20 people at the time it
+- an Organization with a People Count of fewer than 6 people at the time it
   uses the Software.
 
-"Large Organization" means an Organization with a People Count of 20 or more
+"Large Organization" means an Organization with a People Count of 6 or more
 people.
 
 2. Free License for Qualified Free Users

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ bash test --integration     # Include integration tests with mock agents
 ## License
 
 Clud Proprietary License. Free use is available for individuals and
-organizations under 20 people, with lifetime grandfathering for organizations
+organizations under 6 people, with lifetime grandfathering for organizations
 that qualified before growing beyond that size. Larger organizations need a
 commercial license unless they have a grandfathered or contributor-granted free
 license. See [LICENSE](LICENSE) for the full terms.


### PR DESCRIPTION
﻿## Summary

- lower the free-use organization cutoff in the Clud Proprietary License from fewer than 20 people to fewer than 6 people
- update the README license summary to match

## Validation

- searched license-facing files for stale 20-person cutoff wording
- `git diff --check`
