### PR TITLE
feat(daemon): hand Ctrl+C tree-kill to daemon for sub-100ms shell return

### DIFF
--- a/crates/clud-bin/assets/dashboard/index.html
+++ b/crates/clud-bin/assets/dashboard/index.html
@@ -134,6 +134,7 @@
     <button class="tab active" data-tab="sessions">Sessions</button>
     <button class="tab" data-tab="gc">Garbage</button>
     <button class="tab" data-tab="repos">Repos</button>
+    <button class="tab" data-tab="ctrl-c">Ctrl-C</button>
   </div>
 
   <section id="sessions" class="active">
@@ -155,6 +156,13 @@
     <div class="card">
       <h2>Repos visited <span id="repos-count" class="meta"></span></h2>
       <div id="repos-body"><p class="empty">loading…</p></div>
+    </div>
+  </section>
+
+  <section id="ctrl-c">
+    <div class="card">
+      <h2>Ctrl-C exit times <span id="ctrl-c-count" class="meta"></span></h2>
+      <div id="ctrl-c-body"><p class="empty">loading…</p></div>
     </div>
   </section>
 
@@ -195,6 +203,14 @@
       if (ms === null || ms === undefined) return '-';
       if (ms < 1000) return `${ms}ms`;
       return `${(ms / 1000).toFixed(2)}s`;
+    }
+    function fmtUnixMs(ms) {
+      if (!ms) return '-';
+      const d = new Date(ms);
+      const hh = String(d.getHours()).padStart(2, '0');
+      const mm = String(d.getMinutes()).padStart(2, '0');
+      const ss = String(d.getSeconds()).padStart(2, '0');
+      return `${hh}:${mm}:${ss}`;
     }
     function esc(s) {
       if (s === null || s === undefined) return '';
@@ -307,6 +323,32 @@
       });
     }
 
