### PR TITLE
feat: add terminal graphics headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +158,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +202,38 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -302,7 +352,9 @@ dependencies = [
  "ctrlc",
  "dirs",
  "fs4",
+ "icy_sixel",
  "ignore",
+ "image",
  "libc",
  "open",
  "redb",
@@ -415,6 +467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -616,10 +677,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -643,6 +719,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -680,6 +766,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -868,6 +960,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +1010,21 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1172,6 +1289,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1317,16 @@ dependencies = [
  "libc",
  "serde_json",
  "terminal_size",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1324,6 +1461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1460,6 +1598,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "bytemuck",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1687,19 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "portable-pty"
@@ -1666,6 +1850,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float",
+ "palette",
+ "rand",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +1889,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rayon"
@@ -1727,6 +1967,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1785,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22df5d7f7c1ca3f94fa65f91607ab4c86e3ce2ce81e617d646abb2a53c055181"
+checksum = "cf6af745b2eae268acd599134ede3b7939b0b410bb24168f0608c6913597cd81"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1875,6 +2135,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -2029,6 +2298,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,6 +2399,12 @@ dependencies = [
  "objc2-io-kit",
  "windows 0.61.3",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2594,6 +2875,16 @@ dependencies = [
  "cmake",
  "fs_extra",
  "semver",
+]
+
+[[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -3140,6 +3431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,3 +3527,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ clud --codex                      # Use Codex as the backend
 clud --claude                     # Use Claude as the backend (default)
 clud --pty                        # Force PTY launch mode
 clud --subprocess                 # Force subprocess launch mode
+clud --pty --graphics=sixel       # Force a Sixel header above PTY output
 clud --detach -p "review this PR" # Start a daemon-managed session without attaching
 clud --detachable -p "fix CI"     # Ctrl+C asks whether to keep the session in background
 clud --transcript session.log -p "debug this" # Tee daemon session output to a file
@@ -90,6 +91,8 @@ clud wasm guest.wasm              # Run a local wasm module with clud's embedded
 | `--codex` | Use Codex as the backend |
 | `--subprocess` | Force subprocess launch mode |
 | `--pty` | Force PTY launch mode |
+| `--graphics <auto\|off\|sixel>` | Control PTY graphics headers. `auto` only enables Sixel from a live terminal probe |
+| `--graphics-image <PATH>` | Render a custom image as the PTY graphics header when Sixel is enabled |
 | `--detach` | Start a daemon-managed session directly in the background |
 | `--detachable` | Run attached under the daemon; `Ctrl+C` prompts whether to background or end |
 | `--transcript <PATH>` | Tee daemon-managed session output bytes to a transcript file |
@@ -104,6 +107,21 @@ Unknown flags are forwarded directly to the backend agent.
 
 `clud` now defaults to subprocess launch mode for Claude and Codex. Use `--pty`
 to opt back into PTY while Claude PTY issues are being investigated.
+
+## PTY Graphics Headers
+
+PTY sessions can reserve a small header area above the backend terminal and
+draw a Sixel image there. `--graphics=auto` is conservative: it only enables
+the header when `running-process` reports Sixel as supported from a live probe
+of the current terminal. Missing metadata, non-TTY attaches, blocked terminals,
+and host-name-only hints stay text-only. Use `--graphics=off` to disable the
+feature or `--graphics=sixel` to force it.
+
+By default clud renders a small bundled banner. Pass `--graphics-image <PATH>`
+to use a PNG or JPEG instead. Direct PTY launches reserve rows before the
+backend starts. Daemon-managed sessions decide at attach time, because the
+detached worker does not know which terminal will attach later; reattach and
+resize paths redraw the header where the terminal reports support.
 
 ## Codex Support
 

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -42,7 +42,9 @@ redb = "2"
 # the redb-open window to a few milliseconds at startup/shutdown so
 # concurrent launches serialize cleanly.
 fs4 = "0.13"
-running-process = { version = "4.0.2", default-features = false, features = ["telemetry"] }
+running-process = { version = "4.0.3", default-features = false, features = ["telemetry"] }
+icy_sixel = "0.5"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.37"

--- a/crates/clud-bin/README.md
+++ b/crates/clud-bin/README.md
@@ -39,6 +39,8 @@ soldr cargo test -p clud-bin     # crate-level Rust tests only
 
 - `clap` (derive) — CLI argument parsing with passthrough for unknown flags
 - `crossterm` / `vt100` / `vte` — terminal I/O and PTY stream parsing
+- `running-process` terminal graphics capability metadata plus
+  `icy_sixel` / `image` — conservative Sixel PTY header rendering
 - `redb` — embedded KV store for session and tracked-entry registries
   (issues #73 / #110; replaced bundled `rusqlite`)
 - `fs4` — cross-platform advisory file lock serializing concurrent redb opens

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+use crate::graphics::GraphicsMode;
+
 /// Fast CLI for running Claude Code and Codex in YOLO mode.
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -33,6 +35,14 @@ pub struct Args {
 
     #[arg(long = "pty", conflicts_with = "subprocess")]
     pub pty: bool,
+
+    /// Control terminal graphics headers for PTY sessions.
+    #[arg(long = "graphics", value_enum, default_value_t = GraphicsMode::Auto)]
+    pub graphics: GraphicsMode,
+
+    /// Render this image as the PTY graphics header when Sixel is enabled.
+    #[arg(long = "graphics-image", value_name = "PATH")]
+    pub graphics_image: Option<PathBuf>,
 
     #[arg(long = "model")]
     pub model: Option<String>,
@@ -315,6 +325,8 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--name",
         "--transcript",
         "--backlog-size",
+        "--graphics",
+        "--graphics-image",
         "--loop-count",
         "--done",
         "--repeat",

--- a/crates/clud-bin/src/args_tests.rs
+++ b/crates/clud-bin/src/args_tests.rs
@@ -60,6 +60,30 @@ fn test_pty_flag() {
 }
 
 #[test]
+fn test_graphics_flag() {
+    let args = parse(&[
+        "clud",
+        "--graphics",
+        "sixel",
+        "--graphics-image",
+        "banner.png",
+    ]);
+    assert_eq!(args.graphics, crate::graphics::GraphicsMode::Sixel);
+    assert_eq!(
+        args.graphics_image.as_ref().map(|p| p.as_os_str()),
+        Some(std::ffi::OsStr::new("banner.png"))
+    );
+    assert!(args.passthrough.is_empty());
+}
+
+#[test]
+fn test_graphics_equals_form_stays_known() {
+    let args = parse(&["clud", "--graphics=off", "--some-backend-flag"]);
+    assert_eq!(args.graphics, crate::graphics::GraphicsMode::Off);
+    assert_eq!(args.passthrough, vec!["--some-backend-flag"]);
+}
+
+#[test]
 fn test_safe_flag() {
     let args = parse(&["clud", "--safe", "-p", "hello"]);
     assert!(args.safe);
@@ -587,6 +611,8 @@ fn test_default_no_flags() {
     assert!(!args.codex);
     assert!(!args.subprocess);
     assert!(!args.pty);
+    assert_eq!(args.graphics, crate::graphics::GraphicsMode::Auto);
+    assert!(args.graphics_image.is_none());
     assert!(!args.safe);
     assert!(!args.dry_run);
     assert!(!args.detach);

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use crate::args::{Args, Command};
 use crate::backend::{Backend, LaunchMode};
+use crate::graphics::GraphicsConfig;
 use crate::loop_spec::{done_marker_contract, git_root_from};
 
 use super::loop_task::{resolve_loop_task, resolve_marker_paths};
@@ -226,6 +227,10 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         cwd: std::env::current_dir()
             .ok()
             .map(|cwd| cwd.to_string_lossy().to_string()),
+        graphics: GraphicsConfig {
+            mode: args.graphics,
+            image_path: args.graphics_image.clone(),
+        },
         repeat_schedule,
         task_summary,
         loop_markers,

--- a/crates/clud-bin/src/command/tests.rs
+++ b/crates/clud-bin/src/command/tests.rs
@@ -524,6 +524,25 @@ fn test_pty_override() {
 }
 
 #[test]
+fn test_graphics_config_threads_into_launch_plan() {
+    let p = plan(&[
+        "clud",
+        "--graphics=sixel",
+        "--graphics-image",
+        "banner.png",
+        "--pty",
+        "-p",
+        "hello",
+    ]);
+    assert_eq!(p.graphics.mode, crate::graphics::GraphicsMode::Sixel);
+    assert_eq!(
+        p.graphics.image_path.as_ref().map(|path| path.as_os_str()),
+        Some(std::ffi::OsStr::new("banner.png"))
+    );
+    assert!(!p.command.iter().any(|arg| arg.starts_with("--graphics")));
+}
+
+#[test]
 fn test_passthrough_flags() {
     let p = plan(&["clud", "--some-flag", "-p", "hello"]);
     assert!(p.command.contains(&"--some-flag".to_string()));

--- a/crates/clud-bin/src/command/types.rs
+++ b/crates/clud-bin/src/command/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::backend::{Backend, LaunchMode};
+use crate::graphics::GraphicsConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LaunchPlan {
@@ -9,6 +10,8 @@ pub struct LaunchPlan {
     pub backend: Backend,
     pub launch_mode: LaunchMode,
     pub cwd: Option<String>,
+    #[serde(default)]
+    pub graphics: GraphicsConfig,
     #[serde(default)]
     pub repeat_schedule: Option<RepeatSchedule>,
     #[serde(default)]

--- a/crates/clud-bin/src/daemon/attach.rs
+++ b/crates/clud-bin/src/daemon/attach.rs
@@ -118,7 +118,17 @@ pub(super) fn attach_to_session(
                 return 1;
             }
         };
-        if let Err(err) = write_json_line(&mut stream, &WorkerClientMessage::Attach) {
+        let terminal =
+            matches!(session.kind, SessionKind::Pty).then(crate::graphics::detect_current_terminal);
+        let (rows, cols) = super::io_helpers::terminal_dimensions();
+        if let Err(err) = write_json_line(
+            &mut stream,
+            &WorkerClientMessage::Attach {
+                terminal,
+                rows: Some(rows),
+                cols: Some(cols),
+            },
+        ) {
             eprintln!("[clud] failed to attach to session {}: {}", session.id, err);
             return 1;
         }

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -519,6 +519,8 @@ mod tests {
             codex: false,
             subprocess: false,
             pty: false,
+            graphics: crate::graphics::GraphicsMode::Auto,
+            graphics_image: None,
             model: None,
             safe: false,
             dry_run: false,

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use running_process::pty::NativePtyProcess;
-use running_process::NativeProcess;
+use running_process::{NativeProcess, TerminalCapabilities};
 use serde::{Deserialize, Serialize};
 use sysinfo::Signal;
 
@@ -273,9 +273,22 @@ pub struct ListRow {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub(super) enum WorkerClientMessage {
-    Attach,
-    Input { data_b64: String, submit: bool },
-    Resize { rows: u16, cols: u16 },
+    Attach {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        terminal: Option<TerminalCapabilities>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        rows: Option<u16>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cols: Option<u16>,
+    },
+    Input {
+        data_b64: String,
+        submit: bool,
+    },
+    Resize {
+        rows: u16,
+        cols: u16,
+    },
     Interrupt,
 }
 
@@ -451,6 +464,19 @@ mod tests {
             }
             other => panic!("expected LiveCwds, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn attach_request_accepts_missing_terminal_metadata() {
+        let parsed: WorkerClientMessage = serde_json::from_str(r#"{"op":"attach"}"#).unwrap();
+        assert!(matches!(
+            parsed,
+            WorkerClientMessage::Attach {
+                terminal: None,
+                rows: None,
+                cols: None
+            }
+        ));
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/worker.rs
+++ b/crates/clud-bin/src/daemon/worker.rs
@@ -11,6 +11,7 @@ use base64::Engine;
 use running_process::pty::NativePtyProcess;
 use running_process::{NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode};
 
+use crate::graphics::GraphicsConfig;
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;
 
@@ -161,8 +162,14 @@ pub(super) fn run_worker(
             Ok((stream, _)) => {
                 let shared = Arc::clone(&shared);
                 let runtime = runtime.clone();
+                let graphics = spec.plan.graphics.clone();
+                let kind = spec.kind.clone();
+                let rows = spec.rows;
+                let cols = spec.cols;
                 thread::spawn(move || {
-                    let _ = handle_worker_client(stream, &shared, &runtime);
+                    let _ = handle_worker_client(
+                        stream, &shared, &runtime, &graphics, kind, rows, cols,
+                    );
                 });
             }
             Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
@@ -467,6 +474,10 @@ fn handle_worker_client(
     mut stream: TcpStream,
     shared: &Arc<WorkerShared>,
     runtime: &SessionRuntime,
+    graphics: &GraphicsConfig,
+    kind: SessionKind,
+    default_rows: u16,
+    default_cols: u16,
 ) -> io::Result<()> {
     let reader_stream = stream.try_clone()?;
     reader_stream.set_read_timeout(Some(Duration::from_millis(250)))?;
@@ -477,14 +488,28 @@ fn handle_worker_client(
     }
     let message: WorkerClientMessage = serde_json::from_str(&line)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
-    if !matches!(message, WorkerClientMessage::Attach) {
-        return write_json_line(
-            &mut stream,
-            &WorkerServerMessage::Error {
-                message: "expected attach handshake".to_string(),
-            },
-        );
-    }
+    let (terminal, attach_rows, attach_cols) = match message {
+        WorkerClientMessage::Attach {
+            terminal,
+            rows,
+            cols,
+        } => (
+            terminal,
+            rows.unwrap_or(default_rows),
+            cols.unwrap_or(default_cols),
+        ),
+        WorkerClientMessage::Input { .. }
+        | WorkerClientMessage::Resize { .. }
+        | WorkerClientMessage::Interrupt => {
+            return write_json_line(
+                &mut stream,
+                &WorkerServerMessage::Error {
+                    message: "expected attach handshake".to_string(),
+                },
+            );
+        }
+    };
+    let is_pty = matches!(kind, SessionKind::Pty);
 
     let shutdown_handle = stream.try_clone()?;
     let (client_id, rx, snapshot, backlog) = match shared.attach_client(shutdown_handle) {
@@ -500,6 +525,30 @@ fn handle_worker_client(
             session: snapshot.clone(),
         },
     )?;
+    let mut header_restore = None;
+    if is_pty {
+        let decision = crate::graphics::decide_sixel(graphics, terminal.as_ref());
+        if decision.enabled {
+            match crate::graphics::render_header(graphics, attach_rows, attach_cols) {
+                Ok(Some(header)) => {
+                    runtime.resize(header.text_rows, attach_cols);
+                    shared.resize_capture(header.text_rows, attach_cols);
+                    write_json_line(
+                        &mut writer,
+                        &WorkerServerMessage::Output {
+                            data_b64: base64::engine::general_purpose::STANDARD
+                                .encode(&header.bytes),
+                        },
+                    )?;
+                    header_restore = Some(header.restore_bytes);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("[clud] warning: failed to render daemon graphics header: {err}");
+                }
+            }
+        }
+    }
     for chunk in backlog {
         write_json_line(
             &mut writer,
@@ -509,6 +558,14 @@ fn handle_worker_client(
         )?;
     }
     if let Some(exit_code) = snapshot.exit_code {
+        if let Some(bytes) = header_restore.as_deref() {
+            write_json_line(
+                &mut writer,
+                &WorkerServerMessage::Output {
+                    data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
+                },
+            )?;
+        }
         write_json_line(&mut writer, &WorkerServerMessage::Exited { exit_code })?;
         shared.detach_client(client_id);
         return Ok(());
@@ -516,7 +573,22 @@ fn handle_worker_client(
 
     let shared_for_writer = Arc::clone(shared);
     let writer_thread = thread::spawn(move || {
+        let mut header_restore = header_restore;
         while let Ok(message) = rx.recv() {
+            if let WorkerServerMessage::Exited { .. } = &message {
+                if let Some(bytes) = header_restore.take() {
+                    if write_json_line(
+                        &mut writer,
+                        &WorkerServerMessage::Output {
+                            data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
+                        },
+                    )
+                    .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
             if write_json_line(&mut writer, &message).is_err() {
                 break;
             }
@@ -536,7 +608,7 @@ fn handle_worker_client(
                     continue;
                 };
                 match message {
-                    WorkerClientMessage::Attach => break,
+                    WorkerClientMessage::Attach { .. } => break,
                     WorkerClientMessage::Input { data_b64, submit } => {
                         if let Ok(data) =
                             base64::engine::general_purpose::STANDARD.decode(data_b64.as_bytes())
@@ -545,8 +617,30 @@ fn handle_worker_client(
                         }
                     }
                     WorkerClientMessage::Resize { rows, cols } => {
-                        runtime.resize(rows, cols);
-                        shared.resize_capture(rows, cols);
+                        let effective_rows = if is_pty
+                            && crate::graphics::decide_sixel(graphics, terminal.as_ref()).enabled
+                        {
+                            match crate::graphics::render_header(graphics, rows, cols) {
+                                Ok(Some(header)) => {
+                                    shared.send_to_client(WorkerServerMessage::Output {
+                                        data_b64: base64::engine::general_purpose::STANDARD
+                                            .encode(&header.bytes),
+                                    });
+                                    header.text_rows
+                                }
+                                Ok(None) => rows,
+                                Err(err) => {
+                                    eprintln!(
+                                        "[clud] warning: failed to redraw daemon graphics header: {err}"
+                                    );
+                                    rows
+                                }
+                            }
+                        } else {
+                            rows
+                        };
+                        runtime.resize(effective_rows, cols);
+                        shared.resize_capture(effective_rows, cols);
                     }
                     WorkerClientMessage::Interrupt => runtime.interrupt(),
                 }

--- a/crates/clud-bin/src/daemon/worker_shared.rs
+++ b/crates/clud-bin/src/daemon/worker_shared.rs
@@ -447,7 +447,7 @@ impl WorkerShared {
         self.send_to_client(WorkerServerMessage::Exited { exit_code });
     }
 
-    fn send_to_client(&self, message: WorkerServerMessage) {
+    pub(super) fn send_to_client(&self, message: WorkerServerMessage) {
         let sender = self
             .client
             .lock()

--- a/crates/clud-bin/src/graphics.rs
+++ b/crates/clud-bin/src/graphics.rs
@@ -1,0 +1,432 @@
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::ValueEnum;
+use icy_sixel::{BackgroundMode, EncodeOptions, QuantizeMethod, SixelImage};
+use running_process::{
+    CapabilityStatus, EvidenceStrength, GraphicsProtocol, TerminalCapabilities,
+    TerminalGraphicsCapabilities,
+};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_HEADER_ROWS: u16 = 6;
+const MIN_TEXT_ROWS: u16 = 8;
+const CELL_WIDTH_PX: u32 = 8;
+const CELL_HEIGHT_PX: u32 = 12;
+const MAX_HEADER_WIDTH_PX: u32 = 520;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphicsMode {
+    #[default]
+    Auto,
+    Off,
+    Sixel,
+}
+
+impl std::fmt::Display for GraphicsMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::Auto => "auto",
+            Self::Off => "off",
+            Self::Sixel => "sixel",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphicsConfig {
+    #[serde(default)]
+    pub mode: GraphicsMode,
+    #[serde(default)]
+    pub image_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphicsDecision {
+    pub enabled: bool,
+    pub forced: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeaderRender {
+    pub bytes: Vec<u8>,
+    pub restore_bytes: Vec<u8>,
+    pub reserved_rows: u16,
+    pub text_rows: u16,
+}
+
+pub fn detect_current_terminal() -> TerminalCapabilities {
+    running_process::current_terminal_capabilities_with_timeout(Duration::from_millis(150))
+}
+
+pub fn unknown_terminal() -> TerminalCapabilities {
+    TerminalCapabilities {
+        is_tty: false,
+        term: None,
+        terminal_program: None,
+        graphics: TerminalGraphicsCapabilities::unknown(),
+    }
+}
+
+pub fn decide_sixel(
+    config: &GraphicsConfig,
+    terminal: Option<&TerminalCapabilities>,
+) -> GraphicsDecision {
+    match config.mode {
+        GraphicsMode::Off => GraphicsDecision {
+            enabled: false,
+            forced: false,
+            reason: "graphics disabled by --graphics=off".to_string(),
+        },
+        GraphicsMode::Sixel => GraphicsDecision {
+            enabled: true,
+            forced: true,
+            reason: "Sixel forced by --graphics=sixel".to_string(),
+        },
+        GraphicsMode::Auto => decide_auto_sixel(terminal),
+    }
+}
+
+fn decide_auto_sixel(terminal: Option<&TerminalCapabilities>) -> GraphicsDecision {
+    let Some(terminal) = terminal else {
+        return GraphicsDecision {
+            enabled: false,
+            forced: false,
+            reason: "graphics auto skipped: missing terminal capability metadata".to_string(),
+        };
+    };
+    if !terminal.is_tty {
+        return GraphicsDecision {
+            enabled: false,
+            forced: false,
+            reason: "graphics auto skipped: attached client is not a TTY".to_string(),
+        };
+    }
+
+    let Some(capability) = terminal
+        .graphics
+        .protocols
+        .iter()
+        .find(|capability| capability.protocol == GraphicsProtocol::Sixel)
+    else {
+        return GraphicsDecision {
+            enabled: false,
+            forced: false,
+            reason: "graphics auto skipped: no Sixel capability record".to_string(),
+        };
+    };
+
+    if capability.status == CapabilityStatus::Supported
+        && capability.evidence == EvidenceStrength::Probe
+    {
+        GraphicsDecision {
+            enabled: true,
+            forced: false,
+            reason: format!(
+                "graphics auto enabled: Sixel supported by probe from {}",
+                capability.source
+            ),
+        }
+    } else {
+        GraphicsDecision {
+            enabled: false,
+            forced: false,
+            reason: format!(
+                "graphics auto skipped: Sixel status={:?} evidence={:?} source={} risks={}",
+                capability.status,
+                capability.evidence,
+                capability.source,
+                capability.risks.join(",")
+            ),
+        }
+    }
+}
+
+pub fn capability_summary(terminal: Option<&TerminalCapabilities>) -> String {
+    let Some(terminal) = terminal else {
+        return "terminal=missing".to_string();
+    };
+    let mut parts = vec![format!("is_tty={}", terminal.is_tty)];
+    if let Some(term) = &terminal.term {
+        parts.push(format!("TERM={term}"));
+    }
+    if let Some(program) = &terminal.terminal_program {
+        parts.push(format!("TERM_PROGRAM={program}"));
+    }
+    for capability in &terminal.graphics.protocols {
+        parts.push(format!(
+            "{:?}:{:?}/{:?}/{}",
+            capability.protocol, capability.status, capability.evidence, capability.source
+        ));
+    }
+    parts.join(" ")
+}
+
+pub fn render_header(
+    config: &GraphicsConfig,
+    terminal_rows: u16,
+    terminal_cols: u16,
+) -> io::Result<Option<HeaderRender>> {
+    if terminal_rows <= MIN_TEXT_ROWS + 1 || terminal_cols < 30 {
+        return Ok(None);
+    }
+
+    let max_reserved = terminal_rows.saturating_sub(MIN_TEXT_ROWS).max(1);
+    let target_rows = DEFAULT_HEADER_ROWS.min(max_reserved);
+    let max_width = u32::from(terminal_cols)
+        .saturating_mul(CELL_WIDTH_PX)
+        .clamp(160, MAX_HEADER_WIDTH_PX);
+    let max_height = u32::from(target_rows).saturating_mul(CELL_HEIGHT_PX);
+
+    let (rgba, width, height) = match &config.image_path {
+        Some(path) => load_image_rgba(path, max_width, max_height)?,
+        None => bundled_banner_rgba(max_width.min(420), max_height.max(48)),
+    };
+    let reserved_rows = rows_for_pixel_height(height).min(max_reserved).max(1);
+    if terminal_rows.saturating_sub(reserved_rows) < MIN_TEXT_ROWS {
+        return Ok(None);
+    }
+
+    let options = EncodeOptions {
+        max_colors: 48,
+        diffusion: 0.0,
+        quantize_method: QuantizeMethod::Wu,
+    };
+    let sixel = SixelImage::try_from_rgba(rgba, width as usize, height as usize)
+        .map_err(|err| io::Error::other(err.to_string()))?
+        .with_background_mode(BackgroundMode::Transparent)
+        .encode_with(&options)
+        .map_err(|err| io::Error::other(err.to_string()))?;
+
+    let first_text_row = reserved_rows + 1;
+    let text_rows = terminal_rows.saturating_sub(reserved_rows).max(1);
+    let mut bytes = Vec::new();
+    write!(
+        bytes,
+        "\x1b[?6l\x1b[r\x1b[H\x1b[J{}\x1b[{};1H\x1b[{};{}r\x1b[?6h\x1b[{};1H",
+        sixel, first_text_row, first_text_row, terminal_rows, first_text_row
+    )
+    .expect("writing into Vec cannot fail");
+    let restore_bytes = format!("\x1b[?6l\x1b[r\x1b[{};1H", terminal_rows).into_bytes();
+
+    Ok(Some(HeaderRender {
+        bytes,
+        restore_bytes,
+        reserved_rows,
+        text_rows,
+    }))
+}
+
+fn load_image_rgba(
+    path: &PathBuf,
+    max_width: u32,
+    max_height: u32,
+) -> io::Result<(Vec<u8>, u32, u32)> {
+    let reader = image::ImageReader::open(path)
+        .map_err(|err| io::Error::other(format!("failed to open graphics image: {err}")))?;
+    let image = reader
+        .decode()
+        .map_err(|err| io::Error::other(format!("failed to decode graphics image: {err}")))?;
+    let resized = image.resize(
+        max_width,
+        max_height.max(1),
+        image::imageops::FilterType::Lanczos3,
+    );
+    let rgba = resized.to_rgba8();
+    let (width, height) = rgba.dimensions();
+    Ok((rgba.into_raw(), width, height))
+}
+
+fn rows_for_pixel_height(height: u32) -> u16 {
+    height
+        .saturating_add(CELL_HEIGHT_PX - 1)
+        .checked_div(CELL_HEIGHT_PX)
+        .unwrap_or(1)
+        .clamp(1, u32::from(u16::MAX)) as u16
+}
+
+fn bundled_banner_rgba(width: u32, height: u32) -> (Vec<u8>, u32, u32) {
+    let width = width.max(160);
+    let height = height.clamp(42, 84);
+    let mut rgba = vec![0u8; (width * height * 4) as usize];
+    for y in 0..height {
+        for x in 0..width {
+            let t = x as f32 / width.max(1) as f32;
+            let base = [
+                (18.0 + 34.0 * t) as u8,
+                (28.0 + 54.0 * t) as u8,
+                (42.0 + 32.0 * (1.0 - t)) as u8,
+                255,
+            ];
+            set_px(&mut rgba, width, x, y, base);
+        }
+    }
+
+    let scale = (height / 10).clamp(4, 7);
+    let glyph_w = 5 * scale;
+    let glyph_h = 7 * scale;
+    let gap = scale * 2;
+    let total_w = glyph_w * 4 + gap * 3;
+    let start_x = width.saturating_sub(total_w) / 2;
+    let start_y = height.saturating_sub(glyph_h) / 2;
+    let color = [222, 245, 255, 255];
+    for (idx, glyph) in [GLYPH_C, GLYPH_L, GLYPH_U, GLYPH_D].iter().enumerate() {
+        draw_glyph(
+            &mut rgba,
+            (width, height),
+            (start_x + idx as u32 * (glyph_w + gap), start_y),
+            scale,
+            glyph,
+            color,
+        );
+    }
+
+    (rgba, width, height)
+}
+
+fn set_px(rgba: &mut [u8], width: u32, x: u32, y: u32, color: [u8; 4]) {
+    let idx = ((y * width + x) * 4) as usize;
+    rgba[idx..idx + 4].copy_from_slice(&color);
+}
+
+fn draw_glyph(
+    rgba: &mut [u8],
+    size: (u32, u32),
+    origin: (u32, u32),
+    scale: u32,
+    glyph: &[&str; 7],
+    color: [u8; 4],
+) {
+    let (width, height) = size;
+    let (x0, y0) = origin;
+    for (gy, row) in glyph.iter().enumerate() {
+        for (gx, ch) in row.as_bytes().iter().enumerate() {
+            if *ch != b'#' {
+                continue;
+            }
+            for dy in 0..scale {
+                for dx in 0..scale {
+                    let x = x0 + gx as u32 * scale + dx;
+                    let y = y0 + gy as u32 * scale + dy;
+                    if x < width && y < height {
+                        set_px(rgba, width, x, y, color);
+                    }
+                }
+            }
+        }
+    }
+}
+
+const GLYPH_C: [&str; 7] = [
+    "#####", "#....", "#....", "#....", "#....", "#....", "#####",
+];
+const GLYPH_L: [&str; 7] = [
+    "#....", "#....", "#....", "#....", "#....", "#....", "#####",
+];
+const GLYPH_U: [&str; 7] = [
+    "#...#", "#...#", "#...#", "#...#", "#...#", "#...#", "#####",
+];
+const GLYPH_D: [&str; 7] = [
+    "####.", "#...#", "#...#", "#...#", "#...#", "#...#", "####.",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use running_process::GraphicsCapability;
+
+    fn terminal_with_sixel(
+        status: CapabilityStatus,
+        evidence: EvidenceStrength,
+    ) -> TerminalCapabilities {
+        TerminalCapabilities {
+            is_tty: true,
+            term: Some("xterm-256color".into()),
+            terminal_program: Some("test".into()),
+            graphics: TerminalGraphicsCapabilities {
+                protocols: vec![GraphicsCapability {
+                    protocol: GraphicsProtocol::Sixel,
+                    status,
+                    evidence,
+                    source: "test".into(),
+                    risks: Vec::new(),
+                }],
+                preferred: Some(GraphicsProtocol::Sixel),
+            },
+        }
+    }
+
+    #[test]
+    fn auto_enables_only_probe_supported_sixel() {
+        let config = GraphicsConfig::default();
+        let terminal = terminal_with_sixel(CapabilityStatus::Supported, EvidenceStrength::Probe);
+        let decision = decide_sixel(&config, Some(&terminal));
+        assert!(decision.enabled);
+        assert!(!decision.forced);
+    }
+
+    #[test]
+    fn auto_rejects_strong_host_signal_for_v1() {
+        let config = GraphicsConfig::default();
+        let terminal = terminal_with_sixel(
+            CapabilityStatus::Supported,
+            EvidenceStrength::StrongHostSignal,
+        );
+        let decision = decide_sixel(&config, Some(&terminal));
+        assert!(!decision.enabled);
+    }
+
+    #[test]
+    fn auto_rejects_missing_and_non_tty_metadata() {
+        let config = GraphicsConfig::default();
+        assert!(!decide_sixel(&config, None).enabled);
+        let mut terminal =
+            terminal_with_sixel(CapabilityStatus::Supported, EvidenceStrength::Probe);
+        terminal.is_tty = false;
+        assert!(!decide_sixel(&config, Some(&terminal)).enabled);
+    }
+
+    #[test]
+    fn explicit_modes_override_capabilities() {
+        let terminal = terminal_with_sixel(
+            CapabilityStatus::Blocked,
+            EvidenceStrength::StrongHostSignal,
+        );
+        let off = GraphicsConfig {
+            mode: GraphicsMode::Off,
+            image_path: None,
+        };
+        assert!(!decide_sixel(&off, Some(&terminal)).enabled);
+        let forced = GraphicsConfig {
+            mode: GraphicsMode::Sixel,
+            image_path: None,
+        };
+        let decision = decide_sixel(&forced, Some(&terminal));
+        assert!(decision.enabled);
+        assert!(decision.forced);
+    }
+
+    #[test]
+    fn header_renderer_skips_tiny_terminals() {
+        let config = GraphicsConfig::default();
+        assert!(render_header(&config, 8, 80).unwrap().is_none());
+        assert!(render_header(&config, 24, 80).unwrap().is_some());
+    }
+
+    #[test]
+    fn header_bytes_manage_scroll_region_and_restore() {
+        let config = GraphicsConfig::default();
+        let header = render_header(&config, 24, 80).unwrap().unwrap();
+        assert!(header.reserved_rows > 0);
+        assert_eq!(header.text_rows, 24 - header.reserved_rows);
+        let text = String::from_utf8_lossy(&header.bytes);
+        assert!(text.contains("\x1b[?6h"));
+        assert!(text.contains("\x1b["));
+        let restore = String::from_utf8_lossy(&header.restore_bytes);
+        assert!(restore.contains("\x1b[r"));
+    }
+}

--- a/crates/clud-bin/src/hook_health.rs
+++ b/crates/clud-bin/src/hook_health.rs
@@ -776,6 +776,8 @@ fn run_backend_prompt(
         codex: matches!(selected_backend, Backend::Codex),
         subprocess: true,
         pty: false,
+        graphics: crate::graphics::GraphicsMode::Off,
+        graphics_image: None,
         model: args.model.clone(),
         safe: args.safe,
         dry_run: false,

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -15,6 +15,7 @@ pub mod console_title;
 pub mod daemon;
 pub mod dnd;
 pub mod gc;
+pub mod graphics;
 pub mod hook_health;
 pub mod large_file_guard;
 pub mod loop_artifacts;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -255,6 +255,10 @@ fn main() {
             "iterations": plan.iterations,
             "backend": backend.executable_name(),
             "launch_mode": plan.launch_mode.as_str(),
+            "graphics": {
+                "mode": plan.graphics.mode.to_string(),
+                "image": plan.graphics.image_path.as_ref().map(|p| p.to_string_lossy().to_string()),
+            },
             "repeat_interval_secs": plan.repeat_schedule.as_ref().map(|s| s.interval_secs),
             "transcript": args.transcript.as_ref().map(|p| p.to_string_lossy().to_string()),
             "loop_markers": plan.loop_markers.as_ref().map(|m| serde_json::json!({

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -543,14 +543,52 @@ pub fn run_plan_pty(
 
     let env = child_env();
     let mut last_exit = 0i32;
-    let (rows, cols) = get_terminal_size();
+    let terminal_capabilities = (plan.graphics.mode != crate::graphics::GraphicsMode::Off)
+        .then(crate::graphics::detect_current_terminal);
+    let graphics_decision =
+        crate::graphics::decide_sixel(&plan.graphics, terminal_capabilities.as_ref());
     if verbose {
         verbose_log::log(format_args!(
-            "[clud] pty: terminal size rows={rows} cols={cols}"
+            "[clud] graphics: {} ({})",
+            graphics_decision.reason,
+            crate::graphics::capability_summary(terminal_capabilities.as_ref())
         ));
     }
 
     for iteration in 0..plan.iterations {
+        let (terminal_rows, cols) = get_terminal_size();
+        let mut rows = terminal_rows;
+        let header = if graphics_decision.enabled {
+            match crate::graphics::render_header(&plan.graphics, terminal_rows, cols) {
+                Ok(Some(header)) => {
+                    rows = header.text_rows;
+                    Some(header)
+                }
+                Ok(None) => {
+                    if verbose {
+                        verbose_log::log(format_args!(
+                            "[clud] graphics: skipped header for terminal rows={terminal_rows} cols={cols}"
+                        ));
+                    }
+                    None
+                }
+                Err(err) => {
+                    eprintln!("[clud] warning: failed to render graphics header: {err}");
+                    if verbose {
+                        verbose_log::log(format_args!("[clud] graphics: render failed: {err}"));
+                    }
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        if verbose {
+            verbose_log::log(format_args!(
+                "[clud] pty: terminal size rows={terminal_rows} cols={cols} pty_rows={rows}"
+            ));
+        }
+
         // Re-check the interrupted flag at the top of every iteration. See
         // the matching guard in `run_plan_subprocess` — same rationale.
         if interrupted.load(Ordering::SeqCst) {
@@ -618,6 +656,11 @@ pub fn run_plan_pty(
             verbose_log::log("[clud] pty: started");
         }
 
+        if let Some(header) = &header {
+            write_terminal_bytes(&header.bytes);
+        }
+        let header_restore = header.as_ref().map(|header| header.restore_bytes.clone());
+        let graphics_resize = header.as_ref().map(|_| plan.graphics.clone());
         let mut hooks = voice::VoiceMode::from_env();
         let _raw_guard = session::enter_raw_mode_if_tty();
         // First iteration takes ownership of the side-channel receivers
@@ -636,15 +679,19 @@ pub fn run_plan_pty(
         } else {
             None
         };
-        let exit_code = session::run_raw_pty_pump_with_extra_rx_verbose(
+        let exit_code = session::run_raw_pty_pump_with_extra_rx_verbose_and_graphics(
             &process,
             interrupted,
             &mut hooks,
             io::stdin(),
             extra_rx,
             verbose,
+            graphics_resize,
         );
         drop(_raw_guard);
+        if let Some(bytes) = header_restore.as_deref() {
+            write_terminal_bytes(bytes);
+        }
         last_exit = normalize_exit_code(exit_code);
         if verbose {
             verbose_log::log(format_args!("[clud] pty: exited code {last_exit}"));
@@ -676,6 +723,13 @@ pub fn run_plan_pty(
     }
 
     last_exit
+}
+
+fn write_terminal_bytes(bytes: &[u8]) {
+    use std::io::Write;
+    let mut out = io::stdout().lock();
+    let _ = out.write_all(bytes);
+    let _ = out.flush();
 }
 
 #[cfg(test)]

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -10,6 +10,7 @@ use running_process::pty::PtySize;
 
 use crate::console_title::OscTitleStripper;
 use crate::dnd::{looks_like_dropped_path, normalize_dropped_path};
+use crate::graphics::GraphicsConfig;
 use crate::verbose_log;
 
 /// Resize the PTY. On Windows, `running_process::pty::NativePtyProcess::resize_impl`
@@ -438,6 +439,32 @@ where
     H: InteractiveHooks,
     R: std::io::Read + Send + 'static,
 {
+    run_raw_pty_pump_with_extra_rx_verbose_and_graphics(
+        process,
+        interrupted,
+        hooks,
+        stdin_source,
+        extra_rx,
+        verbose,
+        None,
+    )
+}
+
+/// Production pump entry with optional clud-level diagnostics and a PTY
+/// header renderer that can redraw/reserve rows after terminal resizes.
+pub fn run_raw_pty_pump_with_extra_rx_verbose_and_graphics<H, R>(
+    process: &NativePtyProcess,
+    interrupted: &AtomicBool,
+    hooks: &mut H,
+    stdin_source: R,
+    extra_rx: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
+    verbose: bool,
+    graphics: Option<GraphicsConfig>,
+) -> i32
+where
+    H: InteractiveHooks,
+    R: std::io::Read + Send + 'static,
+{
     let (resize_tx, resize_rx) = std::sync::mpsc::channel::<(u16, u16)>();
     spawn_os_resize_watcher(resize_tx);
     run_raw_pty_pump_full_verbose(
@@ -447,7 +474,7 @@ where
         stdin_source,
         resize_rx,
         extra_rx,
-        verbose,
+        PumpOptions { verbose, graphics },
     )
 }
 
@@ -543,8 +570,14 @@ where
         stdin_source,
         resize_rx,
         extra_rx,
-        false,
+        PumpOptions::default(),
     )
+}
+
+#[derive(Default)]
+struct PumpOptions {
+    verbose: bool,
+    graphics: Option<GraphicsConfig>,
 }
 
 fn run_raw_pty_pump_full_verbose<H, R>(
@@ -554,7 +587,7 @@ fn run_raw_pty_pump_full_verbose<H, R>(
     stdin_source: R,
     resize_rx: std::sync::mpsc::Receiver<(u16, u16)>,
     extra_rx: Option<std::sync::mpsc::Receiver<Vec<u8>>>,
-    verbose: bool,
+    options: PumpOptions,
 ) -> i32
 where
     H: InteractiveHooks,
@@ -577,7 +610,7 @@ where
     // it in that exact case so `console_input` is the sole consumer.
     let spawn_byte_stream_stdin_reader =
         should_spawn_byte_stream_stdin_reader(interactive_real_stdin, extra_rx.is_some());
-    if verbose {
+    if options.verbose {
         verbose_log::log(format_args!(
             "[clud] pty pump: start interactive_stdin={} normalize_console_stdin={} \
              spawn_byte_stream_stdin_reader={}",
@@ -656,7 +689,14 @@ where
         // Drain resize events — always before stdin so a late-arriving
         // resize doesn't wait on a chunk of typing to unblock the loop.
         while let Ok((rows, cols)) = resize_rx.try_recv() {
-            if let Err(err) = resize_pty(process, rows, cols) {
+            let pty_rows = options
+                .graphics
+                .as_ref()
+                .map(|config| {
+                    redraw_graphics_header_for_resize(config, rows, cols, options.verbose)
+                })
+                .unwrap_or(rows);
+            if let Err(err) = resize_pty(process, pty_rows, cols) {
                 eprintln!("[clud] warning: failed to resize pty: {}", err);
             }
         }
@@ -693,10 +733,10 @@ where
                     );
                 }
                 if requested_interrupt {
-                    if verbose {
+                    if options.verbose {
                         verbose_log::log("[clud] pty pump: interrupt via extra_rx Ctrl+C byte");
                     }
-                    return interrupt_pty_process(process, verbose);
+                    return interrupt_pty_process(process, options.verbose);
                 }
             }
         }
@@ -730,7 +770,7 @@ where
             }
 
             if requested_interrupt || interrupted.load(Ordering::SeqCst) {
-                if verbose {
+                if options.verbose {
                     let source = if requested_interrupt {
                         "stdin Ctrl+C byte"
                     } else {
@@ -738,7 +778,7 @@ where
                     };
                     verbose_log::log(format_args!("[clud] pty pump: interrupt via {source}"));
                 }
-                return interrupt_pty_process(process, verbose);
+                return interrupt_pty_process(process, options.verbose);
             }
         }
 
@@ -752,17 +792,48 @@ where
         if let Ok(Some(code)) =
             running_process::pty::poll_pty_process(&process.handles, &process.returncode)
         {
-            if verbose {
+            if options.verbose {
                 verbose_log::log(format_args!("[clud] pty pump: child exited code {code}"));
             }
             return code;
         }
 
         if interrupted.load(Ordering::SeqCst) {
-            if verbose {
+            if options.verbose {
                 verbose_log::log("[clud] pty pump: interrupt flag observed");
             }
-            return interrupt_pty_process(process, verbose);
+            return interrupt_pty_process(process, options.verbose);
+        }
+    }
+}
+
+fn redraw_graphics_header_for_resize(
+    config: &GraphicsConfig,
+    terminal_rows: u16,
+    terminal_cols: u16,
+    verbose: bool,
+) -> u16 {
+    match crate::graphics::render_header(config, terminal_rows, terminal_cols) {
+        Ok(Some(header)) => {
+            use std::io::Write;
+            let mut out = io::stdout().lock();
+            let _ = out.write_all(&header.bytes);
+            let _ = out.flush();
+            header.text_rows
+        }
+        Ok(None) => {
+            use std::io::Write;
+            let restore = format!("\x1b[?6l\x1b[r\x1b[{};1H", terminal_rows);
+            let mut out = io::stdout().lock();
+            let _ = out.write_all(restore.as_bytes());
+            let _ = out.flush();
+            terminal_rows
+        }
+        Err(err) => {
+            if verbose {
+                verbose_log::log(format_args!("[clud] graphics: resize redraw failed: {err}"));
+            }
+            terminal_rows
         }
     }
 }


### PR DESCRIPTION
## Summary
- add --graphics auto/off/sixel and --graphics-image for PTY graphics headers
- use running-process 4.0.3 terminal graphics capability metadata for conservative Sixel auto decisions
- render and restore Sixel PTY headers in direct sessions, and send attach-time terminal capability metadata for daemon sessions
- document graphics policy, custom image support, and daemon/direct behavior

## Running-process prerequisite
- running-process 4.0.3 release: https://github.com/zackees/running-process/releases/tag/4.0.3

## Validation
- cargo check -p clud --tests
- PATH with C:\\msys64\\ucrt64\\bin first: cargo test -p clud --lib (672 passed)
- PATH with C:\\msys64\\ucrt64\\bin first: cargo test -p clud graphics --lib -- --nocapture
- PATH with C:\\msys64\\ucrt64\\bin first + GNU toolchain: cargo clippy -p clud --all-targets -- -D warnings
- PATH with C:\\msys64\\ucrt64\\bin first: target\\debug\\clud.exe --dry-run --pty --graphics=off -p hello
- git diff --check