### PR TITLE
feat: add launch setup scope selector

### DIFF
--- a/crates/clud-bin/assets/skills/README.md
+++ b/crates/clud-bin/assets/skills/README.md
@@ -1,24 +1,51 @@
 # skills/
 
-Claude Code and Codex "skills" bundled into the `clud` binary as compile-time assets. On every `clud` launch the installer copies each skill into the user's `~/.claude/skills/` and, when Codex is present, Codex's current `~/.agents/skills/` path, so a fresh `clud` install always carries the current canonical playbooks without any extra setup step. Older clud-managed copies under `~/.codex/skills/` are purged on launch.
+Claude Code and Codex skills bundled into the `clud` binary as compile-time
+assets. During global launch setup, the installer copies each skill into the
+selected backend's skill directory (`~/.claude/skills/` for Claude, Codex's
+current `~/.agents/skills/` path when Codex is present). Session-only launches
+do not write persistent skill files. Older clud-managed copies under
+`~/.codex/skills/` are purged only during Codex global setup.
 
 ## Skills
 
-- [clud-issue/](clud-issue/README.md) — File a deeply-researched GitHub issue via investigate → interview → investigate → post, returning a summary plus the issue URL.
-- [clud-issue-triage/](clud-issue-triage/README.md) — Triage GitHub issues: close ones that are clearly resolved and silently file follow-ups for un-addressed CodeRabbit comments; supports single, last-week, or all (parallel sub-agents in worktrees).
-- [clud-pr/](clud-pr/README.md) — Implement a GitHub issue, PR follow-up, or freeform task inside a `.claude/` worktree and ship one clean PR.
-- [clud-tag-release/](clud-tag-release/README.md) — Tag a release after validating version match, clean `main`, and no duplicate tag, then push and surface the auto-release workflow URL.
-- [clud-docker-rust-app-dev/](clud-docker-rust-app-dev/README.md) — Build a Rust app inside Docker for **development iteration** (not deployment) — fast incremental cargo builds via named volumes for `target/` + `CARGO_HOME` + `RUSTUP_HOME`, source bind-mounted, soldr-wrapped cargo, and a Python orchestrator. The `-dev` suffix is load-bearing: this is a per-developer scratch container, not a `docker push`-bound image; use `cargo chef` / multi-stage builds for that path.
+- [clud-issue/](clud-issue/README.md) - File a deeply-researched GitHub issue
+  via investigate -> interview -> investigate -> post, returning a summary plus
+  the issue URL.
+- [clud-issue-triage/](clud-issue-triage/README.md) - Triage GitHub issues:
+  close ones that are clearly resolved and silently file follow-ups for
+  un-addressed CodeRabbit comments; supports single, last-week, or all.
+- [clud-pr/](clud-pr/README.md) - Implement a GitHub issue, PR follow-up, or
+  freeform task inside a `.claude/` worktree and ship one clean PR.
+- [clud-tag-release/](clud-tag-release/README.md) - Tag a release after
+  validating version match, clean `main`, and no duplicate tag, then push and
+  surface the auto-release workflow URL.
+- [clud-docker-rust-app-dev/](clud-docker-rust-app-dev/README.md) - Build a
+  Rust app inside Docker for development iteration, not deployment. It uses
+  fast incremental cargo builds via named volumes for `target/` + `CARGO_HOME`
+  + `RUSTUP_HOME`, source bind-mounted, soldr-wrapped cargo, and a Python
+  orchestrator.
 
-## How skills ship
+## How Skills Ship
 
-Each `SKILL.md` here is embedded into the binary via `include_str!` and written out on launch. Two installers run on every launch:
+Each `SKILL.md` here is embedded into the binary via `include_str!` and written
+out during global setup. Two installer implementations are registered behind
+`launch_setup.rs`:
 
-- **`crates/clud-bin/src/skills.rs`** — multi-backend (`~/.claude/skills`, Codex `~/.agents/skills` gated by `~/.codex`), never overwrites user edits, reads from this directory.
-- **`crates/clud-bin/src/skill_install.rs`** — Claude-only, overwrites on semantic divergence, reads from a separate top-level `skills/` directory in the repo.
+- **`crates/clud-bin/src/skills.rs`** - selected-backend global setup
+  (`~/.claude/skills`, Codex `~/.agents/skills` gated by `~/.codex`), never
+  overwrites user edits, reads from this directory.
+- **`crates/clud-bin/src/skill_install.rs`** - Claude-only global setup,
+  overwrites on semantic divergence, reads from a separate top-level `skills/`
+  directory in the repo.
 
