### PR TITLE
ci: bump setup-soldr v0.9.55 -> v0.9.56

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -69,7 +69,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -59,7 +59,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -54,7 +54,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -54,7 +54,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.55` to `v0.9.56`.

## What's in v0.9.56
Fixes v0.9.55's parentSha derivation on shallow checkouts (the default `actions/checkout` config with `fetch-depth: 1`). Production observation on zccache MSRV (run 26799669322):
```
parent-sha: unexpected git output "\n"; leaving empty
cook: layered keys ... (no parent-fallback — parentSha unavailable, #365)
cook-cache-delta MISS
```

`git log -1 --format=%P HEAD` returns empty for grafted root commits on shallow clones. v0.9.56 adds a `git cat-file -p HEAD` fallback that parses the raw commit object — its `parent` header line is preserved even when the parent commit isn't fetched. This finally activates the cook-cache-delta / target-cache / cargo-registry parent-SHA fallback restore keys.

## Test plan
- [ ] CI green
- [ ] Log shows `parent-sha: derived <sha> from cat-file (#365, shallow-safe)`
- [ ] `cook: layered keys ... delta-fallback=cook-delta-v2-...-g<parent-sha>` appears
- [ ] Second commit after this lands: cook-cache-delta should HIT against this commit's saved entry