+    function renderCtrlCEvents(state) {
+      const events = state.ctrl_c_events || [];
+      document.getElementById('ctrl-c-count').textContent = events.length ? `(${events.length})` : '';
+      if (!events.length) {
+        document.getElementById('ctrl-c-body').innerHTML =
+          '<p class="empty">no Ctrl-C exits recorded yet. Press Ctrl-C in a <code>clud</code> session to populate this view.</p>';
+        return;
+      }
+      const rows = events.map(e => `
+        <tr>
+          <td class="metric">${esc(fmtUnixMs(e.exit_at_ms))}</td>
+          <td class="metric">${esc(fmtMs(e.elapsed_ms))}</td>
+          <td><span class="badge kind">${esc(e.kind)}</span></td>
+          <td>${esc(e.exit_code)}</td>
+          <td>${esc(e.pid)}</td>
+          <td class="path">${esc(e.cwd || '-')}</td>
+        </tr>`).join('');
+      document.getElementById('ctrl-c-body').innerHTML = `
+        <table>
+          <thead><tr>
+            <th>exited at</th><th>elapsed</th><th>kind</th><th>exit</th><th>pid</th><th>cwd</th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table>`;
+    }
+
     function renderRepos(state) {
       const repos = state.repos || [];
       document.getElementById('repos-count').textContent = repos.length ? `(${repos.length})` : '';
@@ -360,6 +402,7 @@
         renderSessions(state);
         renderGc(state);
         renderRepos(state);
+        renderCtrlCEvents(state);
       } catch (err) {
         document.getElementById('daemon-meta').textContent =
           `connection lost: ${err}`;

--- a/crates/clud-bin/src/ctrl_c_track.rs
+++ b/crates/clud-bin/src/ctrl_c_track.rs
@@ -1,0 +1,338 @@
+//! Cross-path Ctrl+C exit timing.
+//!
+//! Records the moment the process first observes Ctrl+C (whether under the
+//! direct runner, an attached daemon session, or the centralized launch
+//! path) and, just before the process exits, writes a JSON event under
+//! `<state_dir>/ctrl_c_events/<unix-ms>-<pid>.json` capturing the elapsed
+//! wall-clock time from "Ctrl+C seen" to "about to exit". The daemon
+//! dashboard reads these files and surfaces them on `clud ui` so the
+//! recurring "Ctrl+C takes forever to drop me back at the shell" problem
+//! has hard numbers attached.
+//!
+//! The on-disk format is intentionally tiny and forwards-compatible:
+//! unknown fields are ignored on read, and the directory is capped so a
+//! long-running daemon never accumulates more than [`MAX_RETAINED_EVENTS`]
+//! files. Existing per-session [`crate::daemon::types::CtrlCProfile`]
+//! handoff/kill telemetry is unchanged.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+pub const EVENTS_DIRNAME: &str = "ctrl_c_events";
+
+/// Hard cap on retained events. The dashboard only needs the recent tail,
+/// and we don't want a debugging dir to balloon over a long-lived daemon.
+pub const MAX_RETAINED_EVENTS: usize = 50;
+
+/// Cap returned by [`read_recent_events`] so `/state.json` payloads stay
+/// small even right after a burst of interrupts.
+pub const DASHBOARD_EVENT_LIMIT: usize = 20;
+
+/// Origin of the interrupt — the dashboard groups events by this so the
+/// "is it the daemon attach path that's slow or the direct runner?"
+/// question has a one-glance answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvocationKind {
+    Direct,
+    Attach,
+    Centralized,
+}
+
+impl InvocationKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Direct => "direct",
+            Self::Attach => "attach",
+            Self::Centralized => "centralized",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CtrlCEvent {
+    pub pid: u32,
+    pub observed_at_ms: u64,
+    pub exit_at_ms: u64,
+    pub elapsed_ms: u64,
+    pub kind: InvocationKind,
+    pub exit_code: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+}
+
+// Process-wide observation point. Recorded once on the first Ctrl+C the
+// signal handler sees, then read by `flush_on_exit`. Using both an
+// `Instant` and a unix-ms timestamp lets the dashboard correlate events
+// against absolute time while keeping the elapsed calculation immune to
+// wall-clock jumps.
+static OBSERVED_INSTANT: OnceLock<Instant> = OnceLock::new();
+static OBSERVED_UNIX_MS: AtomicU64 = AtomicU64::new(0);
+
+/// Mark the process as having observed Ctrl+C. Safe to call from a signal
+/// handler — no allocations, no locks, only atomic / OnceLock writes.
+/// Subsequent calls are no-ops so the very first interrupt wins.
+pub fn record_observed() {
+    if OBSERVED_INSTANT.set(Instant::now()).is_ok() {
+        let unix_ms = unix_millis_now();
+        // Race-free: only the OnceLock-winning thread reaches here, so
+        // this store is the unique writer.
+        OBSERVED_UNIX_MS.store(unix_ms, Ordering::SeqCst);
+    }
+}
+
+pub fn was_observed() -> bool {
+    OBSERVED_INSTANT.get().is_some()
+}
+
+/// If Ctrl+C was observed during this process's lifetime, write an event
+/// file under `<state_dir>/ctrl_c_events/`. Best-effort: every error path
+/// is silent. This must never block exit.
+pub fn flush_on_exit(state_dir: &Path, kind: InvocationKind, exit_code: i32) {
+    let Some(event) = build_event(kind, exit_code) else {
+        return;
+    };
+    let _ = write_event(state_dir, &event);
+}
+
+fn build_event(kind: InvocationKind, exit_code: i32) -> Option<CtrlCEvent> {
+    let observed = OBSERVED_INSTANT.get()?;
+    let observed_at_ms = OBSERVED_UNIX_MS.load(Ordering::SeqCst);
+    let elapsed_ms = observed.elapsed().as_millis() as u64;
+    let exit_at_ms = observed_at_ms.saturating_add(elapsed_ms);
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned());
+    Some(CtrlCEvent {
+        pid: std::process::id(),
+        observed_at_ms,
+        exit_at_ms,
+        elapsed_ms,
+        kind,
+        exit_code,
+        cwd,
+    })
+}
+
+fn write_event(state_dir: &Path, event: &CtrlCEvent) -> io::Result<()> {
+    let dir = events_dir(state_dir);
+    fs::create_dir_all(&dir)?;
+    let filename = format!("{:013}-{}.json", event.exit_at_ms, event.pid);
+    let path = dir.join(filename);
+    let bytes = serde_json::to_vec(event)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    fs::write(&path, bytes)?;
+    prune_old_events(&dir, MAX_RETAINED_EVENTS);
+    Ok(())
+}
+
+pub fn events_dir(state_dir: &Path) -> PathBuf {
+    state_dir.join(EVENTS_DIRNAME)
+}
+
+/// Read newest-first up to `limit` events from `<state_dir>/ctrl_c_events/`.
+/// Used by the dashboard. Missing dir → empty Vec.
+pub fn read_recent_events(state_dir: &Path, limit: usize) -> Vec<CtrlCEvent> {
+    let dir = events_dir(state_dir);
+    let entries = match fs::read_dir(&dir) {
+        Ok(it) => it,
+        Err(_) => return Vec::new(),
+    };
+    let mut events: Vec<CtrlCEvent> = entries
+        .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
+        .filter_map(|e| {
+            let bytes = fs::read(e.path()).ok()?;
+            serde_json::from_slice::<CtrlCEvent>(&bytes).ok()
+        })
+        .collect();
+    events.sort_by(|a, b| b.exit_at_ms.cmp(&a.exit_at_ms));
+    events.truncate(limit);
+    events
+}
+
+fn prune_old_events(dir: &Path, keep: usize) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut files: Vec<(u64, PathBuf)> = entries
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            if path.extension().and_then(|x| x.to_str()) != Some("json") {
+                return None;
+            }
+            let mtime = e
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            Some((mtime, path))
+        })
+        .collect();
+    if files.len() <= keep {
+        return;
+    }
+    // Newest first; keep the head, delete the rest.
+    files.sort_by(|a, b| b.0.cmp(&a.0));
+    for (_, path) in files.into_iter().skip(keep) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+fn unix_millis_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// **Test-only.** Reset the OnceLock-backed observation state. Real
+/// processes only ever observe Ctrl+C once per run; tests need to
+/// simulate fresh observations across cases.
+#[cfg(test)]
+pub(crate) fn reset_for_test() {
+    // OnceLock has no public reset, so we exploit `take` on a clone via
+    // a fresh OnceLock through interior mutation — there is no such API,
+    // so instead tests that need a clean slate must run in a serialized
+    // section and observe via [`record_observed`] from a fresh process.
+    // To keep things simple, this resets only the timestamp atomic; the
+    // OnceLock retention is acceptable because [`build_event`] reads
+    // both the instant and the millis, and tests that probe build_event
+    // use a brand-new module via `cargo test` per-process isolation.
+    OBSERVED_UNIX_MS.store(0, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn invocation_kind_str_round_trips() {
+        assert_eq!(InvocationKind::Direct.as_str(), "direct");
+        assert_eq!(InvocationKind::Attach.as_str(), "attach");
+        assert_eq!(InvocationKind::Centralized.as_str(), "centralized");
+    }
+
+    #[test]
+    fn ctrl_c_event_round_trips_through_json() {
+        let event = CtrlCEvent {
+            pid: 1234,
+            observed_at_ms: 1_700_000_000_000,
+            exit_at_ms: 1_700_000_000_250,
+            elapsed_ms: 250,
+            kind: InvocationKind::Direct,
+            exit_code: 130,
+            cwd: Some("/tmp/x".to_string()),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""kind":"direct""#));
+        assert!(json.contains(r#""elapsed_ms":250"#));
+        let back: CtrlCEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.pid, 1234);
+        assert_eq!(back.elapsed_ms, 250);
+        assert_eq!(back.kind, InvocationKind::Direct);
+        assert_eq!(back.cwd.as_deref(), Some("/tmp/x"));
+    }
+
+    #[test]
+    fn read_recent_events_returns_empty_when_dir_missing() {
+        let tmp = tempdir().unwrap();
+        let events = read_recent_events(tmp.path(), 10);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn read_recent_events_returns_newest_first_and_respects_limit() {
+        let tmp = tempdir().unwrap();
+        let dir = events_dir(tmp.path());
+        fs::create_dir_all(&dir).unwrap();
+        for i in 0..5u64 {
+            let event = CtrlCEvent {
+                pid: 100 + i as u32,
+                observed_at_ms: 1_700_000_000_000 + i * 1000,
+                exit_at_ms: 1_700_000_000_500 + i * 1000,
+                elapsed_ms: 500,
+                kind: InvocationKind::Direct,
+                exit_code: 130,
+                cwd: None,
+            };
+            let path = dir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
+            fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();
+        }
+        let events = read_recent_events(tmp.path(), 3);
+        assert_eq!(events.len(), 3);
+        // Newest first means the largest exit_at_ms comes first.
+        assert_eq!(events[0].exit_at_ms, 1_700_000_000_500 + 4_000);
+        assert_eq!(events[1].exit_at_ms, 1_700_000_000_500 + 3_000);
+        assert_eq!(events[2].exit_at_ms, 1_700_000_000_500 + 2_000);
+    }
+
+    #[test]
+    fn read_recent_events_skips_unparseable_files() {
+        let tmp = tempdir().unwrap();
+        let dir = events_dir(tmp.path());
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("garbage.json"), b"not json").unwrap();
+        let good = CtrlCEvent {
+            pid: 1,
+            observed_at_ms: 100,
+            exit_at_ms: 200,
+            elapsed_ms: 100,
+            kind: InvocationKind::Attach,
+            exit_code: 130,
+            cwd: None,
+        };
+        fs::write(dir.join("good.json"), serde_json::to_vec(&good).unwrap()).unwrap();
+        let events = read_recent_events(tmp.path(), 10);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].pid, 1);
+    }
+
+    #[test]
+    fn prune_old_events_keeps_newest() {
+        let tmp = tempdir().unwrap();
+        let dir = events_dir(tmp.path());
+        fs::create_dir_all(&dir).unwrap();
+        // Create 10 files with monotonically-increasing mtime by writing
+        // them in order; on most filesystems that's enough to differentiate.
+        for i in 0..10u64 {
+            let path = dir.join(format!("evt-{i:02}.json"));
+            fs::write(&path, b"{}").unwrap();
+            // Tiny sleep so mtimes can differ on coarse-grained filesystems.
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        prune_old_events(&dir, 3);
+        let remaining = fs::read_dir(&dir).unwrap().count();
+        assert_eq!(remaining, 3, "prune must keep exactly the cap");
+    }
+
+    #[test]
+    fn flush_on_exit_is_noop_when_never_observed() {
+        // Side-stepping OnceLock retention: in a fresh test process the
+        // `OBSERVED_INSTANT` is unset, so flush_on_exit must write
+        // nothing. We can't reset OnceLock from inside the process, so
+        // this test only runs cleanly when no other test in this module
+        // has already called `record_observed`. Since we never do, this
+        // test pins the "no observation, no file" contract.
+        reset_for_test();
+        let tmp = tempdir().unwrap();
+        flush_on_exit(tmp.path(), InvocationKind::Direct, 0);
+        let dir = events_dir(tmp.path());
+        if dir.exists() {
+            // Directory creation only happens inside write_event; if it
+            // exists, no event files should be inside.
+            let count = fs::read_dir(&dir).unwrap().count();
+            assert_eq!(count, 0);
+        }
+    }
+}

--- a/crates/clud-bin/src/daemon/attach.rs
+++ b/crates/clud-bin/src/daemon/attach.rs
@@ -90,6 +90,7 @@ pub(super) fn run_attach(session_id: &str, state_dir: &Path, interrupted: &Atomi
         DaemonResponse::Created { .. }
         | DaemonResponse::Terminated { .. }
         | DaemonResponse::Interrupted { .. }
+        | DaemonResponse::AdoptKillAck { .. }
         | DaemonResponse::Gc { .. }
         | DaemonResponse::LiveCwds { .. }
         | DaemonResponse::ShutdownAck { .. } => 1,

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -194,6 +194,48 @@ pub(super) fn request_session_termination(
     }
 }
 
+/// Fire-and-forget handoff: ask the daemon to kill these process trees
+/// on a background thread so the CLI can return from a Ctrl+C teardown
+/// immediately. Returns `true` if the daemon acked the handoff. On
+/// failure the caller is expected to fall back to a synchronous kill
+/// (best behavior: same as before this op existed).
+///
+/// Uses tight read/write timeouts so a wedged daemon never blocks the
+/// CLI for more than ~250ms total — the entire point of this call is
+/// sub-100ms latency on Ctrl+C. Errors are logged at most once via the
+/// returned bool; the caller decides whether to surface them.
+pub fn try_handoff_kill_to_daemon(state_dir: &Path, pids: &[u32], reason: Option<&str>) -> bool {
+    if pids.is_empty() {
+        return true;
+    }
+    let info = match read_json_file::<DaemonInfo>(&daemon_info_path(state_dir)) {
+        Ok(info) => info,
+        Err(_) => return false,
+    };
+    let mut stream = match TcpStream::connect_timeout(
+        &std::net::SocketAddr::from(([127, 0, 0, 1], info.port)),
+        Duration::from_millis(150),
+    ) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(150)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(150)));
+    let request = DaemonRequest::AdoptKill {
+        pids: pids.to_vec(),
+        reason: reason.map(|s| s.to_string()),
+    };
+    if write_json_line(&mut stream, &request).is_err() {
+        return false;
+    }
+    // We could parse the ack here, but the wire contract guarantees the
+    // daemon spawns its worker before replying; receiving any bytes back
+    // means our PIDs are queued.
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    matches!(reader.read_line(&mut line), Ok(n) if n > 0)
+}
+
 pub(super) fn request_session_interrupt(
     state_dir: &Path,
     session_id: &str,

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -361,6 +361,7 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         DaemonResponse::Session { .. }
         | DaemonResponse::Terminated { .. }
         | DaemonResponse::Interrupted { .. }
+        | DaemonResponse::AdoptKillAck { .. }
         | DaemonResponse::Gc { .. }
         | DaemonResponse::LiveCwds { .. }
         | DaemonResponse::ShutdownAck { .. } => 1,

--- a/crates/clud-bin/src/daemon/http.rs
+++ b/crates/clud-bin/src/daemon/http.rs
@@ -31,6 +31,7 @@ use super::process_utils::pid_is_alive;
 use super::types::{
     CtrlCProfile, DaemonInfo, GcOp, GcReply, ListRow, RepoVisit, SessionKind, SessionSnapshot,
 };
+use crate::ctrl_c_track::{self, CtrlCEvent};
 use crate::session_registry::LiveSession;
 
 /// Supplier of live session-registry rows. Injected at the dashboard
@@ -69,6 +70,12 @@ pub struct DashboardState {
     pub sessions: Vec<SessionView>,
     pub gc: Vec<ListRow>,
     pub repos: Vec<RepoVisit>,
+    /// Recent cross-path Ctrl+C exit events. Each entry is one CLI
+    /// process that observed Ctrl+C and recorded the elapsed wall-clock
+    /// time from observation to process-exit. Capped at
+    /// [`ctrl_c_track::DASHBOARD_EVENT_LIMIT`], newest first.
+    #[serde(default)]
+    pub ctrl_c_events: Vec<CtrlCEvent>,
     pub stats: Stats,
 }
 
@@ -379,6 +386,9 @@ fn build_dashboard_state(
         *gc_by_kind.entry(row.kind.clone()).or_insert(0) += 1;
     }
 
+    let ctrl_c_events =
+        ctrl_c_track::read_recent_events(state_dir, ctrl_c_track::DASHBOARD_EVENT_LIMIT);
+
     let stats = Stats {
         session_count: sessions.len(),
         live_session_count,
@@ -400,6 +410,7 @@ fn build_dashboard_state(
         sessions,
         gc: gc_rows,
         repos,
+        ctrl_c_events,
         stats,
     })
 }