-The two source trees ship different subsets — see [docs/architecture/skill-system.md](../../../../docs/architecture/skill-system.md) for the full divergence map, rationale, and the eventual consolidation plan ([DD-008](../../../../docs/DESIGN_DECISIONS.md#dd-008-dual-skill-installer-skillsrs-vs-skill_installrs--interim-state)).
+The two source trees ship different subsets. See
+[docs/architecture/skill-system.md](../../../../docs/architecture/skill-system.md)
+for the full divergence map, rationale, and eventual consolidation plan
+([DD-008](../../../../docs/DESIGN_DECISIONS.md#dd-008-dual-skill-installer-skillsrs-vs-skill_installrs--interim-state)).
 
-## Adding a skill
+## Adding a Skill
 
-See the checklist in [docs/architecture/skill-system.md](../../../../docs/architecture/skill-system.md#adding-a-skill) — it covers which installer to register with, where to place `SKILL.md`, the unit-test invariants, and the README expectation. Register with `skills.rs` for Codex coverage.
+See the checklist in
+[docs/architecture/skill-system.md](../../../../docs/architecture/skill-system.md#adding-a-skill).
+Register with `skills.rs` for Codex coverage.

--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -1,96 +1,186 @@
 # src/
 
-Entry point and source tree for the `clud-bin` Rust binary. The binary launches a backend agent (`claude` or `codex`) in YOLO mode, optionally through a PTY, with first-class support for loop iterations, drag-and-drop, voice input, and a per-user daemon for backgrounded/detachable sessions. `main.rs` does cross-cutting startup work (trampoline unlock, console title, skill install, session-cap registration, GC scanner) and then hands off to `runner.rs`, which drives the per-iteration subprocess/PTY launch loop for a single [`LaunchPlan`]. Submodules under `command/`, `daemon/`, `dnd/`, and `voice/` carry the bulk of the domain logic; the top-level `.rs` files here are the orchestration glue and standalone utilities consumed by both `main.rs` and the integration tests.
+Entry point and source tree for the `clud-bin` Rust binary. The binary launches
+a backend agent (`claude` or `codex`) in YOLO mode, optionally through a PTY,
+with first-class support for loop iterations, drag-and-drop, voice input, and a
+per-user daemon for backgrounded/detachable sessions. `main.rs` does
+cross-cutting startup work (trampoline unlock, console title, launch setup
+selection, session-cap registration, GC scanner) and then hands off to
+`runner.rs`, which drives the per-iteration subprocess/PTY launch loop for a
+single [`LaunchPlan`]. Submodules under `command/`, `daemon/`, `dnd/`, and
+`voice/` carry the bulk of the domain logic; the top-level `.rs` files here are
+the orchestration glue and standalone utilities consumed by both `main.rs` and
+the integration tests.
 
 ## Subdirectories
 
-- [command/](command/README.md) — `LaunchPlan` construction: backend argv assembly, YOLO/safe injection, `loop`/`up`/`rebase`/`fix` prompt synthesis, `--repeat` schedule parsing, DONE/BLOCKED contract.
-- [daemon/](daemon/README.md) — long-lived session manager for `--detach` / `attach` / `list` / `kill` / `logs` / `--repeat`: TCP JSON IPC, per-session worker subprocesses, snapshot + log persistence, attach broker.
-- [dnd/](dnd/README.md) — drag-and-drop into the terminal: cross-platform path-string normalizer plus Windows-only `IDropTarget` adapter with per-launch-mode injectors (subprocess `WriteConsoleInputW`, PTY master writer).
-- [voice/](voice/README.md) — F3 push-to-talk voice mode: `cpal`/`arecord` mic capture, start/stop cues, `whisper-rs` worker thread, transcript injection into the backend PTY.
+- [command/](command/README.md) - `LaunchPlan` construction: backend argv
+  assembly, YOLO/safe injection, `loop`/`up`/`rebase`/`fix` prompt synthesis,
+  `--repeat` schedule parsing, DONE/BLOCKED contract.
+- [daemon/](daemon/README.md) - long-lived session manager for `--detach` /
+  `attach` / `list` / `kill` / `logs` / `--repeat`: TCP JSON IPC, per-session
+  worker subprocesses, snapshot + log persistence, attach broker.
+- [dnd/](dnd/README.md) - drag-and-drop into the terminal: cross-platform
+  path-string normalizer plus Windows-only `IDropTarget` adapter with
+  per-launch-mode injectors.
+- [voice/](voice/README.md) - F3 push-to-talk voice mode: mic capture,
+  start/stop cues, `whisper-rs` worker thread, transcript injection into the
+  backend PTY.
 
-## Top-level modules
+## Top-Level Modules
 
 Entry and orchestration:
 
-- `main.rs` — process entry: launch clock, trampoline unlock, console title stamp + keeper, skill install, large-file guard, session-cap registration, GC scanner, dispatch to runner / daemon / hook-health / GC subcommands.
-- `lib.rs` — library facade so integration tests under `tests/` can link against internals; `main.rs` imports through this rather than re-declaring `mod ...`.
-- `runner.rs` — per-iteration subprocess- and PTY-mode runner for a single `LaunchPlan`; owns child-env construction, stream-json fallback, Ctrl-C-aware teardown, and OLE drag-drop registration wiring.
-- `startup.rs` — launch-time helpers factored out of `main.rs`: drag-target gating (`--no-dnd`, `--dry-run`), session-cap enforcement, Ctrl+C flag installer.
+- `main.rs` - process entry: launch clock, trampoline unlock, console title
+  stamp + keeper, launch setup selection, large-file guard, session-cap
+  registration, GC scanner, dispatch to runner / daemon / hook-health / GC
+  subcommands.
+- `lib.rs` - library facade so integration tests under `tests/` can link
+  against internals; `main.rs` imports through this rather than re-declaring
+  `mod ...`.
+- `runner.rs` - per-iteration subprocess- and PTY-mode runner for a single
+  `LaunchPlan`; owns child-env construction, stream-json fallback,
+  Ctrl-C-aware teardown, and OLE drag-drop registration wiring.
+- `startup.rs` - launch-time helpers factored out of `main.rs`: drag-target
+  gating (`--no-dnd`, `--dry-run`), session-cap enforcement, Ctrl+C flag
+  installer.
 
 CLI surface and backend resolution:
 
-- `args.rs` — `clap` `Args` and `Command` definitions; passthrough for unknown flags; subcommand definitions for `loop`, `up`, `rebase`, `fix`, `gc`, etc.
-- `backend.rs` — `Backend` enum (`Claude` / `Codex`), `LaunchMode` (`Subprocess` / `Pty`), PATH lookup, and backend-path resolution.
-- `subprocess.rs` — single decision point for the Windows `.cmd`/`.bat` rewrite (BatBadBat / CVE-2024-24576) via `running-process-core`'s `CommandSpec::Shell`.
+- `args.rs` - `clap` `Args` and `Command` definitions; passthrough for unknown
+  flags; subcommand definitions for `loop`, `up`, `rebase`, `fix`, `gc`, etc.
+- `backend.rs` - `Backend` enum (`Claude` / `Codex`), `LaunchMode`
+  (`Subprocess` / `Pty`), PATH lookup, and backend-path resolution.
+- `subprocess.rs` - single decision point for the Windows `.cmd`/`.bat`
+  rewrite (BatBadBat / CVE-2024-24576) via `running-process-core`'s
+  `CommandSpec::Shell`.
 
 Console and terminal:
 
-- `console_input.rs` — Windows `ReadConsoleInputW` translator (issue #141): pure-function map from `KEY_EVENT_RECORD` slices to PTY stdin bytes (Shift+Enter → `\n`, plain Enter → `\r`).
-- `console_setup.rs` — RAII guard that enables `ENABLE_VIRTUAL_TERMINAL_INPUT` for the lifetime of a PTY session and restores the prior console mode on drop; no-op on POSIX.
-- `console_title.rs` — stamps `clud <cwd-name>` once on launch and runs a background keeper that re-applies the title when downstream OSC 0/2 sequences overwrite it.
-- `capture.rs` — server-side terminal emulator (`vt100` + `vte` sticky-mode sniffer) that lets the daemon synthesize a repaint when a mid-session client attaches.
-- `session.rs` — raw-PTY pump (`run_raw_pty_pump`), resize handling, F3 voice observer hook, OSC-title stripper integration, dropped-path injection on the PTY master.
+- `console_input.rs` - Windows `ReadConsoleInputW` translator (issue #141):
+  pure-function map from `KEY_EVENT_RECORD` slices to PTY stdin bytes.
+- `console_setup.rs` - RAII guard that enables
+  `ENABLE_VIRTUAL_TERMINAL_INPUT` for the lifetime of a PTY session and
+  restores the prior console mode on drop; no-op on POSIX.
+- `console_title.rs` - stamps `clud <cwd-name>` once on launch and runs a
+  background keeper that re-applies the title when downstream OSC 0/2 sequences
+  overwrite it.
+- `capture.rs` - server-side terminal emulator (`vt100` + `vte` sticky-mode
+  sniffer) that lets the daemon synthesize a repaint when a mid-session client
+  attaches.
+- `session.rs` - raw-PTY pump (`run_raw_pty_pump`), resize handling, F3 voice
+  observer hook, OSC-title stripper integration, dropped-path injection on the
+  PTY master.
 
 Loop subsystem (`clud loop`):
 
-- `loop_spec.rs` — task-spec resolver: classifies the positional (GH URL, `#42`, file, literal), fetches GH issue/PR bodies via `gh` (curl fallback), caches under `.clud/loop/`, locates DONE/BLOCKED marker files.
-- `loop_check.rs` — post-iteration DONE/BLOCKED marker check; file-only and stdout-scanning variants used by PTY and subprocess paths respectively.
-- `loop_artifacts.rs` — durable `<git-root>/.clud/loop/` artifacts: `info.json` (`TaskInfo`), `log.txt`, `motivation.md`, and `.gitignore` auto-injection.
-- `stream_json.rs` — pure renderer for claude's `--output-format stream-json` events; turns one JSON event per line into one human-readable progress line for subprocess-mode loops.
+- `loop_spec.rs` - task-spec resolver: classifies the positional (GH URL,
+  `#42`, file, literal), fetches GH issue/PR bodies via `gh` (curl fallback),
+  caches under `.clud/loop/`, locates DONE/BLOCKED marker files.
+- `loop_check.rs` - post-iteration DONE/BLOCKED marker check; file-only and
+  stdout-scanning variants used by PTY and subprocess paths respectively.
+- `loop_artifacts.rs` - durable `<git-root>/.clud/loop/` artifacts:
+  `info.json` (`TaskInfo`), `log.txt`, `motivation.md`, and `.gitignore`
+  auto-injection.
+- `stream_json.rs` - pure renderer for claude's `--output-format stream-json`
+  events; turns one JSON event per line into one human-readable progress line
+  for subprocess-mode loops.
 
 Process management and GC:
 
-- `process_tree.rs` — best-effort descendant-tree termination via `sysinfo`; fixes the multi-second Ctrl+C hang for `clud --codex` on Windows where `cmd.exe → node.exe` would orphan the real child.
-- `session_registry.rs` — `redb`-backed registry of live `clud` PIDs that caps concurrent siblings (default 64, `CLUD_MAX_INSTANCES`); `Drop` removes the row, startup GCs dead rows.
-- `gc.rs` — `clud gc list` / `purge` / `reconcile` CLI handlers (thin IPC clients against the always-on daemon) and the in-process `WorktreeScanner` thread that polls `.claude/worktrees/agent-*` for new entries. The GC registry itself lives inside the daemon (see `daemon/gc_service.rs`).
-- `worktrees.rs` — `--clean-worktrees` (issue #83): enumerates via `git worktree list --porcelain`, classifies clean / dirty / unpushed / gone, removes safe ones; `--dry-run` faithful.
+- `process_tree.rs` - best-effort descendant-tree termination via `sysinfo`;
+  fixes the multi-second Ctrl+C hang for `clud --codex` on Windows where
+  `cmd.exe -> node.exe` would orphan the real child.
+- `session_registry.rs` - `redb`-backed registry of live `clud` PIDs that caps
+  concurrent siblings; `Drop` removes the row, startup GCs dead rows.
+- `gc.rs` - `clud gc list` / `purge` / `reconcile` CLI handlers and the
+  in-process `WorktreeScanner` thread. The GC registry itself lives inside the
+  daemon.
+- `worktrees.rs` - `--clean-worktrees` (issue #83): enumerates via
+  `git worktree list --porcelain`, classifies clean / dirty / unpushed / gone,
+  removes safe ones; `--dry-run` faithful.
 
 Platform glue:
 
-- `trampoline.rs` — Windows-only: rename-self-and-copy-back trick so `pip install` can always overwrite `Scripts/clud.exe`. No-op on POSIX.
-- `win_creation_flags.rs` — `invisible_helper_creationflags()` returns `CREATE_NO_WINDOW` on Windows for daemon-helper spawns; `0` elsewhere so call sites stay portable.
-- `large_file_guard.rs` — startup-time `ignore`-crate walker that warns about source files large enough to choke agents (issue #132); hard 1 s deadline.
+- `trampoline.rs` - Windows-only rename-self-and-copy-back trick so
+  `pip install` can always overwrite `Scripts/clud.exe`. No-op on POSIX.
+- `win_creation_flags.rs` - `invisible_helper_creationflags()` returns
+  `CREATE_NO_WINDOW` on Windows for daemon-helper spawns; `0` elsewhere so call
+  sites stay portable.
+- `large_file_guard.rs` - startup-time `ignore`-crate walker that warns about
+  source files large enough to choke agents (issue #132); hard 1 s deadline.
+- `launch_setup.rs` - session-only/global setup selector plus
+  selected-backend persistent setup actions for skills and Codex hook
+  normalization.
 
 Skills and hooks:
 
-- `skills.rs` — bundles slash-command skills via `include_str!` and installs them per-backend (`.claude/skills/`, Codex `.agents/skills/` gated on `.codex`) only when the backend home already exists; never overwrites existing files; purges stale clud-managed Codex copies from `.codex/skills/`.
-- `skill_install.rs` — auto-installer for the `clud-*` skill set; compares embedded vs installed `SKILL.md` modulo whitespace and overwrites divergent copies (logging `[clud] updated /<name>`).
-- `hook_health.rs` — `PreToolUse` hook parity diagnostics and `--fix-hooks` remediation (deterministic config edits plus optional agent-driven semantic hook translation).
-- `codex_hook_normalize.rs` — issue #234: idempotent global pass that bumps any `~/.codex/hooks.json` handler `timeout: 5` to `30` (`~/.clud/settings.lock` fs4 guard, green status line on change).
+- `skills.rs` - bundles slash-command skills via `include_str!` and installs
+  them during global launch setup for the selected backend (`.claude/skills/`,
+  Codex `.agents/skills/` gated on `.codex`) only when the backend home already
+  exists; never overwrites existing files; purges stale clud-managed Codex
+  copies from `.codex/skills/`.
+- `skill_install.rs` - Claude global-setup installer for the `clud-*` skill
+  set; compares embedded vs installed `SKILL.md` modulo whitespace and
+  overwrites divergent copies.
+- `hook_health.rs` - `PreToolUse` hook parity diagnostics and `--fix-hooks`
+  remediation.
+- `codex_hook_normalize.rs` - issue #234: idempotent Codex global-setup pass
+  that bumps any `~/.codex/hooks.json` handler `timeout: 5` to `30`
+  (`~/.clud/settings.lock` fs4 guard, green status line on change).
 
 Diagnostics and misc:
 
-- `verbose_log.rs` — launch-clock + opt-in file logging (`CLUD_VERBOSE_LOG_DIR`); `log()` writes timestamped lines to the per-launch log file.
-- `wasm.rs` — `wasmi`-based runner that loads a WASM module, registers a minimal `host.log` import, invokes a named export, and propagates the integer exit code.
+- `verbose_log.rs` - launch-clock + opt-in file logging
+  (`CLUD_VERBOSE_LOG_DIR`); `log()` writes timestamped lines to the per-launch
+  log file.
+- `wasm.rs` - `wasmi`-based runner that loads a WASM module, registers a
+  minimal `host.log` import, invokes a named export, and propagates the integer
+  exit code.
 
-Quick lookup — which file owns a given subcommand:
+Quick lookup, which file owns a given subcommand:
 
-- `clud loop ...` → `command::build_launch_plan` (prompt + markers) + `loop_spec` (task resolution) + `loop_artifacts` (artifact files) + `runner.rs` (iteration loop) + `loop_check` (DONE/BLOCKED scan).
-- `clud --detach`, `clud attach`, `clud list`, `clud kill`, `clud logs` → all in `daemon/` (dispatched from `daemon::handle_special_command`).
-- `clud gc list` / `purge` / `reconcile` → `gc.rs` (CLI handlers) talking to `daemon/gc_service.rs` (registry owner inside the always-on `__daemon`).
-- `clud --clean-worktrees` → `worktrees.rs`.
-- `clud --fix-hooks` → `hook_health.rs`.
+- `clud loop ...` -> `command::build_launch_plan` (prompt + markers) +
+  `loop_spec` (task resolution) + `loop_artifacts` (artifact files) +
+  `runner.rs` (iteration loop) + `loop_check` (DONE/BLOCKED scan).
+- `clud --detach`, `clud attach`, `clud list`, `clud kill`, `clud logs` -> all
+  in `daemon/` (dispatched from `daemon::handle_special_command`).
+- `clud gc list` / `purge` / `reconcile` -> `gc.rs` (CLI handlers) talking to
+  `daemon/gc_service.rs` (registry owner inside the always-on `__daemon`).
+- `clud --clean-worktrees` -> `worktrees.rs`.
+- `clud --fix-hooks` -> `hook_health.rs`.
 
-## Cross-cutting subsystems
+## Cross-Cutting Subsystems
 
-Subsystems that span multiple files have their own topic docs under `docs/architecture/`:
+Subsystems that span multiple files have their own topic docs under
+`docs/architecture/`:
 
-- **Loop subsystem** (`command/`, `loop_spec`, `loop_check`, `loop_artifacts`, `stream_json`, `runner`) → [docs/architecture/loop-subsystem.md](../../../docs/architecture/loop-subsystem.md)
-- **Daemon IPC** (everything under `daemon/`) → [docs/architecture/daemon-ipc.md](../../../docs/architecture/daemon-ipc.md)
-- **Session lifecycle** (`session`, `console_*`, `capture`, `dnd` injection, `voice` hooks) → [docs/architecture/session-lifecycle.md](../../../docs/architecture/session-lifecycle.md)
-- **Skill system** (`skills`, `skill_install`, `assets/skills/`) → [docs/architecture/skill-system.md](../../../docs/architecture/skill-system.md)
-- **GC and registry** (`gc`, `daemon/gc_service`, `session_registry`, `worktrees`) → [docs/architecture/gc-and-registry.md](../../../docs/architecture/gc-and-registry.md)
-- **Windows quirks** (`trampoline`, `subprocess` BatBadBat, `console_*`, `dnd`, `win_creation_flags`, `voice` ARM carveout) → [docs/architecture/windows-quirks.md](../../../docs/architecture/windows-quirks.md)
-- **Launch plan** (`command/types::LaunchPlan` + all consumers) → [docs/architecture/launch-plan.md](../../../docs/architecture/launch-plan.md)
+- **Loop subsystem** (`command/`, `loop_spec`, `loop_check`, `loop_artifacts`,
+  `stream_json`, `runner`) -> [docs/architecture/loop-subsystem.md](../../../docs/architecture/loop-subsystem.md)
+- **Daemon IPC** (everything under `daemon/`) -> [docs/architecture/daemon-ipc.md](../../../docs/architecture/daemon-ipc.md)
+- **Session lifecycle** (`session`, `console_*`, `capture`, `dnd` injection,
+  `voice` hooks) -> [docs/architecture/session-lifecycle.md](../../../docs/architecture/session-lifecycle.md)
+- **Skill system** (`skills`, `skill_install`, `assets/skills/`) -> [docs/architecture/skill-system.md](../../../docs/architecture/skill-system.md)
+- **Launch setup** (`launch_setup`, selected-backend persistent setup) -> [docs/architecture/launch-setup.md](../../../docs/architecture/launch-setup.md)
+- **GC and registry** (`gc`, `daemon/gc_service`, `session_registry`,
+  `worktrees`) -> [docs/architecture/gc-and-registry.md](../../../docs/architecture/gc-and-registry.md)
+- **Windows quirks** (`trampoline`, `subprocess` BatBadBat, `console_*`,
+  `dnd`, `win_creation_flags`, `voice` ARM carveout) -> [docs/architecture/windows-quirks.md](../../../docs/architecture/windows-quirks.md)
+- **Launch plan** (`command/types::LaunchPlan` + all consumers) -> [docs/architecture/launch-plan.md](../../../docs/architecture/launch-plan.md)
 
-Non-obvious design choices (single `LaunchPlan`, `lib.rs` as the only `mod ...` site, cooperative Ctrl+C, redb single-owner) have ADRs in [docs/DESIGN_DECISIONS.md](../../../docs/DESIGN_DECISIONS.md).
+Non-obvious design choices (single `LaunchPlan`, `lib.rs` as the only
+`mod ...` site, cooperative Ctrl+C, redb single-owner) have ADRs in
+[docs/DESIGN_DECISIONS.md](../../../docs/DESIGN_DECISIONS.md).
 
-## Entry point
+## Entry Point
 
-`main.rs` is the binary entry; `lib.rs` re-exports every top-level module (and the four subdirs) as `pub mod ...` so integration tests under `crates/clud-bin/tests/` can link against internals (notably `session::run_raw_pty_pump` and `session::F3Observer`). See [DD-007](../../../docs/DESIGN_DECISIONS.md#dd-007-librs-is-the-only-place-that-declares-modules-mainrs-imports-through-clud) for why the single-instantiation pattern matters.
+`main.rs` is the binary entry; `lib.rs` re-exports every top-level module (and
+the four subdirs) as `pub mod ...` so integration tests under
+`crates/clud-bin/tests/` can link against internals. See
+[DD-007](../../../docs/DESIGN_DECISIONS.md#dd-007-librs-is-the-only-place-that-declares-modules-mainrs-imports-through-clud)
+for why the single-instantiation pattern matters.
 
-## See also
+## See Also
 
 - Parent crate overview: [`../README.md`](../README.md).
 - Top-level project docs and CI matrix: [`../../../CLAUDE.md`](../../../CLAUDE.md).

--- a/crates/clud-bin/src/codex_hook_normalize.rs
+++ b/crates/clud-bin/src/codex_hook_normalize.rs
@@ -6,7 +6,7 @@
 //! particular). Codex's own default is much higher than 30s, so a missing
 //! `timeout` is fine — only the explicit `5` is the trap.
 //!
-//! Behavior on every eligible launch:
+//! Behavior during Codex global launch setup:
 //!
 //! 1. Ensure `~/.clud/` and `~/.clud/settings.json` exist.
 //! 2. Acquire `~/.clud/settings.lock` (cross-platform advisory lock, same
@@ -62,8 +62,8 @@ impl NormalizeOutcome {
     }
 }
 
-/// Entry point called from `main.rs`. Resolves the user's home directory,
-/// runs the normalization pass, and prints the green status line to stderr
+/// Compatibility entry point that resolves the user's home directory, runs the
+/// normalization pass, and prints the green status line to stderr
 /// on any change. All failures are non-fatal — a missing home dir, an
 /// unwritable `~/.clud`, or any I/O hiccup must never block a launch.
 pub fn run_global_normalization(verbose: bool) {
@@ -87,7 +87,7 @@ pub fn run_global_normalization(verbose: bool) {
 /// `run_global_normalization` and the unit tests; `clud_dir` is the dir
 /// that holds the lock file plus the auto-created `settings.json`, and
 /// `hooks_path` is the absolute path to the Codex hooks JSON to inspect.
-pub fn run_at<W: Write>(
+pub fn run_at<W: Write + ?Sized>(
     clud_dir: &Path,
     hooks_path: &Path,
     out: &mut W,

--- a/crates/clud-bin/src/launch_setup.rs
+++ b/crates/clud-bin/src/launch_setup.rs
@@ -1,0 +1,477 @@
+//! Launch-scope selection and per-backend persistent setup.
+//!
+//! Session-only launches are the default for automation and one-shot prompt
+//! paths. Interactive TUI launches can opt into global setup before the backend
+//! starts.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use crossterm::event::{self, Event, KeyCode};
+use crossterm::terminal;
+
+use crate::args::Args;
+use crate::backend::Backend;
+use crate::{codex_hook_normalize, skill_install, skills};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchSetupScope {
+    SessionOnly,
+    Global,
+}
+
+impl LaunchSetupScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LaunchSetupScope::SessionOnly => "session-only",
+            LaunchSetupScope::Global => "global",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectorEvent {
+    Up,
+    Down,
+    Enter,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScopeSelector {
+    selected: LaunchSetupScope,
+}
+
+impl Default for ScopeSelector {
+    fn default() -> Self {
+        Self {
+            selected: LaunchSetupScope::SessionOnly,
+        }
+    }
+}
+
+impl ScopeSelector {
+    pub fn selected(self) -> LaunchSetupScope {
+        self.selected
+    }
+
+    pub fn handle(&mut self, event: SelectorEvent) -> Option<LaunchSetupScope> {
+        match event {
+            SelectorEvent::Up => self.selected = LaunchSetupScope::SessionOnly,
+            SelectorEvent::Down => self.selected = LaunchSetupScope::Global,
+            SelectorEvent::Enter => return Some(self.selected),
+        }
+        None
+    }
+
+    pub fn render<W: Write>(&self, out: &mut W) -> io::Result<()> {
+        writeln!(
+            out,
+            "{} Session only",
+            marker(self.selected == LaunchSetupScope::SessionOnly)
+        )?;
+        writeln!(
+            out,
+            "{} Globally",
+            marker(self.selected == LaunchSetupScope::Global)
+        )?;
+        out.flush()
+    }
+}
+
+fn marker(selected: bool) -> &'static str {
+    if selected {
+        "[x]"
+    } else {
+        "[ ]"
+    }
+}
+
+pub fn should_prompt_for_scope(args: &Args, interactive_terminal: bool) -> bool {
+    interactive_terminal
+        && !args.dry_run
+        && args.prompt.is_none()
+        && args.message.is_none()
+        && !args.continue_session
+        && args.resume.is_none()
+        && args.command.is_none()
+}
+
+pub fn scope_for_non_prompting_launch(
+    args: &Args,
+    interactive_terminal: bool,
+) -> Option<LaunchSetupScope> {
+    (!should_prompt_for_scope(args, interactive_terminal)).then_some(LaunchSetupScope::SessionOnly)
+}
+
+pub fn prompt_scope<W: Write>(out: &mut W) -> io::Result<LaunchSetupScope> {
+    let _raw = RawModeGuard::enable()?;
+    let mut selector = ScopeSelector::default();
+    selector.render(out)?;
+
+    loop {
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        let event = match key.code {
+            KeyCode::Up => SelectorEvent::Up,
+            KeyCode::Down => SelectorEvent::Down,
+            KeyCode::Enter => SelectorEvent::Enter,
+            _ => continue,
+        };
+        if let Some(scope) = selector.handle(event) {
+            writeln!(out)?;
+            out.flush()?;
+            return Ok(scope);
+        }
+        write!(out, "\x1b[2A")?;
+        selector.render(out)?;
+    }
+}
+
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn enable() -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+#[derive(Debug)]
+pub enum SetupError {
+    NoHomeDir,
+    Skills(skills::InstallError),
+    Io(io::Error),
+}
+
+impl std::fmt::Display for SetupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SetupError::NoHomeDir => write!(f, "could not resolve user home directory"),
+            SetupError::Skills(error) => write!(f, "{error}"),
+            SetupError::Io(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for SetupError {}
+
+impl From<skills::InstallError> for SetupError {
+    fn from(error: skills::InstallError) -> Self {
+        SetupError::Skills(error)
+    }
+}
+
+impl From<io::Error> for SetupError {
+    fn from(error: io::Error) -> Self {
+        SetupError::Io(error)
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SetupReport {
+    pub ran: Vec<&'static str>,
+}
+
+pub trait HarnessSetupAction {
+    fn name(&self) -> &'static str;
+    fn backend(&self) -> Backend;
+    fn supports(&self, scope: LaunchSetupScope) -> bool;
+    fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError>;
+}
+
+pub struct SetupContext<'a> {
+    pub home: &'a Path,
+    pub verbose: bool,
+    pub out: &'a mut dyn Write,
+}
+
+struct BundledSkillsAction {
+    backend: Backend,
+}
+
+impl HarnessSetupAction for BundledSkillsAction {
+    fn name(&self) -> &'static str {
+        "bundled-skills"
+    }
+
+    fn backend(&self) -> Backend {
+        self.backend
+    }
+
+    fn supports(&self, scope: LaunchSetupScope) -> bool {
+        matches!(scope, LaunchSetupScope::Global)
+    }
+
+    fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError> {
+        let _ = skills::ensure_installed_for_backend_at(ctx.home, self.backend)?;
+        Ok(())
+    }
+}
+
+struct ClaudeDriftSkillsAction;
+
+impl HarnessSetupAction for ClaudeDriftSkillsAction {
+    fn name(&self) -> &'static str {
+        "claude-drift-skills"
+    }
+
+    fn backend(&self) -> Backend {
+        Backend::Claude
+    }
+
+    fn supports(&self, scope: LaunchSetupScope) -> bool {
+        matches!(scope, LaunchSetupScope::Global)
+    }
+
+    fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError> {
+        skill_install::ensure_installed_at(ctx.home);
+        Ok(())
+    }
+}
+
+struct CodexHookNormalizeAction;
+
+impl HarnessSetupAction for CodexHookNormalizeAction {
+    fn name(&self) -> &'static str {
+        "codex-hook-normalize"
+    }
+
+    fn backend(&self) -> Backend {
+        Backend::Codex
+    }
+
+    fn supports(&self, scope: LaunchSetupScope) -> bool {
+        matches!(scope, LaunchSetupScope::Global)
+    }
+
+    fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError> {
+        let clud_dir = ctx.home.join(".clud");
+        let hooks_path = ctx.home.join(".codex").join("hooks.json");
+        if let Err(error) =
+            codex_hook_normalize::run_at(&clud_dir, &hooks_path, ctx.out, ctx.verbose)
+        {
+            if ctx.verbose {
+                let _ = writeln!(ctx.out, "[clud] codex hook normalize: {error}");
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn setup_actions() -> Vec<Box<dyn HarnessSetupAction>> {
+    vec![
+        Box::new(BundledSkillsAction {
+            backend: Backend::Claude,
+        }),
+        Box::new(BundledSkillsAction {
+            backend: Backend::Codex,
+        }),
+        Box::new(ClaudeDriftSkillsAction),
+        Box::new(CodexHookNormalizeAction),
+    ]
+}
+
+pub fn run_setup(
+    scope: LaunchSetupScope,
+    backend: Backend,
+    verbose: bool,
+    out: &mut dyn Write,
+) -> Result<SetupReport, SetupError> {
+    let home = home_dir().ok_or(SetupError::NoHomeDir)?;
+    run_setup_at(&home, scope, backend, verbose, out)
+}
+
+pub fn run_setup_at(
+    home: &Path,
+    scope: LaunchSetupScope,
+    backend: Backend,
+    verbose: bool,
+    out: &mut dyn Write,
+) -> Result<SetupReport, SetupError> {
+    if matches!(scope, LaunchSetupScope::SessionOnly) {
+        return Ok(SetupReport::default());
+    }
+
+    let mut report = SetupReport::default();
+    let mut ctx = SetupContext { home, verbose, out };
+    for action in setup_actions() {
+        if action.backend() == backend && action.supports(scope) {
+            action.run(&mut ctx)?;
+            report.ran.push(action.name());
+        }
+    }
+    Ok(report)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(p) = std::env::var_os("USERPROFILE") {
+            if !p.is_empty() {
+                return Some(PathBuf::from(p));
+            }
+        }
+    }
+    if let Some(p) = std::env::var_os("HOME") {
+        if !p.is_empty() {
+            return Some(PathBuf::from(p));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::args::Args;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn parse(argv: &[&str]) -> Args {
+        Args::parse_from_raw(argv.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn selector_defaults_to_session_only() {
+        let selector = ScopeSelector::default();
+        assert_eq!(selector.selected(), LaunchSetupScope::SessionOnly);
+
+        let mut out = Vec::new();
+        selector.render(&mut out).unwrap();
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "[x] Session only\n[ ] Globally\n"
+        );
+    }
+
+    #[test]
+    fn selector_navigation_and_enter() {
+        let mut selector = ScopeSelector::default();
+        assert_eq!(selector.handle(SelectorEvent::Down), None);
+        assert_eq!(selector.selected(), LaunchSetupScope::Global);
+        assert_eq!(selector.handle(SelectorEvent::Up), None);
+        assert_eq!(selector.selected(), LaunchSetupScope::SessionOnly);
+        assert_eq!(
+            selector.handle(SelectorEvent::Enter),
+            Some(LaunchSetupScope::SessionOnly)
+        );
+    }
+
+    #[test]
+    fn prompt_scope_only_for_interactive_bare_launches() {
+        assert!(should_prompt_for_scope(&parse(&["clud", "--codex"]), true));
+        assert!(should_prompt_for_scope(&parse(&["clud", "--claude"]), true));
+        assert!(!should_prompt_for_scope(
+            &parse(&["clud", "--codex"]),
+            false
+        ));
+        assert!(!should_prompt_for_scope(
+            &parse(&["clud", "--codex", "--dry-run"]),
+            true
+        ));
+        assert!(!should_prompt_for_scope(
+            &parse(&["clud", "--codex", "-p", "hello"]),
+            true
+        ));
+        assert!(!should_prompt_for_scope(
+            &parse(&["clud", "--codex", "loop"]),
+            true
+        ));
+    }
+
+    #[test]
+    fn non_prompting_launches_default_to_session_only() {
+        let args = parse(&["clud", "--codex", "--dry-run"]);
+        assert_eq!(
+            scope_for_non_prompting_launch(&args, true),
+            Some(LaunchSetupScope::SessionOnly)
+        );
+    }
+
+    #[test]
+    fn session_only_setup_does_not_write_agent_home_files() {
+        let home = tempdir().unwrap();
+        fs::create_dir_all(home.path().join(".claude")).unwrap();
+        fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+        let mut out = Vec::new();
+        let report = run_setup_at(
+            home.path(),
+            LaunchSetupScope::SessionOnly,
+            Backend::Codex,
+            false,
+            &mut out,
+        )
+        .unwrap();
+
+        assert!(report.ran.is_empty());
+        assert!(!home.path().join(".agents").exists());
+        assert!(!home.path().join(".claude/skills").exists());
+        assert!(!home.path().join(".clud").exists());
+    }
+
+    #[test]
+    fn codex_global_setup_is_selected_backend_only() {
+        let home = tempdir().unwrap();
+        fs::create_dir_all(home.path().join(".claude")).unwrap();
+        fs::create_dir_all(home.path().join(".codex")).unwrap();
+        fs::write(
+            home.path().join(".codex/hooks.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"timeout":5}]}]}}"#,
+        )
+        .unwrap();
+
+        let mut out = Vec::new();
+        let report = run_setup_at(
+            home.path(),
+            LaunchSetupScope::Global,
+            Backend::Codex,
+            false,
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(report.ran, vec!["bundled-skills", "codex-hook-normalize"]);
+        assert!(home.path().join(".agents/skills/clud-pr/SKILL.md").exists());
+        assert!(!home.path().join(".claude/skills").exists());
+        let hooks = fs::read_to_string(home.path().join(".codex/hooks.json")).unwrap();
+        assert!(hooks.contains(r#""timeout": 30"#), "{hooks}");
+        assert!(home.path().join(".clud/settings.json").exists());
+    }
+
+    #[test]
+    fn claude_global_setup_is_selected_backend_only() {
+        let home = tempdir().unwrap();
+        fs::create_dir_all(home.path().join(".claude")).unwrap();
+        fs::create_dir_all(home.path().join(".codex")).unwrap();
+        fs::write(
+            home.path().join(".codex/hooks.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"timeout":5}]}]}}"#,
+        )
+        .unwrap();
+
+        let mut out = Vec::new();
+        let report = run_setup_at(
+            home.path(),
+            LaunchSetupScope::Global,
+            Backend::Claude,
+            false,
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(report.ran, vec!["bundled-skills", "claude-drift-skills"]);
+        assert!(home.path().join(".claude/skills/clud-pr/SKILL.md").exists());
+        assert!(!home.path().join(".agents").exists());
+        assert!(!home.path().join(".clud").exists());
+        let hooks = fs::read_to_string(home.path().join(".codex/hooks.json")).unwrap();
+        assert!(hooks.contains(r#""timeout":5"#), "{hooks}");
+    }
+}

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -19,6 +19,7 @@ pub mod gc;
 pub mod graphics;
 pub mod hook_health;
 pub mod large_file_guard;
+pub mod launch_setup;
 pub mod loop_artifacts;
 pub mod loop_check;
 pub mod loop_spec;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,7 @@
 use clud::{
-    args, backend, backend_bootstrap, codex_hook_normalize, command, console_setup, console_title,
-    daemon, gc, graphics, hook_health, large_file_guard, loop_artifacts, loop_spec, runner,
-    skill_install, skills, startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
+    args, backend, backend_bootstrap, command, console_setup, console_title, daemon, gc, graphics,
+    hook_health, large_file_guard, launch_setup, loop_artifacts, loop_spec, runner, startup,
+    trampoline, trash, ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -62,32 +62,6 @@ fn main() {
             }
         }
     }
-
-    // Expand bundled slash-command skills (clud-issue, clud-pr) into every
-    // backend's global skills directory that already exists. Claude Code uses
-    // ~/.claude/skills/; Codex is gated on ~/.codex/ but uses the current
-    // ~/.agents/skills/ location, with stale clud-managed ~/.codex/skills/
-    // copies purged best-effort. Existing active-target files are left alone
-    // so user edits survive. Failures are non-fatal — we log and continue,
-    // since a skills hiccup must never block a launch.
-    if let Err(e) = skills::ensure_installed() {
-        eprintln!("[clud] note: could not install bundled skills: {e}");
-    }
-
-    // Additionally run the narrower `skill_install` flow from PR #88 (drift
-    // detection for the single bundled `/clud-pr` skill). Redundant with the
-    // broader `skills::ensure_installed()` above, but harmless — both flows
-    // are idempotent and never overwrite existing user-edited skill files.
-    skill_install::ensure_installed();
-
-    // Issue #234: bump any `~/.codex/hooks.json` `PreToolUse` hook handler
-    // with `"timeout": 5` to `"timeout": 30`. Codex's documented default is
-    // much higher than 30, so values without an explicit `timeout` are
-    // already fine; this targets only the exact `5` trap that times out
-    // under normal clud-driven interactive load. Idempotent and silent
-    // when nothing changes; emits a green status line on actual edits.
-    // All failures are non-fatal — never blocks a launch.
-    codex_hook_normalize::run_global_normalization(args.verbose);
 
     // Issue #110: `clud gc <subcommand>` is a self-contained
     // maintenance path that never launches a backend. Dispatch before
@@ -267,6 +241,38 @@ fn main() {
             }
         }
     };
+
+    // Issue #242: mutable harness setup is scoped per launch. Automation,
+    // dry-runs, piped prompts, and one-shot prompt launches default to
+    // session-only and do not write backend home files. Bare interactive TUI
+    // launches can opt into global setup through a reusable selector; global
+    // setup runs only the selected backend's actions.
+    let setup_interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
+    let setup_scope = if let Some(scope) =
+        launch_setup::scope_for_non_prompting_launch(&args, setup_interactive)
+    {
+        scope
+    } else {
+        let mut err = io::stderr().lock();
+        match launch_setup::prompt_scope(&mut err) {
+            Ok(scope) => scope,
+            Err(error) => {
+                eprintln!(
+                    "[clud] note: could not read launch setup scope ({error}); using session-only"
+                );
+                launch_setup::LaunchSetupScope::SessionOnly
+            }
+        }
+    };
+    if matches!(setup_scope, launch_setup::LaunchSetupScope::Global) {
+        let mut err = io::stderr().lock();
+        if let Err(error) = launch_setup::run_setup(setup_scope, backend, args.verbose, &mut err) {
+            eprintln!("[clud] note: global setup failed: {error}");
+        }
+    }
+    if args.verbose {
+        verbose_log::log(format_args!("[clud] setup scope: {}", setup_scope.as_str()));
+    }
 
     let plan = command::build_launch_plan(&args, backend, &backend_path);
     if args.verbose {

--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -1,8 +1,8 @@
 //! Auto-installer for the bundled `clud-*` skills.
 //!
-//! On every `clud` launch we ensure each entry in [`BUNDLED_SKILLS`] is
-//! present at `~/.claude/skills/<name>/SKILL.md` and matches the version
-//! baked into this binary via `include_str!`.
+//! During Claude global launch setup, we ensure each entry in
+//! [`BUNDLED_SKILLS`] is present at `~/.claude/skills/<name>/SKILL.md` and
+//! matches the version baked into this binary via `include_str!`.
 //!
 //! Three states per skill:
 //! - **Missing** — write the embedded copy, log a one-line install notice.
@@ -52,19 +52,25 @@ const BUNDLED_SKILLS: &[Skill] = &[
     },
 ];
 
-/// Run the install/check for every bundled skill on launch. Cheap on the
-/// steady state (one stat + one read per skill). Failures degrade silently
-/// to a stderr note.
+/// Compatibility helper that runs the install/check using the current home
+/// directory. Production launch setup calls [`ensure_installed_at`] only for
+/// Claude global setup. Cheap on the steady state (one stat + one read per
+/// skill). Failures degrade silently to a stderr note.
 pub fn ensure_installed() {
+    let Some(home) = home_dir() else {
+        return;
+    };
+    ensure_installed_at(&home);
+}
+
+pub fn ensure_installed_at(home: &Path) {
     for skill in BUNDLED_SKILLS {
-        ensure_skill_installed(skill);
+        ensure_skill_installed_at(home, skill);
     }
 }
 
-fn ensure_skill_installed(skill: &Skill) {
-    let Some(path) = target_path(skill.name) else {
-        return;
-    };
+fn ensure_skill_installed_at(home: &Path, skill: &Skill) {
+    let path = target_path_at(home, skill.name);
     match classify(&path, skill.content) {
         Existing::Missing => write_install(&path, skill),
         Existing::Matches => {}
@@ -105,14 +111,11 @@ fn normalize(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn target_path(skill_name: &str) -> Option<PathBuf> {
-    let home = home_dir()?;
-    Some(
-        home.join(".claude")
-            .join("skills")
-            .join(skill_name)
-            .join("SKILL.md"),
-    )
+fn target_path_at(home: &Path, skill_name: &str) -> PathBuf {
+    home.join(".claude")
+        .join("skills")
+        .join(skill_name)
+        .join("SKILL.md")
 }
 
 fn home_dir() -> Option<PathBuf> {

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -23,6 +23,8 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
+use crate::backend::Backend;
+
 const MANAGED_BY_CLUD_MARKER: &str = "managed-by: clud";
 
 /// One bundled skill: the directory name and the literal `SKILL.md` body.
@@ -68,6 +70,8 @@ pub const BUNDLED_SKILLS: &[BundledSkill] = &[
 /// new tool is a one-line append to [`SKILL_BACKENDS`] — the on-disk layout
 /// is the same as Claude Code's, just rooted under the tool's home subdir.
 pub struct SkillBackend {
+    /// Backend this install target belongs to.
+    pub backend: Backend,
     /// Display name for log messages.
     pub name: &'static str,
     /// Path under the user's home dir where this backend stores config
@@ -103,12 +107,14 @@ impl SkillBackend {
 /// append a `SkillBackend { ... }` entry here.
 pub const SKILL_BACKENDS: &[SkillBackend] = &[
     SkillBackend {
+        backend: Backend::Claude,
         name: "Claude Code",
         home_subdir: ".claude",
         skills_home_subdir: None,
         skills_subdir: "skills",
     },
     SkillBackend {
+        backend: Backend::Codex,
         name: "Codex",
         home_subdir: ".codex",
         skills_home_subdir: Some(".agents"),
@@ -116,6 +122,7 @@ pub const SKILL_BACKENDS: &[SkillBackend] = &[
     },
     // To add a new backend (e.g. OpenRouter CLI):
     // SkillBackend {
+    //     backend: Backend::OpenRouter,
     //     name: "OpenRouter",
     //     home_subdir: ".openrouter",
     //     skills_home_subdir: None,
@@ -161,10 +168,12 @@ pub struct LegacyPurgeReport {
     pub failed: Vec<&'static str>,
 }
 
-/// Install bundled skills into every backend whose home subdir exists.
-/// Returns one `(backend, report)` per backend actually written to.
-/// Returns [`InstallError::NoHomeDir`] only when the home dir itself
-/// cannot be resolved.
+/// Compatibility helper that installs bundled skills into every backend whose
+/// home subdir exists. Production launch setup calls
+/// [`ensure_installed_for_backend`] for the selected backend instead. Returns
+/// one `(backend, report)` per backend actually written to. Returns
+/// [`InstallError::NoHomeDir`] only when the home dir itself cannot be
+/// resolved.
 pub fn ensure_installed() -> Result<Vec<(&'static SkillBackend, InstallReport)>, InstallError> {
     let home = home_dir().ok_or(InstallError::NoHomeDir)?;
     ensure_installed_at(&home)
@@ -180,6 +189,34 @@ pub fn ensure_installed_at(
         results.push((backend, report));
     }
     Ok(results)
+}
+
+pub fn ensure_installed_for_backend(
+    backend: Backend,
+) -> Result<Option<(&'static SkillBackend, InstallReport)>, InstallError> {
+    let home = home_dir().ok_or(InstallError::NoHomeDir)?;
+    ensure_installed_for_backend_at(&home, backend)
+}
+
+pub fn ensure_installed_for_backend_at(
+    home: &Path,
+    backend: Backend,
+) -> Result<Option<(&'static SkillBackend, InstallReport)>, InstallError> {
+    if matches!(backend, Backend::Codex) {
+        let _ = purge_legacy_codex_skills(home, BUNDLED_SKILLS);
+    }
+    let Some(skill_backend) = backend_for(backend) else {
+        return Ok(None);
+    };
+    if !skill_backend.root_exists(home) {
+        return Ok(None);
+    }
+    let report = install_to(&skill_backend.skills_dir(home), BUNDLED_SKILLS)?;
+    Ok(Some((skill_backend, report)))
+}
+
+pub fn backend_for(backend: Backend) -> Option<&'static SkillBackend> {
+    SKILL_BACKENDS.iter().find(|b| b.backend == backend)
 }
 
 /// All `SkillBackend`s whose home subdir currently exists under `home` —
@@ -421,12 +458,12 @@ mod tests {
 
     #[test]
     fn skill_backends_include_claude_and_codex() {
-        let backends: Vec<(&str, &str, Option<&str>)> = SKILL_BACKENDS
+        let backends: Vec<(Backend, &str, &str, Option<&str>)> = SKILL_BACKENDS
             .iter()
-            .map(|b| (b.name, b.home_subdir, b.skills_home_subdir))
+            .map(|b| (b.backend, b.name, b.home_subdir, b.skills_home_subdir))
             .collect();
-        assert!(backends.contains(&("Claude Code", ".claude", None)));
-        assert!(backends.contains(&("Codex", ".codex", Some(".agents"))));
+        assert!(backends.contains(&(Backend::Claude, "Claude Code", ".claude", None)));
+        assert!(backends.contains(&(Backend::Codex, "Codex", ".codex", Some(".agents"))));
     }
 
     #[test]
@@ -472,6 +509,7 @@ mod tests {
     fn skills_dir_resolves_under_backend_root() {
         let home = tempdir().unwrap();
         let backend = SkillBackend {
+            backend: Backend::Claude,
             name: "Test",
             home_subdir: ".testtool",
             skills_home_subdir: None,
@@ -488,10 +526,8 @@ mod tests {
         let home = tempdir().unwrap();
         std::fs::create_dir_all(home.path().join(".codex")).unwrap();
 
-        let results = ensure_installed_at(home.path()).unwrap();
-        let codex = results
-            .iter()
-            .find(|(backend, _)| backend.name == "Codex")
+        let codex = ensure_installed_for_backend_at(home.path(), Backend::Codex)
+            .unwrap()
             .expect("codex backend should be active");
 
         assert_eq!(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,27 +1,32 @@
 # clud Architecture
 
-Index of subsystem architecture docs. Each file is self-contained for one cross-cutting concept; per-directory READMEs link in here instead of re-explaining.
+Index of subsystem architecture docs. Each file is self-contained for one
+cross-cutting concept; per-directory READMEs link here instead of
+re-explaining.
 
-## Subsystem docs
+## Subsystem Docs
 
 | Document | Lines | What it covers |
 |---|---|---|
 | [architecture/loop-subsystem.md](architecture/loop-subsystem.md) | ~250 | `clud loop`: task resolution, plan synthesis, iteration run, DONE/BLOCKED marker contract, artifact rollover, repeat scheduling |
 | [architecture/daemon-ipc.md](architecture/daemon-ipc.md) | ~250 | Always-on clud daemon hosting session ops + GC: TCP JSON IPC, daemon/worker re-entry model, snapshot persistence, attach broker |
 | [architecture/session-lifecycle.md](architecture/session-lifecycle.md) | ~300 | PTY session pump, console mode setup, OSC title keeper, capture for attach, drag-drop and voice injection points |
-| [architecture/skill-system.md](architecture/skill-system.md) | ~200 | Skill bundling (`include_str!`), dual-installer model (`skills.rs` vs `skill_install.rs`), multi-backend install |
+| [architecture/skill-system.md](architecture/skill-system.md) | ~200 | Skill bundling (`include_str!`), dual-installer model (`skills.rs` vs `skill_install.rs`), selected-backend global setup |
+| [architecture/launch-setup.md](architecture/launch-setup.md) | ~70 | Session-only vs global launch setup, persistent setup actions, selected-backend gating |
 | [architecture/gc-and-registry.md](architecture/gc-and-registry.md) | ~250 | always-on `clud __daemon` single-owner redb model, session cap registry, worktree scanner, GC subcommands |
 | [architecture/windows-quirks.md](architecture/windows-quirks.md) | ~300 | Windows-only platform code: trampoline, BatBadBat `.cmd` rewrite, console modes, Shift+Enter key translation, `IDropTarget`, `CREATE_NO_WINDOW`, ARM whisper carveout |
 | [architecture/launch-plan.md](architecture/launch-plan.md) | ~180 | `LaunchPlan` as the single source of truth: construction, consumers, `--dry-run` JSON |
 
-## Quick reference
+## Quick Reference
 
-- **"How does `clud loop` decide when to stop?"** → [loop-subsystem.md](architecture/loop-subsystem.md)
-- **"How do `attach` / `list` / `kill` talk to the daemon?"** → [daemon-ipc.md](architecture/daemon-ipc.md)
-- **"What happens between Ctrl-D and process exit in a PTY session?"** → [session-lifecycle.md](architecture/session-lifecycle.md)
-- **"Why are there two skill installers?"** → [skill-system.md](architecture/skill-system.md)
-- **"Why is `~/.clud/data.redb` behind a daemon?"** → [gc-and-registry.md](architecture/gc-and-registry.md)
-- **"Why does Windows do X differently?"** → [windows-quirks.md](architecture/windows-quirks.md)
-- **"Where does the argv that clud runs come from?"** → [launch-plan.md](architecture/launch-plan.md)
+- **"How does `clud loop` decide when to stop?"** -> [loop-subsystem.md](architecture/loop-subsystem.md)
+- **"How do `attach` / `list` / `kill` talk to the daemon?"** -> [daemon-ipc.md](architecture/daemon-ipc.md)
+- **"What happens between Ctrl-D and process exit in a PTY session?"** -> [session-lifecycle.md](architecture/session-lifecycle.md)
+- **"Why are there two skill installers?"** -> [skill-system.md](architecture/skill-system.md)
+- **"When does clud write agent setup files?"** -> [launch-setup.md](architecture/launch-setup.md)
+- **"Why is `~/.clud/data.redb` behind a daemon?"** -> [gc-and-registry.md](architecture/gc-and-registry.md)
+- **"Why does Windows do X differently?"** -> [windows-quirks.md](architecture/windows-quirks.md)
+- **"Where does the argv that clud runs come from?"** -> [launch-plan.md](architecture/launch-plan.md)
 
-See also: [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md) for rationale behind the choices these subsystems embody.
+See also: [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md) for rationale behind the
+choices these subsystems embody.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -89,7 +89,7 @@ Decisions are numbered for stable cross-references (e.g. `DD-005`). Numbers are 
 
 **Context:** Users run different upstream agents (`claude` and `codex`) with similar but not identical CLI surfaces. Each backend has its own arg conventions, model-flag placement, prompt-injection mechanism, and skill-install location.
 
-**Decision:** clud detects which backends are on `PATH` and supports either via `--claude` / `--codex` flags. The `Backend` enum is plumbed through every code path that constructs argv. Where backends diverge (`--model` placement, `-p` semantics, `stream-json` injection, the `exec`/`resume` keywords), the divergence is encoded inside `command/`. Skills bundled into the `clud` binary install to `~/.claude/skills/` for Claude Code and Codex's current `~/.agents/skills/` location when the corresponding backend homes already exist; stale clud-managed copies under the retired `~/.codex/skills/` path are purged best-effort.
+**Decision:** clud detects which backends are on `PATH` and supports either via `--claude` / `--codex` flags. The `Backend` enum is plumbed through every code path that constructs argv and every persistent launch-setup action. Where backends diverge (`--model` placement, `-p` semantics, `stream-json` injection, the `exec`/`resume` keywords), the divergence is encoded inside `command/`. Skills bundled into the `clud` binary install to `~/.claude/skills/` for Claude Code and Codex's current `~/.agents/skills/` location only during global launch setup for the selected backend; stale clud-managed copies under the retired `~/.codex/skills/` path are purged best-effort during Codex global setup.
 
 **Rationale:**
 - Locks clud into supporting users on either backend without forking the binary.
@@ -192,14 +192,14 @@ The separate session-cap registry (`sessions.redb`) keeps file-lock-based serial
 
 ## DD-008: Dual skill installer (`skills.rs` vs `skill_install.rs`) — interim state
 
-**Context:** Skills are slash-commands (`/clud-pr`, `/clud-issue`, etc.) bundled into the `clud` binary via `include_str!` and installed into the user's backend home(s) on launch. Two installer implementations exist in the codebase today:
+**Context:** Skills are slash-commands (`/clud-pr`, `/clud-issue`, etc.) bundled into the `clud` binary via `include_str!` and installed into the user's backend home(s) during global launch setup. Session-only launches do not write persistent skill files. Two installer implementations exist in the codebase today:
 
 - `src/skills.rs` — multi-backend (`~/.claude/skills/`, Codex `~/.agents/skills/` gated by `~/.codex`), non-overwriting (preserves user edits), reads from `crates/clud-bin/assets/skills/`, and purges stale clud-managed Codex copies from `~/.codex/skills/`.
 - `src/skill_install.rs` — Claude-only (`~/.claude/skills/`), overwrites on semantic divergence (whitespace-tolerant compare), reads from a separate top-level `skills/` directory.
 
 Their `BUNDLED_SKILLS` constants ship different subsets of skills.
 
-**Decision:** Accept the duality as interim state. Both installers run on every launch. Document the divergence explicitly in [skill-system.md](architecture/skill-system.md) and the dir READMEs so contributors aren't surprised. Plan to consolidate later (single installer, single source tree).
+**Decision:** Accept the duality as interim state. Both installers remain registered behind the launch setup scope gate, and global setup runs only the selected backend's actions. Document the divergence explicitly in [skill-system.md](architecture/skill-system.md) and the dir READMEs so contributors aren't surprised. Plan to consolidate later (single installer, single source tree).
 
 **Rationale:**
 - The two installers evolved independently — `skill_install.rs` predates `skills.rs` — and consolidating now would be a non-trivial change with its own design questions (which overwrite policy wins? which source tree?).
@@ -214,7 +214,7 @@ Their `BUNDLED_SKILLS` constants ship different subsets of skills.
 | Delete one installer | Either drops Codex support (`skill_install.rs` alone) or drops semantic overwrite (`skills.rs` alone). |
 
 **Consequences:**
-- Two install passes run on every `clud` launch; cost is negligible (compile-time strings, file existence checks).
+- Two installer implementations remain live, but they run only during selected-backend global setup. Session-only launches skip both.
 - Adding a new skill requires editing `BUNDLED_SKILLS` in **both** files (and possibly placing the `SKILL.md` in both source trees). [skill-system.md](architecture/skill-system.md) documents the checklist.
 - This DD should be revisited when consolidation lands; mark superseded then.
 

--- a/docs/architecture/launch-setup.md
+++ b/docs/architecture/launch-setup.md
@@ -1,0 +1,43 @@
+# Launch Setup
+
+Launch setup is the narrow gate for persistent agent-home mutations that happen
+before clud starts a backend. It lives in `crates/clud-bin/src/launch_setup.rs`.
+
+## Scope Selector
+
+Bare interactive TUI launches prompt on stderr before the backend starts:
+
+```text
+[x] Session only
+[ ] Globally
+```
+
+The default is session-only. Enter accepts the highlighted option, Up selects
+session-only, and Down selects global. Non-interactive launches, piped stdin,
+`--dry-run`, one-shot prompt launches (`-p` / `-m`), continuations, resumes,
+and maintenance commands do not prompt; they use session-only.
+
+Session-only launches skip persistent setup. They must not create or modify
+agent home setup files under `~/.claude`, `~/.codex`, `~/.agents`, or
+`~/.clud` as part of harness setup.
+
+## Global Actions
+
+Global setup runs only the selected backend's registered actions:
+
+| Backend | Action | Persistent paths |
+|---|---|---|
+| Claude | bundled skills | `~/.claude/skills/` |
+| Claude | Claude drift skills | `~/.claude/skills/` |
+| Codex | bundled skills | `~/.agents/skills/` gated by `~/.codex`; stale clud-managed `~/.codex/skills/` copies are purged |
+| Codex | hook timeout normalization | `~/.codex/hooks.json` and `~/.clud/settings.lock` / `settings.json` |
+
+All setup failures are non-fatal. `main.rs` logs a `[clud] note: ...` line and
+continues to build and run the backend `LaunchPlan`.
+
+## Adding an Action
+
+Add a `HarnessSetupAction` implementation in `launch_setup.rs`, give it a
+backend, and make `supports(SessionOnly)` false unless the action is proven not
+to write persistent agent setup state. Tests should cover both session-only
+no-write behavior and selected-backend global behavior.

--- a/docs/architecture/skill-system.md
+++ b/docs/architecture/skill-system.md
@@ -3,10 +3,12 @@
 Skills are slash-command playbooks (`/clud-pr`, `/clud-issue`, etc.) that ship
 embedded inside the `clud` binary as compile-time string assets and are
 installed into the user's backend skill directories (`~/.claude/skills/` and
-Codex's current `~/.agents/skills/`) on every launch. A fresh `clud` install
-always carries the current canonical copy of every bundled skill without any
-extra setup step. Older clud-managed Codex copies in `~/.codex/skills/` are
-purged best-effort during the same launch-time pass.
+Codex's current `~/.agents/skills/`) only during global launch setup. Regular
+session-only launches do not write persistent agent setup files. Bare
+interactive launches can opt into global setup with the selector in
+`launch_setup.rs`; automation, piped stdin, `--dry-run`, and one-shot prompt
+launches default to session-only. Older clud-managed Codex copies in
+`~/.codex/skills/` are purged best-effort only when Codex global setup runs.
 
 ## Component map
 
@@ -17,64 +19,70 @@ purged best-effort during the same launch-time pass.
 | Multi-backend source tree | `crates/clud-bin/assets/skills/<name>/` | Holds `SKILL.md` + `README.md` for skills consumed by `skills.rs`. |
 | Top-level source tree | `skills/<name>/SKILL.md` | Holds skills consumed by `skill_install.rs` (no per-skill READMEs). |
 | `BUNDLED_SKILLS` (multi-backend) | `crates/clud-bin/src/skills.rs:32` | Compile-time list paired with `include_str!("../assets/skills/<name>/SKILL.md")`. |
-| `BUNDLED_SKILLS` (Claude-only) | `crates/clud-bin/src/skill_install.rs:32` | Same name, different content — paired with `include_str!("../../../skills/<name>/SKILL.md")`. |
-| Launch dispatch | `crates/clud-bin/src/main.rs:36-44` | Calls both installers in sequence at startup. |
+| `BUNDLED_SKILLS` (Claude-only) | `crates/clud-bin/src/skill_install.rs:32` | Same name, different content; paired with `include_str!("../../../skills/<name>/SKILL.md")`. |
+| Launch setup gate | `crates/clud-bin/src/launch_setup.rs` | Selects session-only vs global setup and dispatches selected-backend setup actions. |
 
-## Why two installers
+## Why Two Installers
 
-The two installers are an interim historical reality, not a designed-in
-split. `skill_install.rs` predates `skills.rs` (introduced in PR #88 for the
-single `/clud-pr` skill) and was kept in place when the broader multi-backend
-expander landed. The two flows now serve overlapping but distinct purposes:
+The two installers are an interim historical reality, not a designed-in split.
+`skill_install.rs` predates `skills.rs` and was kept in place when the broader
+multi-backend expander landed. The two flows now serve overlapping but distinct
+purposes:
 
 | Concern | `skills.rs` | `skill_install.rs` |
 |---|---|---|
-| Backends targeted | Every entry in `SKILL_BACKENDS` whose home subdir exists (Claude + Codex today; Codex is gated on `~/.codex` and writes to `~/.agents/skills`) | Hard-coded `~/.claude/skills/` only |
+| Backends targeted | The selected backend during global setup (Claude + Codex today; Codex is gated on `~/.codex` and writes to `~/.agents/skills`) | Hard-coded `~/.claude/skills/` only; run only for Claude global setup |
 | Source tree | `crates/clud-bin/assets/skills/` | Top-level `skills/` |
-| Behavior on existing file | Skip — user edits are preserved | Compare modulo whitespace; overwrite when semantically divergent |
+| Behavior on existing file | Skip; user edits are preserved | Compare modulo whitespace; overwrite when semantically divergent |
 | Bundled skill set | `clud-issue`, `clud-issue-triage`, `clud-pr`, `clud-tag-release` | `clud-pr`, `clud-pr-merge`, `clud-issue` |
 | Error policy | Non-fatal; one `[clud] note: ...` on failure | Non-fatal; one `[clud] note: ...` on failure |
 
 Both invariants are enforced by tests in their respective modules: see
-`skips_existing_and_preserves_user_edits` in `skills.rs:225` and
-`semantic_diff_overwrites_with_embedded_copy` in `skill_install.rs:258`.
+`skips_existing_and_preserves_user_edits` in `skills.rs` and
+`semantic_diff_overwrites_with_embedded_copy` in `skill_install.rs`.
 
-## Install-on-launch flow
+## Global Setup Flow
 
-`main()` runs both installers near the top of `clud` startup, after the
-trampoline unlock and the console-title stamp but before argument parsing.
-The order (see `crates/clud-bin/src/main.rs:36-44`):
+`main()` resolves the backend first, then asks `launch_setup.rs` for a setup
+scope before building the final `LaunchPlan`. Non-prompting launches receive
+`SessionOnly` and skip all persistent setup actions. Bare interactive launches
+show this selector on stderr:
 
-1. `skills::ensure_installed()` — multi-backend, preserve-existing pass.
-   It first purges stale clud-managed Codex copies from `~/.codex/skills/`,
-   then returns a per-backend `InstallReport` listing what was installed vs
-   skipped in the active target directories. Errors only when
-   `$HOME`/`$USERPROFILE` cannot be resolved or active-target installs fail.
-2. `skill_install::ensure_installed()` — Claude-only drift pass. No return
+```text
+[x] Session only
+[ ] Globally
+```
+
+Enter accepts the highlighted option. Up selects session-only; Down selects
+global. When the selected scope is global, `launch_setup::run_setup` runs only
+the actions registered for the selected backend:
+
+1. `skills::ensure_installed_for_backend()` - multi-backend,
+   preserve-existing pass for the selected backend. Codex global setup first
+   purges stale clud-managed Codex copies from `~/.codex/skills/`, then writes
+   bundled skills to `~/.agents/skills/` when `~/.codex` exists.
+2. `skill_install::ensure_installed()` - Claude-only drift pass. It runs only
+   when the selected backend is Claude and the scope is global. No return
    value; logs `[clud] installed /<name>` on first install and
-   `[clud] updated /<name>` (green) on a semantic overwrite.
+   `[clud] updated /<name>` on a semantic overwrite.
 
 Both are wrapped so a failure logs a `[clud] note: ...` line on stderr and
-launch continues. A skills hiccup must never block the backend from
-starting — see the "best-effort startup nudges" entry in
-`crates/clud-bin/src/README.md`.
+launch continues. A skills hiccup must never block the backend from starting.
+See [launch-setup.md](launch-setup.md) for the selector contract and the other
+global setup actions.
 
-## Bundling mechanism
+## Bundling Mechanism
 
-Each `SKILL.md` is pulled into the binary at compile time with
-`include_str!`. There is no `include_dir` crate in `Cargo.toml` and no
-runtime filesystem lookup of source content — the embedded string is the
-single source of truth. Consequences:
+Each `SKILL.md` is pulled into the binary at compile time with `include_str!`.
+There is no runtime filesystem lookup of source content. Consequences:
 
-- Adding a `SKILL.md` to the source tree without registering it in the
-  matching `BUNDLED_SKILLS` constant does nothing at runtime.
+- Adding a `SKILL.md` to the source tree without registering it in the matching
+  `BUNDLED_SKILLS` constant does nothing at runtime.
 - A typo in the `include_str!` path is a build-time error.
-- A zero-byte source file compiles cleanly but ships an empty skill — the
-  `bundled_skills_are_non_empty` test in `skills.rs:263` and
-  `every_bundled_skill_has_real_content` in `skill_install.rs:296` guard
-  against that.
+- A zero-byte source file compiles cleanly but ships an empty skill. The
+  bundled-skill tests guard against that.
 
-## Source-tree divergence
+## Source-Tree Divergence
 
 Two source trees back the two installers, and their contents do not match:
 
@@ -88,85 +96,80 @@ Two source trees back the two installers, and their contents do not match:
 
 Practical consequences:
 
-- `clud-pr-merge` is Claude-only — Codex users never get it.
+- `clud-pr-merge` is Claude-only; Codex users never get it.
 - `clud-issue-triage` and `clud-tag-release` are installed only via the
-  preserve-existing path, so once written they are never refreshed by the
-  drift installer.
-- For `clud-issue` and `clud-pr`, the two source files can drift apart in
-  the repo. The drift installer treats the top-level `skills/<name>/SKILL.md`
-  as canonical for Claude and will overwrite a Claude install whose content
+  preserve-existing path, so once written they are never refreshed by the drift
+  installer.
+- For `clud-issue` and `clud-pr`, the two source files can drift apart in the
+  repo. The drift installer treats the top-level `skills/<name>/SKILL.md` as
+  canonical for Claude and will overwrite a Claude install whose content
   matches the `assets/skills/` copy but not the top-level one.
 
-The `assets/skills/` README flags this explicitly as a future-consolidation
-target — see `crates/clud-bin/assets/skills/README.md:14-19`.
-
-## Adding a skill
+## Adding a Skill
 
 Use this checklist:
 
-1. **Decide which installer(s) the skill ships through.** Multi-backend
-   coverage requires `skills.rs`; drift-on-divergence semantics require
+1. Decide which installer(s) the skill ships through. Multi-backend coverage
+   requires `skills.rs`; drift-on-divergence semantics require
    `skill_install.rs`. Most new skills want `skills.rs` only.
-2. **Drop the source file.**
-   - For `skills.rs`: `crates/clud-bin/assets/skills/<name>/SKILL.md`
-     with standard frontmatter (`name:`, `description:`, `triggers:`) and
-     the `<!-- managed-by: clud -->` marker. Add a sibling `README.md`
-     describing the skill for contributors.
-   - For `skill_install.rs`: `skills/<name>/SKILL.md` at the repo root.
-     The frontmatter must include `name: <name>` — the
-     `every_bundled_skill_has_real_content` test asserts it.
-3. **Register the entry.** Append a `BundledSkill { name, skill_md:
+2. Drop the source file.
+   - For `skills.rs`: `crates/clud-bin/assets/skills/<name>/SKILL.md` with
+     standard frontmatter (`name:`, `description:`, `triggers:`) and the
+     `<!-- managed-by: clud -->` marker. Add a sibling `README.md` describing
+     the skill for contributors.
+   - For `skill_install.rs`: `skills/<name>/SKILL.md` at the repo root. The
+     frontmatter must include `name: <name>`.
+3. Register the entry. Append a `BundledSkill { name, skill_md:
    include_str!("...") }` to the relevant `BUNDLED_SKILLS` constant
-   (`skills.rs:32` or `skill_install.rs:32`). The two constants share a
-   name but have different field shapes (`skill_md` vs `content`) and live
-   in different modules.
-4. **Link the README** from the **Skills** section of
+   (`skills.rs` or `skill_install.rs`). The two constants share a name but have
+   different field shapes (`skill_md` vs `content`) and live in different
+   modules.
+4. Link the README from the Skills section of
    `crates/clud-bin/assets/skills/README.md` if applicable.
-5. **Run `bash lint` and `bash test`.** The bundle tests assert non-empty
-   content, unique names, and the `managed-by: clud` marker.
+5. Run `bash lint` and `bash test`. The bundle tests assert non-empty content,
+   unique names, and the `managed-by: clud` marker.
 
-## Key types / constants
+## Key Types / Constants
 
-- `BundledSkill` (`skills.rs:25`): public struct with `name` and `skill_md`
+- `BundledSkill` (`skills.rs`): public struct with `name` and `skill_md`
   fields; used by `install_to` in tests and by external callers.
-- `Skill` (`skill_install.rs:25`): private struct with `name` and `content`
+- `Skill` (`skill_install.rs`): private struct with `name` and `content`
   fields; module-internal only.
-- `BUNDLED_SKILLS` (both modules): same identifier in both files,
-  different element type, different source-tree backing. **This collision
-  is the single biggest footgun when navigating between the two installers
-  — always check which module you are in.**
-- `SKILL_BACKENDS` (`skills.rs:83`): the list of backend install gates and
-  skill target directories the multi-backend installer iterates. Codex uses
+- `BUNDLED_SKILLS` (both modules): same identifier in both files, different
+  element type, different source-tree backing.
+- `SKILL_BACKENDS` (`skills.rs`): the list of backend install gates and skill
+  target directories the multi-backend installer can target. Codex uses
   `.codex` as the installed-backend gate and `.agents/skills` as the current
-  skill target. Adding a new CLI is a one-line append; see the commented
-  OpenRouter example.
-- `ensure_installed` (both modules): the public launch-time entry point;
-  same name, different return type (`Result<Vec<...>, InstallError>` vs
-  `()`).
-- `normalize` (`skill_install.rs:96`): the whitespace-tolerant equality
-  helper that makes CRLF-vs-LF a no-op on Windows checkouts.
-- `Existing` (`skill_install.rs:71`): four-variant state classifier
+  skill target.
+- `ensure_installed_for_backend` (`skills.rs`): the global-setup entry point
+  used by `launch_setup.rs` for the selected backend.
+- `ensure_installed` (both modules): compatibility helpers; same name,
+  different return type (`Result<Vec<...>, InstallError>` vs `()`), but
+  `main.rs` no longer calls them unconditionally on every launch.
+- `normalize` (`skill_install.rs`): the whitespace-tolerant equality helper
+  that makes CRLF-vs-LF a no-op on Windows checkouts.
+- `Existing` (`skill_install.rs`): four-variant state classifier
   (`Missing` / `Matches` / `Diverges` / `Unreadable`) that drives the
   drift-installer's action choice.
-- `InstallReport` (`skills.rs:127`): per-backend result of an install
-  pass, listing `installed` and `skipped_existing` skills by name.
-- `LegacyPurgeReport` (`skills.rs:127`): best-effort cleanup summary for
-  clud-managed `~/.codex/skills/<name>/SKILL.md` copies removed during the
-  migration away from the legacy Codex skill directory.
+- `InstallReport` (`skills.rs`): per-backend result of an install pass,
+  listing `installed` and `skipped_existing` skills by name.
+- `LegacyPurgeReport` (`skills.rs`): best-effort cleanup summary for
+  clud-managed `~/.codex/skills/<name>/SKILL.md` copies removed during Codex
+  global setup after the migration away from the legacy Codex skill directory.
 
-## Consolidation plan (open)
+## Consolidation Plan
 
-The dual installer is acknowledged interim state. The
-`assets/skills/README.md` notes the redundancy and the per-skill READMEs
-document which installer each skill ships through. Future work should
-collapse this into a single installer with a single source tree; the
-resolution (which behavior wins on existing files, which source tree
-survives, how to keep Codex coverage while preserving drift detection for
-Claude) is not prescribed here.
+The dual installer is acknowledged interim state. The `assets/skills/README.md`
+notes the redundancy and the per-skill READMEs document which installer each
+skill ships through. Future work should collapse this into a single installer
+with a single source tree; the resolution is not prescribed here. The current
+installers remain behind the launch setup scope gate so session-only launches
+stay side-effect free.
 
-## See also
+## See Also
 
-- `../../crates/clud-bin/assets/skills/README.md` — bundled-skill index and
+- `../../crates/clud-bin/assets/skills/README.md` - bundled-skill index and
   the original dual-installer caveat.
-- `../DESIGN_DECISIONS.md` (DD-008) — design rationale for the skill-system
+- `launch-setup.md` - selector and persistent setup action contract.
+- `../DESIGN_DECISIONS.md` (DD-008) - design rationale for the skill-system
   shape.


### PR DESCRIPTION
﻿## Summary

- Add a reusable launch setup scope selector with session-only as the default and global as the explicit opt-in.
- Move persistent skill installation and Codex hook timeout normalization behind selected-backend global setup.
- Document session-only/global setup behavior and selected-backend setup actions.

Closes #242

## Tests

- `soldr cargo fmt`
- `soldr cargo test -p clud launch_setup::tests`
- `soldr cargo test -p clud skills::tests`
- `soldr cargo test -p clud skill_install::tests`
- `soldr cargo test -p clud`
- `soldr cargo clippy -p clud --all-targets -- -D warnings`
- `soldr cargo build -p clud --bin clud`
- `python -m pytest tests/test_hello.py`
- Runtime smoke: `--dry-run --codex -p hello` with a temp home left hooks unchanged and created no `.agents`, `.claude/skills`, or `.clud` setup files.
