### PR TITLE
feat(skills): add /goal invocations to clud-pr, issue-triage, tag-release

### DIFF
--- a/crates/clud-bin/assets/skills/clud-issue-triage/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-issue-triage/SKILL.md
@@ -30,21 +30,22 @@ When this skill files a follow-up issue for a bug fix or feature implementation,
 ## Single-issue workflow
 
 1. **Resolve the input.** Accept a bare number, a `#NNN`, or a full GitHub URL. `gh issue view <num> --json number,state,title,body,url,labels,closedByPullRequestsReferences,timelineItems`. If the call fails, say so and stop.
-2. **If already CLOSED** → don't re-close. But still run step 5 (CodeRabbit follow-ups) against any linked PRs, then report.
-3. **Find resolving PRs.** Scan `closedByPullRequestsReferences`, the timeline `cross-referenced` events, and `gh search prs "Closes #<num>" OR "Fixes #<num>" OR "Resolves #<num>" --repo <owner>/<repo>`. For each candidate:
+2. **Set the goal.** Invoke `/goal Triage issue #<num>: close if unambiguously resolved, file CodeRabbit follow-ups for any un-addressed substantive threads, or report exactly why neither happened.` so the harness Stop hook blocks until the closure decision is made and follow-ups are filed. The goal auto-clears once the final report is emitted.
+3. **If already CLOSED** → don't re-close. But still run step 6 (CodeRabbit follow-ups) against any linked PRs, then report.
+4. **Find resolving PRs.** Scan `closedByPullRequestsReferences`, the timeline `cross-referenced` events, and `gh search prs "Closes #<num>" OR "Fixes #<num>" OR "Resolves #<num>" --repo <owner>/<repo>`. For each candidate:
    - `gh pr view <pr> --json state,merged,mergeCommit,baseRefName,files`.
    - Confirm `merged == true` AND `baseRefName == <default-branch>` (else the code didn't reach main — see `/clud-pr` step 3).
    - Read the diff (`gh pr diff <pr>`) and confirm it actually implements the issue's acceptance criteria. Don't trust the PR title or "Closes #" mention alone.
-4. **Decide closure.** Bias toward caution:
+5. **Decide closure.** Bias toward caution:
    - Resolved unambiguously (merged + on default branch + diff matches criteria) → `gh issue close <num> --comment "Resolved by #<pr>. Verified: <one-line evidence>."`
    - Anything ambiguous (partial implementation, stack-base merge, criteria not fully met, no clear PR) → leave open. Don't comment unless the user asked you to triage-comment.
-5. **Scan for un-addressed CodeRabbit comments.** For every PR linked to this issue (resolving or merely referencing):
+6. **Scan for un-addressed CodeRabbit comments.** For every PR linked to this issue (resolving or merely referencing):
    - `gh api repos/<owner>/<repo>/pulls/<pr>/comments` (review-thread comments) and `gh pr view <pr> --json reviews,comments`.
    - Filter authors matching `coderabbitai*` (`coderabbitai`, `coderabbitai[bot]`).
    - Drop nits, praise, "consider", and threads marked `outdated` or `resolved: true`.
    - Group remaining comments by file/topic.
-6. **File follow-up issues silently.** For each cluster of substantive un-addressed CodeRabbit comments, `gh issue create --title "follow-up: <topic> from #<pr>" --body ...`. The body must include: source PR link, source comment permalinks, the CodeRabbit suggestion verbatim, a one-line "why this matters" framing, and RED -> GREEN acceptance criteria when the follow-up is a bug fix or feature implementation. Label `coderabbit-followup` if the repo has it; otherwise skip the label.
-7. **Report.** Output exactly:
+7. **File follow-up issues silently.** For each cluster of substantive un-addressed CodeRabbit comments, `gh issue create --title "follow-up: <topic> from #<pr>" --body ...`. The body must include: source PR link, source comment permalinks, the CodeRabbit suggestion verbatim, a one-line "why this matters" framing, and RED -> GREEN acceptance criteria when the follow-up is a bug fix or feature implementation. Label `coderabbit-followup` if the repo has it; otherwise skip the label.
+8. **Report.** Output exactly:
    - One line: closed (yes/no) + one-line evidence or one-line reason left open.
    - One line per follow-up issue filed: `#<num> — <title> — <url>`.
    - Nothing else.
@@ -55,16 +56,17 @@ When this skill files a follow-up issue for a bug fix or feature implementation,
    - No arg → `gh issue list --state open --limit 200 --search "created:>=$(date -d '7 days ago' --iso-8601 2>/dev/null || date -v-7d +%Y-%m-%d)" --json number,title,labels,createdAt,updatedAt`.
    - `all` → `gh issue list --state open --limit 1000 --json number,title,labels,createdAt,updatedAt`.
 2. **Filter (main agent, fast pass).** Drop issues that are obviously not triage candidates: anything labeled `discussion`, `meta`, `roadmap`, `wontfix`, `duplicate`, `question`; anything updated in the last 24h (active conversation); anything with zero linked PRs/cross-references. The remainder is the work set.
-3. **Stale-worktree prompt + .gitignore gate.** Same as `/clud-pr`'s **Worktree workspace** section. Confirm `.gitignore` covers `.claude/`. Ask the user about deleting any stale `.claude/worktrees/triage-*` older than 24h before starting.
-4. **Plan worktrees.** One worktree per issue: `.claude/worktrees/triage-<num>/`. Branch off `origin/<default>` (read-only — these worktrees only inspect, they don't commit code). `git fetch origin && git worktree add --detach .claude/worktrees/triage-<num> origin/<default>` for each.
-5. **Dispatch sub-agents in parallel.** Single tool-use block, one Agent call per issue. Each sub-agent gets:
+3. **Set the goal.** With `<N>` candidates known, invoke `/goal Triage <N> candidate issues; for each: close if unambiguously resolved or file CodeRabbit follow-ups, then report aggregate Closed/Follow-ups counts and tear down every worktree.` so the harness Stop hook blocks until the aggregate report is emitted and every worktree is gone. If the filtered set is empty, report that and clear the goal — do not set it.
+4. **Stale-worktree prompt + .gitignore gate.** Same as `/clud-pr`'s **Worktree workspace** section. Confirm `.gitignore` covers `.claude/`. Ask the user about deleting any stale `.claude/worktrees/triage-*` older than 24h before starting.
+5. **Plan worktrees.** One worktree per issue: `.claude/worktrees/triage-<num>/`. Branch off `origin/<default>` (read-only — these worktrees only inspect, they don't commit code). `git fetch origin && git worktree add --detach .claude/worktrees/triage-<num> origin/<default>` for each.
+6. **Dispatch sub-agents in parallel.** Single tool-use block, one Agent call per issue. Each sub-agent gets:
    - The issue number and URL
    - The repo `<owner>/<repo>`
    - Its dedicated worktree path
-   - Instruction: run the **Single-issue workflow** (steps 1–6 above) for this issue, in this worktree, and return a structured report (closed: bool, reason, follow-ups: list of {num, title, url})
+   - Instruction: run the **Single-issue workflow** (steps 1–7 above, skipping the per-issue `/goal` step since the bulk goal already covers it) for this issue, in this worktree, and return a structured report (closed: bool, reason, follow-ups: list of {num, title, url})
    - Hard constraint: do not touch any path outside the assigned worktree; do not modify code in the main checkout
-6. **Aggregate.** Collect every sub-agent's report. Tear down every worktree (`git worktree remove .claude/worktrees/triage-<num>` per issue). Confirm `git worktree list` shows none of them and `.claude/worktrees/` is empty (or holds only unrelated entries).
-7. **Report (main agent).** Two sections:
+7. **Aggregate.** Collect every sub-agent's report. Tear down every worktree (`git worktree remove .claude/worktrees/triage-<num>` per issue). Confirm `git worktree list` shows none of them and `.claude/worktrees/` is empty (or holds only unrelated entries).
+8. **Report (main agent).** Two sections:
    - **Closed (N):** one line per closed issue: `#<num> — <title> — resolved by #<pr>`.
    - **Follow-ups filed (M):** one line per filed follow-up: `#<num> — <title> — <url>`.
    - If both sections are empty, say so in one line. Nothing else.

--- a/crates/clud-bin/assets/skills/clud-pr/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-pr/SKILL.md
@@ -14,12 +14,13 @@ triggers:
 
 Read the user's task, express the bug fix or feature requirement as a failing test first, implement the fix until that test turns green, push it as one PR with no files left behind, then give the user the PR URL. The task may be an issue URL, issue number, PR URL, PR number, or a plain sentence.
 
-Four hard rules:
+Five hard rules:
 
-1. **Use a disposable worktree.** Do all PR work inside `.claude/worktrees/<branch>/`, never on the main checkout.
-2. **Push the PR.** Finish with `gh pr create`; a local branch or commit is not the deliverable.
-3. **Leave nothing behind.** After the PR exists, remove the worktree and verify the main checkout's `git status` is clean.
-4. **RED -> GREEN for code changes.** Before implementing a bug fix or feature, add or identify an automated test that fails because the requirement is unmet. Run the focused test and capture the RED failure. Then implement until that test is GREEN. If no automated test is practical, document the reason and use the closest executable repro/check before coding.
+1. **Lock the goal in.** Before any code or merge work, invoke the `/goal <one-line deliverable>` slash command so the harness Stop hook blocks until you ship. Use the deliverable phrasings under each mode below. Skip only for PR Triage Mode until triage decides to act.
+2. **Use a disposable worktree.** Do all PR work inside `.claude/worktrees/<branch>/`, never on the main checkout.
+3. **Push the PR.** Finish with `gh pr create`; a local branch or commit is not the deliverable.
+4. **Leave nothing behind.** After the PR exists, remove the worktree and verify the main checkout's `git status` is clean.
+5. **RED -> GREEN for code changes.** Before implementing a bug fix or feature, add or identify an automated test that fails because the requirement is unmet. Run the focused test and capture the RED failure. Then implement until that test is GREEN. If no automated test is practical, document the reason and use the closest executable repro/check before coding.
 
 ## Worktree Workspace
 
@@ -42,13 +43,14 @@ Look at the input first:
 
 Use this when the user asks to merge, land, or ship an already-open PR.
 
-1. **Resolve the PR.** `gh pr view --json number,headRefName,baseRefName,state,mergeable,statusCheckRollup,url`. Refuse if state is not `OPEN` or mergeability is a clear blocker.
-2. **Poll with a cap and visible status.** Estimate recent CI duration from `gh run list --branch <default> --limit 10 --json conclusion,startedAt,updatedAt`; announce the cap before waiting. Poll every 30 seconds, and check `gh pr view <num> --json state` first every time so a manually merged/closed PR exits immediately.
-3. **Classify CI failures.** A check passing on default but failing on the PR is a regression. A check already failing on default is pre-existing and not merge-blocking. A PR-only check missing on default must be compared against recent PRs before calling it pre-existing.
-4. **Collect review findings.** Pull CodeRabbit review comments and unresolved substantive review comments. Skip praise, nits, resolved/outdated threads, and comments explicitly out of scope.
-5. **Fix rounds, max 3.** For each regression or actionable review finding, follow RED -> GREEN: add or identify the focused failing test/repro/CI check first, capture the RED failure, implement only the scoped fix, then verify that focused signal is GREEN before running `bash lint` and `bash test`. Commit and push each completed round.
-6. **Merge only when gates are green.** Never merge with PR regressions, unresolved substantive review comments, merge conflicts, required human reviews, or timed-out CI. If `gh pr merge` reports the PR was already merged, treat that as success.
-7. **Final response.** Give the merged PR URL and the checks/fix rounds that mattered.
+1. **Set the goal.** Invoke `/goal Merge PR #<num> to main and report the merged URL.` so the Stop hook blocks until the PR is merged or you explicitly clear the goal.
+2. **Resolve the PR.** `gh pr view --json number,headRefName,baseRefName,state,mergeable,statusCheckRollup,url`. Refuse if state is not `OPEN` or mergeability is a clear blocker.
+3. **Poll with a cap and visible status.** Estimate recent CI duration from `gh run list --branch <default> --limit 10 --json conclusion,startedAt,updatedAt`; announce the cap before waiting. Poll every 30 seconds, and check `gh pr view <num> --json state` first every time so a manually merged/closed PR exits immediately.
+4. **Classify CI failures.** A check passing on default but failing on the PR is a regression. A check already failing on default is pre-existing and not merge-blocking. A PR-only check missing on default must be compared against recent PRs before calling it pre-existing.
+5. **Collect review findings.** Pull CodeRabbit review comments and unresolved substantive review comments. Skip praise, nits, resolved/outdated threads, and comments explicitly out of scope.
+6. **Fix rounds, max 3.** For each regression or actionable review finding, follow RED -> GREEN: add or identify the focused failing test/repro/CI check first, capture the RED failure, implement only the scoped fix, then verify that focused signal is GREEN before running `bash lint` and `bash test`. Commit and push each completed round.
+7. **Merge only when gates are green.** Never merge with PR regressions, unresolved substantive review comments, merge conflicts, required human reviews, or timed-out CI. If `gh pr merge` reports the PR was already merged, treat that as success.
+8. **Final response.** Give the merged PR URL and the checks/fix rounds that mattered.
 
 ## PR Triage Mode
 
@@ -65,21 +67,22 @@ Use this when the user asks to merge, land, or ship an already-open PR.
 ## Task To PR Workflow
 
 1. **Read the task.** If the input includes an issue URL/number, fetch it with `gh issue view <num>` or the URL and extract acceptance criteria. If it is a plain sentence, treat that sentence as the acceptance criteria and infer the repo from the current checkout.
-2. **Issue-only checks.** For issue inputs only:
+2. **Set the goal.** After reading the task and before any worktree or code work, invoke `/goal Ship PR for <issue-or-task-summary>: report URL and confirm main checkout is clean.` so the Stop hook blocks until the PR URL is reported and the worktree is torn down. If issue-only checks resolve the work without a new PR, clear the goal before stopping.
+3. **Issue-only checks.** For issue inputs only:
    - Verify the issue is open.
    - Search for PRs that already resolve it.
    - If a resolving PR is already merged to the default branch, offer to close the issue and stop.
    - If the issue is blocked by same-repo dependencies, take those first in dependency order unless the user overrides. Cross-repo dependencies require explicit user approval per repo.
-3. **Set up the worktree.** Follow the Worktree Workspace section.
-4. **Plan the fix.** Identify touched files and decide whether independent chunks can run in parallel. Use parallel agents only for genuinely independent file-scoped work; otherwise implement directly.
-5. **Prove RED.** For a bug, add a regression test that fails on the current behavior. For a feature, add or update the narrowest unit/integration/e2e test that encodes the acceptance criteria and fails before the implementation. Run the focused test before coding and keep the failure output for the PR/testing note.
-6. **Implement to GREEN.** Give any agent its exact scope, owned files, worktree path, the RED test command/output, and instruction not to touch files outside scope. Implement only enough to satisfy the requirement, then re-run the focused test until it passes.
-7. **Lint and test.** Run the repo's normal lint and test commands inside the worktree after the focused RED test is GREEN. Do not use `--no-verify`; fix hook failures.
-8. **Clean tree gate.** Run `git status` inside the worktree. Commit source changes that belong in the PR. Delete tmp, scratch, and build artifacts. The worktree must be clean before push.
-9. **Commit.** Use a conventional commit. Reference the issue when one exists (`Closes #<num>` in the commit body or PR body). For freeform tasks, summarize the task instead.
-10. **Push and open PR.** `git push -u origin <branch>`, then `gh pr create`. The body should include the issue link when present, a concise summary, and tests run.
-11. **Remove the worktree.** Run `git worktree remove .claude/worktrees/<branch>`, then `git worktree prune`, confirm it is gone, then verify the main checkout's `git status` is clean.
-12. **Final response.** Give the PR URL and any essential test note. Keep it short.
+4. **Set up the worktree.** Follow the Worktree Workspace section.
+5. **Plan the fix.** Identify touched files and decide whether independent chunks can run in parallel. Use parallel agents only for genuinely independent file-scoped work; otherwise implement directly.
+6. **Prove RED.** For a bug, add a regression test that fails on the current behavior. For a feature, add or update the narrowest unit/integration/e2e test that encodes the acceptance criteria and fails before the implementation. Run the focused test before coding and keep the failure output for the PR/testing note.
+7. **Implement to GREEN.** Give any agent its exact scope, owned files, worktree path, the RED test command/output, and instruction not to touch files outside scope. Implement only enough to satisfy the requirement, then re-run the focused test until it passes.
+8. **Lint and test.** Run the repo's normal lint and test commands inside the worktree after the focused RED test is GREEN. Do not use `--no-verify`; fix hook failures.
+9. **Clean tree gate.** Run `git status` inside the worktree. Commit source changes that belong in the PR. Delete tmp, scratch, and build artifacts. The worktree must be clean before push.
+10. **Commit.** Use a conventional commit. Reference the issue when one exists (`Closes #<num>` in the commit body or PR body). For freeform tasks, summarize the task instead.
+11. **Push and open PR.** `git push -u origin <branch>`, then `gh pr create`. The body should include the issue link when present, a concise summary, and tests run.
+12. **Remove the worktree.** Run `git worktree remove .claude/worktrees/<branch>`, then `git worktree prune`, confirm it is gone, then verify the main checkout's `git status` is clean.
+13. **Final response.** Give the PR URL and any essential test note. Keep it short.
 
 ## Failure Modes To Avoid
 

--- a/crates/clud-bin/assets/skills/clud-tag-release/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-tag-release/SKILL.md
@@ -33,7 +33,8 @@ This skill should not implement fixes or features. If the release is blocked by 
 3. **Resolve the tag to push.**
    - No arg → use the detected version verbatim. Tell the user: "I'll tag `<version>` (or `v<version>` if your existing tags use that prefix)." Pick the prefix that matches the most recent existing release tag; default to bare (no `v`) if there are no prior releases.
    - Arg `<version>` or `v<version>` → use as given, but validate it matches the workspace version. On mismatch: stop and tell the user to bump (`crates/.../Cargo.toml` or `pyproject.toml`) first.
-4. **Pre-flight gates.** Every gate is blocking. Run them in parallel where possible (`git fetch` and `gh api` calls). Report the first failure and stop:
+4. **Set the goal.** With the resolved tag known, invoke `/goal Tag <tag> and confirm the auto-release workflow transitioned to in_progress or queued; report the run URL.` so the harness Stop hook blocks until the workflow run is located and surfaced. If any pre-flight gate (step 5) fails the skill aborts before pushing — clear the goal then.
+5. **Pre-flight gates.** Every gate is blocking. Run them in parallel where possible (`git fetch` and `gh api` calls). Report the first failure and stop:
    - `git rev-parse --abbrev-ref HEAD` is `main` (or the repo's default — `gh api repos/<owner>/<repo> --jq .default_branch`).
    - `git status --porcelain` is empty.
    - `git fetch origin && git rev-list HEAD...origin/<default>` is empty (in sync, no diverging commits).
@@ -41,17 +42,17 @@ This skill should not implement fixes or features. If the release is blocked by 
    - `git ls-remote --tags origin <tag>` and same with `v<tag>` are empty (no remote tag).
    - `gh api repos/<owner>/<repo>/releases/tags/<tag>` returns 404 (no published release).
    - Last CI run on `<default>` is green: `gh run list --branch <default> --limit 1 --json conclusion,headSha`. If red or in progress, surface and ask before proceeding — don't silently ship a broken main.
-5. **Confirm with the user.** Show:
+6. **Confirm with the user.** Show:
    - Tag to push: `<tag>`
    - HEAD SHA: `<sha>` (and one-line commit subject)
    - Workflow that will fire: `<release-workflow-path>`
    - Last CI status on `<default>`: green/red/in-progress
    Wait for explicit confirmation. Don't proceed on silence.
-6. **Tag and push.**
+7. **Tag and push.**
    - `git tag -a <tag> -m "Release <version>"` — **annotated**, not lightweight, so `git describe` works downstream.
    - `git push origin <tag>` — push *just the tag*, not `--tags` (which would push every local tag).
-7. **Locate the triggered run.** Poll `gh run list --workflow=<release-workflow-file> --event=push --limit 5 --json databaseId,headSha,status,url` for up to 30 seconds, looking for a run whose `headSha` matches the tagged commit's SHA. The workflow can take a few seconds to register. If none appears after 30s, surface that — the workflow may not be configured to trigger on this tag pattern.
-8. **Report.** Output exactly:
+8. **Locate the triggered run.** Poll `gh run list --workflow=<release-workflow-file> --event=push --limit 5 --json databaseId,headSha,status,url` for up to 30 seconds, looking for a run whose `headSha` matches the tagged commit's SHA. The workflow can take a few seconds to register. If none appears after 30s, surface that — the workflow may not be configured to trigger on this tag pattern.
+9. **Report.** Output exactly:
    - Tag pushed: `<tag>` → `<sha>`
    - Workflow run: `<url>` (status: `<queued|in_progress>`)
    - One line on what the workflow will do (build, publish to PyPI/crates.io, attach release artifacts) — pulled from the workflow file's job names, not invented.

--- a/skills/clud-pr/SKILL.md
+++ b/skills/clud-pr/SKILL.md
@@ -14,12 +14,13 @@ triggers:
 
 Read the user's task, express the bug fix or feature requirement as a failing test first, implement the fix until that test turns green, push it as one PR with no files left behind, then give the user the PR URL. The task may be an issue URL, issue number, PR URL, PR number, or a plain sentence.
 
-Four hard rules:
+Five hard rules:
 
-1. **Use a disposable worktree.** Do all PR work inside `.claude/worktrees/<branch>/`, never on the main checkout.
-2. **Push the PR.** Finish with `gh pr create`; a local branch or commit is not the deliverable.
-3. **Leave nothing behind.** After the PR exists, remove the worktree and verify the main checkout's `git status` is clean.
-4. **RED -> GREEN for code changes.** Before implementing a bug fix or feature, add or identify an automated test that fails because the requirement is unmet. Run the focused test and capture the RED failure. Then implement until that test is GREEN. If no automated test is practical, document the reason and use the closest executable repro/check before coding.
+1. **Lock the goal in.** Before any code or merge work, invoke the `/goal <one-line deliverable>` slash command so the harness Stop hook blocks until you ship. Use the deliverable phrasings under each mode below. Skip only for PR Triage Mode until triage decides to act.
+2. **Use a disposable worktree.** Do all PR work inside `.claude/worktrees/<branch>/`, never on the main checkout.
+3. **Push the PR.** Finish with `gh pr create`; a local branch or commit is not the deliverable.
+4. **Leave nothing behind.** After the PR exists, remove the worktree and verify the main checkout's `git status` is clean.
+5. **RED -> GREEN for code changes.** Before implementing a bug fix or feature, add or identify an automated test that fails because the requirement is unmet. Run the focused test and capture the RED failure. Then implement until that test is GREEN. If no automated test is practical, document the reason and use the closest executable repro/check before coding.
 
 ## Worktree Workspace
 
@@ -42,13 +43,14 @@ Look at the input first:
 
 Use this when the user asks to merge, land, or ship an already-open PR.
 
-1. **Resolve the PR.** `gh pr view --json number,headRefName,baseRefName,state,mergeable,statusCheckRollup,url`. Refuse if state is not `OPEN` or mergeability is a clear blocker.
-2. **Poll with a cap and visible status.** Estimate recent CI duration from `gh run list --branch <default> --limit 10 --json conclusion,startedAt,updatedAt`; announce the cap before waiting. Poll every 30 seconds, and check `gh pr view <num> --json state` first every time so a manually merged/closed PR exits immediately.
-3. **Classify CI failures.** A check passing on default but failing on the PR is a regression. A check already failing on default is pre-existing and not merge-blocking. A PR-only check missing on default must be compared against recent PRs before calling it pre-existing.
-4. **Collect review findings.** Pull CodeRabbit review comments and unresolved substantive review comments. Skip praise, nits, resolved/outdated threads, and comments explicitly out of scope.
-5. **Fix rounds, max 3.** For each regression or actionable review finding, follow RED -> GREEN: add or identify the focused failing test/repro/CI check first, capture the RED failure, implement only the scoped fix, then verify that focused signal is GREEN before running `bash lint` and `bash test`. Commit and push each completed round.
-6. **Merge only when gates are green.** Never merge with PR regressions, unresolved substantive review comments, merge conflicts, required human reviews, or timed-out CI. If `gh pr merge` reports the PR was already merged, treat that as success.
-7. **Final response.** Give the merged PR URL and the checks/fix rounds that mattered.
+1. **Set the goal.** Invoke `/goal Merge PR #<num> to main and report the merged URL.` so the Stop hook blocks until the PR is merged or you explicitly clear the goal.
+2. **Resolve the PR.** `gh pr view --json number,headRefName,baseRefName,state,mergeable,statusCheckRollup,url`. Refuse if state is not `OPEN` or mergeability is a clear blocker.
+3. **Poll with a cap and visible status.** Estimate recent CI duration from `gh run list --branch <default> --limit 10 --json conclusion,startedAt,updatedAt`; announce the cap before waiting. Poll every 30 seconds, and check `gh pr view <num> --json state` first every time so a manually merged/closed PR exits immediately.
+4. **Classify CI failures.** A check passing on default but failing on the PR is a regression. A check already failing on default is pre-existing and not merge-blocking. A PR-only check missing on default must be compared against recent PRs before calling it pre-existing.
+5. **Collect review findings.** Pull CodeRabbit review comments and unresolved substantive review comments. Skip praise, nits, resolved/outdated threads, and comments explicitly out of scope.
+6. **Fix rounds, max 3.** For each regression or actionable review finding, follow RED -> GREEN: add or identify the focused failing test/repro/CI check first, capture the RED failure, implement only the scoped fix, then verify that focused signal is GREEN before running `bash lint` and `bash test`. Commit and push each completed round.
+7. **Merge only when gates are green.** Never merge with PR regressions, unresolved substantive review comments, merge conflicts, required human reviews, or timed-out CI. If `gh pr merge` reports the PR was already merged, treat that as success.
+8. **Final response.** Give the merged PR URL and the checks/fix rounds that mattered.
 
 ## PR Triage Mode
 
@@ -65,21 +67,22 @@ Use this when the user asks to merge, land, or ship an already-open PR.
 ## Task To PR Workflow
 
 1. **Read the task.** If the input includes an issue URL/number, fetch it with `gh issue view <num>` or the URL and extract acceptance criteria. If it is a plain sentence, treat that sentence as the acceptance criteria and infer the repo from the current checkout.
-2. **Issue-only checks.** For issue inputs only:
+2. **Set the goal.** After reading the task and before any worktree or code work, invoke `/goal Ship PR for <issue-or-task-summary>: report URL and confirm main checkout is clean.` so the Stop hook blocks until the PR URL is reported and the worktree is torn down. If issue-only checks resolve the work without a new PR, clear the goal before stopping.
+3. **Issue-only checks.** For issue inputs only:
    - Verify the issue is open.
    - Search for PRs that already resolve it.
    - If a resolving PR is already merged to the default branch, offer to close the issue and stop.
    - If the issue is blocked by same-repo dependencies, take those first in dependency order unless the user overrides. Cross-repo dependencies require explicit user approval per repo.
-3. **Set up the worktree.** Follow the Worktree Workspace section.
-4. **Plan the fix.** Identify touched files and decide whether independent chunks can run in parallel. Use parallel agents only for genuinely independent file-scoped work; otherwise implement directly.
-5. **Prove RED.** For a bug, add a regression test that fails on the current behavior. For a feature, add or update the narrowest unit/integration/e2e test that encodes the acceptance criteria and fails before the implementation. Run the focused test before coding and keep the failure output for the PR/testing note.
-6. **Implement to GREEN.** Give any agent its exact scope, owned files, worktree path, the RED test command/output, and instruction not to touch files outside scope. Implement only enough to satisfy the requirement, then re-run the focused test until it passes.
-7. **Lint and test.** Run the repo's normal lint and test commands inside the worktree after the focused RED test is GREEN. Do not use `--no-verify`; fix hook failures.
-8. **Clean tree gate.** Run `git status` inside the worktree. Commit source changes that belong in the PR. Delete tmp, scratch, and build artifacts. The worktree must be clean before push.
-9. **Commit.** Use a conventional commit. Reference the issue when one exists (`Closes #<num>` in the commit body or PR body). For freeform tasks, summarize the task instead.
-10. **Push and open PR.** `git push -u origin <branch>`, then `gh pr create`. The body should include the issue link when present, a concise summary, and tests run.
-11. **Remove the worktree.** Run `git worktree remove .claude/worktrees/<branch>`, then `git worktree prune`, confirm it is gone, then verify the main checkout's `git status` is clean.
-12. **Final response.** Give the PR URL and any essential test note. Keep it short.
+4. **Set up the worktree.** Follow the Worktree Workspace section.
+5. **Plan the fix.** Identify touched files and decide whether independent chunks can run in parallel. Use parallel agents only for genuinely independent file-scoped work; otherwise implement directly.
+6. **Prove RED.** For a bug, add a regression test that fails on the current behavior. For a feature, add or update the narrowest unit/integration/e2e test that encodes the acceptance criteria and fails before the implementation. Run the focused test before coding and keep the failure output for the PR/testing note.
+7. **Implement to GREEN.** Give any agent its exact scope, owned files, worktree path, the RED test command/output, and instruction not to touch files outside scope. Implement only enough to satisfy the requirement, then re-run the focused test until it passes.
+8. **Lint and test.** Run the repo's normal lint and test commands inside the worktree after the focused RED test is GREEN. Do not use `--no-verify`; fix hook failures.
+9. **Clean tree gate.** Run `git status` inside the worktree. Commit source changes that belong in the PR. Delete tmp, scratch, and build artifacts. The worktree must be clean before push.
+10. **Commit.** Use a conventional commit. Reference the issue when one exists (`Closes #<num>` in the commit body or PR body). For freeform tasks, summarize the task instead.
+11. **Push and open PR.** `git push -u origin <branch>`, then `gh pr create`. The body should include the issue link when present, a concise summary, and tests run.
+12. **Remove the worktree.** Run `git worktree remove .claude/worktrees/<branch>`, then `git worktree prune`, confirm it is gone, then verify the main checkout's `git status` is clean.
+13. **Final response.** Give the PR URL and any essential test note. Keep it short.
 
 ## Failure Modes To Avoid
 


### PR DESCRIPTION
## Summary
- `clud-pr`: new hard rule #1 requires `/goal <one-line deliverable>` before any code or merge work. PR Merge Mode and Task To PR Workflow each add an explicit `/goal` step at the top of their steps. PR Triage Mode is exempt until triage decides to act.
- `clud-issue-triage`: per-issue workflow sets a triage goal after resolving the input; the bulk workflow sets an aggregate triage goal once the candidate set is known.
- `clud-tag-release`: sets a tag-and-confirm goal after the tag is resolved; if pre-flight gates fail, the skill clears the goal.
- Both copies of `clud-pr/SKILL.md` (bundled asset + top-level `skills/`) updated in lockstep.

The frontmatter is unchanged across all four files, so the existing `skills::` and `skill_install::` guardrail tests still pass.

## Test plan
- [x] `soldr cargo test -p clud --lib skills::` — 19 passed
- [x] `soldr cargo test -p clud --lib skill_install::` — 15 passed (frontmatter still parses; managed-by marker preserved)
- [ ] CI: full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)