### PR TITLE
ci: bump setup-soldr v0.9.61 -> v0.9.62

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -69,7 +69,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the real build see the same `linker: fast` environment.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -59,7 +59,7 @@ jobs:
       # routed through soldr/zccache. Install mold before setup so dependency
       # cooking and the dev wheel build share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -54,7 +54,7 @@ jobs:
       # through soldr/zccache. Install mold before setup so dependency cooking
       # and clippy share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           toolchain: "1.94.1"
           version: "0.7.45"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -54,7 +54,7 @@ jobs:
       # cargo test invocations routed through soldr/zccache. Install mold before
       # setup so dependency cooking and tests share the same linker fingerprint.
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           toolchain: "1.94.1"
           version: "0.7.45"


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.61` to `v0.9.62`.

## What's in v0.9.62 — perf win
Drops per-job suffix from cargo-registry cache key (closes setup-soldr#375).

cargo-registry content is `$CARGO_HOME/registry/` + `.global-cache` + `git/` — keyed on Cargo.lock content, identical across matrix jobs (check, test, doc, msrv all download the same crates). Per-job suffix made each job save its own ~56 MB copy.

Production observation on zccache 9-job matrix: ~500 MB redundant uploads per CI cycle. After this fix: first job saves, rest exact-HIT (was FALLBACK with redundant save).

Mirrors #371 (drop SHA from same key) and #237 (drop SHA from build-cache). build-cache KEEPS suffix because target/ content differs per job; cargo-registry does not.

## Test plan
- [ ] CI green
- [ ] First cache-saving job in matrix shows cargo-registry SAVED; subsequent jobs show SKIPPED-RACE (instead of FALLBACK+SAVED)
- [ ] Aggregate cargo-registry uploads per CI cycle drops from ~500 MB to ~56 MB
