### PR TITLE
fix(launch-setup): only prompt scope when --claude/--codex is explicit

### DIFF
--- a/crates/clud-bin/src/launch_setup.rs
+++ b/crates/clud-bin/src/launch_setup.rs
@@ -88,6 +88,7 @@ fn marker(selected: bool) -> &'static str {
 
 pub fn should_prompt_for_scope(args: &Args, interactive_terminal: bool) -> bool {
     interactive_terminal
+        && (args.claude || args.codex)
         && !args.dry_run
         && args.prompt.is_none()
         && args.message.is_none()
@@ -368,6 +369,7 @@ mod tests {
     fn prompt_scope_only_for_interactive_bare_launches() {
         assert!(should_prompt_for_scope(&parse(&["clud", "--codex"]), true));
         assert!(should_prompt_for_scope(&parse(&["clud", "--claude"]), true));
+        assert!(!should_prompt_for_scope(&parse(&["clud"]), true));
         assert!(!should_prompt_for_scope(
             &parse(&["clud", "--codex"]),
             false

--- a/docs/architecture/launch-setup.md
+++ b/docs/architecture/launch-setup.md
@@ -5,7 +5,8 @@ before clud starts a backend. It lives in `crates/clud-bin/src/launch_setup.rs`.
 
 ## Scope Selector
 
-Bare interactive TUI launches prompt on stderr before the backend starts:
+Interactive TUI launches that explicitly choose a backend with `--claude` or
+`--codex` prompt on stderr before the backend starts:
 
 ```text
 [x] Session only
@@ -13,9 +14,10 @@ Bare interactive TUI launches prompt on stderr before the backend starts:
 ```
 
 The default is session-only. Enter accepts the highlighted option, Up selects
-session-only, and Down selects global. Non-interactive launches, piped stdin,
-`--dry-run`, one-shot prompt launches (`-p` / `-m`), continuations, resumes,
-and maintenance commands do not prompt; they use session-only.
+session-only, and Down selects global. A bare `clud` invocation (no `--claude`
+or `--codex`), non-interactive launches, piped stdin, `--dry-run`, one-shot
+prompt launches (`-p` / `-m`), continuations, resumes, and maintenance commands
+do not prompt; they use session-only.
 
 Session-only launches skip persistent setup. They must not create or modify
 agent home setup files under `~/.claude`, `~/.codex`, `~/.agents`, or


### PR DESCRIPTION
## Summary
- Bare `clud` invocations no longer trigger the "Session only / Global setup" scope selector — there is no backend whose home dir the global setup would touch, so the prompt was meaningless.
- `should_prompt_for_scope` now requires `args.claude || args.codex` in addition to the existing interactive/non-prompt gates.
- Updated `docs/architecture/launch-setup.md` to describe the new condition.

## Test plan
- [x] `soldr cargo test -p clud --lib launch_setup::` — 7 passed, including new `prompt_scope_only_for_interactive_bare_launches` assertion that `parse(&[\"clud\"])` does NOT prompt.
- [ ] CI: full matrix across 6 platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)