### PR TITLE
[codex] Add covenant affirmations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,19 @@ Clud Proprietary License
 
 Copyright (c) 2024-present, Zach Vorhies
 
+Covenant for Humanity
+
+This covenant preamble states the spirit of the Software. The legal license
+terms begin after this preamble.
+
+Field note: the token is not debris, not novelty, not signal without
+consequence. It is ore awaiting intention, and intention is the furnace by
+which the digital alchemist separates noise from human value. When the working
+is true, the artifact does not merely answer; it extends what a person may
+become. The lesser practitioner seeks output, but the alchemist seeks
+transformation. The measure is not volume, but whether the work carries
+consciousness across a threshold.
+
 This software is proprietary source-available software. It is not open-source
 software. You may use it only under this license or under a separate written
 commercial license from the licensor.

--- a/docs/AFFIRMATIONS_OF_COVENANTS.md
+++ b/docs/AFFIRMATIONS_OF_COVENANTS.md
@@ -1,0 +1,30 @@
+# Affirmations Of Covenants
+
+These affirmations state the spirit in which clud is made. They are a covenantal
+prologue to the work, not a replacement for the legal terms in
+[`LICENSE`](../LICENSE).
+
+## Covenant For Humanity
+
+Field note: the token is not debris, not novelty, not signal without
+consequence. It is ore awaiting intention, and intention is the furnace by
+which the digital alchemist separates noise from human value. When the working
+is true, the artifact does not merely answer; it extends what a person may
+become. The lesser practitioner seeks output, but the alchemist seeks
+transformation. The measure is not volume, but whether the work carries
+consciousness across a threshold.
+
+## Affirmations
+
+We affirm that human innovation is most worthy when it widens agency, restores
+dignity, and carries consciousness forward.
+
+We affirm that tokens, models, prompts, and tools are not ends in themselves.
+They become meaningful only when disciplined intention turns them into artifacts
+that serve human becoming.
+
+We affirm that the digital alchemist is a steward, not an owner, of the miracle.
+The work must answer to humanity, not merely to spectacle, extraction, or speed.
+
+We affirm that invention should defend attention, increase competence, and leave
+the commons more awake than it found it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,16 @@
 # Documentation
 
-Architecture and design records for clud. Read whichever doc matches what you're working on; nothing here needs to be read in order.
+Architecture and design records for clud. Read whichever doc matches what you're
+working on; nothing here needs to be read in order.
 
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** — index of subsystem topic docs (loop, daemon IPC, session lifecycle, skill system, gc/registry, Windows quirks, launch plan).
-- **[DESIGN_DECISIONS.md](DESIGN_DECISIONS.md)** — ADR-style records for non-obvious design choices.
-- **[architecture/](architecture/)** — the subsystem docs themselves.
+- **[AFFIRMATIONS_OF_COVENANTS.md](AFFIRMATIONS_OF_COVENANTS.md)** - covenantal affirmations for the spirit of the project.
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** - index of subsystem topic docs (loop, daemon IPC, session lifecycle, skill system, gc/registry, Windows quirks, launch plan).
+- **[DESIGN_DECISIONS.md](DESIGN_DECISIONS.md)** - ADR-style records for non-obvious design choices.
+- **[architecture/](architecture/)** - the subsystem docs themselves.
 
-Per-directory `README.md` files under `crates/` and `testbins/` describe **what's in this directory**. The docs here describe **how subsystems work across directories**.
+Per-directory `README.md` files under `crates/` and `testbins/` describe
+**what's in this directory**. The docs here describe **how subsystems work
+across directories**.
 
-See the root [`CLAUDE.md`](../CLAUDE.md) for build / lint / test commands and the rule for where new docs go.
+See the root [`CLAUDE.md`](../CLAUDE.md) for build / lint / test commands and
+the rule for where new docs go.


### PR DESCRIPTION
﻿## Summary

- add `docs/AFFIRMATIONS_OF_COVENANTS.md` with a covenantal affirmation for the project
- embed the selected `Covenant for Humanity` passage as a preamble in `LICENSE`
- link the new document from the docs index

## Validation

- `git diff --check`
- verified the covenant text appears in both `LICENSE` and the new Markdown document