@@ -799,6 +810,32 @@ mod tests {
         assert!(json.get("daemon_pid").is_none());
         assert!(json.get("worker_pid").is_none());
         assert!(json.get("root_pid").is_none());
+    }
+
+    #[test]
+    fn build_state_includes_ctrl_c_events_when_present() {
+        use crate::ctrl_c_track::{events_dir, CtrlCEvent, InvocationKind};
+        let dir = tempfile::tempdir().unwrap();
+        let edir = events_dir(dir.path());
+        std::fs::create_dir_all(&edir).unwrap();
+        for i in 0..3u64 {
+            let event = CtrlCEvent {
+                pid: 1_000 + i as u32,
+                observed_at_ms: 1_700_000_000_000 + i * 1000,
+                exit_at_ms: 1_700_000_000_500 + i * 1000,
+                elapsed_ms: 500 + i,
+                kind: InvocationKind::Direct,
+                exit_code: 130,
+                cwd: Some(format!("/tmp/a{i}")),
+            };
+            let path = edir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
+            std::fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();
+        }
+        let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
+        assert_eq!(state.ctrl_c_events.len(), 3);
+        // Newest first
+        assert_eq!(state.ctrl_c_events[0].exit_at_ms, 1_700_000_000_500 + 2_000);
+        assert_eq!(state.ctrl_c_events[2].exit_at_ms, 1_700_000_000_500);
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -16,7 +16,7 @@ mod worker_shared;
 
 pub use client::{
     ensure_daemon, gc_client_insert, gc_client_list, gc_client_list_repo_visits, gc_client_purge,
-    gc_client_reconcile, gc_client_record_repo_visit,
+    gc_client_reconcile, gc_client_record_repo_visit, try_handoff_kill_to_daemon,
 };
 pub use entry::{experimental_enabled, handle_special_command, run_centralized_session};
 pub use http::{

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -184,6 +184,12 @@ fn handle_daemon_connection(
                 message: err.to_string(),
             },
         },
+        DaemonRequest::AdoptKill { pids, reason } => {
+            spawn_adopt_kill_worker(pids.clone(), reason);
+            DaemonResponse::AdoptKillAck {
+                accepted: pids.len(),
+            }
+        }
         DaemonRequest::Gc { payload } => {
             let reply = dispatch_gc_op(gc_tx.as_ref(), payload);
             DaemonResponse::Gc { reply }
@@ -343,6 +349,30 @@ fn reap_worker_when_done(
     });
 }
 
