### PR TITLE
feat: add hook catch-all and hero header

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ of the current terminal. Missing metadata, non-TTY attaches, blocked terminals,
 and host-name-only hints stay text-only. Use `--graphics=off` to disable the
 feature or `--graphics=sixel` to force it.
 
-By default clud renders a small bundled banner. Pass `--graphics-image <PATH>`
-to use a PNG or JPEG instead. Direct PTY launches reserve rows before the
-backend starts. Daemon-managed sessions decide at attach time, because the
+By default clud renders the bundled README hero image. Pass
+`--graphics-image <PATH>` to use a PNG or JPEG instead. Direct PTY launches
+reserve rows before the backend starts. Daemon-managed sessions decide at attach
+time, because the
 detached worker does not know which terminal will attach later; reattach and
 resize paths redraw the header where the terminal reports support.
 
@@ -150,6 +151,12 @@ Run `clud --dry-run --fix-hooks` to see the planned repair actions. Run
 `clud --fix-hooks` only when you want clud to add deterministic Codex trust
 entries or ask the selected backend to translate a missing hook between Claude
 Code and Codex.
+
+Codex hook matchers may use `*` as a catch-all. When equivalent Claude Code
+hooks use the same command across several tool matchers, the Codex repair plan
+prefers one catch-all hook instead of repeated per-tool prompts. That reduces
+duplicate Codex hook review/trust approvals while keeping per-tool hooks when
+commands differ.
 
 On Windows, Codex hook commands that call a `.cmd` or `.bat` wrapper need
 explicit exit-code propagation. If the command does not include

