### PR TITLE
test(integration): accept '(pty, handed to daemon)' Ctrl+C variant

### DIFF
--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -580,6 +580,9 @@ class TestInterruptReporting:
         # the message to check against. Without `--verbose` the diagnostic is
         # silenced by design and the test had been failing on every platform's
         # integration run since #145 landed.
+        # PR #251 added a second variant on the daemon-handoff path
+        # ("(pty, handed to daemon)"). The assertion below matches the common
+        # prefix "(pty" so it accepts both forms.
         proc = subprocess.Popen(
             [
                 str(clud_binary),
@@ -616,7 +619,7 @@ class TestInterruptReporting:
             assert proc.returncode == 130
 
         if proc.returncode == 130:
-            assert "[clud] interrupted via Ctrl+C (pty)" in stderr
+            assert "[clud] interrupted via Ctrl+C (pty" in stderr
 
 
 class TestStdinForwarding:


### PR DESCRIPTION
## Summary

- All integration jobs (macOS x86 + ARM, Linux x86 + ARM, Windows x86 + ARM) have been failing on `main` since #251 landed.
- Root cause: #251 added a daemon-handoff Ctrl+C diagnostic — `[clud] interrupted via Ctrl+C (pty, handed to daemon)` — but `test_ctrl_c_reports_pty_mode_when_forced` was checking the literal substring `(pty)`, which is **not** a substring of the new message (the closing paren follows `, handed to daemon`).
- Relax the assertion to the common prefix `[clud] interrupted via Ctrl+C (pty` so both the direct-PTY path and the daemon-handoff path satisfy it. Behavioral intent (clud reports an interrupt in PTY mode) is preserved.

## Test plan

- [x] `bash lint` — All checks passed.
- [ ] CI: full matrix; specifically the previously red `macOS ARM Integration Test` / `macOS x86 Integration Test` / `Linux *Integration Test` / `Windows *Integration Test` jobs should turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)