### PR TITLE
ci: bump setup-soldr v0.9.57 -> v0.9.59

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -69,7 +69,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -59,7 +59,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -54,7 +54,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -54,7 +54,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.57` to `v0.9.59`.

## What's in v0.9.58–v0.9.59
- **v0.9.58** — Eviction log splits foundation-protected vs age-floor-protected counts (diagnostic).
- **v0.9.59** — **PERF**: drops git SHA from cargo-registry cache key (closes setup-soldr#371). Same anti-pattern fix as #237 did for build-cache. Production-observed: every commit's cargo-registry exact-key probe missed (only matched same-SHA retries), and the action burned ~56 MB upload bandwidth saving a new entry that no future probe could hit. After this fix, exact-key hit rate climbs to ~100% per (lockHash, digest) generation, save status flips to `skipped-race` for subsequent matrix jobs, and per-CI-cycle redundant uploads drop by ~50 MB × matrix-job-count.

## Test plan
- [ ] CI green
- [ ] cargo-registry log shows `HIT` instead of `FALLBACK` on subsequent commits with same lockHash
- [ ] Per-layer save table shows cargo-registry status flipping to `skipped-race` for jobs after the first save