--- a/crates/clud-bin/src/graphics.rs
+++ b/crates/clud-bin/src/graphics.rs
@@ -215,7 +215,7 @@ pub fn render_header(
 
     let (rgba, width, height) = match &config.image_path {
         Some(path) => load_image_rgba(path, max_width, max_height)?,
-        None => bundled_banner_rgba(max_width.min(420), max_height.max(48)),
+        None => load_image_rgba_from_memory(HERO_CLUD_JPG, max_width, max_height)?,
     };
     let reserved_rows = rows_for_pixel_height(height).min(max_reserved).max(1);
     if terminal_rows.saturating_sub(reserved_rows) < MIN_TEXT_ROWS {
@@ -302,91 +302,6 @@ fn rows_for_pixel_height(height: u32) -> u16 {
         .unwrap_or(1)
         .clamp(1, u32::from(u16::MAX)) as u16
 }
-
-fn bundled_banner_rgba(width: u32, height: u32) -> (Vec<u8>, u32, u32) {
-    let width = width.max(160);
-    let height = height.clamp(42, 84);
-    let mut rgba = vec![0u8; (width * height * 4) as usize];
-    for y in 0..height {
-        for x in 0..width {
-            let t = x as f32 / width.max(1) as f32;
-            let base = [
-                (18.0 + 34.0 * t) as u8,
-                (28.0 + 54.0 * t) as u8,
-                (42.0 + 32.0 * (1.0 - t)) as u8,
-                255,
-            ];
-            set_px(&mut rgba, width, x, y, base);
-        }
-    }
-
-    let scale = (height / 10).clamp(4, 7);
-    let glyph_w = 5 * scale;
-    let glyph_h = 7 * scale;
-    let gap = scale * 2;
-    let total_w = glyph_w * 4 + gap * 3;
-    let start_x = width.saturating_sub(total_w) / 2;
-    let start_y = height.saturating_sub(glyph_h) / 2;
-    let color = [222, 245, 255, 255];
-    for (idx, glyph) in [GLYPH_C, GLYPH_L, GLYPH_U, GLYPH_D].iter().enumerate() {
-        draw_glyph(
-            &mut rgba,
-            (width, height),
-            (start_x + idx as u32 * (glyph_w + gap), start_y),
-            scale,
-            glyph,
-            color,
-        );
-    }
-
-    (rgba, width, height)
-}
-
-fn set_px(rgba: &mut [u8], width: u32, x: u32, y: u32, color: [u8; 4]) {
-    let idx = ((y * width + x) * 4) as usize;
-    rgba[idx..idx + 4].copy_from_slice(&color);
-}
-
-fn draw_glyph(
-    rgba: &mut [u8],
-    size: (u32, u32),
-    origin: (u32, u32),
-    scale: u32,
-    glyph: &[&str; 7],
-    color: [u8; 4],
-) {
-    let (width, height) = size;
-    let (x0, y0) = origin;
-    for (gy, row) in glyph.iter().enumerate() {
-        for (gx, ch) in row.as_bytes().iter().enumerate() {
-            if *ch != b'#' {
-                continue;
-            }
-            for dy in 0..scale {
-                for dx in 0..scale {
-                    let x = x0 + gx as u32 * scale + dx;
-                    let y = y0 + gy as u32 * scale + dy;
-                    if x < width && y < height {
-                        set_px(rgba, width, x, y, color);
-                    }
-                }
-            }
-        }
-    }
-}
-
-const GLYPH_C: [&str; 7] = [
-    "#####", "#....", "#....", "#....", "#....", "#....", "#####",
-];
-const GLYPH_L: [&str; 7] = [
-    "#....", "#....", "#....", "#....", "#....", "#....", "#####",
-];
-const GLYPH_U: [&str; 7] = [
-    "#...#", "#...#", "#...#", "#...#", "#...#", "#...#", "#####",
-];
-const GLYPH_D: [&str; 7] = [
-    "####.", "#...#", "#...#", "#...#", "#...#", "#...#", "####.",
-];
 
 #[cfg(test)]
 mod tests {
@@ -482,6 +397,54 @@ mod tests {
         assert!(text.contains("\x1b["));
         let restore = String::from_utf8_lossy(&header.restore_bytes);
         assert!(restore.contains("\x1b[r"));
+    }
+
+    #[test]
+    fn default_header_uses_bundled_hero_asset() {
+        let temp = tempfile::tempdir().unwrap();
+        let hero_path = temp.path().join("hero.jpg");
+        std::fs::write(&hero_path, HERO_CLUD_JPG).unwrap();
+
+        let default = render_header(&GraphicsConfig::default(), 24, 80)
+            .unwrap()
+            .unwrap();
+        let explicit_hero = render_header(
+            &GraphicsConfig {
+                mode: GraphicsMode::Auto,
+                image_path: Some(hero_path),
+            },
+            24,
+            80,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(default.bytes, explicit_hero.bytes);
+        assert_eq!(default.reserved_rows, explicit_hero.reserved_rows);
+    }
+
+    #[test]
+    fn explicit_header_image_override_takes_precedence() {
+        let temp = tempfile::tempdir().unwrap();
+        let override_path = temp.path().join("override.png");
+        let image = image::RgbaImage::from_pixel(16, 16, image::Rgba([255, 0, 0, 255]));
+        image.save(&override_path).unwrap();
+
+        let default = render_header(&GraphicsConfig::default(), 24, 80)
+            .unwrap()
+            .unwrap();
+        let override_header = render_header(
+            &GraphicsConfig {
+                mode: GraphicsMode::Auto,
+                image_path: Some(override_path),
+            },
+            24,
+            80,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_ne!(default.bytes, override_header.bytes);
     }
 
     #[test]

--- a/crates/clud-bin/src/hook_health.rs
+++ b/crates/clud-bin/src/hook_health.rs
@@ -20,6 +20,7 @@ use toml_edit::{table, value, DocumentMut, Item};
 
 const PRE_TOOL_USE: &str = "PreToolUse";
 const CODEX_PRE_TOOL_USE_STATE: &str = "pre_tool_use";
+const CATCH_ALL_MATCHER: &str = "*";
 const FIX_HINT: &str = "Run `clud --fix-hooks`.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -316,29 +317,113 @@ pub fn plan_repairs(report: &HookHealthReport) -> Vec<RepairAction> {
 
     let claude_by_matcher = report.claude.hook_by_matcher();
     let codex_by_matcher = report.codex.hook_by_matcher();
-    for (matcher, hook) in &claude_by_matcher {
-        if !codex_by_matcher.contains_key(matcher) {
-            actions.push(RepairAction::BackendPrompt {
-                source: HookFrontend::Claude,
-                target: HookFrontend::Codex,
-                matcher: matcher.clone(),
-                source_path: hook.source_path.clone(),
-                prompt: migration_prompt(hook, HookFrontend::Codex),
-            });
-        }
-    }
-    for (matcher, hook) in &codex_by_matcher {
-        if !claude_by_matcher.contains_key(matcher) {
-            actions.push(RepairAction::BackendPrompt {
-                source: HookFrontend::Codex,
-                target: HookFrontend::Claude,
-                matcher: matcher.clone(),
-                source_path: hook.source_path.clone(),
-                prompt: migration_prompt(hook, HookFrontend::Claude),
-            });
-        }
-    }
+    plan_backend_prompts(
+        &mut actions,
+        HookFrontend::Claude,
+        HookFrontend::Codex,
+        &claude_by_matcher,
+        &codex_by_matcher,
+    );
+    plan_backend_prompts(
+        &mut actions,
+        HookFrontend::Codex,
+        HookFrontend::Claude,
+        &codex_by_matcher,
+        &claude_by_matcher,
+    );
     actions
+}
+
+fn plan_backend_prompts(
+    actions: &mut Vec<RepairAction>,
+    source: HookFrontend,
+    target: HookFrontend,
+    source_by_matcher: &BTreeMap<String, NormalizedHook>,
+    target_by_matcher: &BTreeMap<String, NormalizedHook>,
+) {
+    let missing_hooks = source_by_matcher
+        .iter()
+        .filter_map(|(matcher, hook)| {
+            (!matcher_is_covered_by(source, target_by_matcher, matcher)).then_some(hook)
+        })
+        .collect::<Vec<_>>();
+
+    if target == HookFrontend::Codex {
+        let mut handled = BTreeSet::new();
+        for hooks in codex_catch_all_groups(&missing_hooks).values() {
+            if hooks.len() < 2 {
+                continue;
+            }
+            let first = hooks[0];
+            actions.push(RepairAction::BackendPrompt {
+                source,
+                target,
+                matcher: CATCH_ALL_MATCHER.to_string(),
+                source_path: first.source_path.clone(),
+                prompt: catch_all_migration_prompt(hooks, target),
+            });
+            handled.extend(hooks.iter().map(|hook| hook.matcher.clone()));
+        }
+
+        for hook in missing_hooks {
+            if handled.contains(&hook.matcher) {
+                continue;
+            }
+            actions.push(RepairAction::BackendPrompt {
+                source,
+                target,
+                matcher: hook.matcher.clone(),
+                source_path: hook.source_path.clone(),
+                prompt: migration_prompt(hook, target),
+            });
+        }
+        return;
+    }
+
+    for hook in missing_hooks {
+        actions.push(RepairAction::BackendPrompt {
+            source,
+            target,
+            matcher: hook.matcher.clone(),
+            source_path: hook.source_path.clone(),
+            prompt: migration_prompt(hook, target),
+        });
+    }
+}
+
+fn matcher_is_covered_by(
+    source: HookFrontend,
+    target_by_matcher: &BTreeMap<String, NormalizedHook>,
+    source_matcher: &str,
+) -> bool {
+    target_by_matcher.contains_key(source_matcher)
+        || (source_matcher != CATCH_ALL_MATCHER
+            && target_by_matcher.contains_key(CATCH_ALL_MATCHER))
+        || (source == HookFrontend::Codex
+            && source_matcher == CATCH_ALL_MATCHER
+            && !target_by_matcher.is_empty())
+}
+
+fn codex_catch_all_groups<'a>(
+    hooks: &[&'a NormalizedHook],
+) -> BTreeMap<String, Vec<&'a NormalizedHook>> {
+    let mut groups = BTreeMap::new();
+    for hook in hooks {
+        if hook.matcher == CATCH_ALL_MATCHER {
+            continue;
+        }
+        let Some(command) = hook.command.as_deref().map(str::trim) else {
+            continue;
+        };
+        if command.is_empty() {
+            continue;
+        }
+        groups
+            .entry(command.to_string())
+            .or_insert_with(Vec::new)
+            .push(*hook);
+    }
+    groups
 }
 
 fn collect_claude(repo_root: &Path, home: Option<&Path>) -> FrontendHookSummary {
@@ -532,7 +617,7 @@ fn build_warnings(claude: &FrontendHookSummary, codex: &FrontendHookSummary) -> 
     let codex_matchers = codex.active_matchers();
     if !claude_matchers.is_empty()
         && !codex_matchers.is_empty()
-        && claude_matchers != codex_matchers
+        && !matcher_sets_are_compatible(&claude_matchers, &codex_matchers)
     {
         warnings.push(format!(
             "Claude and Codex PreToolUse hook matchers differ (Claude: {}; Codex: {}). {FIX_HINT}",
@@ -541,6 +626,13 @@ fn build_warnings(claude: &FrontendHookSummary, codex: &FrontendHookSummary) -> 
         ));
     }
     warnings
+}
+
+fn matcher_sets_are_compatible(
+    claude_matchers: &BTreeSet<String>,
+    codex_matchers: &BTreeSet<String>,
+) -> bool {
+    claude_matchers == codex_matchers || codex_matchers.contains(CATCH_ALL_MATCHER)
 }
 
 #[derive(Debug)]
@@ -684,6 +776,44 @@ After editing the target config, validate that the target hook config parses. If
         source_path = display_path(&hook.source_path),
         target_path = target_path,
         matcher = hook.matcher
+    )
+}
+
+fn catch_all_migration_prompt(hooks: &[&NormalizedHook], target: HookFrontend) -> String {
+    let first = hooks[0];
+    let target_path = match target {
+        HookFrontend::Claude => ".claude/settings.json",
+        HookFrontend::Codex => ".codex/hooks.json",
+    };
+    let matchers = hooks
+        .iter()
+        .map(|hook| hook.matcher.clone())
+        .collect::<BTreeSet<_>>();
+    let command = first.command.as_deref().unwrap_or("(no command recorded)");
+    format!(
+        "\
+You are fixing Claude/Codex PreToolUse hook parity for this repository.
+
+Migrate or copy these equivalent hooks from {source} to {target} as one Codex catch-all hook.
+
+Source config: {source_path}
+Target config: {target_path}
+Event: PreToolUse
+Matcher/tool pattern: {catch_all}
+Source matchers covered by the catch-all hook: {matchers}
+Shared command: {command}
+
+Use matcher \"*\" for the target Codex hook so one reviewed hook can cover all matching tools and avoid repeated Codex trust approvals for the same command. Preserve the hook intent conservatively. Claude and Codex PreToolUse hooks are similar but not full parity: permission decisions, input rewriting, context injection, matcher names, and tool coverage can differ. Do not pretend unsupported target behavior is enforceable; document unsupported semantics in the target config comment or adjacent note if needed.
+
+After editing the target config, validate that the target hook config parses. If parsing fails, fix only the affected target hook/config file and reparse. Stop when the migrated hook parses cleanly or when the migration is blocked by unsupported target semantics.
+",
+        source = first.frontend.display_name(),
+        target = target.display_name(),
+        source_path = display_path(&first.source_path),
+        target_path = target_path,
+        catch_all = CATCH_ALL_MATCHER,
+        matchers = join_matchers(&matchers),
+        command = command
     )
 }
 

--- a/crates/clud-bin/src/hook_health_tests.rs
+++ b/crates/clud-bin/src/hook_health_tests.rs
@@ -187,13 +187,84 @@ fn deterministic_trust_repair_adds_canonical_key() {
 }
 
 #[test]
-fn per_hook_prompt_planning_uses_one_action_per_missing_matcher() {
+fn catch_all_codex_hook_satisfies_specific_claude_matchers() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");
     let home = temp.path().join("home");
     write(
         &repo.join(".claude").join("settings.json"),
         r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{}]},{"matcher":"Read","hooks":[{}]}]}}"#,
