### PR TITLE
feat(memory): embedder (local fastembed + remote + Windows-ARM carve-out) (#257)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -27,6 +29,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -114,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,10 +149,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "ascii"
@@ -146,10 +192,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -184,6 +285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +309,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -243,6 +359,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
@@ -295,6 +417,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,7 +455,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -406,12 +537,13 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 name = "clud"
 version = "2.0.17"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "clap",
  "cpal",
  "crossterm",
  "ctrlc",
- "dirs",
+ "dirs 5.0.1",
+ "fastembed",
  "fs4 0.13.1",
  "icy_sixel",
  "ignore",
@@ -456,6 +588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,12 +610,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -633,6 +819,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +876,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -686,7 +947,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -697,8 +967,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -746,10 +1028,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -765,6 +1082,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -792,10 +1130,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
+name = "fastembed"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c269a76bfc6cea69553b7d040acb16c793119cebd97c756d21e08d0f075ff8"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "image",
+ "ndarray",
+ "ort",
+ "ort-sys",
+ "rayon",
+ "serde_json",
+ "tokenizers",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -815,6 +1176,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -850,6 +1221,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -893,10 +1279,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -911,7 +1329,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -963,6 +1385,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1411,36 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1029,16 +1491,153 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hf-hub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+dependencies = [
+ "dirs 6.0.0",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "rand 0.9.4",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "htmlescape"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1139,6 +1738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,12 +1788,37 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -1203,6 +1833,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "web-time",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1856,23 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-docker"
@@ -1253,6 +1913,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1342,6 +2011,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "levenshtein_automata"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +2027,16 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -1463,6 +2148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +2178,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -1534,6 +2264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +2307,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +2355,38 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
 
 [[package]]
 name = "ndk"
@@ -1628,6 +2418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,6 +2448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +2465,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "ntapi"
@@ -1677,6 +2497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -1758,6 +2587,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2"
@@ -1860,6 +2695,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "open"
 version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +2725,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1883,6 +2783,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+dependencies = [
+ "flate2",
+ "pkg-config",
+ "sha2",
+ "tar",
+ "ureq",
 ]
 
 [[package]]
@@ -1942,6 +2866,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,6 +2923,21 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2060,6 +3011,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2159,6 +3129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "quantette"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +3156,12 @@ dependencies = [
  "ref-cast",
  "wide",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2212,7 +3197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2222,6 +3207,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2233,6 +3219,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2249,6 +3245,9 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rand_distr"
@@ -2270,6 +3269,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +3332,17 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
 ]
 
 [[package]]
@@ -2316,6 +3382,17 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2366,6 +3443,55 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -2547,10 +3673,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2599,6 +3757,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2696,6 +3866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,10 +3896,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "sqlite-vec"
@@ -2736,6 +3948,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string-interner"
@@ -2768,6 +3986,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -2811,6 +4038,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tantivy"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,7 +4066,7 @@ checksum = "96599ea6fccd844fc833fed21d2eecac2e6a7c1afd9e044057391d78b1feb141"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "byteorder",
  "census",
@@ -2916,7 +4164,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847434d4af57b32e309f4ab1b4f1707a6c566656264caa427ff4285c4d9d0b82"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -2956,6 +4204,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -3021,6 +4280,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +4347,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,6 +4464,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,6 +4544,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -3147,6 +4579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,11 +4602,16 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
+ "flate2",
  "log",
+ "native-tls",
  "once_cell",
  "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
  "url",
  "webpki-roots 0.26.11",
 ]
@@ -3216,6 +4659,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,6 +4710,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3360,6 +4823,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmi"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +4912,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,6 +4938,12 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
@@ -3595,7 +5087,7 @@ dependencies = [
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -3654,6 +5146,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,12 +5175,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3714,6 +5235,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3764,11 +5294,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3799,6 +5346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,6 +5368,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3835,10 +5394,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3859,6 +5430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,6 +5452,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3895,6 +5478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3911,6 +5500,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4044,6 +5639,22 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -4187,6 +5798,15 @@ name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,26 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,15 +1014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,21 +1194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,8 +1311,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1366,9 +1324,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1411,25 +1371,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1501,7 +1442,6 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
- "native-tls",
  "rand 0.9.4",
  "reqwest",
  "serde",
@@ -1572,7 +1512,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1596,22 +1535,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1632,11 +1556,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2166,6 +2088,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,12 +2192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,23 +2277,6 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "ndarray"
@@ -2725,49 +2630,6 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3164,6 +3026,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,30 +3369,27 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3485,6 +3399,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3628,6 +3543,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3673,42 +3589,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -4038,27 +3922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tantivy"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4347,6 +4210,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4391,16 +4269,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -4605,7 +4473,6 @@ dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
- "native-tls",
  "once_cell",
  "rustls",
  "rustls-pki-types",
@@ -5087,7 +4954,7 @@ dependencies = [
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5146,17 +5013,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5175,30 +5031,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -116,7 +116,20 @@ whisper-rs = "0.16"
 # Optional + behind the `memory_local_embed` feature so Windows-ARM CI
 # can build with `--no-default-features` and fall through to the remote
 # or disabled embedder at runtime.
-fastembed = { version = "4", optional = true }
+#
+# `default-features = false` disables fastembed's default `hf-hub-native-tls`,
+# which transitively pulls `native-tls → openssl-sys → libssl.so.3`. The
+# maturin-built `clud` binary does not co-distribute the resulting hashed
+# `libssl-<hash>.so.3` artifact, so the Linux wheel would crash at startup
+# with "error while loading shared libraries". `hf-hub-rustls-tls` routes
+# hf-hub through `reqwest`'s rustls backend (pure Rust, no system OpenSSL).
+# `ort-download-binaries` is re-enabled here because it is also part of
+# fastembed's default feature set and provides the prebuilt ONNX Runtime
+# shared library that ort dynamically loads at runtime.
+fastembed = { version = "4", optional = true, default-features = false, features = [
+    "hf-hub-rustls-tls",
+    "ort-download-binaries",
+] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 cpal = "0.16"

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -8,6 +8,14 @@ repository.workspace = true
 homepage.workspace = true
 description = "Fast CLI for running Claude Code and Codex in YOLO mode"
 
+[features]
+# Issue #257: gate the in-process ONNX embedder (fastembed + ort) behind
+# a feature so the `aarch64-pc-windows-msvc` target — which lacks an ort
+# prebuilt — can build with `--no-default-features`. Mirrors the
+# `whisper-rs` carve-out at the bottom of this file.
+default = ["memory_local_embed"]
+memory_local_embed = ["dep:fastembed"]
+
 [dependencies]
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
@@ -102,6 +110,13 @@ path = "tests/pty_behavior.rs"
 # (see `voice.rs`).
 [target.'cfg(not(all(target_arch = "aarch64", target_os = "windows")))'.dependencies]
 whisper-rs = "0.16"
+# Issue #257: in-process ONNX embedder (MiniLM-L6-v2, 384-dim). Gated to
+# the same target list as whisper-rs because the underlying `ort` ONNX
+# Runtime crate does not yet ship prebuilts for aarch64-pc-windows-msvc.
+# Optional + behind the `memory_local_embed` feature so Windows-ARM CI
+# can build with `--no-default-features` and fall through to the remote
+# or disabled embedder at runtime.
+fastembed = { version = "4", optional = true }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 cpal = "0.16"

--- a/crates/clud-bin/src/memory/README.md
+++ b/crates/clud-bin/src/memory/README.md
@@ -2,9 +2,10 @@
 
 Agent-memory storage layer: SQLite + sqlite-vec for content + KNN,
 tantivy for BM25 lexical, and RRF over the two. Pure storage; tier
-lifecycle, embeddings, MCP server, daemon IPC, and CLI verbs all live
+lifecycle, MCP server, daemon IPC, and CLI verbs all live
 in sibling sub-issues under META #255 — this directory only owns the
-durable on-disk layer and the hybrid-search math.
+durable on-disk layer, the hybrid-search math, and (as of #257) the
+embedder abstraction that produces the dense vectors storage stores.
 
 See [`docs/architecture/memory.md`](../../../../docs/architecture/memory.md)
 for the cross-cutting subsystem sketch and
@@ -15,10 +16,16 @@ for the rationale on rusqlite + redb coexistence.
 
 - `mod.rs` — public surface; re-exports `SqliteStore`, `LexicalIndex`,
   `HybridSearchConfig`, `MemoryRow`, `Tier`, `MemoryId`, `MemoryError`,
-  `KnnHit`, `LexicalHit`, `FusedHit`, `rrf_fuse`, plus the identity
-  surface: `RepoScope`, `resolve_repo_scope`, `normalize_origin_url`,
+  `KnnHit`, `LexicalHit`, `FusedHit`, `rrf_fuse`; the identity surface
+  `RepoScope`, `resolve_repo_scope`, `normalize_origin_url`,
   `scope_key`, `branch_isolate`, `branch_unisolate`,
-  `cross_repo_glob_filter`.
+  `cross_repo_glob_filter`; and (from `embedder/`) `Embedder`,
+  `EmbedderTrait`, `RemoteEmbedder`, `RemoteProvider`,
+  `embedder_from_env`, `reembed_all`, `EMBED_DIM_MINILM_L6_V2`.
+- `embedder/` — embedder abstraction (`Local` / `Remote` / `Disabled`),
+  fastembed wrapper, four-provider HTTP client, deterministic
+  `TestEmbedder`. Carved out on Windows-ARM. See
+  [`embedder/README.md`](embedder/README.md).
 - `error.rs:3` `MemoryError` — thiserror enum; `Tantivy(String)` is
   intentionally stringified because some tantivy variants are not
   `Send + 'static`.

--- a/crates/clud-bin/src/memory/embedder/README.md
+++ b/crates/clud-bin/src/memory/embedder/README.md
@@ -1,0 +1,140 @@
+# memory/embedder/
+
+Embedder abstraction for the agent-memory subsystem (issue #257). Three
+kinds: `Local` (fastembed/ort, MiniLM-L6-v2, 384-dim), `Remote` (HTTP to
+Anthropic/OpenAI/Gemini/Ollama), and `Disabled` (returns
+`MemoryError::EmbedderDisabled` with the four-path remediation message).
+
+See [`docs/architecture/memory.md`](../../../../../docs/architecture/memory.md#embedder)
+for the cross-cutting subsystem sketch and
+[DD-014](../../../../../docs/DESIGN_DECISIONS.md#dd-014-local-embedder-via-fastembed--windows-arm-carve-out)
+for why `LocalEmbedder` is gated behind `memory_local_embed` + a non-Windows-ARM
+target stanza.
+
+## Files
+
+- `mod.rs` — public surface; `EmbedderTrait`, `Embedder` enum,
+  `embedder_from_env`, `reembed_all` library primitive,
+  `EMBED_DIM_MINILM_L6_V2 = 384`, and the env-var constants below.
+- `local.rs` — `LocalEmbedder` wrapping `fastembed::TextEmbedding`. Gated
+  on `cfg(all(feature = "memory_local_embed", not(all(target_arch =
+  "aarch64", target_os = "windows"))))`. First-run downloads the model
+  into `<state_dir>/memory/models/` via fastembed's built-in cache;
+  progress is surfaced to stderr.
+- `remote.rs` — `RemoteEmbedder` HTTP client for the four supported
+  providers. Pure blocking `ureq` (no tokio). One trait impl, one body
+  shape per provider, normalised parse errors.
+- `test_embedder.rs` — `TestEmbedder` for unit tests. Hashes input into
+  a deterministic `Vec<f32>` of configurable dim so storage + embed
+  contracts can be exercised without the real MiniLM model.
+
+## Public surface
+
+```rust
+pub trait EmbedderTrait {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError>;
+    fn dim(&self) -> usize;
+    fn name(&self) -> &str;
+}
+
+pub enum Embedder { Local(LocalEmbedder), Remote(RemoteEmbedder), Disabled { reason: String } }
+pub fn embedder_from_env() -> Result<Embedder, MemoryError>;
+pub fn reembed_all<E: EmbedderTrait>(store: &mut SqliteStore, embedder: &E) -> Result<usize, MemoryError>;
+```
+
+`reembed_all` is the library primitive the `clud memory reembed` CLI verb
+(landing in #262) will wrap with `--resume` checkpointing and the
+shadow-table swap for dim drift.
+
+## Environment variables
+
+| Var | Effect |
+|---|---|
+| `CLUD_MEMORY_EMBEDDER` | `local` (default on non-Windows-ARM) / `remote` / `disabled`. |
+| `CLUD_MEMORY_EMBEDDER_PROVIDER` | `anthropic` (= voyage) / `openai` / `gemini` / `ollama`. Setting this implies `CLUD_MEMORY_EMBEDDER=remote`. |
+| `CLUD_MEMORY_EMBEDDER_URL` | Override the provider default URL (e.g. self-hosted Ollama). |
+| `CLUD_MEMORY_EMBEDDER_API_KEY` | Bearer token for Anthropic/OpenAI, `x-goog-api-key` for Gemini. Unused for Ollama. |
+| `CLUD_MEMORY_EMBEDDER_MODEL` | Override the provider default model id. |
+
+## Resolution order in `embedder_from_env`
+
+1. `CLUD_MEMORY_EMBEDDER=disabled` → `Embedder::Disabled` (the four-path
+   message lives in `mod.rs::disabled_reason`).
+2. `CLUD_MEMORY_EMBEDDER=remote` *or* any of `_PROVIDER` / `_URL` set →
+   `Embedder::Remote` via `RemoteEmbedder::from_env`.
+3. `cfg(memory_local_embed && not Windows-ARM)` → `Embedder::Local` with
+   the default MiniLM-L6-v2 model (downloads on first run).
+4. Otherwise → `Embedder::Disabled`.
+
+## Windows-ARM carve-out
+
+`fastembed` pulls in `ort` (ONNX Runtime) which has no prebuilt for
+`aarch64-pc-windows-msvc`. Mirrors the `whisper-rs` stanza at
+`crates/clud-bin/Cargo.toml:103`:
+
+```toml
+[features]
+default = ["memory_local_embed"]
+memory_local_embed = ["dep:fastembed"]
+
+[target.'cfg(not(all(target_arch = "aarch64", target_os = "windows")))'.dependencies]
+fastembed = { version = "4", optional = true }
+```
+
+On Windows-ARM, `Embedder::Local` is **not a variant** (the enum literally
+doesn't have it on that cfg); `embedder_from_env` falls through to step
+4 above and returns `Embedder::Disabled`. CI on `windows-11-arm` runs
+`cargo build --no-default-features` to verify.
+
+## Recipe: Ollama on a sibling x86/Linux/macOS box (Windows-ARM workaround)
+
+On the sibling:
+
+```
+ollama pull nomic-embed-text
+OLLAMA_HOST=0.0.0.0:11434 ollama serve
+```
+
+Verify reachable from Windows-ARM:
+
+```
+curl http://<host>:11434/api/tags
+```
+
+On the Windows-ARM clud machine, set:
+
+```
+setx CLUD_MEMORY_EMBEDDER_PROVIDER ollama
+setx CLUD_MEMORY_EMBEDDER_URL      http://<host>:11434/api/embeddings
+```
+
+Restart the daemon. Memory saves now embed remotely (768-dim), so the
+storage layer's `embed_dim` must match — a future `clud memory init` /
+`clud memory reembed` will handle the dim swap; for v0.1 of #257 the dim
+mismatch surfaces as `MemoryError::DimMismatch` at insert time.
+
+## Testing
+
+Default `cargo test`:
+
+- `memory::embedder::remote::tests::*` — provider parsing, response
+  shapes, mock-client round-trip.
+- `memory::embedder::test_embedder::tests::*` — deterministic
+  hash-based embedder (used by `reembed_all` test below).
+- `memory::embedder::tests::*` — `Disabled` error path, env
+  dispatch, `reembed_all_replaces_vectors_in_place`,
+  `reembed_all_rejects_dim_mismatch`.
+
+`#[ignore]`'d (manual smoke):
+
+- `memory::embedder::local::tests::local_embedder_produces_384_dim_vectors`
+- `memory::embedder::local::tests::local_embedder_two_distinct_texts_have_cosine_similarity_below_1`
+- `memory::embedder::tests::embedder_from_env_local_default_when_no_env_set`
+
+Run with:
+
+```
+soldr cargo test -p clud --lib memory::embedder::local::tests:: -- --ignored --nocapture
+```
+
+These download the MiniLM model (~80 MB) on first run; not part of CI.

--- a/crates/clud-bin/src/memory/embedder/local.rs
+++ b/crates/clud-bin/src/memory/embedder/local.rs
@@ -1,0 +1,135 @@
+//! In-process [`LocalEmbedder`] using fastembed (ONNX Runtime).
+//!
+//! Default model: MiniLM-L6-v2 (384-dim), cached under
+//! `<state_dir>/memory/models/`. Gated on the `memory_local_embed` Cargo
+//! feature and the non-Windows-ARM target carve-out.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+
+use crate::memory::embedder::{EmbedderTrait, EMBED_DIM_MINILM_L6_V2};
+use crate::memory::error::MemoryError;
+use crate::memory::paths::memory_dir;
+
+pub struct LocalEmbedder {
+    inner: Mutex<TextEmbedding>,
+    dim: usize,
+    name: String,
+}
+
+impl LocalEmbedder {
+    /// Load the default model (MiniLM-L6-v2). First-run downloads cache
+    /// the ONNX file under `<state_dir>/memory/models/`. Surfaces
+    /// download progress to stderr via fastembed's `show_download_progress`.
+    pub fn load_default() -> Result<Self, MemoryError> {
+        let cache_dir = default_model_cache_dir()
+            .map_err(|e| MemoryError::EmbedderModelLoad(format!("resolve cache dir: {e}")))?;
+        std::fs::create_dir_all(&cache_dir)?;
+
+        let init = InitOptions::new(EmbeddingModel::AllMiniLML6V2)
+            .with_cache_dir(cache_dir)
+            .with_show_download_progress(true);
+
+        let model = TextEmbedding::try_new(init)
+            .map_err(|e| MemoryError::EmbedderModelLoad(format!("fastembed init: {e}")))?;
+
+        Ok(Self {
+            inner: Mutex::new(model),
+            dim: EMBED_DIM_MINILM_L6_V2,
+            name: "fastembed/all-MiniLM-L6-v2".to_string(),
+        })
+    }
+}
+
+impl EmbedderTrait for LocalEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|e| MemoryError::EmbedderModelLoad(format!("lock poisoned: {e}")))?;
+        let mut batch = guard
+            .embed(vec![text.to_string()], None)
+            .map_err(|e| MemoryError::EmbedderModelLoad(format!("fastembed embed: {e}")))?;
+        let v = batch.pop().ok_or_else(|| {
+            MemoryError::EmbedderModelLoad("fastembed returned empty batch".to_string())
+        })?;
+        if v.len() != self.dim {
+            return Err(MemoryError::DimMismatch {
+                expected: self.dim,
+                got: v.len(),
+            });
+        }
+        Ok(v)
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+fn default_model_cache_dir() -> std::io::Result<PathBuf> {
+    Ok(memory_dir()?.join("models"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The two #[ignore]'d tests below exercise the real fastembed +
+    // MiniLM-L6-v2 model load. They download ~80 MB on first run and
+    // take seconds to load even with the model cached. Skipped in default
+    // `cargo test` so CI doesn't pay the model-download cost on every
+    // matrix job. The deterministic `TestEmbedder` (see
+    // `test_embedder.rs`) covers the equivalent dim + similarity contract
+    // for normal CI runs.
+    //
+    // Manual smoke: `soldr cargo test -p clud --lib \
+    //   memory::embedder::local::tests:: -- --ignored --nocapture`.
+
+    #[test]
+    #[ignore = "downloads MiniLM model on first run; manual smoke only"]
+    fn local_embedder_produces_384_dim_vectors() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: this test runs serially via `cargo test -- --ignored`
+        // and mutates the documented `CLUD_DAEMON_STATE_DIR` env var.
+        unsafe {
+            std::env::set_var("CLUD_DAEMON_STATE_DIR", tmp.path());
+        }
+        let e = LocalEmbedder::load_default().expect("local embedder");
+        let v = e.embed("hello").expect("embed");
+        assert_eq!(v.len(), 384);
+        assert_eq!(e.dim(), 384);
+        unsafe {
+            std::env::remove_var("CLUD_DAEMON_STATE_DIR");
+        }
+    }
+
+    #[test]
+    #[ignore = "downloads MiniLM model on first run; manual smoke only"]
+    fn local_embedder_two_distinct_texts_have_cosine_similarity_below_1() {
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("CLUD_DAEMON_STATE_DIR", tmp.path());
+        }
+        let e = LocalEmbedder::load_default().expect("local embedder");
+        let a = e.embed("hello").expect("embed a");
+        let b = e.embed("totally different topic").expect("embed b");
+        let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+        let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let cos = dot / (na * nb);
+        assert!(
+            cos < 0.999,
+            "expected cos<0.999 for unrelated texts, got {cos}"
+        );
+        unsafe {
+            std::env::remove_var("CLUD_DAEMON_STATE_DIR");
+        }
+    }
+}

--- a/crates/clud-bin/src/memory/embedder/mod.rs
+++ b/crates/clud-bin/src/memory/embedder/mod.rs
@@ -265,6 +265,9 @@ mod tests {
         MemoryRow {
             id,
             session_id: None,
+            scope_key: None,
+            branch_name: None,
+            is_orphan: false,
             tier: Tier::Working,
             content: content.to_string(),
             created_at_ms: 1,

--- a/crates/clud-bin/src/memory/embedder/mod.rs
+++ b/crates/clud-bin/src/memory/embedder/mod.rs
@@ -1,0 +1,405 @@
+//! Embedder abstraction for the agent-memory subsystem (issue #257).
+//!
+//! Three concrete embedder kinds live under this module:
+//!
+//! - [`Local`] — in-process MiniLM-L6-v2 via fastembed/ort. Gated on the
+//!   `memory_local_embed` Cargo feature and the
+//!   `cfg(not(all(target_arch = "aarch64", target_os = "windows")))` carve-out
+//!   (no ort prebuilt for Windows-ARM today; mirrors the `whisper-rs` stanza
+//!   at `crates/clud-bin/Cargo.toml:103`).
+//! - [`Remote`] — one of four HTTP providers (Anthropic / OpenAI / Gemini /
+//!   Ollama) via `ureq`. No tokio runtime; selected via env vars.
+//! - [`Disabled`] — explicit no-op for environments without local or remote
+//!   support. `embed()` returns [`MemoryError::EmbedderDisabled`] with the
+//!   four-path remediation message documented in `embedder/README.md`.
+//!
+//! See the module README for env vars, provider URLs, and the Ollama-on-LAN
+//! recipe. `clud memory reembed` (the CLI verb) lands in #262; the library
+//! primitive [`reembed_all`] is exposed here for it.
+//!
+//! [`Local`]: Embedder::Local
+//! [`Remote`]: Embedder::Remote
+//! [`Disabled`]: Embedder::Disabled
+
+use crate::memory::error::MemoryError;
+use crate::memory::store::SqliteStore;
+
+mod remote;
+#[cfg(test)]
+mod test_embedder;
+
+#[cfg(all(
+    feature = "memory_local_embed",
+    not(all(target_arch = "aarch64", target_os = "windows"))
+))]
+mod local;
+
+pub use remote::{RemoteEmbedder, RemoteProvider};
+
+#[cfg(all(
+    feature = "memory_local_embed",
+    not(all(target_arch = "aarch64", target_os = "windows"))
+))]
+pub use local::LocalEmbedder;
+
+#[cfg(test)]
+pub use test_embedder::TestEmbedder;
+
+/// Default embedding width for MiniLM-L6-v2 — the local model the
+/// fastembed wrapper produces and the dimension storage will pin at first
+/// migration. Remote providers advertise their own dim via `dim()`.
+pub const EMBED_DIM_MINILM_L6_V2: usize = 384;
+
+/// Behaviour every embedder kind exposes. `dim` is queried by storage at
+/// open time to decide whether the on-disk `vec0` table matches the live
+/// embedder.
+pub trait EmbedderTrait {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError>;
+    fn dim(&self) -> usize;
+    fn name(&self) -> &str;
+}
+
+/// Top-level embedder dispatch. Constructed via [`embedder_from_env`] in
+/// production; tests build a [`TestEmbedder`] directly.
+///
+/// `Local` is boxed because `fastembed::TextEmbedding` carries the ONNX
+/// session inline; the unboxed variant inflates every `Embedder` value
+/// (including the always-cheap `Disabled` case) to >1 KiB. Boxing keeps
+/// the enum word-sized and matches clippy's `large_enum_variant` lint.
+pub enum Embedder {
+    #[cfg(all(
+        feature = "memory_local_embed",
+        not(all(target_arch = "aarch64", target_os = "windows"))
+    ))]
+    Local(Box<LocalEmbedder>),
+    Remote(RemoteEmbedder),
+    Disabled {
+        reason: String,
+    },
+}
+
+impl EmbedderTrait for Embedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+        match self {
+            #[cfg(all(
+                feature = "memory_local_embed",
+                not(all(target_arch = "aarch64", target_os = "windows"))
+            ))]
+            Embedder::Local(e) => e.embed(text),
+            Embedder::Remote(e) => e.embed(text),
+            Embedder::Disabled { reason } => Err(MemoryError::EmbedderDisabled(reason.clone())),
+        }
+    }
+
+    fn dim(&self) -> usize {
+        match self {
+            #[cfg(all(
+                feature = "memory_local_embed",
+                not(all(target_arch = "aarch64", target_os = "windows"))
+            ))]
+            Embedder::Local(e) => e.dim(),
+            Embedder::Remote(e) => e.dim(),
+            Embedder::Disabled { .. } => 0,
+        }
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            #[cfg(all(
+                feature = "memory_local_embed",
+                not(all(target_arch = "aarch64", target_os = "windows"))
+            ))]
+            Embedder::Local(e) => e.name(),
+            Embedder::Remote(e) => e.name(),
+            Embedder::Disabled { .. } => "disabled",
+        }
+    }
+}
+
+/// Environment variables read by [`embedder_from_env`]. Listed here so the
+/// README and the tests share one source of truth.
+pub const ENV_EMBEDDER_KIND: &str = "CLUD_MEMORY_EMBEDDER";
+pub const ENV_EMBEDDER_PROVIDER: &str = "CLUD_MEMORY_EMBEDDER_PROVIDER";
+pub const ENV_EMBEDDER_URL: &str = "CLUD_MEMORY_EMBEDDER_URL";
+pub const ENV_EMBEDDER_API_KEY: &str = "CLUD_MEMORY_EMBEDDER_API_KEY";
+pub const ENV_EMBEDDER_MODEL: &str = "CLUD_MEMORY_EMBEDDER_MODEL";
+
+/// Resolve an [`Embedder`] from process env. Resolution order:
+///
+/// 1. `CLUD_MEMORY_EMBEDDER=disabled` → [`Embedder::Disabled`].
+/// 2. `CLUD_MEMORY_EMBEDDER=remote` (or any of the `_PROVIDER` / `_URL` /
+///    `_API_KEY` vars set) → [`Embedder::Remote`] using
+///    [`RemoteProvider::from_env`].
+/// 3. `CLUD_MEMORY_EMBEDDER=local` (or unset) on a target that builds
+///    `memory_local_embed` → [`Embedder::Local`] with the default
+///    MiniLM-L6-v2 model. Falls back to [`Embedder::Disabled`] (with the
+///    four-path message) if the local backend is not compiled in.
+pub fn embedder_from_env() -> Result<Embedder, MemoryError> {
+    let kind = std::env::var(ENV_EMBEDDER_KIND).ok();
+    let kind_lower = kind.as_deref().map(|s| s.to_ascii_lowercase());
+
+    if kind_lower.as_deref() == Some("disabled") {
+        return Ok(Embedder::Disabled {
+            reason: disabled_reason("CLUD_MEMORY_EMBEDDER=disabled"),
+        });
+    }
+
+    let want_remote = kind_lower.as_deref() == Some("remote")
+        || std::env::var(ENV_EMBEDDER_PROVIDER).is_ok()
+        || std::env::var(ENV_EMBEDDER_URL).is_ok();
+
+    if want_remote {
+        return RemoteEmbedder::from_env().map(Embedder::Remote);
+    }
+
+    #[cfg(all(
+        feature = "memory_local_embed",
+        not(all(target_arch = "aarch64", target_os = "windows"))
+    ))]
+    {
+        LocalEmbedder::load_default().map(|e| Embedder::Local(Box::new(e)))
+    }
+
+    #[cfg(not(all(
+        feature = "memory_local_embed",
+        not(all(target_arch = "aarch64", target_os = "windows"))
+    )))]
+    {
+        Ok(Embedder::Disabled {
+            reason: disabled_reason(
+                "local embedder unavailable on this build (Windows-ARM or --no-default-features)",
+            ),
+        })
+    }
+}
+
+/// Four-path remediation message returned from a disabled embedder. Kept
+/// concise; the verbatim long-form text lives in the README.
+fn disabled_reason(prefix: &str) -> String {
+    format!(
+        "{prefix}. To enable: (1) set CLUD_MEMORY_EMBEDDER_PROVIDER + \
+         CLUD_MEMORY_EMBEDDER_API_KEY for a remote provider, \
+         (2) set CLUD_MEMORY_EMBEDDER_PROVIDER=ollama + \
+         CLUD_MEMORY_EMBEDDER_URL=http://host:11434 for Ollama on LAN, \
+         (3) run clud inside WSL2 (Ubuntu) on Windows-ARM, or \
+         (4) wait for ort 2.0 stable + an aarch64-windows ONNX Runtime."
+    )
+}
+
+/// Re-embed every row in `store` using `embedder` and rewrite the vec
+/// table in place. Returns the row count processed.
+///
+/// Library primitive only — the `clud memory reembed --model <new>` CLI
+/// verb lands in #262 and will wrap this with `--resume` checkpointing.
+/// This implementation does not currently handle dim drift (the vec0
+/// table dim is fixed at first migration); a follow-up will add a
+/// shadow-table swap when [`Embedder::dim`] differs from
+/// `store.embed_dim()`.
+// TODO(#262): CLI surface + --resume checkpoint + shadow-swap for dim drift.
+pub fn reembed_all<E: EmbedderTrait>(
+    store: &mut SqliteStore,
+    embedder: &E,
+) -> Result<usize, MemoryError> {
+    use rusqlite::params;
+
+    if embedder.dim() != store.embed_dim() {
+        return Err(MemoryError::DimMismatch {
+            expected: store.embed_dim(),
+            got: embedder.dim(),
+        });
+    }
+
+    // Snapshot ids + content first so we don't iterate a cursor while
+    // writing through the same connection.
+    let rows: Vec<(String, String)> = {
+        let conn = store.conn_ref();
+        let mut stmt = conn.prepare("SELECT id, content FROM memories ORDER BY id ASC")?;
+        let mut out = Vec::new();
+        let mut q = stmt.query([])?;
+        while let Some(r) = q.next()? {
+            let id: String = r.get(0)?;
+            let content: String = r.get(1)?;
+            out.push((id, content));
+        }
+        out
+    };
+
+    let mut count = 0usize;
+    for (id, content) in &rows {
+        let embedding = embedder.embed(content)?;
+        if embedding.len() != store.embed_dim() {
+            return Err(MemoryError::DimMismatch {
+                expected: store.embed_dim(),
+                got: embedding.len(),
+            });
+        }
+        let blob = embedding_to_blob(&embedding);
+        let conn = store.conn_mut();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        tx.execute("DELETE FROM memory_vec WHERE id = ?1", params![id.as_str()])?;
+        tx.execute(
+            "INSERT INTO memory_vec(id, embedding) VALUES (?1, ?2)",
+            params![id.as_str(), blob],
+        )?;
+        tx.commit()?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn embedding_to_blob(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for f in v {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::ids::MemoryId;
+    use crate::memory::store::{MemoryRow, Tier};
+
+    fn row(id: MemoryId, content: &str) -> MemoryRow {
+        MemoryRow {
+            id,
+            session_id: None,
+            tier: Tier::Working,
+            content: content.to_string(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            tier_change_at_ms: 1,
+            access_count: 0,
+            last_access_at_ms: 1,
+            metadata_json: None,
+        }
+    }
+
+    #[test]
+    fn embedder_disabled_returns_embedder_disabled_error() {
+        let e = Embedder::Disabled {
+            reason: "test".to_string(),
+        };
+        let err = e.embed("hi").unwrap_err();
+        assert!(matches!(err, MemoryError::EmbedderDisabled(_)));
+    }
+
+    #[cfg(all(
+        feature = "memory_local_embed",
+        not(all(target_arch = "aarch64", target_os = "windows"))
+    ))]
+    #[test]
+    #[ignore = "downloads MiniLM model on first run; manual smoke only"]
+    fn embedder_from_env_local_default_when_no_env_set() {
+        let _g1 = EnvGuard::remove(ENV_EMBEDDER_KIND);
+        let _g2 = EnvGuard::remove(ENV_EMBEDDER_PROVIDER);
+        let _g3 = EnvGuard::remove(ENV_EMBEDDER_URL);
+        let tmp = tempfile::tempdir().unwrap();
+        let _g4 = EnvGuard::set("CLUD_DAEMON_STATE_DIR", tmp.path().to_str().unwrap());
+        let e = embedder_from_env().expect("embedder");
+        assert!(matches!(e, Embedder::Local(_)));
+        assert_eq!(e.dim(), 384);
+    }
+
+    #[test]
+    fn embedder_from_env_disabled_when_kind_disabled() {
+        let _g = EnvGuard::set(ENV_EMBEDDER_KIND, "disabled");
+        let e = embedder_from_env().unwrap();
+        assert!(matches!(e, Embedder::Disabled { .. }));
+        assert_eq!(e.name(), "disabled");
+        assert_eq!(e.dim(), 0);
+    }
+
+    #[test]
+    fn disabled_reason_lists_four_remediation_paths() {
+        let reason = disabled_reason("test");
+        assert!(reason.contains("(1)"));
+        assert!(reason.contains("(2)"));
+        assert!(reason.contains("(3)"));
+        assert!(reason.contains("(4)"));
+        assert!(reason.contains("WSL2"));
+        assert!(reason.contains("Ollama"));
+    }
+
+    #[test]
+    fn reembed_all_replaces_vectors_in_place() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = SqliteStore::open(&tmp.path().join("memory.db"), 8).expect("open");
+        // Seed with placeholder vectors (all zeros) so we can prove they
+        // change after reembed.
+        let mut ids = Vec::new();
+        for content in ["alpha", "beta", "gamma"] {
+            let id = MemoryId::new_v7();
+            store
+                .insert(&row(id.clone(), content), &[0.0_f32; 8])
+                .unwrap();
+            ids.push(id);
+        }
+
+        let embedder = TestEmbedder::with_dim(8);
+        let n = reembed_all(&mut store, &embedder).unwrap();
+        assert_eq!(n, 3);
+
+        // After reembed, the vec blobs for each row should match the
+        // deterministic TestEmbedder output for the original content.
+        for (id, content) in ids.iter().zip(["alpha", "beta", "gamma"]) {
+            let expected = embedder.embed(content).unwrap();
+            let stored = store.fetch_vec_for_test(id).unwrap();
+            assert_eq!(stored, expected, "vec for {content} must be rewritten");
+        }
+    }
+
+    #[test]
+    fn reembed_all_rejects_dim_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut store = SqliteStore::open(&tmp.path().join("memory.db"), 8).expect("open");
+        let embedder = TestEmbedder::with_dim(384);
+        let err = reembed_all(&mut store, &embedder).unwrap_err();
+        assert!(matches!(
+            err,
+            MemoryError::DimMismatch {
+                expected: 8,
+                got: 384
+            }
+        ));
+    }
+
+    /// Single-test env-var guard: sets a var on construction, removes it
+    /// on drop. Tests in this module aren't parallel-safe wrt env vars
+    /// already (see `paths.rs` and `search.rs`); we use the same idiom.
+    struct EnvGuard {
+        key: &'static str,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            // SAFETY: tests in this crate already touch process env; the
+            // module-level convention is that env-mutating tests are not
+            // run concurrently via cargo test default. See ids.rs /
+            // search.rs for the same pattern.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key }
+        }
+
+        #[allow(dead_code)]
+        fn remove(key: &'static str) -> Self {
+            // SAFETY: see Self::set.
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: see Self::set.
+            unsafe {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+}

--- a/crates/clud-bin/src/memory/embedder/remote.rs
+++ b/crates/clud-bin/src/memory/embedder/remote.rs
@@ -1,0 +1,388 @@
+//! HTTP-based [`RemoteEmbedder`] for the four supported providers:
+//! Anthropic (Voyage), OpenAI, Gemini, Ollama.
+//!
+//! Pure blocking `ureq` — no tokio. Each provider's request/response
+//! shape is encoded in [`RemoteEmbedder::embed`]. Provider URL and the
+//! API key come from env vars; see the module README for the full list.
+
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::memory::embedder::EmbedderTrait;
+use crate::memory::error::MemoryError;
+
+use super::{ENV_EMBEDDER_API_KEY, ENV_EMBEDDER_MODEL, ENV_EMBEDDER_PROVIDER, ENV_EMBEDDER_URL};
+
+/// Supported remote embedding providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteProvider {
+    Anthropic,
+    OpenAi,
+    Gemini,
+    Ollama,
+}
+
+impl RemoteProvider {
+    pub fn parse(s: &str) -> Result<Self, MemoryError> {
+        match s.to_ascii_lowercase().as_str() {
+            "anthropic" | "voyage" => Ok(Self::Anthropic),
+            "openai" => Ok(Self::OpenAi),
+            "gemini" | "google" => Ok(Self::Gemini),
+            "ollama" => Ok(Self::Ollama),
+            other => Err(MemoryError::EmbedderRemoteFailure {
+                provider: other.to_string(),
+                message: format!(
+                    "unknown provider `{other}` — expected one of \
+                     anthropic|openai|gemini|ollama"
+                ),
+            }),
+        }
+    }
+
+    pub fn default_url(self) -> &'static str {
+        match self {
+            Self::Anthropic => "https://api.voyageai.com/v1/embeddings",
+            Self::OpenAi => "https://api.openai.com/v1/embeddings",
+            Self::Gemini => "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent",
+            Self::Ollama => "http://localhost:11434/api/embeddings",
+        }
+    }
+
+    pub fn default_model(self) -> &'static str {
+        match self {
+            Self::Anthropic => "voyage-3",
+            Self::OpenAi => "text-embedding-3-small",
+            Self::Gemini => "text-embedding-004",
+            Self::Ollama => "nomic-embed-text",
+        }
+    }
+
+    pub fn default_dim(self) -> usize {
+        match self {
+            Self::Anthropic => 1024,
+            Self::OpenAi => 1536,
+            Self::Gemini => 768,
+            Self::Ollama => 768,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Anthropic => "anthropic",
+            Self::OpenAi => "openai",
+            Self::Gemini => "gemini",
+            Self::Ollama => "ollama",
+        }
+    }
+}
+
+/// HTTP client for a remote embedding provider. One instance per
+/// process; constructed by [`RemoteEmbedder::from_env`].
+pub struct RemoteEmbedder {
+    provider: RemoteProvider,
+    url: String,
+    api_key: Option<String>,
+    model: String,
+    dim: usize,
+    name: String,
+    // Issue #257 (test seam): if set, [`embed`] returns this vector
+    // verbatim instead of issuing a real HTTP request. Production code
+    // never sets this — it's wired by the in-module tests that simulate
+    // a provider response shape without standing up a mock server.
+    #[cfg(test)]
+    mock_response: Option<Vec<f32>>,
+}
+
+impl RemoteEmbedder {
+    pub fn new(
+        provider: RemoteProvider,
+        url: String,
+        api_key: Option<String>,
+        model: String,
+        dim: usize,
+    ) -> Self {
+        let name = format!("{}/{}", provider.as_str(), model);
+        Self {
+            provider,
+            url,
+            api_key,
+            model,
+            dim,
+            name,
+            #[cfg(test)]
+            mock_response: None,
+        }
+    }
+
+    pub fn from_env() -> Result<Self, MemoryError> {
+        let provider_str = std::env::var(ENV_EMBEDDER_PROVIDER).map_err(|_| {
+            MemoryError::EmbedderRemoteFailure {
+                provider: "unset".to_string(),
+                message: format!(
+                    "{ENV_EMBEDDER_PROVIDER} not set; \
+                     expected one of anthropic|openai|gemini|ollama"
+                ),
+            }
+        })?;
+        let provider = RemoteProvider::parse(&provider_str)?;
+        let url =
+            std::env::var(ENV_EMBEDDER_URL).unwrap_or_else(|_| provider.default_url().to_string());
+        let api_key = std::env::var(ENV_EMBEDDER_API_KEY).ok();
+        let model = std::env::var(ENV_EMBEDDER_MODEL)
+            .unwrap_or_else(|_| provider.default_model().to_string());
+        let dim = provider.default_dim();
+        Ok(Self::new(provider, url, api_key, model, dim))
+    }
+
+    /// Issue an HTTP request to the configured provider URL and parse
+    /// the response into a single vector. Split out so the test code
+    /// can short-circuit before hitting the network.
+    fn embed_http(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+        let (body, auth_header): (serde_json::Value, Option<(&str, String)>) = match self.provider {
+            RemoteProvider::Anthropic => {
+                let body = json!({ "input": [text], "model": self.model });
+                let h = self
+                    .api_key
+                    .as_ref()
+                    .map(|k| ("Authorization", format!("Bearer {k}")));
+                (body, h)
+            }
+            RemoteProvider::OpenAi => {
+                let body = json!({ "input": text, "model": self.model });
+                let h = self
+                    .api_key
+                    .as_ref()
+                    .map(|k| ("Authorization", format!("Bearer {k}")));
+                (body, h)
+            }
+            RemoteProvider::Gemini => {
+                let body = json!({
+                    "model": format!("models/{}", self.model),
+                    "content": { "parts": [{ "text": text }] },
+                });
+                let h = self.api_key.as_ref().map(|k| ("x-goog-api-key", k.clone()));
+                (body, h)
+            }
+            RemoteProvider::Ollama => {
+                let body = json!({ "model": self.model, "prompt": text });
+                (body, None)
+            }
+        };
+
+        let mut req = ureq::post(&self.url).set("Content-Type", "application/json");
+        if let Some((name, value)) = auth_header {
+            req = req.set(name, &value);
+        }
+
+        let body_str =
+            serde_json::to_string(&body).map_err(|e| MemoryError::EmbedderRemoteFailure {
+                provider: self.provider.as_str().to_string(),
+                message: format!("serialize body: {e}"),
+            })?;
+        let resp = req
+            .send_string(&body_str)
+            .map_err(|e| MemoryError::EmbedderRemoteFailure {
+                provider: self.provider.as_str().to_string(),
+                message: format!("http error to {}: {e}", self.url),
+            })?;
+
+        let status = resp.status();
+        let text_body = resp
+            .into_string()
+            .map_err(|e| MemoryError::EmbedderRemoteFailure {
+                provider: self.provider.as_str().to_string(),
+                message: format!("read body: {e}"),
+            })?;
+        if !(200..300).contains(&status) {
+            let excerpt: String = text_body.chars().take(256).collect();
+            return Err(MemoryError::EmbedderRemoteFailure {
+                provider: self.provider.as_str().to_string(),
+                message: format!("HTTP {status}: {excerpt}"),
+            });
+        }
+
+        parse_response(self.provider, &text_body)
+    }
+}
+
+#[cfg(test)]
+impl RemoteEmbedder {
+    pub(crate) fn with_mock_response(mut self, response: Vec<f32>) -> Self {
+        self.dim = response.len();
+        self.mock_response = Some(response);
+        self
+    }
+}
+
+impl EmbedderTrait for RemoteEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+        #[cfg(test)]
+        if let Some(mock) = &self.mock_response {
+            // Branch on text emptiness only as a sanity check; mocks just
+            // echo their preset vector.
+            if text.is_empty() {
+                return Err(MemoryError::EmbedderRemoteFailure {
+                    provider: self.provider.as_str().to_string(),
+                    message: "empty text".to_string(),
+                });
+            }
+            return Ok(mock.clone());
+        }
+        self.embed_http(text)
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[derive(Deserialize)]
+struct OpenAiEmbedding {
+    embedding: Vec<f32>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    data: Vec<OpenAiEmbedding>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicEmbedding {
+    embedding: Vec<f32>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicResponse {
+    data: Vec<AnthropicEmbedding>,
+}
+
+#[derive(Deserialize)]
+struct GeminiValues {
+    values: Vec<f32>,
+}
+
+#[derive(Deserialize)]
+struct GeminiResponse {
+    embedding: GeminiValues,
+}
+
+#[derive(Deserialize)]
+struct OllamaResponse {
+    embedding: Vec<f32>,
+}
+
+fn parse_response(provider: RemoteProvider, body: &str) -> Result<Vec<f32>, MemoryError> {
+    let fail = |what: &str, e: serde_json::Error| MemoryError::EmbedderRemoteFailure {
+        provider: provider.as_str().to_string(),
+        message: format!("parse {what}: {e}"),
+    };
+    let v = match provider {
+        RemoteProvider::OpenAi => {
+            let r: OpenAiResponse = serde_json::from_str(body).map_err(|e| fail("openai", e))?;
+            r.data.into_iter().next().map(|e| e.embedding)
+        }
+        RemoteProvider::Anthropic => {
+            let r: AnthropicResponse =
+                serde_json::from_str(body).map_err(|e| fail("anthropic", e))?;
+            r.data.into_iter().next().map(|e| e.embedding)
+        }
+        RemoteProvider::Gemini => {
+            let r: GeminiResponse = serde_json::from_str(body).map_err(|e| fail("gemini", e))?;
+            Some(r.embedding.values)
+        }
+        RemoteProvider::Ollama => {
+            let r: OllamaResponse = serde_json::from_str(body).map_err(|e| fail("ollama", e))?;
+            Some(r.embedding)
+        }
+    };
+    v.ok_or_else(|| MemoryError::EmbedderRemoteFailure {
+        provider: provider.as_str().to_string(),
+        message: "no embedding in response".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_provider_accepts_aliases() {
+        assert_eq!(
+            RemoteProvider::parse("Anthropic").unwrap(),
+            RemoteProvider::Anthropic
+        );
+        assert_eq!(
+            RemoteProvider::parse("voyage").unwrap(),
+            RemoteProvider::Anthropic
+        );
+        assert_eq!(
+            RemoteProvider::parse("openai").unwrap(),
+            RemoteProvider::OpenAi
+        );
+        assert_eq!(
+            RemoteProvider::parse("Google").unwrap(),
+            RemoteProvider::Gemini
+        );
+        assert_eq!(
+            RemoteProvider::parse("ollama").unwrap(),
+            RemoteProvider::Ollama
+        );
+    }
+
+    #[test]
+    fn parse_provider_rejects_unknown() {
+        let err = RemoteProvider::parse("cohere").unwrap_err();
+        assert!(matches!(err, MemoryError::EmbedderRemoteFailure { .. }));
+    }
+
+    #[test]
+    fn default_dims_match_provider_advertised_values() {
+        assert_eq!(RemoteProvider::Anthropic.default_dim(), 1024);
+        assert_eq!(RemoteProvider::OpenAi.default_dim(), 1536);
+        assert_eq!(RemoteProvider::Gemini.default_dim(), 768);
+        assert_eq!(RemoteProvider::Ollama.default_dim(), 768);
+    }
+
+    #[test]
+    fn remote_embedder_anthropic_mock_client_returns_dim() {
+        let preset = vec![0.1_f32; 1024];
+        let e = RemoteEmbedder::new(
+            RemoteProvider::Anthropic,
+            "http://unused".to_string(),
+            Some("key".to_string()),
+            "voyage-3".to_string(),
+            1024,
+        )
+        .with_mock_response(preset.clone());
+        let out = e.embed("hello").unwrap();
+        assert_eq!(out.len(), 1024);
+        assert_eq!(out, preset);
+        assert_eq!(e.dim(), 1024);
+        assert!(e.name().contains("anthropic"));
+    }
+
+    #[test]
+    fn parse_response_openai_returns_first_embedding() {
+        let body = r#"{"data": [{"embedding": [0.1, 0.2, 0.3]}]}"#;
+        let v = parse_response(RemoteProvider::OpenAi, body).unwrap();
+        assert_eq!(v, vec![0.1_f32, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn parse_response_gemini_unwraps_values() {
+        let body = r#"{"embedding": {"values": [1.0, 2.0]}}"#;
+        let v = parse_response(RemoteProvider::Gemini, body).unwrap();
+        assert_eq!(v, vec![1.0_f32, 2.0]);
+    }
+
+    #[test]
+    fn parse_response_ollama_unwraps_embedding() {
+        let body = r#"{"embedding": [0.5, 0.6]}"#;
+        let v = parse_response(RemoteProvider::Ollama, body).unwrap();
+        assert_eq!(v, vec![0.5_f32, 0.6]);
+    }
+}

--- a/crates/clud-bin/src/memory/embedder/test_embedder.rs
+++ b/crates/clud-bin/src/memory/embedder/test_embedder.rs
@@ -1,0 +1,88 @@
+//! Deterministic in-process test embedder. Hashes input text into a
+//! fixed-dim `Vec<f32>` so unit tests can exercise the embedder
+//! interface — and `reembed_all` — without downloading the MiniLM model.
+
+use crate::memory::embedder::EmbedderTrait;
+use crate::memory::error::MemoryError;
+
+pub struct TestEmbedder {
+    dim: usize,
+    name: String,
+}
+
+impl TestEmbedder {
+    pub fn with_dim(dim: usize) -> Self {
+        Self {
+            dim,
+            name: format!("test/{dim}d"),
+        }
+    }
+}
+
+impl EmbedderTrait for TestEmbedder {
+    fn embed(&self, text: &str) -> Result<Vec<f32>, MemoryError> {
+        // Splitmix64 starting from a FNV-1a digest of `text`. The PRNG is
+        // deterministic per-input, which is exactly what the tests need.
+        let mut state: u64 = 0xcbf2_9ce4_8422_2325;
+        for b in text.as_bytes() {
+            state ^= *b as u64;
+            state = state.wrapping_mul(0x100_0000_01b3);
+        }
+        let mut out = Vec::with_capacity(self.dim);
+        for _ in 0..self.dim {
+            state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+            let mut z = state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            z ^= z >> 31;
+            // Map to [-1, 1) so the vectors have non-trivial variance.
+            let scaled = (z as f32 / u64::MAX as f32) * 2.0 - 1.0;
+            out.push(scaled);
+        }
+        Ok(out)
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_embedder_produces_requested_dim() {
+        let e = TestEmbedder::with_dim(384);
+        let v = e.embed("hello").unwrap();
+        assert_eq!(v.len(), 384);
+        assert_eq!(e.dim(), 384);
+    }
+
+    #[test]
+    fn test_embedder_is_deterministic() {
+        let e = TestEmbedder::with_dim(64);
+        let a = e.embed("hello").unwrap();
+        let b = e.embed("hello").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_embedder_two_distinct_texts_have_cosine_similarity_below_1() {
+        let e = TestEmbedder::with_dim(128);
+        let a = e.embed("hello").unwrap();
+        let b = e.embed("world").unwrap();
+        let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+        let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let cos = dot / (na * nb);
+        assert!(
+            cos < 0.999,
+            "expected cos<0.999 for different texts, got {cos}"
+        );
+    }
+}

--- a/crates/clud-bin/src/memory/error.rs
+++ b/crates/clud-bin/src/memory/error.rs
@@ -20,4 +20,13 @@ pub enum MemoryError {
     NotFound(MemoryId),
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
+    // Issue #257: embedder couldn't service the request. `Disabled` carries
+    // the four-path remediation message; `RemoteFailure` wraps provider HTTP
+    // errors with a short body excerpt for diagnostics.
+    #[error("embedder disabled: {0}")]
+    EmbedderDisabled(String),
+    #[error("embedder remote failure ({provider}): {message}")]
+    EmbedderRemoteFailure { provider: String, message: String },
+    #[error("embedder model load: {0}")]
+    EmbedderModelLoad(String),
 }

--- a/crates/clud-bin/src/memory/mod.rs
+++ b/crates/clud-bin/src/memory/mod.rs
@@ -7,6 +7,7 @@
 //! `LexicalIndex::upsert` accepts an explicit `Tier` instead of inferring
 //! one.
 
+pub mod embedder;
 pub mod error;
 pub mod identity;
 pub mod ids;
@@ -16,6 +17,10 @@ pub mod schema;
 pub mod search;
 pub mod store;
 
+pub use embedder::{
+    embedder_from_env, reembed_all, Embedder, EmbedderTrait, RemoteEmbedder, RemoteProvider,
+    EMBED_DIM_MINILM_L6_V2,
+};
 pub use error::MemoryError;
 pub use identity::{
     branch_isolate, branch_unisolate, cross_repo_glob_filter, normalize_origin_url,

--- a/crates/clud-bin/src/memory/store.rs
+++ b/crates/clud-bin/src/memory/store.rs
@@ -153,6 +153,40 @@ impl SqliteStore {
         &self.conn
     }
 
+    // Issue #257: the embedder module's `reembed_all` walks rows then
+    // rewrites the vec table. It owns its own transactions so it asks for
+    // both a read-only handle (to enumerate ids+content) and a mutable
+    // handle (to start `BEGIN IMMEDIATE` per row). These accessors keep
+    // the connection encapsulated everywhere else.
+    pub(crate) fn conn_ref(&self) -> &Connection {
+        &self.conn
+    }
+
+    pub(crate) fn conn_mut(&mut self) -> &mut Connection {
+        &mut self.conn
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fetch_vec_for_test(&self, id: &MemoryId) -> Result<Vec<f32>, MemoryError> {
+        let blob: Vec<u8> = self.conn.query_row(
+            "SELECT embedding FROM memory_vec WHERE id = ?1",
+            params![id.as_str()],
+            |r| r.get(0),
+        )?;
+        if blob.len() % 4 != 0 {
+            return Err(MemoryError::Migration(format!(
+                "vec blob length {} is not a multiple of 4",
+                blob.len()
+            )));
+        }
+        let mut out = Vec::with_capacity(blob.len() / 4);
+        for chunk in blob.chunks_exact(4) {
+            let bytes: [u8; 4] = chunk.try_into().unwrap();
+            out.push(f32::from_le_bytes(bytes));
+        }
+        Ok(out)
+    }
+
     pub fn insert(&mut self, row: &MemoryRow, embedding: &[f32]) -> Result<(), MemoryError> {
         if embedding.len() != self.embed_dim {
             return Err(MemoryError::DimMismatch {

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -397,3 +397,33 @@ This supersedes the "separate GC daemon" half of [DD-006](#dd-006--cluddataredb-
 - Renaming a remote (e.g., `zackees/clud-old` → `zackees/clud`) produces a new partition. We accept the user-visible rename as the trigger for a deliberate `clud memory rekey` (deferred to v0.5; out of scope for #267).
 - Forks are isolated by default — exactly what the user wants. Bridging two forks requires the explicit `--repo-glob` flag at query time (consumer wiring in #259 / #262).
 - The marker file lives at `<common_dir>/.clud/memory-branch-isolate` instead of inside the SQLite store. That's deliberate: the decision should travel with the working tree via `git`, not be hidden in a per-user database.
+
+---
+
+## DD-015: Local embedder via fastembed + Windows-ARM carve-out
+
+**Context:** The agent-memory subsystem (META #255) needs to turn arbitrary text into a dense vector before it can be stored in the `memory_vec` `vec0` virtual table. The choice is between (a) calling a remote embedding API on every save (Anthropic/OpenAI/Gemini), (b) running a local model in-process, or (c) shelling out to an external embedder service. The default-experience target — `clud memory_save` after `claude` ships a long-form lesson — is latency-sensitive (sub-second), privacy-sensitive (lessons may contain proprietary code), and offline-capable (a clud user on a flight should not lose memory).
+
+**Decision:** Default to a local in-process embedder via `fastembed = "4"` (which pulls `ort = "2.0.0-rc.x"` ONNX Runtime). Model: `AllMiniLML6V2` (384-dim, ~80 MB on disk, ~30 ms / embed on CPU). The dep is feature-gated behind `memory_local_embed` (default-on) and target-gated to `cfg(not(all(target_arch = "aarch64", target_os = "windows")))` because `ort` does not yet ship a prebuilt `aarch64-pc-windows-msvc` ONNX Runtime. The carve-out mirrors the existing `whisper-rs` stanza at `crates/clud-bin/Cargo.toml:103`. On Windows-ARM, `Embedder::Local` is not a variant of the enum (compile-time absent, not a stub); `embedder_from_env` falls through to `Embedder::Remote` (if `CLUD_MEMORY_EMBEDDER_PROVIDER` is set) or `Embedder::Disabled` (with a verbose four-path remediation message).
+
+**Rationale:**
+- In-process ONNX is 10–100× cheaper than the round-trip to a remote API and runs offline. For a feature whose UX is "type once, save once, search later", any user-visible latency on save is felt directly.
+- `fastembed`'s default cache lives under a state dir we control (`<state_dir>/memory/models/`), so the model is downloaded once and reused — matches the existing `whisper-rs` cache pattern.
+- Remote providers remain a first-class fallback for users who can't or won't run a local model (corp policy, Windows-ARM, embedded systems). Four providers cover the four common buying patterns: existing Anthropic key, existing OpenAI key, existing Google key, self-hosted Ollama on LAN.
+- Compile-time variant absence on Windows-ARM (versus a `Local(())` stub returning `Err`) forces every caller to handle the case at the type level — the same trick `voice/worker.rs:18-21` uses for `WhisperContextHandle`, but stricter: a misuse is a build error, not a silent no-op at runtime.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Remote-only (no local at all) | Latency, privacy, offline. Defeats the "claude saves a lesson and it's instantly searchable" UX. |
+| Local-only (no remote fallback) | Strands Windows-ARM users and corp-firewalled installs; ort prebuild story is too immature to bet on. |
+| Pre-bundle the MiniLM .onnx in the wheel | +80 MB wheel size on every platform; download-on-first-use is fine for a daemon that has hours/days of runtime. |
+| `Local(())` stub returning `Err` on Windows-ARM | Defers the carve-out to runtime; loses the type-level guarantee that no caller forgets to handle the absent backend. |
+| Re-use the whisper-rs ONNX runtime (it links one already) | whisper-rs uses GGML, not ONNX; sharing ort would require a different whisper backend entirely (unrelated PR). |
+
+**Consequences:**
+- Adding `fastembed/ort` pulls a sizeable C++ link step on 5 of 6 platforms; CI cold-build time goes up by ~1–2 min, amortized after one cache hit. zccache via soldr handles incremental compiles.
+- Windows-ARM CI runs `cargo build --no-default-features` to verify the carve-out continues to compile cleanly. Users on Windows-ARM see the four-path message until they set `CLUD_MEMORY_EMBEDDER_PROVIDER` or switch to WSL2.
+- `ort 2.0.0-rc.x` is pre-release; fastembed v4 is the integration point. Risk: rc churn. Mitigation: if rc.x breaks, pin fastembed v3 + ort 1.16; the `Embedder` trait is stable across either backend.
+- `clud memory reembed --model <new>` (CLI verb lands in #262) will use this PR's `reembed_all` library primitive to swap embedders end-to-end, including across dim changes (Local 384 → Ollama 768).

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -124,9 +124,61 @@ Plus `idx_memories_scope ON memories(scope_key)`.
 filters. `rrf_fuse` stays scope-unaware (pure rank math) — the filter
 is applied upstream on both ranking sources.
 
+## Embedder
+
+PR2 (#257) adds the embedder abstraction under
+[`crates/clud-bin/src/memory/embedder/`](../../crates/clud-bin/src/memory/embedder/README.md).
+Three kinds:
+
+- `Local(LocalEmbedder)` — `fastembed::TextEmbedding` with
+  MiniLM-L6-v2 (384-dim). Cached under `<state_dir>/memory/models/`.
+  Gated on the `memory_local_embed` Cargo feature and on
+  `cfg(not(all(target_arch = "aarch64", target_os = "windows")))` —
+  no ort prebuilt for Windows-ARM today; same carve-out shape
+  `whisper-rs` uses ([DD-015](../DESIGN_DECISIONS.md#dd-015-local-embedder-via-fastembed--windows-arm-carve-out)).
+- `Remote(RemoteEmbedder)` — pure-`ureq` HTTP client. Four providers:
+  Anthropic (Voyage), OpenAI, Gemini, Ollama. Selected via
+  `CLUD_MEMORY_EMBEDDER_PROVIDER`.
+- `Disabled { reason }` — explicit no-op. `embed()` returns
+  `MemoryError::EmbedderDisabled` with the four-path remediation
+  message (remote API key / Ollama on LAN / WSL2 / wait for ort 2.0).
+
+`embedder_from_env()` picks one based on the documented env var
+ladder. Storage layer does not own the embedder — `SqliteStore` still
+takes `&[f32]` slices. The library primitive `reembed_all(store,
+embedder)` walks every row and rewrites the vec table; the
+`clud memory reembed` CLI verb lands in #262 and wraps this with
+`--resume` checkpointing.
+
+### Recipe: Ollama on a sibling x86/Linux/macOS box (Windows-ARM workaround)
+
+On the sibling (Linux / macOS / Windows-x64):
+
+```
+ollama pull nomic-embed-text
+OLLAMA_HOST=0.0.0.0:11434 ollama serve
+```
+
+Verify reachable:
+
+```
+curl http://<host>:11434/api/tags
+```
+
+On the Windows-ARM clud client:
+
+```
+setx CLUD_MEMORY_EMBEDDER_PROVIDER ollama
+setx CLUD_MEMORY_EMBEDDER_URL      http://<host>:11434/api/embeddings
+```
+
+Restart the daemon. Switching the embedder model after rows exist
+will need `clud memory reembed --model nomic-embed-text` (#262) to
+rewrite the vec table at the new 768-dim.
+
 ## Sibling sub-issues (META #255)
 
-- Embeddings (local + remote + Windows-ARM strategy)
+- ~~Embeddings (local + remote + Windows-ARM strategy)~~ — #257 (this PR).
 - Tier lifecycle (Working / Episodic / Semantic + decay + promotion)
 - MCP server in daemon + `clud mcp` stdio bridge
 - Daemon HTTP/IPC routes for memory ops


### PR DESCRIPTION
## Summary
- Add `crates/clud-bin/src/memory/embedder/` with `Embedder::{Local, Remote, Disabled}` and the `EmbedderTrait`.
- `LocalEmbedder` uses fastembed (MiniLM-L6-v2, 384-dim) gated behind `memory_local_embed` feature; carved out on `aarch64-pc-windows-msvc` mirroring `whisper-rs`.
- `RemoteEmbedder` HTTP clients for Anthropic/OpenAI/Gemini/Ollama; falls through cleanly.
- Library primitive `reembed_all()` for the upcoming `clud memory reembed` CLI verb (lands in #262).
- DD-014 added; `docs/architecture/memory.md` updated with the embedder section + Ollama-on-LAN recipe.

Closes #257. Part of meta #255 (PR2 of 5 — embeddings half).

## Test plan
- [x] `soldr cargo test -p clud --lib memory::embedder::` — green (15 embedder tests, 41 memory tests total, 774 clud-lib tests).
- [x] `soldr cargo build -p clud --no-default-features` — clean (proves Windows-ARM compatibility locally).
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean (both with and without default features).
- [x] `soldr cargo fmt --all --check` — clean.
- [x] `ruff check src tests ci` + banned-imports — clean.
- [ ] CI green on all 6 platforms.

Heavy local-embed tests (`local_embedder_produces_384_dim_vectors`, `local_embedder_two_distinct_texts_have_cosine_similarity_below_1`, `embedder_from_env_local_default_when_no_env_set`) are `#[ignore]`'d so CI does not pay the ~80 MB MiniLM model download per matrix job; deterministic `TestEmbedder` covers the equivalent dim + similarity contract. Run manual smoke with:

\`\`\`
soldr cargo test -p clud --lib memory::embedder::local::tests:: -- --ignored --nocapture
\`\`\`

Generated with [Claude Code](https://claude.com/claude-code)