### PR TITLE
ci: bump setup-soldr v0.9.60 -> v0.9.61

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -69,7 +69,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.60
+        uses: zackees/setup-soldr@v0.9.61
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -59,7 +59,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.60
+        uses: zackees/setup-soldr@v0.9.61
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -54,7 +54,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.60
+        uses: zackees/setup-soldr@v0.9.61
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -54,7 +54,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.60
+        uses: zackees/setup-soldr@v0.9.61
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.60` to `v0.9.61`.

## What's in v0.9.61 — perf win
Cache-eviction now sorts evictable entries by size descending (biggest first) instead of age ascending. Same byte-target reached with ~10× fewer API calls.

Production observation on zccache (v0.9.60 cascade run):
- 304 entries deleted to free 1.33 GB
- 70% were <1 MB sccache shards (~100 MB total)
- 3% were >100 MB entries (~1 GB total)

Combined with v0.9.60's parallel deletes, cache-eviction wall-clock should drop from ~12s to ~1-2s per CI cycle.

## Test plan
- [ ] CI green
- [ ] Post-step eviction log shows ~10 deletions (instead of ~300) when over-budget