+    );
+    let codex = repo.join(".codex").join("hooks.json");
+    write(
+        &codex,
+        r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{}]}]}}"#,
+    );
+    write(
+        &home.join(".codex").join("config.toml"),
+        &format!(
+            "[projects.'{}']\ntrust_level = \"trusted\"\n{}",
+            codex_project_key(&repo),
+            trusted_state_for(&codex, 0, 0)
+        ),
+    );
+
+    let report = inspect_paths(&repo, Some(&home));
+
+    assert!(
+        !report
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("matchers differ")),
+        "catch-all Codex matcher should satisfy specific Claude matchers: {:?}",
+        report.warnings
+    );
+    assert!(
+        plan_repairs(&report)
+            .into_iter()
+            .filter(|action| matches!(action, RepairAction::BackendPrompt { .. }))
+            .collect::<Vec<_>>()
+            .is_empty(),
+        "catch-all target coverage should not request per-tool migrations"
+    );
+}
+
+#[test]
+fn same_command_claude_hooks_plan_one_codex_catch_all_prompt() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let home = temp.path().join("home");
+    write(
+        &repo.join(".claude").join("settings.json"),
+        r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"python check.py"}]},{"matcher":"Read","hooks":[{"type":"command","command":"python check.py"}]}]}}"#,
+    );
+
+    let report = inspect_paths(&repo, Some(&home));
+    let prompts = plan_repairs(&report)
+        .into_iter()
+        .filter(|action| matches!(action, RepairAction::BackendPrompt { .. }))
+        .collect::<Vec<_>>();
+
+    assert_eq!(prompts.len(), 1);
+    assert!(matches!(
+        &prompts[0],
+        RepairAction::BackendPrompt {
+            target: HookFrontend::Codex,
+            matcher,
+            prompt,
+            ..
+        } if matcher == "*" && prompt.contains("catch-all")
+    ));
+}
+
+#[test]
+fn different_command_claude_hooks_stay_per_matcher_prompts() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let home = temp.path().join("home");
+    write(
+        &repo.join(".claude").join("settings.json"),
+        r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"python bash.py"}]},{"matcher":"Read","hooks":[{"type":"command","command":"python read.py"}]}]}}"#,
     );
 
     let report = inspect_paths(&repo, Some(&home));