+/// Background `kill_tree` for [`DaemonRequest::AdoptKill`].
+///
+/// The CLI hands us a list of root PIDs it was about to wait on and we
+/// finish the job from out here so the foreground `clud` can drop the
+/// user back to the shell immediately. Best-effort and fire-and-forget:
+/// failures are silent because the parent CLI already returned 130 and
+/// nobody is on the other end to receive a reply. The kill walk uses
+/// `process_tree::kill_tree` for parity with the synchronous path it
+/// replaces (see `runner::teardown_interrupted_child`).
+fn spawn_adopt_kill_worker(pids: Vec<u32>, reason: Option<String>) {
+    let _ = thread::Builder::new()
+        .name("clud-adopt-kill".to_string())
+        .spawn(move || {
+            for pid in pids {
+                crate::process_tree::kill_tree(pid);
+            }
+            // `reason` is for telemetry / future event-logging — hold a
+            // reference so the field doesn't get optimized out and so a
+            // future change can route it into `ctrl_c_events` without
+            // touching the wire format again.
+            let _ = reason;
+        });
+}
+
 fn daemon_terminate_session(
     state_dir: &Path,
     workers: &Arc<Mutex<HashMap<String, Arc<NativeProcess>>>>,
@@ -481,4 +511,35 @@ fn merge_ctrl_c_profile_for_daemon(session: &mut SessionSnapshot, mut update: Ct
         current.daemon_received_at_ms = update.daemon_received_at_ms;
     }
     current.fast_path = true;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    /// `spawn_adopt_kill_worker` must return immediately — the whole
+    /// point of the AdoptKill IPC is that the CLI's wait time is bounded
+    /// by an `mpsc` thread-spawn, not by the eventual `kill_tree` walk.
+    /// Hand it a PID that's almost certainly dead so `kill_tree` returns
+    /// fast, and pin the spawn-side latency below 100ms even on slow CI.
+    #[test]
+    fn spawn_adopt_kill_worker_returns_promptly() {
+        let started = Instant::now();
+        spawn_adopt_kill_worker(vec![u32::MAX], Some("test".to_string()));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "spawn took too long: {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn spawn_adopt_kill_worker_accepts_empty_pids() {
+        // Zero-PID payload is valid wire data (the CLI may have lost the
+        // root PID); the worker must still spawn without panicking.
+        let started = Instant::now();
+        spawn_adopt_kill_worker(Vec::new(), None);
+        assert!(started.elapsed() < Duration::from_millis(100));
+    }
 }

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -176,6 +176,18 @@ pub(super) enum DaemonRequest {
         session_id: String,
         profile: CtrlCProfile,
     },
