### PR TITLE
feat: profile daemon Ctrl-C handoff

### DIFF
--- a/crates/clud-bin/assets/dashboard/index.html
+++ b/crates/clud-bin/assets/dashboard/index.html
@@ -85,6 +85,7 @@
     }
     th { color: var(--muted); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
     td.path, td.id { font-family: ui-monospace, "Menlo", "Consolas", monospace; font-size: 12px; word-break: break-all; }
+    td.metric { font-family: ui-monospace, "Menlo", "Consolas", monospace; font-size: 12px; white-space: nowrap; }
     .badge {
       display: inline-block;
       padding: 1px 6px;
@@ -190,11 +191,25 @@
       if (m > 0) return `${m}m ${sec}s`;
       return `${sec}s`;
     }
+    function fmtMs(ms) {
+      if (ms === null || ms === undefined) return '-';
+      if (ms < 1000) return `${ms}ms`;
+      return `${(ms / 1000).toFixed(2)}s`;
+    }
     function esc(s) {
       if (s === null || s === undefined) return '';
       return String(s).replace(/[&<>"']/g, c => ({
         '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
       })[c]);
+    }
+
+    function renderCtrlC(profile) {
+      if (!profile) return '-';
+      const cli = fmtMs(profile.cli_handoff_ms);
+      const daemon = profile.daemon_kill_ms === null || profile.daemon_kill_ms === undefined
+        ? 'killing'
+        : fmtMs(profile.daemon_kill_ms);
+      return `${esc(cli)} cli / ${esc(daemon)} daemon`;
     }
 
     function renderHeader(state) {
@@ -227,12 +242,13 @@
             ? '<span class="badge live">live</span>'
             : `<span class="badge gone">exit ${esc(s.exit_code ?? '?')}</span>`}</td>
           <td>${esc(fmtAge(s.created_at))}</td>
+          <td class="metric">${renderCtrlC(s.ctrl_c)}</td>
           <td class="path">${esc(s.cwd || '-')}</td>
         </tr>`).join('');
       document.getElementById('sessions-body').innerHTML = `
         <table>
           <thead><tr>
