### PR TITLE
fix: reset graphics layout on resize fallback

### DIFF
--- a/crates/clud-bin/src/daemon/worker.rs
+++ b/crates/clud-bin/src/daemon/worker.rs
@@ -628,11 +628,23 @@ fn handle_worker_client(
                                     });
                                     header.text_rows
                                 }
-                                Ok(None) => rows,
+                                Ok(None) => {
+                                    shared.send_to_client(WorkerServerMessage::Output {
+                                        data_b64: base64::engine::general_purpose::STANDARD.encode(
+                                            crate::graphics::reset_layout_bytes(rows, true),
+                                        ),
+                                    });
+                                    rows
+                                }
                                 Err(err) => {
                                     eprintln!(
                                         "[clud] warning: failed to redraw daemon graphics header: {err}"
                                     );
+                                    shared.send_to_client(WorkerServerMessage::Output {
+                                        data_b64: base64::engine::general_purpose::STANDARD.encode(
+                                            crate::graphics::reset_layout_bytes(rows, true),
+                                        ),
+                                    });
                                     rows
                                 }
                             }

--- a/crates/clud-bin/src/graphics.rs
+++ b/crates/clud-bin/src/graphics.rs
@@ -59,6 +59,15 @@ pub struct HeaderRender {
     pub text_rows: u16,
 }
 
+pub fn reset_layout_bytes(terminal_rows: u16, clear_screen: bool) -> Vec<u8> {
+    let row = terminal_rows.max(1);
+    if clear_screen {
+        format!("\x1b[?6l\x1b[r\x1b[H\x1b[J\x1b[{row};1H").into_bytes()
+    } else {
+        format!("\x1b[?6l\x1b[r\x1b[{row};1H").into_bytes()
+    }
+}
+
 pub fn detect_current_terminal() -> TerminalCapabilities {
     running_process::current_terminal_capabilities_with_timeout(Duration::from_millis(150))
 }
@@ -211,7 +220,7 @@ pub fn render_header(
         sixel, first_text_row, first_text_row, terminal_rows, first_text_row
     )
     .expect("writing into Vec cannot fail");
-    let restore_bytes = format!("\x1b[?6l\x1b[r\x1b[{};1H", terminal_rows).into_bytes();
+    let restore_bytes = reset_layout_bytes(terminal_rows, false);
 
     Ok(Some(HeaderRender {
         bytes,
@@ -428,5 +437,18 @@ mod tests {
         assert!(text.contains("\x1b["));
         let restore = String::from_utf8_lossy(&header.restore_bytes);
         assert!(restore.contains("\x1b[r"));
+    }
+
+    #[test]
+    fn reset_layout_bytes_can_clear_for_resize_skip() {
+        let clear = String::from_utf8_lossy(&reset_layout_bytes(24, true)).into_owned();
+        assert!(clear.contains("\x1b[r"));
+        assert!(clear.contains("\x1b[H\x1b[J"));
+        assert!(clear.ends_with("\x1b[24;1H"));
+
+        let restore = String::from_utf8_lossy(&reset_layout_bytes(24, false)).into_owned();
+        assert!(restore.contains("\x1b[r"));
+        assert!(!restore.contains("\x1b[H\x1b[J"));
+        assert!(restore.ends_with("\x1b[24;1H"));
     }
 }

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -823,9 +823,9 @@ fn redraw_graphics_header_for_resize(
         }
         Ok(None) => {
             use std::io::Write;
-            let restore = format!("\x1b[?6l\x1b[r\x1b[{};1H", terminal_rows);
+            let restore = crate::graphics::reset_layout_bytes(terminal_rows, true);
             let mut out = io::stdout().lock();
-            let _ = out.write_all(restore.as_bytes());
+            let _ = out.write_all(&restore);
             let _ = out.flush();
             terminal_rows
         }
@@ -833,6 +833,11 @@ fn redraw_graphics_header_for_resize(
             if verbose {
                 verbose_log::log(format_args!("[clud] graphics: resize redraw failed: {err}"));
             }
+            use std::io::Write;
+            let restore = crate::graphics::reset_layout_bytes(terminal_rows, true);
+            let mut out = io::stdout().lock();
+            let _ = out.write_all(&restore);
+            let _ = out.flush();
             terminal_rows
         }
     }


### PR DESCRIPTION
## Summary

- add shared graphics layout reset bytes for scroll-region cleanup
- clear/reset the direct PTY layout when resize redraw skips or fails
- clear/reset daemon-attached clients when graphics resize redraw skips or fails

## Verification

- `cargo test -p clud graphics --lib -- --nocapture`
- `cargo check -p clud --tests`
- `cargo test -p clud --lib`
- `rustup run 1.94.1-x86_64-pc-windows-gnu cargo clippy -p clud --all-targets -- -D warnings`
- `git diff --check`