@@ -204,7 +275,9 @@ fn per_hook_prompt_planning_uses_one_action_per_missing_matcher() {
 
     assert_eq!(prompts.len(), 2);
     assert!(prompts.iter().all(|action| match action {
-        RepairAction::BackendPrompt { prompt, .. } => prompt.contains("exactly one hook"),
+        RepairAction::BackendPrompt {
+            matcher, prompt, ..
+        } => matcher != "*" && prompt.contains("exactly one hook"),
         _ => false,
     }));
 }


### PR DESCRIPTION
## Summary

- Use the bundled README hero image as the default PTY Sixel header while keeping `--graphics-image` as an override.
- Teach hook repair planning to treat Codex `*` as catch-all coverage and consolidate equivalent Claude tool hooks into one Codex catch-all migration prompt.
- Document the hero header default and the Codex catch-all hook behavior.

Closes #238
Closes #240

## Validation

- `soldr cargo test -p clud --lib hook_health::tests`
- `soldr cargo test -p clud --lib graphics::tests`
- `bash lint` with `CARGO_TARGET_DIR=C:\t\clud-target` to avoid Windows CMake path-length failures in the disposable worktree
- `git diff --check`
- `bash test --integration tests/integration/test_aaa_windows_probe.py::test_probe_demo_gfx_sixel_emits_sixel_bytes`