+    /// Fire-and-forget handoff: the CLI is exiting and wants the daemon
+    /// to kill these process trees on a background thread so the user-
+    /// visible Ctrl+C-to-shell latency stays sub-100ms. The daemon
+    /// replies `AdoptKillAck` immediately (before doing the kill) so the
+    /// CLI's `send_daemon_request` call returns ASAP. PIDs are typically
+    /// the root spawned by `runner::run_plan_subprocess` /
+    /// `run_plan_pty`.
+    AdoptKill {
+        pids: Vec<u32>,
+        #[serde(default)]
+        reason: Option<String>,
+    },
     /// Issue #135: GC ops served by the registry worker thread (see
     /// `gc_service.rs`). Carry the original `gc.*` op inside a single
     /// enum variant so the wire format and the registry-worker dispatch
@@ -205,6 +217,11 @@ pub(super) enum DaemonResponse {
     },
     Interrupted {
         session: SessionSnapshot,
+    },
+    /// Ack for [`DaemonRequest::AdoptKill`]. Returned before the daemon
+    /// actually performs the kill, so the CLI can exit immediately.
+    AdoptKillAck {
+        accepted: usize,
     },
     Gc {
         reply: GcReply,
@@ -560,6 +577,58 @@ mod tests {
         assert!(wire.contains(r#""op":"interrupt""#));
         assert!(wire.contains(r#""cli_handoff_ms":10"#));
         assert!(wire.contains(r#""fast_path":true"#));
+    }
+
+    #[test]
+    fn adopt_kill_request_roundtrips_pids_and_reason() {
+        let request = DaemonRequest::AdoptKill {
+            pids: vec![1234, 5678],
+            reason: Some("ctrl_c_handoff".to_string()),
+        };
+        let wire = serde_json::to_string(&request).unwrap();
+        assert!(wire.contains(r#""op":"adopt_kill""#));
+        assert!(wire.contains(r#""pids":[1234,5678]"#));
+        let parsed: DaemonRequest = serde_json::from_str(&wire).unwrap();
+        match parsed {
+            DaemonRequest::AdoptKill { pids, reason } => {
+                assert_eq!(pids, vec![1234, 5678]);
+                assert_eq!(reason.as_deref(), Some("ctrl_c_handoff"));
+            }
+            other => panic!("expected AdoptKill, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adopt_kill_request_omits_reason_when_none() {
+        let request = DaemonRequest::AdoptKill {
+            pids: vec![99],
+            reason: None,
+        };
+        let wire = serde_json::to_string(&request).unwrap();
+        assert!(wire.contains(r#""pids":[99]"#));
+        // `reason` is `#[serde(default)]`; absence on the wire round-trips.
+        let parsed: DaemonRequest =
+            serde_json::from_str(r#"{"op":"adopt_kill","pids":[99]}"#).unwrap();
+        match parsed {
+            DaemonRequest::AdoptKill { pids, reason } => {
+                assert_eq!(pids, vec![99]);
+                assert!(reason.is_none());
+            }
+            other => panic!("expected AdoptKill, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adopt_kill_ack_response_roundtrips() {
+        let response = DaemonResponse::AdoptKillAck { accepted: 2 };
+        let wire = serde_json::to_string(&response).unwrap();
+        assert!(wire.contains(r#""op":"adopt_kill_ack""#));
+        assert!(wire.contains(r#""accepted":2"#));
+        let parsed: DaemonResponse = serde_json::from_str(&wire).unwrap();
+        assert!(matches!(
+            parsed,
+            DaemonResponse::AdoptKillAck { accepted: 2 }
+        ));
     }
 
     #[test]

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -13,6 +13,7 @@ pub mod command;
 pub mod console_input;
 pub mod console_setup;
 pub mod console_title;
+pub mod ctrl_c_track;
 pub mod daemon;
 pub mod dnd;
 pub mod gc;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,7 @@
 use clud::{
-    args, backend, backend_bootstrap, command, console_setup, console_title, daemon, gc, graphics,
-    hook_health, large_file_guard, launch_setup, loop_artifacts, loop_spec, runner, startup,
-    trampoline, trash, ui, verbose_log, wasm, worktrees,
+    args, backend, backend_bootstrap, command, console_setup, console_title, ctrl_c_track, daemon,
+    gc, graphics, hook_health, large_file_guard, launch_setup, loop_artifacts, loop_spec, runner,
+    startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -163,6 +163,7 @@ fn main() {
 
     let interrupted = startup::install_ctrl_c_flag();
     if let Some(exit_code) = daemon::handle_special_command(&args, interrupted.as_ref()) {
+        flush_ctrl_c_exit_event(ctrl_c_track::InvocationKind::Attach, exit_code);
         std::process::exit(exit_code);
     }
 
@@ -434,7 +435,26 @@ fn main() {
     if args.verbose {
         verbose_log::log(format_args!("[clud] exit: code {exit_code}"));
     }
+    let kind = if centralized {
+        ctrl_c_track::InvocationKind::Centralized
+    } else {
+        ctrl_c_track::InvocationKind::Direct
+    };
+    flush_ctrl_c_exit_event(kind, exit_code);
     std::process::exit(exit_code);
+}
+
+/// Write the cross-path Ctrl+C exit-timing event (issue: `clud ui` ctrl-c
+/// tracking) if a Ctrl+C was observed during this process's lifetime.
+/// Best-effort: resolves the state dir lazily so an unreadable home dir
+/// can't block the process exit. Errors are swallowed inside the tracker.
+fn flush_ctrl_c_exit_event(kind: ctrl_c_track::InvocationKind, exit_code: i32) {
+    if !ctrl_c_track::was_observed() {
+        return;
+    }
+    if let Ok(state_dir) = daemon::default_state_dir() {
+        ctrl_c_track::flush_on_exit(&state_dir, kind, exit_code);
+    }
 }
 
 /// Issue #183: best-effort upsert of `(repo_root, cwd)` into the daemon's

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -332,45 +332,44 @@ enum ProcessOutcome {
 /// Tear down a backend child that has not exited yet because the user
 /// just hit Ctrl+C.
 ///
-/// Sequence:
-///
-/// 1. Windows-only, when the direct child is a native executable: send
-///    `CTRL_BREAK_EVENT` to the child's console process group. The
-///    backend is spawned with
-///    `CREATE_NEW_PROCESS_GROUP` so the OS does *not* deliver the
-///    user's `CTRL_C_EVENT` to it — that prevents stray
-///    `KeyboardInterrupt` tracebacks from blocking `subprocess` waits
-///    in the `nodejs-wheel` Python launcher used by some Claude Code
-///    installs. The break we send here is the cooperative path for any
-///    backend that *does* install a Ctrl+Break handler. Failures and
-///    non-Windows targets short-circuit silently and we proceed to the
-///    hard kill.
-///
-///    When the direct child is `cmd.exe` running a `.cmd` / `.bat`
-///    backend wrapper, skip this step. Ctrl+Break makes cmd's batch
-///    interpreter display `Terminate batch job (Y/N)?` and wait on
-///    stdin, so the clean interrupt path must go straight to `kill_tree`.
-/// 2. `kill_tree`: snapshot the PID *before* killing the direct child
-///    so we can walk descendants. On Windows the direct child is
-///    cmd.exe (BatBadBat wrapper, see `subprocess.rs`) and the real
-///    agent (node.exe for codex / claude) is a grandchild — plain
-///    `process.kill()` would only TerminateProcess the cmd.exe and the
-///    orphan would keep writing to the console until our Job Object
-///    closes, producing the multi-second hang users reported.
-/// 3. `process.kill()` + `process.wait(2s)`: final TerminateProcess on
-///    the direct handle and a bounded wait so we don't return while
-///    the child is still draining.
+/// **Goal: sub-100ms return to shell.** The legacy path did a synchronous
+/// `kill_tree` + bounded `process.wait(2s)`, which produced the user-
+/// reported up-to-4s Ctrl+C lag (kill_tree's sysinfo refresh plus the
+/// blocking wait; in the stream-JSON path the post-loop `process.wait(2s)`
+/// could add a second 2s window). We now hand the root PID to the always-
+/// on daemon over a fire-and-forget IPC, then return immediately and let
+/// the kill-on-close Job Object (running-process-core 3.4+) TerminateProcess
+/// the direct child as our process exits. `TerminateProcess` is synchronous
+/// and silent — no signal, so cmd.exe never gets a chance to print
+/// `Terminate batch job (Y/N)?`. If the daemon isn't available we fall
+/// back to the old synchronous path (with the cooperative Ctrl+Break +
+/// `kill_tree` + bounded wait) so `--no-daemon` users still get cleanup.
 fn teardown_interrupted_child(process: &running_process::NativeProcess, batch_wrapped: bool) {
     if let Some(pid) = process.pid() {
-        // Cooperative Ctrl+Break first when it is safe. No-op on POSIX
-        // (returns false), and any Windows failure is non-fatal because
-        // the hard kill below always runs.
+        if let Ok(state_dir) = crate::daemon::default_state_dir() {
+            if crate::daemon::try_handoff_kill_to_daemon(
+                &state_dir,
+                &[pid],
+                Some("ctrl_c_subprocess"),
+            ) {
+                // The daemon will kill_tree on a background thread; our
+                // job is just to get out of the way so the user gets
+                // their shell back. The Job Object reaps the direct
+                // child via TerminateProcess as we exit.
+                return;
+            }
+        }
+        // Daemon-less fallback: keep the legacy synchronous behavior so
+        // `--no-daemon` invocations still leave the process tree clean.
         if process_tree::should_cooperative_break(batch_wrapped) {
             let _ = process_tree::try_break_group(pid);
         }
         process_tree::kill_tree(pid);
     }
     let _ = process.kill();
+    // Daemon-less fallback only: bounded wait so the legacy path doesn't
+    // race itself. Skipped when we successfully handed off above — that's
+    // the whole point of the fast return.
     let _ = process.wait(Some(std::time::Duration::from_secs(2)));
 }
 

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -1030,9 +1030,34 @@ fn reap_pty_exit(process: &NativePtyProcess) -> i32 {
 /// pump has observed the flag. Platform-split because `send_interrupt_impl`
 /// is a byte-write on Windows (duplicates the 0x03 already forwarded via
 /// raw-mode stdin) and a pgroup-SIGINT on POSIX (cooperative, no duplicate).
+///
+/// Both branches now try a fire-and-forget daemon handoff first so the
+/// CLI can return to the shell in sub-100ms instead of blocking on
+/// `process.wait_impl(Some(2.0))` (POSIX) or the ConPTY close-event
+/// chain that occasionally lets cmd.exe surface the `Terminate batch job
+/// (Y/N)?` prompt (Windows). The daemon's background thread does the
+/// real kill_tree from out of the user's hot path.
 fn interrupt_pty_process(process: &NativePtyProcess, verbose: bool) -> i32 {
+    let pid = process.pid().ok().flatten();
+    let handed_off = pid.is_some_and(|pid| {
+        if let Ok(state_dir) = crate::daemon::default_state_dir() {
+            crate::daemon::try_handoff_kill_to_daemon(&state_dir, &[pid], Some("ctrl_c_pty"))
+        } else {
+            false
+        }
+    });
+
     #[cfg(windows)]
     {
+        if handed_off {
+            // Daemon owns the kill. Skip ConPTY close so cmd.exe doesn't
+            // get a chance to print "Terminate batch job (Y/N)?" before
+            // the Job Object reaps it on our process exit.
+            if verbose {
+                verbose_log::log("[clud] interrupted via Ctrl+C (pty, handed to daemon)");
+            }
+            return 130;
+        }
         // Closing the PTY triggers ConPTY's CTRL_CLOSE_EVENT path and
         // tears the child down without writing a second 0x03 byte.
         let _ = process.close_impl();
@@ -1043,6 +1068,14 @@ fn interrupt_pty_process(process: &NativePtyProcess, verbose: bool) -> i32 {
     }
     #[cfg(not(windows))]
     {
+        if handed_off {
+            // Daemon will SIGKILL the tree; skip the 2s blocking wait.
+            let _ = process.close_impl();
+            if verbose {
+                verbose_log::log("[clud] interrupted via Ctrl+C (pty, handed to daemon)");
+            }
+            return 130;
+        }
         // Belt-and-braces: portable-pty's `send_interrupt` queries
         // `tcgetpgrp(master_fd)` to find the FG pgroup and signals it.
         // If that query returns None (no controlling-terminal coupling

--- a/crates/clud-bin/src/startup.rs
+++ b/crates/clud-bin/src/startup.rs
@@ -161,6 +161,10 @@ pub fn install_ctrl_c_flag() -> Arc<AtomicBool> {
     let interrupted = Arc::new(AtomicBool::new(false));
     let handler_flag = Arc::clone(&interrupted);
     if let Err(e) = ctrlc::set_handler(move || {
+        // Stamp the first-Ctrl+C wall-clock observation before we flip
+        // the flag the rest of the process polls, so the elapsed-time
+        // measurement covers everything from signal-delivery onward.
+        crate::ctrl_c_track::record_observed();
         handler_flag.store(true, Ordering::SeqCst);
     }) {
         eprintln!("[clud] warning: failed to install Ctrl+C handler: {}", e);


### PR DESCRIPTION
## Summary
- New `AdoptKill` daemon IPC: CLI fires-and-forgets a list of root PIDs to the daemon; daemon spawns a background `kill_tree` worker and acks immediately. CLI returns to the shell while the kill happens out-of-band.
- `runner::teardown_interrupted_child` and `session::interrupt_pty_process` both try the handoff first; if the daemon is unreachable they fall back to the legacy synchronous `kill_tree` + bounded `process.wait(2s)` (so `--no-daemon` still cleans up).
- New `ctrl_c_track` module: signal handler stamps the first-Ctrl+C wall-clock moment; just before exit we write a tiny JSON event under `<state_dir>/ctrl_c_events/` (PID, observed_at_ms, exit_at_ms, elapsed_ms, kind ∈ {direct,attach,centralized}, exit_code, cwd). Capped at 50 retained files.
- Dashboard `/state.json` carries the recent tail (max 20, newest first) and the UI gets a new Ctrl-C tab listing exit-time, elapsed, kind, exit, pid, cwd.

## Test plan
- [x] `soldr cargo test -p clud --lib ctrl_c_track::` — 7 passed
- [x] `soldr cargo test -p clud --lib daemon::` — 84 passed (includes new AdoptKill wire-format tests, server spawn-latency test, dashboard ctrl_c_events test)
- [x] `bash lint` — clean
- [ ] CI: full matrix
- [ ] Manual: Ctrl+C during a real `clud --claude` session and confirm shell prompt returns instantly + event shows up on `clud ui` dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)