-            <th>id</th><th>name</th><th>kind</th><th>state</th><th>age</th><th>cwd</th>
+            <th>id</th><th>name</th><th>kind</th><th>state</th><th>age</th><th>ctrl-c</th><th>cwd</th>
           </tr></thead>
           <tbody>${rows}</tbody>
         </table>`;

--- a/crates/clud-bin/src/daemon/attach.rs
+++ b/crates/clud-bin/src/daemon/attach.rs
@@ -10,7 +10,7 @@ use base64::Engine;
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 
 use super::client::{
-    ensure_daemon, request_session_termination, send_daemon_request, send_worker_message,
+    ensure_daemon, request_session_interrupt, send_daemon_request, send_worker_message,
     shutdown_worker_connection,
 };
 use super::io_helpers::write_json_line;
@@ -18,12 +18,14 @@ use super::keys::translate_key_event;
 use super::process_utils::pid_is_alive;
 use super::sessions::resolve_session_id;
 use super::types::{
-    BackgroundPromptDecision, DaemonRequest, DaemonResponse, KeyAction, LocalAttachResult,
-    RawTerminalGuard, SessionKind, SessionSnapshot, WorkerClientMessage, WorkerServerMessage,
-    BACKGROUND_PROMPT_TIMEOUT,
+    unix_millis_now, BackgroundPromptDecision, CtrlCProfile, DaemonRequest, DaemonResponse,
+    KeyAction, LocalAttachResult, LocalInterruptProfile, RawTerminalGuard, SessionKind,
+    SessionSnapshot, WorkerClientMessage, WorkerServerMessage, BACKGROUND_PROMPT_TIMEOUT,
 };
 use crate::session::{InteractiveHooks, PtyInputSink};
 use crate::voice::VoiceMode;
+
+const INTERRUPT_EXIT_GRACE: Duration = Duration::from_millis(500);
 
 /// `PtyInputSink` impl that forwards bytes to the daemon-owned PTY as a
 /// `WorkerClientMessage::Input` TCP frame. This is what lets centralized
@@ -87,6 +89,7 @@ pub(super) fn run_attach(session_id: &str, state_dir: &Path, interrupted: &Atomi
         }
         DaemonResponse::Created { .. }
         | DaemonResponse::Terminated { .. }
+        | DaemonResponse::Interrupted { .. }
         | DaemonResponse::Gc { .. }
         | DaemonResponse::LiveCwds { .. }
         | DaemonResponse::ShutdownAck { .. } => 1,
@@ -257,7 +260,7 @@ pub(super) fn attach_to_session(
 
     let (local_result, backgrounded) = match local_result {
         LocalAttachResult::Completed(code) => (code, false),
-        LocalAttachResult::InterruptRequested => {
+        LocalAttachResult::InterruptRequested(interrupt) => {
             interrupted.store(false, Ordering::SeqCst);
             if session.detachable {
                 match prompt_continue_in_background(interrupted) {
@@ -268,15 +271,12 @@ pub(super) fn attach_to_session(
                     }
                     BackgroundPromptDecision::EndSession => {
                         eprintln!("[clud] ending session {}", session.id);
-                        let _ = request_session_termination(state_dir, &session.id);
-                        let _ = shutdown_worker_connection(&writer);
+                        send_interrupt_fast_path(state_dir, &session.id, &writer, interrupt);
                         (130, false)
                     }
                 }
             } else {
-                let _ = send_worker_message(&writer, &WorkerClientMessage::Interrupt);
-                wait_for_remote_exit(&exit_code, Duration::from_secs(5));
-                let _ = shutdown_worker_connection(&writer);
+                send_interrupt_fast_path(state_dir, &session.id, &writer, interrupt);
                 (130, false)
             }
         }
@@ -294,6 +294,36 @@ pub(super) fn attach_to_session(
         .expect("exit code mutex poisoned")
         .unwrap_or(local_result);
     final_exit_code
+}
+
+fn send_interrupt_fast_path(
+    state_dir: &Path,
+    session_id: &str,
+    writer: &Arc<Mutex<TcpStream>>,
+    interrupt: LocalInterruptProfile,
+) {
+    let now = unix_millis_now();
+    let profile = CtrlCProfile {
+        cli_pid: Some(std::process::id()),
+        cli_observed_at_ms: Some(interrupt.observed_at_ms),
+        cli_handoff_at_ms: Some(now),
+        cli_return_ready_at_ms: Some(now),
+        cli_handoff_ms: Some(interrupt.elapsed_ms()),
+        fast_path: true,
+        ..CtrlCProfile::default()
+    };
+    if let Err(err) = request_session_interrupt(state_dir, session_id, profile.clone()) {
+        eprintln!("[clud] warning: failed to hand Ctrl+C to daemon: {err}");
+        if let Err(err) = send_worker_message(
+            writer,
+            &WorkerClientMessage::Interrupt {
+                profile: Some(profile),
+            },
+        ) {
+            eprintln!("[clud] warning: failed to hand Ctrl+C to daemon worker: {err}");
+        }
+    }
+    let _ = shutdown_worker_connection(writer);
 }
 
 fn run_remote_interactive(
@@ -333,7 +363,7 @@ fn run_remote_interactive(
         (None, None);
     loop {
         if interrupted.load(Ordering::SeqCst) {
-            return LocalAttachResult::InterruptRequested;
+            return LocalAttachResult::InterruptRequested(LocalInterruptProfile::now());
         }
         match event::poll(Duration::from_millis(25)) {
             Ok(true) => match event::read() {
@@ -349,7 +379,7 @@ fn run_remote_interactive(
                         );
                     }
                     KeyAction::Interrupt => {
-                        return LocalAttachResult::InterruptRequested;
+                        return LocalAttachResult::InterruptRequested(LocalInterruptProfile::now());
                     }
                     KeyAction::F3Press => {
                         if voice.intercept_f3() {
@@ -427,24 +457,27 @@ fn wait_for_remote_or_interrupt(
         thread::sleep(Duration::from_millis(25));
     }
     if interrupted.load(Ordering::SeqCst) {
-        LocalAttachResult::InterruptRequested
+        LocalAttachResult::InterruptRequested(LocalInterruptProfile::now())
+    } else if exit_code
+        .lock()
+        .expect("exit code mutex poisoned")
+        .is_some()
+    {
+        wait_for_late_interrupt(interrupted)
     } else {
         LocalAttachResult::Completed(0)
     }
 }
 
-fn wait_for_remote_exit(exit_code: &Arc<Mutex<Option<i32>>>, timeout: Duration) {
+fn wait_for_late_interrupt(interrupted: &AtomicBool) -> LocalAttachResult {
     let started = Instant::now();
-    while started.elapsed() < timeout {
-        if exit_code
-            .lock()
-            .expect("exit code mutex poisoned")
-            .is_some()
-        {
-            break;
+    while started.elapsed() < INTERRUPT_EXIT_GRACE {
+        if interrupted.load(Ordering::SeqCst) {
+            return LocalAttachResult::InterruptRequested(LocalInterruptProfile::now());
         }
-        thread::sleep(Duration::from_millis(25));
+        thread::sleep(Duration::from_millis(10));
     }
+    LocalAttachResult::Completed(0)
 }
 
 fn prompt_continue_in_background(interrupted: &AtomicBool) -> BackgroundPromptDecision {

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -18,8 +18,8 @@ use super::paths::{
 };
 use super::process_utils::{pid_is_alive, signal_process_tree};
 use super::types::{
-    DaemonInfo, DaemonRequest, DaemonResponse, GcOp, GcReply, ListRow, RepoVisit, SessionSnapshot,
-    WorkerClientMessage,
+    CtrlCProfile, DaemonInfo, DaemonRequest, DaemonResponse, GcOp, GcReply, ListRow, RepoVisit,
+    SessionSnapshot, WorkerClientMessage,
 };
 
 /// Idempotent best-effort daemon spawn (issue #135). Always called via
@@ -186,6 +186,27 @@ pub(super) fn request_session_termination(
         },
     )? {
         DaemonResponse::Terminated { session } => Ok(session),
+        DaemonResponse::Error { message } => Err(io::Error::other(message)),
+        response => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unexpected daemon response: {response:?}"),
+        )),
+    }
+}
+
+pub(super) fn request_session_interrupt(
+    state_dir: &Path,
+    session_id: &str,
+    profile: CtrlCProfile,
+) -> io::Result<SessionSnapshot> {
+    match send_daemon_request(
+        state_dir,
+        &DaemonRequest::Interrupt {
+            session_id: session_id.to_string(),
+            profile,
+        },
+    )? {
+        DaemonResponse::Interrupted { session } => Ok(session),
         DaemonResponse::Error { message } => Err(io::Error::other(message)),
         response => Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/crates/clud-bin/src/daemon/commands.rs
+++ b/crates/clud-bin/src/daemon/commands.rs
@@ -384,6 +384,7 @@ mod tests {
             worker_port: 0,
             root_pid: None,
             exit_code,
+            ctrl_c: None,
         };
         write_json_file(&session_snapshot_path(state_dir, id), &snap).unwrap();
     }

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -360,6 +360,7 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         }
         DaemonResponse::Session { .. }
         | DaemonResponse::Terminated { .. }
+        | DaemonResponse::Interrupted { .. }
         | DaemonResponse::Gc { .. }
         | DaemonResponse::LiveCwds { .. }
         | DaemonResponse::ShutdownAck { .. } => 1,

--- a/crates/clud-bin/src/daemon/http.rs
+++ b/crates/clud-bin/src/daemon/http.rs
@@ -28,7 +28,9 @@ use super::gc_service::{GcRequestMsg, WORKER_REPLY_TIMEOUT};
 use super::io_helpers::read_json_file;
 use super::paths::{daemon_info_path, sessions_dir};
 use super::process_utils::pid_is_alive;
-use super::types::{DaemonInfo, GcOp, GcReply, ListRow, RepoVisit, SessionKind, SessionSnapshot};
+use super::types::{
+    CtrlCProfile, DaemonInfo, GcOp, GcReply, ListRow, RepoVisit, SessionKind, SessionSnapshot,
+};
 use crate::session_registry::LiveSession;
 
 /// Supplier of live session-registry rows. Injected at the dashboard
@@ -99,6 +101,21 @@ pub struct SessionView {
     pub exit_code: Option<i32>,
     pub worker_port: u16,
     pub live: bool,
+    pub ctrl_c: Option<CtrlCProfileView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CtrlCProfileView {
+    pub cli_pid: Option<u32>,
+    pub cli_observed_at_ms: Option<u64>,
+    pub cli_handoff_at_ms: Option<u64>,
+    pub cli_return_ready_at_ms: Option<u64>,
+    pub cli_handoff_ms: Option<u64>,
+    pub daemon_received_at_ms: Option<u64>,
+    pub daemon_kill_started_at_ms: Option<u64>,
+    pub daemon_kill_finished_at_ms: Option<u64>,
+    pub daemon_kill_ms: Option<u64>,
+    pub fast_path: bool,
 }
 
 /// Counts derived from the rest of the document.
@@ -422,6 +439,7 @@ fn read_session_views(state_dir: &Path) -> io::Result<Vec<SessionView>> {
             exit_code: snap.exit_code,
             worker_port: snap.worker_port,
             live,
+            ctrl_c: snap.ctrl_c.map(ctrl_c_profile_view),
         });
     }
     // Newest first.
@@ -462,11 +480,27 @@ fn merge_registry_sessions(sessions: &mut Vec<SessionView>, live_sessions: Vec<L
             worker_port: 0,
             // The registry already filtered by OS PID liveness probe.
             live: true,
+            ctrl_c: None,
         });
     }
 
     // Newest first across the merged list.
     sessions.sort_by(|a, b| b.created_at.unwrap_or(0).cmp(&a.created_at.unwrap_or(0)));
+}
+
+fn ctrl_c_profile_view(profile: CtrlCProfile) -> CtrlCProfileView {
+    CtrlCProfileView {
+        cli_pid: profile.cli_pid,
+        cli_observed_at_ms: profile.cli_observed_at_ms,
+        cli_handoff_at_ms: profile.cli_handoff_at_ms,
+        cli_return_ready_at_ms: profile.cli_return_ready_at_ms,
+        cli_handoff_ms: profile.cli_handoff_ms,
+        daemon_received_at_ms: profile.daemon_received_at_ms,
+        daemon_kill_started_at_ms: profile.daemon_kill_started_at_ms,
+        daemon_kill_finished_at_ms: profile.daemon_kill_finished_at_ms,
+        daemon_kill_ms: profile.daemon_kill_ms,
+        fast_path: profile.fast_path,
+    }
 }
 
 // ---------- IPC plumbing ----------
@@ -613,7 +647,7 @@ fn current_unix() -> i64 {
 mod tests {
     use super::*;
     use crate::daemon::gc_service::spawn_registry_worker_with;
-    use crate::daemon::types::{SessionKind, SessionSnapshot};
+    use crate::daemon::types::{CtrlCProfile, SessionKind, SessionSnapshot};
     use crate::gc::Registry;
     use std::io::Write;
 
@@ -644,6 +678,7 @@ mod tests {
             worker_port: 12345,
             root_pid: None,
             exit_code: None,
+            ctrl_c: None,
         }
     }
 
@@ -764,6 +799,31 @@ mod tests {
         assert!(json.get("daemon_pid").is_none());
         assert!(json.get("worker_pid").is_none());
         assert!(json.get("root_pid").is_none());
+    }
+
+    #[test]
+    fn build_state_includes_ctrl_c_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut snap = fake_snapshot("sess-ctrl-c", "interrupt", "/dev/ctrl-c");
+        snap.ctrl_c = Some(CtrlCProfile {
+            cli_pid: Some(777),
+            cli_observed_at_ms: Some(10_000),
+            cli_handoff_at_ms: Some(10_025),
+            cli_return_ready_at_ms: Some(10_025),
+            cli_handoff_ms: Some(25),
+            daemon_received_at_ms: Some(10_026),
+            daemon_kill_started_at_ms: Some(10_026),
+            daemon_kill_finished_at_ms: Some(10_090),
+            daemon_kill_ms: Some(64),
+            fast_path: true,
+        });
+        write_fake_session(dir.path(), "sess-ctrl-c", snap);
+
+        let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
+        let profile = state.sessions[0].ctrl_c.as_ref().expect("profile");
+        assert_eq!(profile.cli_handoff_ms, Some(25));
+        assert_eq!(profile.daemon_kill_ms, Some(64));
+        assert!(profile.fast_path);
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -21,7 +21,8 @@ use super::paths::{daemon_info_path, session_snapshot_path, sessions_dir, spec_p
 use super::process_utils::{pid_is_alive, signal_process_tree};
 use super::sessions::list_live_session_cwds;
 use super::types::{
-    DaemonInfo, DaemonRequest, DaemonResponse, GcReply, SessionSnapshot, WorkerLaunchSpec,
+    unix_millis_now, CtrlCProfile, DaemonInfo, DaemonRequest, DaemonResponse, GcReply,
+    SessionSnapshot, WorkerLaunchSpec,
 };
 
 fn current_unix() -> i64 {
@@ -174,6 +175,15 @@ fn handle_daemon_connection(
                 },
             }
         }
+        DaemonRequest::Interrupt {
+            session_id,
+            profile,
+        } => match daemon_interrupt_session(state_dir, workers, &session_id, profile) {
+            Ok(session) => DaemonResponse::Interrupted { session },
+            Err(err) => DaemonResponse::Error {
+                message: err.to_string(),
+            },
+        },
         DaemonRequest::Gc { payload } => {
             let reply = dispatch_gc_op(gc_tx.as_ref(), payload);
             DaemonResponse::Gc { reply }
@@ -365,4 +375,110 @@ fn daemon_terminate_session(
     write_json_file(&path, &session)?;
     let _ = fs::remove_file(spec_path(state_dir, session_id));
     Ok(session)
+}
+
+fn daemon_interrupt_session(
+    state_dir: &Path,
+    workers: &Arc<Mutex<HashMap<String, Arc<NativeProcess>>>>,
+    session_id: &str,
+    profile: CtrlCProfile,
+) -> io::Result<SessionSnapshot> {
+    let path = session_snapshot_path(state_dir, session_id);
+    let mut session = read_json_file::<SessionSnapshot>(&path)?;
+    merge_ctrl_c_profile_for_daemon(&mut session, profile);
+    session.background = false;
+    session.exit_code = Some(130);
+    write_json_file(&path, &session)?;
+
+    let state_dir = state_dir.to_path_buf();
+    let workers = Arc::clone(workers);
+    let session_id = session_id.to_string();
+    thread::spawn(move || {
+        finish_daemon_interrupt_session(&state_dir, &workers, &session_id);
+    });
+
+    Ok(session)
+}
+
+fn finish_daemon_interrupt_session(
+    state_dir: &Path,
+    workers: &Arc<Mutex<HashMap<String, Arc<NativeProcess>>>>,
+    session_id: &str,
+) {
+    let path = session_snapshot_path(state_dir, session_id);
+    let mut session = match read_json_file::<SessionSnapshot>(&path) {
+        Ok(session) => session,
+        Err(_) => return,
+    };
+    let started_at_ms = unix_millis_now();
+    {
+        let profile = session.ctrl_c.get_or_insert_with(CtrlCProfile::default);
+        if profile.daemon_kill_started_at_ms.is_none() {
+            profile.daemon_kill_started_at_ms = Some(started_at_ms);
+        }
+        profile.fast_path = true;
+    }
+    let _ = write_json_file(&path, &session);
+
+    if let Some(root_pid) = session.root_pid {
+        signal_process_tree(root_pid, Signal::Term);
+        thread::sleep(Duration::from_millis(150));
+        signal_process_tree(root_pid, Signal::Kill);
+    }
+
+    if let Some(worker) = workers
+        .lock()
+        .expect("workers mutex poisoned")
+        .remove(session_id)
+    {
+        let _ = worker.kill();
+        let _ = worker.wait(Some(Duration::from_secs(2)));
+    } else if pid_is_alive(session.worker_pid) {
+        signal_process_tree(session.worker_pid, Signal::Term);
+        thread::sleep(Duration::from_millis(150));
+        signal_process_tree(session.worker_pid, Signal::Kill);
+    }
+
+    let finished_at_ms = unix_millis_now();
+    if let Ok(mut latest) = read_json_file::<SessionSnapshot>(&path) {
+        latest.background = false;
+        latest.exit_code = Some(130);
+        let profile = latest.ctrl_c.get_or_insert_with(CtrlCProfile::default);
+        if profile.daemon_kill_started_at_ms.is_none() {
+            profile.daemon_kill_started_at_ms = Some(started_at_ms);
+        }
+        profile.daemon_kill_finished_at_ms = Some(finished_at_ms);
+        profile.daemon_kill_ms = Some(finished_at_ms.saturating_sub(started_at_ms));
+        profile.fast_path = true;
+        let _ = write_json_file(&path, &latest);
+    }
+    let _ = fs::remove_file(spec_path(state_dir, session_id));
+}
+
+fn merge_ctrl_c_profile_for_daemon(session: &mut SessionSnapshot, mut update: CtrlCProfile) {
+    let now = unix_millis_now();
+    update.fast_path = true;
+    if update.daemon_received_at_ms.is_none() {
+        update.daemon_received_at_ms = Some(now);
+    }
+    let current = session.ctrl_c.get_or_insert_with(CtrlCProfile::default);
+    if update.cli_pid.is_some() {
+        current.cli_pid = update.cli_pid;
+    }
+    if update.cli_observed_at_ms.is_some() {
+        current.cli_observed_at_ms = update.cli_observed_at_ms;
+    }
+    if update.cli_handoff_at_ms.is_some() {
+        current.cli_handoff_at_ms = update.cli_handoff_at_ms;
+    }
+    if update.cli_return_ready_at_ms.is_some() {
+        current.cli_return_ready_at_ms = update.cli_return_ready_at_ms;
+    }
+    if update.cli_handoff_ms.is_some() {
+        current.cli_handoff_ms = update.cli_handoff_ms;
+    }
+    if update.daemon_received_at_ms.is_some() {
+        current.daemon_received_at_ms = update.daemon_received_at_ms;
+    }
+    current.fast_path = true;
 }

--- a/crates/clud-bin/src/daemon/sessions.rs
+++ b/crates/clud-bin/src/daemon/sessions.rs
@@ -196,6 +196,7 @@ mod tests {
             worker_port: 0,
             root_pid: None,
             exit_code,
+            ctrl_c: None,
         };
         write_json_file(&session_snapshot_path(state_dir, id), &snap).unwrap();
     }

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use running_process::pty::NativePtyProcess;
 use running_process::{NativeProcess, TerminalCapabilities};
@@ -34,6 +34,13 @@ pub(super) const LOG_ROTATE_BYTES: u64 = 10 * 1024 * 1024;
 
 pub(super) fn default_attachable() -> bool {
     true
+}
+
+pub(super) fn unix_millis_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,6 +96,36 @@ pub(super) struct SessionSnapshot {
     pub(super) worker_port: u16,
     pub(super) root_pid: Option<u32>,
     pub(super) exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) ctrl_c: Option<CtrlCProfile>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct CtrlCProfile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) cli_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) cli_observed_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) cli_handoff_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) cli_return_ready_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) cli_handoff_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) daemon_received_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) daemon_kill_started_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) daemon_kill_finished_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) daemon_kill_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub(super) fast_path: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -135,6 +172,10 @@ pub(super) enum DaemonRequest {
     Terminate {
         session_id: String,
     },
+    Interrupt {
+        session_id: String,
+        profile: CtrlCProfile,
+    },
     /// Issue #135: GC ops served by the registry worker thread (see
     /// `gc_service.rs`). Carry the original `gc.*` op inside a single
     /// enum variant so the wire format and the registry-worker dispatch
@@ -160,6 +201,9 @@ pub(super) enum DaemonResponse {
         paths: Vec<PathBuf>,
     },
     Terminated {
+        session: SessionSnapshot,
+    },
+    Interrupted {
         session: SessionSnapshot,
     },
     Gc {
@@ -289,7 +333,10 @@ pub(super) enum WorkerClientMessage {
         rows: u16,
         cols: u16,
     },
-    Interrupt,
+    Interrupt {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        profile: Option<CtrlCProfile>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -312,17 +359,6 @@ impl SessionRuntime {
         match self {
             Self::Subprocess(process) => process.pid(),
             Self::Pty(process) => process.pid().ok().flatten(),
-        }
-    }
-
-    pub(super) fn interrupt(&self) {
-        match self {
-            Self::Subprocess(process) => {
-                let _ = process.kill();
-            }
-            Self::Pty(process) => {
-                let _ = process.send_interrupt_impl();
-            }
         }
     }
 
@@ -368,7 +404,26 @@ pub(super) type AttachClientResult = (
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum LocalAttachResult {
     Completed(i32),
-    InterruptRequested,
+    InterruptRequested(LocalInterruptProfile),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct LocalInterruptProfile {
+    pub(super) observed_at_ms: u64,
+    observed_at: Instant,
+}
+
+impl LocalInterruptProfile {
+    pub(super) fn now() -> Self {
+        Self {
+            observed_at_ms: unix_millis_now(),
+            observed_at: Instant::now(),
+        }
+    }
+
+    pub(super) fn elapsed_ms(&self) -> u64 {
+        self.observed_at.elapsed().as_millis() as u64
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -477,6 +532,34 @@ mod tests {
                 cols: None
             }
         ));
+    }
+
+    #[test]
+    fn interrupt_request_accepts_legacy_unit_shape() {
+        let parsed: WorkerClientMessage = serde_json::from_str(r#"{"op":"interrupt"}"#).unwrap();
+        assert!(matches!(
+            parsed,
+            WorkerClientMessage::Interrupt { profile: None }
+        ));
+    }
+
+    #[test]
+    fn interrupt_request_serializes_ctrl_c_profile() {
+        let wire = serde_json::to_string(&WorkerClientMessage::Interrupt {
+            profile: Some(CtrlCProfile {
+                cli_pid: Some(42),
+                cli_observed_at_ms: Some(1000),
+                cli_handoff_at_ms: Some(1010),
+                cli_return_ready_at_ms: Some(1010),
+                cli_handoff_ms: Some(10),
+                fast_path: true,
+                ..CtrlCProfile::default()
+            }),
+        })
+        .unwrap();
+        assert!(wire.contains(r#""op":"interrupt""#));
+        assert!(wire.contains(r#""cli_handoff_ms":10"#));
+        assert!(wire.contains(r#""fast_path":true"#));
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/worker.rs
+++ b/crates/clud-bin/src/daemon/worker.rs
@@ -15,12 +15,12 @@ use crate::graphics::GraphicsConfig;
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;
 
-use super::io_helpers::{child_env, read_json_file, write_json_file, write_json_line};
-use super::paths::{session_snapshot_path, spec_path};
+use super::io_helpers::{child_env, read_json_file, write_json_line};
+use super::paths::spec_path;
 use super::process_utils::pid_is_alive;
 use super::types::{
-    SessionKind, SessionRuntime, SessionSnapshot, WorkerClientMessage, WorkerLaunchSpec,
-    WorkerServerMessage, DEFAULT_BACKLOG_LIMIT_BYTES,
+    CtrlCProfile, SessionKind, SessionRuntime, SessionSnapshot, WorkerClientMessage,
+    WorkerLaunchSpec, WorkerServerMessage, DEFAULT_BACKLOG_LIMIT_BYTES,
 };
 use super::worker_shared::WorkerShared;
 
@@ -77,6 +77,7 @@ pub(super) fn run_worker(
         worker_port,
         root_pid: None,
         exit_code: None,
+        ctrl_c: None,
     };
     let backlog_limit = spec.backlog_bytes.unwrap_or(DEFAULT_BACKLOG_LIMIT_BYTES);
     let shared = Arc::new(WorkerShared::new_with_backlog(
@@ -213,6 +214,7 @@ fn run_repeat_worker(
         worker_port: 0,
         root_pid: None,
         exit_code: None,
+        ctrl_c: None,
     };
     let shared = Arc::new(WorkerShared::new_with_backlog(
         state_dir.to_path_buf(),
@@ -500,7 +502,7 @@ fn handle_worker_client(
         ),
         WorkerClientMessage::Input { .. }
         | WorkerClientMessage::Resize { .. }
-        | WorkerClientMessage::Interrupt => {
+        | WorkerClientMessage::Interrupt { .. } => {
             return write_json_line(
                 &mut stream,
                 &WorkerServerMessage::Error {
@@ -654,7 +656,10 @@ fn handle_worker_client(
                         runtime.resize(effective_rows, cols);
                         shared.resize_capture(effective_rows, cols);
                     }
-                    WorkerClientMessage::Interrupt => runtime.interrupt(),
+                    WorkerClientMessage::Interrupt { profile } => {
+                        start_interrupt_fast_path(shared, runtime, profile);
+                        break;
+                    }
                 }
             }
         }
@@ -663,6 +668,22 @@ fn handle_worker_client(
     shared.detach_client(client_id);
     let _ = writer_thread.join();
     Ok(())
+}
+
+fn start_interrupt_fast_path(
+    shared: &Arc<WorkerShared>,
+    runtime: &SessionRuntime,
+    profile: Option<CtrlCProfile>,
+) {
+    shared.record_ctrl_c_handoff(profile.unwrap_or_default());
+    let shared = Arc::clone(shared);
+    let runtime = runtime.clone();
+    thread::spawn(move || {
+        let started_at_ms = shared.record_ctrl_c_kill_started();
+        runtime.cleanup_tree();
+        shared.record_ctrl_c_kill_finished(started_at_ms);
+        shared.broadcast_exit(130);
+    });
 }
 
 fn read_worker_line(
@@ -691,14 +712,11 @@ fn read_worker_line(
 }
 
 fn persist_snapshot(
-    state_dir: &Path,
-    session_id: &str,
+    _state_dir: &Path,
+    _session_id: &str,
     shared: &Arc<WorkerShared>,
 ) -> io::Result<()> {
-    write_json_file(
-        &session_snapshot_path(state_dir, session_id),
-        &shared.snapshot(),
-    )
+    shared.persist_current_snapshot()
 }
 
 // Silence import warnings for items consumed only by the `Write` trait or

--- a/crates/clud-bin/src/daemon/worker_shared.rs
+++ b/crates/clud-bin/src/daemon/worker_shared.rs
@@ -13,13 +13,13 @@ use running_process::telemetry::{
 
 use crate::capture::TerminalCapture;
 
-use super::io_helpers::write_json_file;
+use super::io_helpers::{read_json_file, write_json_file};
 use super::paths::{session_log_path, session_snapshot_path};
 #[cfg(test)]
 use super::types::DEFAULT_BACKLOG_LIMIT_BYTES;
 use super::types::{
-    AttachClientResult, AttachedClient, BacklogState, SessionKind, SessionSnapshot,
-    WorkerServerMessage, LOG_ROTATE_BYTES,
+    unix_millis_now, AttachClientResult, AttachedClient, BacklogState, CtrlCProfile, SessionKind,
+    SessionSnapshot, WorkerServerMessage, LOG_ROTATE_BYTES,
 };
 
 /// Probe whether the peer of `stream` has closed the connection, without
@@ -288,13 +288,16 @@ impl WorkerShared {
         let _ = self.persist_snapshot(&snapshot);
     }
 
-    pub(super) fn set_exit_code(&self, exit_code: i32) {
+    pub(super) fn set_exit_code(&self, exit_code: i32) -> i32 {
         let snapshot = {
             let mut guard = self.snapshot.lock().expect("snapshot mutex poisoned");
-            guard.exit_code = Some(exit_code);
+            if guard.exit_code.is_none() {
+                guard.exit_code = Some(exit_code);
+            }
             guard.clone()
         };
         let _ = self.persist_snapshot(&snapshot);
+        snapshot.exit_code.unwrap_or(exit_code)
     }
 
     pub(super) fn set_background(&self, background: bool) {
@@ -314,6 +317,55 @@ impl WorkerShared {
             let mut guard = self.snapshot.lock().expect("snapshot mutex poisoned");
             guard.repeat_running = running;
             guard.repeat_next_run_at = next_run_at;
+            guard.clone()
+        };
+        let _ = self.persist_snapshot(&snapshot);
+    }
+
+    pub(super) fn record_ctrl_c_handoff(&self, mut profile: CtrlCProfile) {
+        profile.fast_path = true;
+        let snapshot = {
+            let mut guard = self.snapshot.lock().expect("snapshot mutex poisoned");
+            let current = guard.ctrl_c.get_or_insert_with(CtrlCProfile::default);
+            merge_ctrl_c_profile(current, profile);
+            if current.daemon_received_at_ms.is_none() {
+                current.daemon_received_at_ms = Some(unix_millis_now());
+            }
+            current.fast_path = true;
+            guard.clone()
+        };
+        let _ = self.persist_snapshot(&snapshot);
+    }
+
+    pub(super) fn record_ctrl_c_kill_started(&self) -> u64 {
+        let now = unix_millis_now();
+        let snapshot = {
+            let mut guard = self.snapshot.lock().expect("snapshot mutex poisoned");
+            let current = guard.ctrl_c.get_or_insert_with(CtrlCProfile::default);
+            if current.daemon_received_at_ms.is_none() {
+                current.daemon_received_at_ms = Some(now);
+            }
+            if current.daemon_kill_started_at_ms.is_none() {
+                current.daemon_kill_started_at_ms = Some(now);
+            }
+            current.fast_path = true;
+            guard.clone()
+        };
+        let _ = self.persist_snapshot(&snapshot);
+        now
+    }
+
+    pub(super) fn record_ctrl_c_kill_finished(&self, started_at_ms: u64) {
+        let now = unix_millis_now();
+        let snapshot = {
+            let mut guard = self.snapshot.lock().expect("snapshot mutex poisoned");
+            let current = guard.ctrl_c.get_or_insert_with(CtrlCProfile::default);
+            if current.daemon_kill_started_at_ms.is_none() {
+                current.daemon_kill_started_at_ms = Some(started_at_ms);
+            }
+            current.daemon_kill_finished_at_ms = Some(now);
+            current.daemon_kill_ms = Some(now.saturating_sub(started_at_ms));
+            current.fast_path = true;
             guard.clone()
         };
         let _ = self.persist_snapshot(&snapshot);
@@ -442,7 +494,7 @@ impl WorkerShared {
     }
 
     pub(super) fn broadcast_exit(&self, exit_code: i32) {
-        self.set_exit_code(exit_code);
+        let exit_code = self.set_exit_code(exit_code);
         self.stop_accepting.store(true, Ordering::Release);
         self.send_to_client(WorkerServerMessage::Exited { exit_code });
     }
@@ -459,12 +511,58 @@ impl WorkerShared {
         }
     }
 
-    fn persist_snapshot(&self, snapshot: &SessionSnapshot) -> io::Result<()> {
-        write_json_file(
-            &session_snapshot_path(&self.state_dir, &self.session_id),
-            snapshot,
-        )
+    pub(super) fn persist_current_snapshot(&self) -> io::Result<()> {
+        let snapshot = self.snapshot();
+        self.persist_snapshot(&snapshot)
     }
+
+    fn persist_snapshot(&self, snapshot: &SessionSnapshot) -> io::Result<()> {
+        let path = session_snapshot_path(&self.state_dir, &self.session_id);
+        let mut snapshot = snapshot.clone();
+        if let Ok(current) = read_json_file::<SessionSnapshot>(&path) {
+            if let Some(profile) = current.ctrl_c {
+                let target = snapshot.ctrl_c.get_or_insert_with(CtrlCProfile::default);
+                let fast_path = profile.fast_path;
+                merge_ctrl_c_profile(target, profile);
+                if fast_path && current.exit_code.is_some() {
+                    snapshot.exit_code = current.exit_code;
+                    snapshot.background = current.background;
+                }
+            }
+        }
+        write_json_file(&path, &snapshot)
+    }
+}
+
+fn merge_ctrl_c_profile(current: &mut CtrlCProfile, update: CtrlCProfile) {
+    if update.cli_pid.is_some() {
+        current.cli_pid = update.cli_pid;
+    }
+    if update.cli_observed_at_ms.is_some() {
+        current.cli_observed_at_ms = update.cli_observed_at_ms;
+    }
+    if update.cli_handoff_at_ms.is_some() {
+        current.cli_handoff_at_ms = update.cli_handoff_at_ms;
+    }
+    if update.cli_return_ready_at_ms.is_some() {
+        current.cli_return_ready_at_ms = update.cli_return_ready_at_ms;
+    }
+    if update.cli_handoff_ms.is_some() {
+        current.cli_handoff_ms = update.cli_handoff_ms;
+    }
+    if update.daemon_received_at_ms.is_some() {
+        current.daemon_received_at_ms = update.daemon_received_at_ms;
+    }
+    if update.daemon_kill_started_at_ms.is_some() {
+        current.daemon_kill_started_at_ms = update.daemon_kill_started_at_ms;
+    }
+    if update.daemon_kill_finished_at_ms.is_some() {
+        current.daemon_kill_finished_at_ms = update.daemon_kill_finished_at_ms;
+    }
+    if update.daemon_kill_ms.is_some() {
+        current.daemon_kill_ms = update.daemon_kill_ms;
+    }
+    current.fast_path |= update.fast_path;
 }
 
 impl Drop for WorkerShared {
@@ -531,6 +629,7 @@ mod tests {
             worker_port: 0,
             root_pid: None,
             exit_code: None,
+            ctrl_c: None,
         };
         Arc::new(WorkerShared::new(
             state_dir.to_path_buf(),
@@ -557,6 +656,7 @@ mod tests {
             worker_port: 0,
             root_pid: None,
             exit_code: None,
+            ctrl_c: None,
         };
         let shared = Arc::new(WorkerShared::new(tmp.path().to_path_buf(), id.into(), snap));
         shared.init_log_file();
@@ -693,6 +793,62 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_c_profile_records_handoff_and_daemon_kill_timings() {
+        let tmp = TempDir::new().unwrap();
+        let shared = test_shared(tmp.path(), SessionKind::Subprocess);
+        shared.record_ctrl_c_handoff(CtrlCProfile {
+            cli_pid: Some(123),
+            cli_observed_at_ms: Some(1000),
+            cli_handoff_at_ms: Some(1015),
+            cli_return_ready_at_ms: Some(1015),
+            cli_handoff_ms: Some(15),
+            fast_path: true,
+            ..CtrlCProfile::default()
+        });
+        let started_at_ms = shared.record_ctrl_c_kill_started();
+        shared.record_ctrl_c_kill_finished(started_at_ms);
+
+        let profile = shared.snapshot().ctrl_c.expect("ctrl-c profile");
+        assert_eq!(profile.cli_pid, Some(123));
+        assert_eq!(profile.cli_handoff_ms, Some(15));
+        assert!(profile.daemon_received_at_ms.is_some());
+        assert!(profile.daemon_kill_started_at_ms.is_some());
+        assert!(profile.daemon_kill_finished_at_ms.is_some());
+        assert!(profile.daemon_kill_ms.is_some());
+        assert!(profile.fast_path);
+    }
+
+    #[test]
+    fn worker_exit_preserves_daemon_written_ctrl_c_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        let shared = test_shared(tmp.path(), SessionKind::Subprocess);
+        shared.persist_current_snapshot().unwrap();
+
+        let path = session_snapshot_path(tmp.path(), "test-session");
+        let mut daemon_snapshot = shared.snapshot();
+        daemon_snapshot.exit_code = Some(130);
+        daemon_snapshot.background = false;
+        daemon_snapshot.ctrl_c = Some(CtrlCProfile {
+            cli_pid: Some(321),
+            cli_handoff_ms: Some(12),
+            daemon_received_at_ms: Some(100),
+            fast_path: true,
+            ..CtrlCProfile::default()
+        });
+        write_json_file(&path, &daemon_snapshot).unwrap();
+
+        shared.set_exit_code(1);
+
+        let persisted: SessionSnapshot = read_json_file(&path).unwrap();
+        assert_eq!(persisted.exit_code, Some(130));
+        assert_eq!(persisted.background, false);
+        let profile = persisted.ctrl_c.expect("ctrl-c profile should survive");
+        assert_eq!(profile.cli_pid, Some(321));
+        assert_eq!(profile.cli_handoff_ms, Some(12));
+        assert!(profile.fast_path);
+    }
+
+    #[test]
     fn transcript_file_receives_output_through_running_process_tee() {
         let tmp = TempDir::new().unwrap();
         let shared = test_shared(tmp.path(), SessionKind::Pty);
@@ -751,6 +907,7 @@ mod tests {
             worker_port: 0,
             root_pid: None,
             exit_code: None,
+            ctrl_c: None,
         };
         let shared = Arc::new(WorkerShared::new_with_backlog(
             tmp.path().to_path_buf(),

--- a/tests/integration/test_daemon_managed_sessions.py
+++ b/tests/integration/test_daemon_managed_sessions.py
@@ -11,6 +11,7 @@ import pytest
 
 from ._daemon_helpers import (
     DETACH_EXIT_TIMEOUT,
+    daemon_env,
     kill_daemon_for_session,
     launch_detached,
     managed_env,
@@ -321,6 +322,87 @@ class TestDaemonManagedSessionFlags:
         assert session_id in listed.stdout
 
         kill_daemon_for_session(state_dir, session_id)
+
+    def test_foreground_ctrl_c_fast_paths_daemon_kill_and_profiles(
+        self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        errors: list[str] = []
+        attempts = 5 if sys.platform == "win32" else 1
+
+        for attempt in range(attempts):
+            state_dir = tmp_path / f"daemon-state-{attempt}"
+            env = daemon_env(mock_env, state_dir)
+            kwargs: dict[str, object] = {}
+            if sys.platform == "win32":
+                kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+            proc = subprocess.Popen(
+                [
+                    str(clud_binary),
+                    "--codex",
+                    "-p",
+                    "fast-ctrl-c",
+                    "--",
+                    "--mock-sleep-ms",
+                    "30000",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                text=True,
+                env=env,
+                **kwargs,
+            )
+
+            session_id = ""
+            try:
+                session_id = read_session_id(proc)
+                time.sleep(0.5)
+                started = time.perf_counter()
+                if sys.platform == "win32":
+                    proc.send_signal(signal.CTRL_BREAK_EVENT)
+                else:
+                    proc.send_signal(signal.SIGINT)
+                proc.wait(timeout=3.0)
+                elapsed = time.perf_counter() - started
+                if proc.returncode != 130:
+                    errors.append(f"attempt {attempt}: returncode {proc.returncode}")
+                    continue
+                if elapsed >= 2.0:
+                    errors.append(f"attempt {attempt}: handoff took {elapsed:.3f}s")
+                    continue
+
+                deadline = time.time() + 10.0
+                metadata = session_metadata(state_dir, session_id)
+                profile = metadata.get("ctrl_c") or {}
+                while time.time() < deadline:
+                    metadata = session_metadata(state_dir, session_id)
+                    profile = metadata.get("ctrl_c") or {}
+                    if (
+                        metadata.get("exit_code") == 130
+                        and profile.get("daemon_kill_ms") is not None
+                    ):
+                        break
+                    time.sleep(0.1)
+                else:
+                    errors.append(
+                        f"attempt {attempt}: daemon profile incomplete: {metadata!r}"
+                    )
+                    continue
+
+                assert profile.get("fast_path") is True
+                assert isinstance(profile.get("cli_handoff_ms"), int)
+                assert profile["cli_handoff_ms"] < 2000
+                assert isinstance(profile.get("daemon_kill_ms"), int)
+                return
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                if session_id:
+                    kill_daemon_for_session(state_dir, session_id)
+
+        raise AssertionError("Ctrl-C daemon fast path did not complete: " + "; ".join(errors))
 
     def test_loop_repeat_registers_background_job_and_lists_status(
         self, clud_binary: Path, mock_env: dict[str, str], tmp_path: Path


### PR DESCRIPTION
## Summary
- add a daemon fast path for foreground Ctrl-C interrupts so attach returns quickly while cleanup continues in the daemon
- persist a Ctrl-C timing profile across daemon and worker snapshot writes
- surface Ctrl-C handoff/kill timing in the dashboard session table

## Tests
- `python -m ruff check tests/integration/test_daemon_managed_sessions.py`
- `soldr cargo fmt -- --check`
- `soldr cargo check -p clud`
- `soldr cargo test -p clud --lib daemon::`
- `soldr cargo build -p clud -p mock-agent`
- `python -m pytest tests/integration/test_daemon_managed_sessions.py::TestDaemonManagedSessionFlags::test_foreground_ctrl_c_fast_paths_daemon_kill_and_profiles -q`

Note: `soldr` currently emits a cargo-GC duration-format warning for `604800secs`, but the wrapped cargo commands completed successfully.