### PR TITLE
feat(memory): daemon integration -- service spawn, consolidation timer, HTTP route stubs (#261)

### DIFF
--- a/crates/clud-bin/src/daemon/README.md
+++ b/crates/clud-bin/src/daemon/README.md
@@ -18,6 +18,7 @@ Internal helper subcommands `__daemon` and `__worker` re-enter the same binary i
 - `client.rs` — client-side daemon RPC: `ensure_daemon` (idempotent fs4-locked auto-spawn), `send_daemon_request`, `request_session_termination`, `gc_client_*` IPC wrappers for the four `clud gc` ops, stale-state cleanup.
 - `server.rs` — daemon-process entry: binds the loopback listener, spawns the GC registry worker, accepts `Create`/`Session`/`Terminate`/`Gc` requests, spawns worker subprocesses, reaps them.
 - `gc_service.rs` — single-owner registry worker thread (issue #135): opens `~/.clud/data.redb` once, serializes every `gc.*` op through an `mpsc::Receiver<GcRequestMsg>`. Replaces the standalone `gc_daemon` process that shipped in Phase 1.
+- `memory_service.rs` — agent-memory service running in-process (issue #261). Owns `Arc<Mutex<SqliteStore>>`, `Arc<Mutex<LexicalIndex>>`, `Arc<Embedder>`, and `TierConfig`. Runs a consolidation timer thread (`promote_candidates` → `apply_promotions` → `forget_expired` every 5 min, env-tunable) and an hourly `PRAGMA wal_checkpoint(TRUNCATE)`. Reconciliation pass on startup re-upserts every SQLite row into tantivy so a crash between SQLite commit and tantivy commit self-heals on next boot. Loaded by `server::run_daemon` alongside the GC service and the dashboard.
 - `worker.rs` — worker-process entry: starts the backend (subprocess or PTY), serves attach connections, runs the repeat-job loop.
 - `worker_shared.rs` — per-worker shared state: snapshot, in-memory backlog, optional `TerminalCapture` for PTY attach-replay, log file rotation, single-client attach gate.
 - `attach.rs` — interactive client-side attach loop: handshake, raw-terminal keyboard forwarding, Ctrl-C → background-prompt flow, exit-code propagation.
@@ -45,6 +46,8 @@ Internal helper subcommands `__daemon` and `__worker` re-enter the same binary i
 - `const DEFAULT_BACKLOG_LIMIT_BYTES = 256 KiB` — `types.rs:20`
 - `const LOG_ROTATE_BYTES = 10 MiB` — `types.rs:28`
 - `fn run_daemon(&Path) -> i32` — `server.rs:23`
+- `pub fn spawn_memory_service(&Path) -> Result<MemoryService, MemoryError>` — `memory_service.rs:114`
+- `pub struct MemoryService { store, lexical, embedder, tier_config, consolidate_interval_ms }` — `memory_service.rs:52`
 - `fn run_worker(&Path, &str, u32, &Path) -> i32` — `worker.rs:28`
 - `fn ensure_daemon(&Path) -> io::Result<()>` — `client.rs:18`
 - `fn send_daemon_request(&Path, &DaemonRequest)` — `client.rs:51`

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -84,7 +84,7 @@ fn spawn_and_await_daemon(state_dir: &Path) -> io::Result<()> {
                 return Ok(());
             }
         }
-        if started.elapsed() > Duration::from_secs(5) {
+        if started.elapsed() > Duration::from_secs(60) {
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "timed out waiting for daemon startup",

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -552,6 +552,7 @@ mod tests {
             port: 0,
             dashboard_port: None,
             version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            memory_mcp_port: None,
         };
         assert!(daemon_version_matches(&info));
     }
@@ -566,6 +567,7 @@ mod tests {
             port: 0,
             dashboard_port: None,
             version: Some("0.0.0-not-the-current".to_string()),
+            memory_mcp_port: None,
         };
         assert!(!daemon_version_matches(&info));
     }
@@ -581,6 +583,7 @@ mod tests {
             port: 0,
             dashboard_port: None,
             version: None,
+            memory_mcp_port: None,
         };
         assert!(!daemon_version_matches(&info));
     }
@@ -592,6 +595,7 @@ mod tests {
             port,
             dashboard_port: None,
             version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            memory_mcp_port: None,
         };
         super::super::io_helpers::write_json_file(&daemon_info_path(state_dir), &info).unwrap();
     }

--- a/crates/clud-bin/src/daemon/http.rs
+++ b/crates/clud-bin/src/daemon/http.rs
@@ -26,12 +26,14 @@ use tiny_http::{Header, Method, Request, Response, Server};
 
 use super::gc_service::{GcRequestMsg, RegistryMsg, WORKER_REPLY_TIMEOUT};
 use super::io_helpers::read_json_file;
+use super::memory_service::MemoryService;
 use super::paths::{daemon_info_path, sessions_dir};
 use super::process_utils::pid_is_alive;
 use super::types::{
     CtrlCProfile, DaemonInfo, GcOp, GcReply, ListRow, RepoVisit, SessionKind, SessionSnapshot,
 };
 use crate::ctrl_c_track::{self, CtrlCEvent};
+use crate::memory::embedder::EmbedderTrait;
 use crate::session_registry::LiveSession;
 
 /// Supplier of live session-registry rows. Injected at the dashboard
@@ -169,6 +171,7 @@ pub(super) fn spawn_dashboard(
     ipc_port: u16,
     started_at_unix: i64,
     live_sessions_provider: LiveSessionsProvider,
+    memory: Option<std::sync::Arc<MemoryService>>,
 ) -> Option<u16> {
     let server = match Server::http("127.0.0.1:0") {
         Ok(s) => s,
@@ -194,6 +197,7 @@ pub(super) fn spawn_dashboard(
                 ipc_port,
                 started_at_unix,
                 live_sessions_provider,
+                memory,
             )
         });
     match res {
@@ -212,6 +216,7 @@ fn run_dashboard_loop(
     ipc_port: u16,
     started_at_unix: i64,
     live_sessions_provider: LiveSessionsProvider,
+    memory: Option<std::sync::Arc<MemoryService>>,
 ) {
     for request in server.incoming_requests() {
         let method = request.method().clone();
@@ -233,6 +238,26 @@ fn run_dashboard_loop(
             }
             (Method::Post, "/gc/purge") => {
                 handle_purge(request, gc_tx.as_ref());
+            }
+            // Issue #261: scaffolding for the memory dashboard routes.
+            // Bodies are stubs in this PR; the real reads (recent
+            // memories, BM25 + KNN hybrid search, tier counts) land in
+            // #263 alongside the dashboard JS.
+            (Method::Get, "/memory/recent") => {
+                handle_memory_recent(request, memory.as_ref());
+            }
+            (Method::Get, "/memory/search") => {
+                handle_memory_search(request, memory.as_ref());
+            }
+            (Method::Get, "/memory/stats") => {
+                handle_memory_stats(request, memory.as_ref());
+            }
+            (Method::Post, "/memory/save") => {
+                handle_memory_save(request, memory.as_ref());
+            }
+            (m, p) if m == Method::Post && p.starts_with("/memory/forget/") => {
+                let id = p.trim_start_matches("/memory/forget/").to_string();
+                handle_memory_forget(request, &id, memory.as_ref());
             }
             _ => {
                 respond_text(request, 404, b"not found");
@@ -357,6 +382,109 @@ fn respond_purge_reply(request: Request, reply: GcReply) {
             );
         }
     }
+}
+
+// ---------- memory route stubs (issue #261) ----------
+//
+// All five routes are wired to the live `Arc<MemoryService>` so #263 can
+// fill in the bodies in a follow-up without touching this file's match
+// arms. On `memory.is_none()` (memory subsystem failed to start) every
+// route returns 503 — the daemon keeps serving session + GC traffic.
+
+fn handle_memory_recent(request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
+    if memory.is_none() {
+        respond_json(
+            request,
+            503,
+            json_error_bytes("memory subsystem unavailable").as_slice(),
+        );
+        return;
+    }
+    // TODO(#263): pull recent rows from `MemoryService::store` and
+    // render them as `[{id, tier, content, created_at_ms}]`. Empty array
+    // until then so the dashboard's JS can already poll the route.
+    respond_json(request, 200, b"[]");
+}
+
+fn handle_memory_search(request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
+    if memory.is_none() {
+        respond_json(
+            request,
+            503,
+            json_error_bytes("memory subsystem unavailable").as_slice(),
+        );
+        return;
+    }
+    // TODO(#263): parse `?q=` + `?k=`, run hybrid search via embedder +
+    // store + lexical, return `[{id, tier, content, score}]`.
+    respond_json(request, 200, b"[]");
+}
+
+fn handle_memory_stats(request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
+    let Some(svc) = memory else {
+        respond_json(
+            request,
+            503,
+            json_error_bytes("memory subsystem unavailable").as_slice(),
+        );
+        return;
+    };
+    // The embedder name is cheap and useful even before #263 ships, so
+    // populate it now. Counts stay at 0 until #263 wires them up.
+    let embedder_status =
+        <crate::memory::Embedder as EmbedderTrait>::name(svc.embedder.as_ref()).to_string();
+    let body = serde_json::json!({
+        "tier_counts": {
+            "working": 0,
+            "episodic": 0,
+            "semantic": 0,
+        },
+        "embedder_status": embedder_status,
+        "consolidate_interval_ms": svc.consolidate_interval_ms,
+    });
+    let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
+    respond_json(request, 200, &bytes);
+}
+
+fn handle_memory_save(request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
+    if memory.is_none() {
+        respond_json(
+            request,
+            503,
+            json_error_bytes("memory subsystem unavailable").as_slice(),
+        );
+        return;
+    }
+    // TODO(#263): parse `{content, tier, session_id?, scope_key?}`,
+    // embed, store, lexical-upsert, return `{id}`. Stub returns 501 so
+    // the dashboard's save form gets a deterministic error until then.
+    respond_json(
+        request,
+        501,
+        json_error_bytes("memory save not implemented in this build (see #263)").as_slice(),
+    );
+}
+
+fn handle_memory_forget(
+    request: Request,
+    _id: &str,
+    memory: Option<&std::sync::Arc<MemoryService>>,
+) {
+    if memory.is_none() {
+        respond_json(
+            request,
+            503,
+            json_error_bytes("memory subsystem unavailable").as_slice(),
+        );
+        return;
+    }
+    // TODO(#263): validate id, call `SqliteStore::delete` +
+    // `LexicalIndex::delete`, return `{deleted: true}`.
+    respond_json(
+        request,
+        501,
+        json_error_bytes("memory forget not implemented in this build (see #263)").as_slice(),
+    );
 }
 
 // ---------- state aggregation ----------
@@ -939,6 +1067,7 @@ mod tests {
             9999,
             100,
             empty_live_provider(),
+            None,
         )
         .expect("dashboard spawned");
 
@@ -989,6 +1118,7 @@ mod tests {
             9999,
             100,
             empty_live_provider(),
+            None,
         )
         .expect("dashboard spawned");
 
@@ -1073,6 +1203,7 @@ mod tests {
             9999,
             100,
             empty_live_provider(),
+            None,
         )
         .expect("dashboard spawned");
 
@@ -1118,6 +1249,18 @@ mod tests {
     /// Tiny HTTP/1.0 client for tests. Connect, send a request, read the
     /// body. Avoids pulling in a real HTTP client dep just for tests.
     fn fetch_path(port: u16, method: &str, path: &str, body: Option<String>) -> io::Result<String> {
+        fetch_path_with_status(port, method, path, body).map(|(_, body)| body)
+    }
+
+    /// Same as `fetch_path` but also returns the HTTP status code from the
+    /// status line — required by the issue #261 stub-route tests that
+    /// assert 503 / 501 / 200 outcomes.
+    fn fetch_path_with_status(
+        port: u16,
+        method: &str,
+        path: &str,
+        body: Option<String>,
+    ) -> io::Result<(u16, String)> {
         let mut stream = TcpStream::connect(("127.0.0.1", port))?;
         stream.set_read_timeout(Some(Duration::from_secs(5)))?;
         stream.set_write_timeout(Some(Duration::from_secs(5)))?;
@@ -1136,9 +1279,138 @@ mod tests {
         stream.flush()?;
         let mut buf = Vec::with_capacity(4096);
         stream.read_to_end(&mut buf)?;
+        let status_line_end = buf
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .or_else(|| buf.windows(1).position(|w| w == b"\n"))
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no status line"))?;
+        let status_line = std::str::from_utf8(&buf[..status_line_end])
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        let status: u16 = status_line
+            .split_whitespace()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no status code"))?;
         let body_start = find_body_start(&buf)
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no header terminator"))?;
-        String::from_utf8(buf[body_start..].to_vec())
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+        let body = String::from_utf8(buf[body_start..].to_vec())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        Ok((status, body))
+    }
+
+    // ---------- issue #261: memory-route stub coverage ----------
+
+    /// With `memory: None`, every memory route must return 503 with a
+    /// JSON error body. The daemon keeps serving session + GC traffic.
+    #[test]
+    fn memory_routes_return_503_when_subsystem_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let port = spawn_dashboard(
+            dir.path().to_path_buf(),
+            None,
+            9999,
+            100,
+            empty_live_provider(),
+            None,
+        )
+        .expect("dashboard spawned");
+
+        for (method, path) in [
+            ("GET", "/memory/recent"),
+            ("GET", "/memory/search?q=foo"),
+            ("GET", "/memory/stats"),
+        ] {
+            let (status, body) = fetch_path_with_status(port, method, path, None).expect("fetch");
+            assert_eq!(status, 503, "{method} {path}");
+            assert!(body.contains("memory subsystem unavailable"), "body={body}");
+        }
+        let (status, _) =
+            fetch_path_with_status(port, "POST", "/memory/save", Some("{}".to_string()))
+                .expect("save");
+        assert_eq!(status, 503);
+        let (status, _) =
+            fetch_path_with_status(port, "POST", "/memory/forget/abc", Some("{}".to_string()))
+                .expect("forget");
+        assert_eq!(status, 503);
+    }
+
+    /// With a live `MemoryService`, the stub bodies #263 will replace
+    /// are wired through: stats returns 200 with the documented JSON
+    /// shape; recent/search return 200 with an empty array; save/forget
+    /// return 501 until #263 implements them.
+    #[test]
+    fn memory_routes_serve_stubs_when_subsystem_present() {
+        // Force the embedder to `Disabled` so the test doesn't try to
+        // download a fastembed model.
+        let saved: Vec<(&str, Option<String>)> = [
+            "CLUD_MEMORY_EMBEDDER",
+            "CLUD_MEMORY_EMBEDDER_PROVIDER",
+            "CLUD_MEMORY_EMBEDDER_URL",
+            "CLUD_MEMORY_EMBEDDER_API_KEY",
+            "CLUD_MEMORY_EMBEDDER_MODEL",
+        ]
+        .iter()
+        .map(|k| (*k, std::env::var(*k).ok()))
+        .collect();
+        for (k, _) in &saved {
+            unsafe {
+                std::env::remove_var(k);
+            }
+        }
+        unsafe {
+            std::env::set_var("CLUD_MEMORY_EMBEDDER", "disabled");
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let svc = crate::daemon::memory_service::spawn_memory_service(dir.path())
+            .expect("memory service");
+        let svc = std::sync::Arc::new(svc);
+
+        let port = spawn_dashboard(
+            dir.path().to_path_buf(),
+            None,
+            9999,
+            100,
+            empty_live_provider(),
+            Some(svc.clone()),
+        )
+        .expect("dashboard spawned");
+
+        let (status, body) =
+            fetch_path_with_status(port, "GET", "/memory/stats", None).expect("stats");
+        assert_eq!(status, 200);
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert!(parsed.get("tier_counts").is_some(), "body={body}");
+        assert!(parsed.get("embedder_status").is_some(), "body={body}");
+
+        let (status, body) =
+            fetch_path_with_status(port, "GET", "/memory/recent", None).expect("recent");
+        assert_eq!(status, 200);
+        assert_eq!(body.trim(), "[]");
+
+        let (status, body) =
+            fetch_path_with_status(port, "GET", "/memory/search?q=foo", None).expect("search");
+        assert_eq!(status, 200);
+        assert_eq!(body.trim(), "[]");
+
+        let (status, _) =
+            fetch_path_with_status(port, "POST", "/memory/save", Some("{}".to_string()))
+                .expect("save");
+        assert_eq!(status, 501);
+
+        let (status, _) =
+            fetch_path_with_status(port, "POST", "/memory/forget/abc", Some("{}".to_string()))
+                .expect("forget");
+        assert_eq!(status, 501);
+
+        svc.shutdown();
+
+        // Restore env.
+        for (k, v) in saved {
+            match v {
+                Some(val) => unsafe { std::env::set_var(k, val) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
     }
 }

--- a/crates/clud-bin/src/daemon/memory_service.rs
+++ b/crates/clud-bin/src/daemon/memory_service.rs
@@ -1,0 +1,533 @@
+//! Issue #261: agent-memory service running in-process inside the clud
+//! daemon.
+//!
+//! Spawned by `daemon::server::run_daemon` alongside the GC registry
+//! worker and the dashboard HTTP listener. Owns the four storage
+//! resources downstream subsystems (#259 MCP server, #260 hooks, #262
+//! CLI verbs, #263 dashboard JS) need to share:
+//!
+//! - `Arc<Mutex<SqliteStore>>` — single-writer SQLite handle (the
+//!   sqlite-vec extension is registered process-globally).
+//! - `Arc<Mutex<LexicalIndex>>` — single `IndexWriter` over the tantivy
+//!   directory.
+//! - `Arc<Embedder>` — loaded once at daemon start; `Send + Sync`, no
+//!   internal mutex.
+//! - `TierConfig` — promotion + auto-forget thresholds resolved from
+//!   the documented env vars.
+//!
+//! See [docs/architecture/memory.md] "Daemon integration" for the
+//! concurrency model and [DD-017] for why the service lives in-process.
+//!
+//! This PR is scope-limited to the daemon plumbing; the dashboard route
+//! bodies are stubs (#263) and there is no MCP server yet (#259).
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::memory::embedder::EmbedderTrait;
+use crate::memory::{
+    embedder_from_env, Embedder, LexicalIndex, MemoryError, SqliteStore, Tier, TierConfig,
+    EMBED_DIM_MINILM_L6_V2,
+};
+
+/// Default consolidation tick — five minutes. Override via
+/// `CLUD_MEMORY_CONSOLIDATE_INTERVAL_MS`.
+const DEFAULT_CONSOLIDATE_INTERVAL_MS: u64 = 300_000;
+
+/// One `PRAGMA wal_checkpoint(TRUNCATE)` per N ticks. With the default
+/// 5-minute interval that's hourly. Override via
+/// `CLUD_MEMORY_CHECKPOINT_EVERY_N_TICKS`.
+const DEFAULT_CHECKPOINT_EVERY_N_TICKS: u64 = 12;
+
+const ENV_CONSOLIDATE_INTERVAL_MS: &str = "CLUD_MEMORY_CONSOLIDATE_INTERVAL_MS";
+const ENV_CHECKPOINT_EVERY_N_TICKS: &str = "CLUD_MEMORY_CHECKPOINT_EVERY_N_TICKS";
+
+/// Live handles shared with the rest of the daemon. Cloning the wrapping
+/// `Arc<MemoryService>` is cheap; per-resource access is gated by the
+/// inner `Mutex`es.
+#[allow(dead_code)]
+pub struct MemoryService {
+    pub store: Arc<Mutex<SqliteStore>>,
+    pub lexical: Arc<Mutex<LexicalIndex>>,
+    pub embedder: Arc<Embedder>,
+    pub tier_config: TierConfig,
+    /// Consolidation cadence used to size the dashboard's "next tick in
+    /// N seconds" hint (#263 will surface this).
+    pub consolidate_interval_ms: u64,
+    /// Set to `true` by `shutdown()` to break the timer's wait loop.
+    /// Held inside an `Arc` so the timer thread can observe the same
+    /// flag the service drops on the way out.
+    shutdown: Arc<AtomicBool>,
+}
+
+impl std::fmt::Debug for MemoryService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryService")
+            .field("tier_config", &self.tier_config)
+            .field("consolidate_interval_ms", &self.consolidate_interval_ms)
+            .field(
+                "embedder",
+                &<Embedder as EmbedderTrait>::name(&self.embedder),
+            )
+            .finish()
+    }
+}
+
+#[allow(dead_code)]
+impl MemoryService {
+    /// Cooperative shutdown for tests and for the future graceful-exit
+    /// path on the daemon's main loop. The timer thread polls the flag
+    /// every `consolidate_interval_ms / 10` so the wait wakes within a
+    /// few seconds on a default-tuned daemon.
+    pub fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    /// Tick used by tests: drives one round of promote → apply →
+    /// forget against an explicit `now_ms`. The timer thread calls this
+    /// helper in its loop; pulling it out keeps the cadence orchestration
+    /// untestable but the lifecycle math fully covered.
+    pub(crate) fn run_one_consolidation_tick(
+        &self,
+        now_ms: u64,
+    ) -> Result<TickReport, MemoryError> {
+        run_one_consolidation_tick(&self.store, &self.lexical, &self.tier_config, now_ms)
+    }
+}
+
+/// Counts surfaced by one consolidation pass. Logged once per tick; the
+/// dashboard will surface the most recent value in a later PR.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TickReport {
+    pub promoted: usize,
+    pub forgotten: usize,
+}
+
+/// Open every memory-subsystem resource and start the consolidation
+/// timer. Returns the live `MemoryService`. The daemon owns the
+/// resulting `Arc` for the rest of its lifetime; the timer thread holds
+/// weak-style clones of the same `Arc<Mutex<...>>` handles so dropping
+/// the daemon's reference is enough to wind everything down.
+pub fn spawn_memory_service(state_dir: &Path) -> Result<MemoryService, MemoryError> {
+    // 1. Resolve on-disk layout under the daemon's state dir. We don't
+    //    rely on `memory::paths` (which composes off the process-global
+    //    `CLUD_DAEMON_STATE_DIR` env) because callers may pass an
+    //    explicit `--daemon-state-dir`.
+    let memory_dir = state_dir.join("memory");
+    std::fs::create_dir_all(&memory_dir)?;
+    let memory_db_path = memory_dir.join("memory.db");
+    let tantivy_dir = memory_dir.join("tantivy");
+
+    // 2. Embedder first — its dim drives the SQLite vec0 column width.
+    //    `embedder_from_env` may panic on bad env config; the Result
+    //    bubbles up to the daemon, which logs and continues without
+    //    memory (`server.rs` treats failures as soft).
+    let embedder_result = embedder_from_env();
+    let embed_dim = match &embedder_result {
+        Ok(e) => {
+            let d = <Embedder as EmbedderTrait>::dim(e);
+            if d == 0 {
+                EMBED_DIM_MINILM_L6_V2
+            } else {
+                d
+            }
+        }
+        Err(_) => EMBED_DIM_MINILM_L6_V2,
+    };
+
+    // 3. Open the SQLite store. Migrations run inside `open`; if a
+    //    previous daemon crashed mid-write, sqlite's WAL replay handles
+    //    recovery transparently.
+    let mut store = SqliteStore::open(&memory_db_path, embed_dim)?;
+
+    // 4. WAL recovery — truncate the WAL up to the last durable commit.
+    //    Cheap when the WAL is already drained; bounded by WAL size when
+    //    it isn't.
+    store.checkpoint_truncate()?;
+
+    // 5. Open the tantivy index. Half-written segments from a previous
+    //    crash are discarded on open.
+    let mut lexical = LexicalIndex::open_or_create(&tantivy_dir)?;
+
+    // 6. Reconciliation pass — for every row in `memories`, ensure the
+    //    lexical index has a matching doc. We can't cheaply ask tantivy
+    //    "do you contain id X?" without a per-id search, so the pass
+    //    re-upserts every row; tantivy's delete-then-add inside `upsert`
+    //    keeps the resulting index correct. Bounded by the row count;
+    //    typical daemons see hundreds of memories, not millions.
+    reconcile_lexical(&store, &mut lexical)?;
+
+    // 7. Wrap the embedder Result. A failed load doesn't kill the
+    //    daemon — we keep going with `Embedder::Disabled` so the rest of
+    //    the subsystem (HTTP routes, future MCP server) can render a
+    //    consistent "embedder unavailable" surface.
+    let embedder: Arc<Embedder> = match embedder_result {
+        Ok(e) => Arc::new(e),
+        Err(err) => {
+            eprintln!("[clud] note: memory embedder unavailable: {err}");
+            Arc::new(Embedder::Disabled {
+                reason: err.to_string(),
+            })
+        }
+    };
+
+    // Dim drift warning: the embedder may report a different dim than
+    // the stored vec0 column width if the user swapped providers
+    // between runs. `reembed` (CLI verb in #262) is the manual fix.
+    let actual_dim = <Embedder as EmbedderTrait>::dim(embedder.as_ref());
+    if actual_dim != 0 && actual_dim != store.embed_dim() {
+        eprintln!(
+            "[clud] warn: embedder dim ({}) != stored vec dim ({}); run `clud memory reembed`",
+            actual_dim,
+            store.embed_dim()
+        );
+    }
+
+    let store = Arc::new(Mutex::new(store));
+    let lexical = Arc::new(Mutex::new(lexical));
+    let tier_config = TierConfig::from_env();
+    let consolidate_interval_ms =
+        env_u64(ENV_CONSOLIDATE_INTERVAL_MS, DEFAULT_CONSOLIDATE_INTERVAL_MS);
+    let checkpoint_every_n_ticks = env_u64(
+        ENV_CHECKPOINT_EVERY_N_TICKS,
+        DEFAULT_CHECKPOINT_EVERY_N_TICKS,
+    )
+    .max(1);
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    // 8. Consolidation timer thread. Cheap-clones of the Arcs keep the
+    //    store + lexical alive even if the daemon dropped its outer
+    //    `Arc<MemoryService>` early; once `shutdown` is set the thread
+    //    drops them on its way out.
+    spawn_consolidation_thread(
+        Arc::clone(&store),
+        Arc::clone(&lexical),
+        tier_config,
+        consolidate_interval_ms,
+        checkpoint_every_n_ticks,
+        Arc::clone(&shutdown),
+    );
+
+    Ok(MemoryService {
+        store,
+        lexical,
+        embedder,
+        tier_config,
+        consolidate_interval_ms,
+        shutdown,
+    })
+}
+
+/// Re-index every SQLite row in the lexical store. Cheap on a clean
+/// daemon (no rows); on a daemon with N rows the cost is O(N) `upsert`
+/// calls plus one commit. Tantivy's `delete_term`-then-`add` inside
+/// `LexicalIndex::upsert` keeps the operation idempotent.
+fn reconcile_lexical(store: &SqliteStore, lexical: &mut LexicalIndex) -> Result<(), MemoryError> {
+    let mut count = 0usize;
+    for tier in [Tier::Working, Tier::Episodic, Tier::Semantic] {
+        for row in store.list_by_tier(tier)? {
+            lexical.upsert(
+                &row.id,
+                row.session_id.as_deref(),
+                row.scope_key.as_deref(),
+                row.tier,
+                &row.content,
+            )?;
+            count += 1;
+        }
+    }
+    if count > 0 {
+        lexical.commit()?;
+    }
+    Ok(())
+}
+
+fn spawn_consolidation_thread(
+    store: Arc<Mutex<SqliteStore>>,
+    lexical: Arc<Mutex<LexicalIndex>>,
+    cfg: TierConfig,
+    interval_ms: u64,
+    checkpoint_every_n_ticks: u64,
+    shutdown: Arc<AtomicBool>,
+) {
+    let res = thread::Builder::new()
+        .name("clud-memory-consolidate".to_string())
+        .spawn(move || {
+            let mut tick: u64 = 0;
+            // Poll the shutdown flag at a finer cadence so cooperative
+            // shutdown wakes within seconds, not minutes.
+            let poll_step = Duration::from_millis((interval_ms / 10).max(50));
+            let mut next_due = std::time::Instant::now() + Duration::from_millis(interval_ms);
+            while !shutdown.load(Ordering::SeqCst) {
+                thread::sleep(poll_step);
+                let now = std::time::Instant::now();
+                if now < next_due {
+                    continue;
+                }
+                next_due = now + Duration::from_millis(interval_ms);
+                tick = tick.wrapping_add(1);
+
+                let report =
+                    match run_one_consolidation_tick(&store, &lexical, &cfg, unix_millis_now()) {
+                        Ok(r) => r,
+                        Err(err) => {
+                            eprintln!("[clud] memory consolidation tick failed: {err}");
+                            continue;
+                        }
+                    };
+
+                let mut checkpointed = false;
+                if tick % checkpoint_every_n_ticks == 0 {
+                    if let Ok(mut s) = store.lock() {
+                        if let Err(err) = s.checkpoint_truncate() {
+                            eprintln!("[clud] memory wal checkpoint failed: {err}");
+                        } else {
+                            checkpointed = true;
+                        }
+                    }
+                }
+                eprintln!(
+                    "[clud] memory tick #{tick} promoted={} forgotten={} checkpoint={}",
+                    report.promoted, report.forgotten, checkpointed
+                );
+            }
+        });
+    if let Err(err) = res {
+        eprintln!("[clud] note: memory consolidation thread spawn failed: {err}");
+    }
+}
+
+/// One round of promotion + auto-forget. Pulled out of the timer thread
+/// so tests can call it with a deterministic `now_ms`.
+pub(crate) fn run_one_consolidation_tick(
+    store: &Arc<Mutex<SqliteStore>>,
+    lexical: &Arc<Mutex<LexicalIndex>>,
+    cfg: &TierConfig,
+    now_ms: u64,
+) -> Result<TickReport, MemoryError> {
+    let promotions = {
+        let s = store.lock().expect("memory store mutex poisoned");
+        crate::memory::promote_candidates(&s, now_ms, cfg)?
+    };
+
+    let promoted = promotions.len();
+    if !promotions.is_empty() {
+        let mut s = store.lock().expect("memory store mutex poisoned");
+        let mut l = lexical.lock().expect("memory lexical mutex poisoned");
+        crate::memory::apply_promotions(&mut s, &mut l, &promotions, now_ms)?;
+    }
+
+    let forgotten = {
+        let mut s = store.lock().expect("memory store mutex poisoned");
+        let mut l = lexical.lock().expect("memory lexical mutex poisoned");
+        crate::memory::forget_expired(&mut s, &mut l, now_ms, cfg)?
+    };
+
+    Ok(TickReport {
+        promoted,
+        forgotten,
+    })
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+fn unix_millis_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::ids::MemoryId;
+    use crate::memory::store::MemoryRow;
+
+    /// Reset env vars that the embedder + tier config read, so test
+    /// runs are deterministic regardless of the host environment.
+    struct EnvGuard {
+        keys: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn clear(keys: &[&'static str]) -> Self {
+            let saved: Vec<(&'static str, Option<String>)> =
+                keys.iter().map(|k| (*k, std::env::var(*k).ok())).collect();
+            for k in keys {
+                unsafe {
+                    std::env::remove_var(k);
+                }
+            }
+            Self { keys: saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.keys {
+                match v {
+                    Some(val) => unsafe { std::env::set_var(k, val) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+            }
+        }
+    }
+
+    // The local-embedder load path (fastembed) downloads a 90 MB ONNX
+    // model on first run; force `Disabled` so tests stay hermetic.
+    fn disabled_embedder_guard() -> EnvGuard {
+        let g = EnvGuard::clear(&[
+            crate::memory::embedder::ENV_EMBEDDER_KIND,
+            crate::memory::embedder::ENV_EMBEDDER_PROVIDER,
+            crate::memory::embedder::ENV_EMBEDDER_URL,
+            crate::memory::embedder::ENV_EMBEDDER_API_KEY,
+            crate::memory::embedder::ENV_EMBEDDER_MODEL,
+        ]);
+        unsafe {
+            std::env::set_var(crate::memory::embedder::ENV_EMBEDDER_KIND, "disabled");
+        }
+        g
+    }
+
+    fn write_row(store: &Arc<Mutex<SqliteStore>>, row: &MemoryRow) {
+        let mut s = store.lock().unwrap();
+        let dim = s.embed_dim();
+        let vec: Vec<f32> = (0..dim).map(|i| 0.1 + i as f32 * 0.001).collect();
+        s.insert(row, &vec).unwrap();
+    }
+
+    fn make_row(tier: Tier, access_count: u32, last_access_at_ms: u64, content: &str) -> MemoryRow {
+        MemoryRow {
+            id: MemoryId::new_v7(),
+            session_id: None,
+            scope_key: None,
+            branch_name: None,
+            is_orphan: false,
+            tier,
+            content: content.to_string(),
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            tier_change_at_ms: 0,
+            access_count,
+            last_access_at_ms,
+            metadata_json: None,
+        }
+    }
+
+    #[test]
+    fn spawn_memory_service_opens_store_and_lexical_in_state_dir() {
+        let _g = disabled_embedder_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = spawn_memory_service(tmp.path()).unwrap();
+        assert!(tmp.path().join("memory").join("memory.db").exists());
+        assert!(tmp.path().join("memory").join("tantivy").is_dir());
+        assert_eq!(svc.consolidate_interval_ms, DEFAULT_CONSOLIDATE_INTERVAL_MS);
+        svc.shutdown();
+    }
+
+    #[test]
+    fn spawn_memory_service_creates_dirs_if_missing() {
+        let _g = disabled_embedder_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("does").join("not").join("exist");
+        let svc = spawn_memory_service(&nested).unwrap();
+        assert!(nested.join("memory").exists());
+        assert!(nested.join("memory").join("memory.db").exists());
+        svc.shutdown();
+    }
+
+    #[test]
+    fn wal_recovery_on_open_does_not_panic() {
+        let _g = disabled_embedder_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        // Open once to materialize the schema + WAL companions.
+        {
+            let svc = spawn_memory_service(tmp.path()).unwrap();
+            svc.shutdown();
+        }
+        // Reopen — exercises the wal_checkpoint(TRUNCATE) recovery path
+        // on an existing DB. Must not panic and must not error.
+        let svc = spawn_memory_service(tmp.path()).unwrap();
+        svc.shutdown();
+    }
+
+    #[test]
+    fn consolidation_tick_promotes_and_forgets() {
+        let _g = disabled_embedder_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = spawn_memory_service(tmp.path()).unwrap();
+
+        // Working row stale enough to be auto-forgotten.
+        let stale = make_row(Tier::Working, 0, 0, "stale");
+        // Working row hot enough to be promoted to Episodic.
+        let hot = make_row(Tier::Working, 99, 1_000_000_000, "hot promotable");
+
+        write_row(&svc.store, &stale);
+        write_row(&svc.store, &hot);
+
+        // now_ms picked so:
+        //   - `stale.last_access_at_ms = 0` is older than working_ttl_ms
+        //     (default 24 h)
+        //   - `hot.tier_change_at_ms = 0` clears the default 1-h dwell gate
+        let now_ms = svc.tier_config.working_ttl_ms + svc.tier_config.promote_dwell_ms + 1;
+
+        let report = svc.run_one_consolidation_tick(now_ms).unwrap();
+        // The stale row gets dropped before the promotion query sees it.
+        // What matters is that the cycle ran and didn't error.
+        assert!(report.promoted + report.forgotten >= 1);
+
+        svc.shutdown();
+    }
+
+    #[test]
+    fn reconciliation_reindexes_missing_lexical_rows() {
+        let _g = disabled_embedder_guard();
+        let tmp = tempfile::tempdir().unwrap();
+
+        // First open: insert a row, then tear down the lexical index
+        // directory so a second open has to reconcile.
+        {
+            let svc = spawn_memory_service(tmp.path()).unwrap();
+            let row = make_row(Tier::Semantic, 1, 0, "reconcile target");
+            write_row(&svc.store, &row);
+            svc.shutdown();
+        }
+
+        let tantivy = tmp.path().join("memory").join("tantivy");
+        std::fs::remove_dir_all(&tantivy).unwrap();
+
+        // Second open: tantivy dir is gone; reconciliation pass must
+        // recreate it and re-upsert the SQLite row.
+        let svc = spawn_memory_service(tmp.path()).unwrap();
+        assert!(tantivy.exists());
+        let lex = svc.lexical.lock().unwrap();
+        let hits = lex.search("reconcile", 10, None, None, None).unwrap();
+        assert_eq!(hits.len(), 1);
+        drop(lex);
+        svc.shutdown();
+    }
+
+    #[test]
+    fn daemon_info_includes_memory_mcp_port_field() {
+        use super::super::types::DaemonInfo;
+        // Construct via the serialized wire shape so the test fails the
+        // moment the field is dropped from the struct.
+        let wire = serde_json::json!({
+            "pid": 1,
+            "port": 5,
+            "memory_mcp_port": 7777u16,
+        });
+        let info: DaemonInfo = serde_json::from_value(wire).unwrap();
+        assert_eq!(info.memory_mcp_port, Some(7777));
+    }
+}

--- a/crates/clud-bin/src/daemon/memory_service.rs
+++ b/crates/clud-bin/src/daemon/memory_service.rs
@@ -279,7 +279,7 @@ fn spawn_consolidation_thread(
             // tantivy's per-directory `LockBusy`. Production with a
             // 5-minute interval still ticks every 5 minutes; the bound
             // only governs shutdown latency.
-            let poll_step = Duration::from_millis((interval_ms / 10).max(50).min(500));
+            let poll_step = Duration::from_millis((interval_ms / 10).clamp(50, 500));
             let mut next_due = std::time::Instant::now() + Duration::from_millis(interval_ms);
             while !shutdown.load(Ordering::SeqCst) {
                 thread::sleep(poll_step);

--- a/crates/clud-bin/src/daemon/memory_service.rs
+++ b/crates/clud-bin/src/daemon/memory_service.rs
@@ -61,6 +61,12 @@ pub struct MemoryService {
     /// Held inside an `Arc` so the timer thread can observe the same
     /// flag the service drops on the way out.
     shutdown: Arc<AtomicBool>,
+    /// JoinHandle for the consolidation timer thread. `shutdown()` joins
+    /// this so callers can deterministically wait for the timer to
+    /// release its `Arc<Mutex<LexicalIndex>>` clone — tests reopen the
+    /// same on-disk index immediately and would otherwise hit tantivy's
+    /// per-directory `LockBusy`.
+    timer: Mutex<Option<thread::JoinHandle<()>>>,
 }
 
 impl std::fmt::Debug for MemoryService {
@@ -84,6 +90,11 @@ impl MemoryService {
     /// few seconds on a default-tuned daemon.
     pub fn shutdown(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
+        if let Ok(mut slot) = self.timer.lock() {
+            if let Some(handle) = slot.take() {
+                let _ = handle.join();
+            }
+        }
     }
 
     /// Tick used by tests: drives one round of promote → apply →
@@ -202,8 +213,11 @@ pub fn spawn_memory_service(state_dir: &Path) -> Result<MemoryService, MemoryErr
     // 8. Consolidation timer thread. Cheap-clones of the Arcs keep the
     //    store + lexical alive even if the daemon dropped its outer
     //    `Arc<MemoryService>` early; once `shutdown` is set the thread
-    //    drops them on its way out.
-    spawn_consolidation_thread(
+    //    drops them on its way out. The JoinHandle is held in
+    //    `MemoryService.timer` so `shutdown()` can deterministically
+    //    join, which matters for tests that reopen the same tantivy
+    //    directory (tantivy holds a per-directory `LockBusy`).
+    let timer = spawn_consolidation_thread(
         Arc::clone(&store),
         Arc::clone(&lexical),
         tier_config,
@@ -219,6 +233,7 @@ pub fn spawn_memory_service(state_dir: &Path) -> Result<MemoryService, MemoryErr
         tier_config,
         consolidate_interval_ms,
         shutdown,
+        timer: Mutex::new(timer),
     })
 }
 
@@ -253,14 +268,19 @@ fn spawn_consolidation_thread(
     interval_ms: u64,
     checkpoint_every_n_ticks: u64,
     shutdown: Arc<AtomicBool>,
-) {
+) -> Option<thread::JoinHandle<()>> {
     let res = thread::Builder::new()
         .name("clud-memory-consolidate".to_string())
         .spawn(move || {
             let mut tick: u64 = 0;
-            // Poll the shutdown flag at a finer cadence so cooperative
-            // shutdown wakes within seconds, not minutes.
-            let poll_step = Duration::from_millis((interval_ms / 10).max(50));
+            // Bounded poll cadence: tests calling `shutdown()` need the
+            // thread to release its `Arc<Mutex<LexicalIndex>>` clone
+            // within ~half a second so the test's reopen doesn't race
+            // tantivy's per-directory `LockBusy`. Production with a
+            // 5-minute interval still ticks every 5 minutes; the bound
+            // only governs shutdown latency.
+            let poll_step =
+                Duration::from_millis((interval_ms / 10).max(50).min(500));
             let mut next_due = std::time::Instant::now() + Duration::from_millis(interval_ms);
             while !shutdown.load(Ordering::SeqCst) {
                 thread::sleep(poll_step);
@@ -296,8 +316,12 @@ fn spawn_consolidation_thread(
                 );
             }
         });
-    if let Err(err) = res {
-        eprintln!("[clud] note: memory consolidation thread spawn failed: {err}");
+    match res {
+        Ok(handle) => Some(handle),
+        Err(err) => {
+            eprintln!("[clud] note: memory consolidation thread spawn failed: {err}");
+            None
+        }
     }
 }
 

--- a/crates/clud-bin/src/daemon/memory_service.rs
+++ b/crates/clud-bin/src/daemon/memory_service.rs
@@ -279,8 +279,7 @@ fn spawn_consolidation_thread(
             // tantivy's per-directory `LockBusy`. Production with a
             // 5-minute interval still ticks every 5 minutes; the bound
             // only governs shutdown latency.
-            let poll_step =
-                Duration::from_millis((interval_ms / 10).max(50).min(500));
+            let poll_step = Duration::from_millis((interval_ms / 10).max(50).min(500));
             let mut next_due = std::time::Instant::now() + Duration::from_millis(interval_ms);
             while !shutdown.load(Ordering::SeqCst) {
                 thread::sleep(poll_step);

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -6,6 +6,7 @@ mod gc_service;
 mod http;
 mod io_helpers;
 mod keys;
+mod memory_service;
 mod paths;
 mod process_utils;
 mod server;

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -19,6 +19,7 @@ use super::gc_service::{
 };
 use super::http::{default_live_sessions_provider, spawn_dashboard};
 use super::io_helpers::{new_session_id, read_json_file, write_json_file, write_json_line};
+use super::memory_service::{spawn_memory_service, MemoryService};
 use super::paths::{daemon_info_path, session_snapshot_path, sessions_dir, spec_path, specs_dir};
 use super::process_utils::{pid_is_alive, signal_process_tree};
 use super::sessions::list_live_session_cwds;
@@ -67,6 +68,18 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
         }
     };
 
+    // Issue #261: agent-memory subsystem. Opens the SQLite store, tantivy
+    // index, and embedder in-process, and runs a consolidation timer.
+    // Failures are non-fatal — the rest of the daemon (sessions, GC,
+    // dashboard) still works; memory-dependent routes return 503.
+    let memory_service: Option<Arc<MemoryService>> = match spawn_memory_service(state_dir) {
+        Ok(svc) => Some(Arc::new(svc)),
+        Err(err) => {
+            eprintln!("[clud] note: memory subsystem unavailable: {err}");
+            None
+        }
+    };
+
     // Issue #183: in-process HTTP dashboard. Bind a second loopback port
     // alongside the IPC listener and run a `tiny_http` server on a worker
     // thread. The port is recorded in `daemon.json` so `clud ui` can
@@ -79,6 +92,7 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
         port,
         started_at_unix,
         default_live_sessions_provider(),
+        memory_service.clone(),
     );
 
     let info = DaemonInfo {
@@ -86,6 +100,9 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
         port,
         dashboard_port,
         version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        // The MCP server itself lands in #259; this PR ships the field
+        // as `None` so the wire format stays stable across the rollout.
+        memory_mcp_port: None,
     };
     if let Err(err) = write_json_file(&daemon_info_path(state_dir), &info) {
         eprintln!("[clud] failed to persist daemon info: {}", err);

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -67,6 +67,13 @@ pub(super) struct DaemonInfo {
     /// `None` for daemon.json files written by clud <= 2.0.14.
     #[serde(default)]
     pub(super) version: Option<String>,
+    /// Issue #261: loopback port for the agent-memory MCP server. The
+    /// listener is bound by #259; this PR reserves the field so the wire
+    /// format stays stable across the rollout. `None` while the MCP
+    /// server is not running, e.g. on this PR or when the memory
+    /// subsystem failed to start.
+    #[serde(default)]
+    pub(super) memory_mcp_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -456,3 +456,35 @@ This supersedes the "separate GC daemon" half of [DD-006](#dd-006--cluddataredb-
 - Users who outgrow Working scratch must manually delete (via the eventual MCP delete verb) or wait for the TTL. There is no "decay-driven forget" escape hatch in v1.
 - `retention_score` returning a low value is informative, not actionable on the storage path — sibling sub-issues may build surfacing UIs from it (forget-candidate review).
 - This DD is at the policy layer, not the API layer: `SqliteStore::delete` still accepts any id. The tier-gated rule lives inside `tiers::forget_expired` and is the only daemon-driven caller.
+
+---
+
+## DD-017: Memory service runs in-process inside the existing clud daemon
+
+**Context:** The agent-memory subsystem (META #255) needs a process to own four resources: the SQLite store, the tantivy `IndexWriter`, the embedder, and the consolidation timer. The natural choice is between a sidecar `clud-memory` process (mirroring how Phase 1 of #135 ran the standalone `gc_daemon`) and folding it into the existing `clud` daemon next to the GC registry worker and the dashboard's `tiny_http` listener.
+
+**Decision:** Spawn the memory subsystem in-process inside `clud`'s session daemon. `daemon::memory_service::spawn_memory_service(state_dir)` runs alongside `gc_service::spawn_registry_worker_for_state` and `http::spawn_dashboard` from `daemon::server::run_daemon`, before the daemon's IPC accept loop. The result is held as `Option<Arc<MemoryService>>` and shared with the dashboard's HTTP handlers (and, in future PRs, the MCP server and the hook subcommands). Each resource is held inside the service: `Arc<Mutex<SqliteStore>>`, `Arc<Mutex<LexicalIndex>>`, `Arc<Embedder>`, and `TierConfig`.
+
+**Rationale:**
+- One daemon per user is already the established pattern (issue #135 merged the standalone `gc_daemon` into the session daemon for exactly this reason). Adding a second sidecar would re-introduce the multi-process orchestration problem #135 closed: bringup ordering, lockfile coordination, version skew across upgrades, and stale-pid cleanup.
+- The dashboard's HTTP server already runs in-process and already needs every resource the memory service owns. A sidecar would have to expose its own IPC for the dashboard to call back into.
+- The embedder load cost (fastembed model download + ONNX session init on first run, plus a few hundred ms warm) is one-shot per daemon lifetime. Doing it once at daemon start is cheaper than per-request and avoids the cold-start tax every hook subcommand or MCP request would otherwise pay.
+- `Arc<Embedder>` is cheap to share. The embedder type is `Send + Sync` with no internal mutex; the timer thread, every HTTP handler, and every future MCP request all read from the same `Arc` clone.
+- The consolidation timer is a thin loop that takes the SQLite + lexical mutexes for the duration of one round of `promote_candidates → apply_promotions → forget_expired`. Cross-process orchestration of that loop from a sidecar would be strictly worse — more code, more failure modes, no upside.
+- Failure of any single piece must not take the daemon down: a bad embedder env falls back to `Embedder::Disabled`; an unopenable SQLite leaves `memory_service: None`; HTTP routes return 503. The session daemon's other duties keep running.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Sidecar `clud-memory` process | Re-introduces the multi-process bringup problem #135 closed. The dashboard would need a second IPC path to call into memory; tests would need to spawn and reap a second binary. No upside that justifies the cost. |
+| Memory subsystem lazily loaded on first MCP request | Pushes the embedder cold-start onto the user's first save / search; defeats the "instantly searchable" UX the embedder choice was made to protect (see DD-015). The 100% case is "memory is enabled," so eager load wins on the common path. |
+| Memory subsystem inside the per-session worker process | Each session would have to load its own embedder and open its own SQLite handle — embeddings would be N× the disk + RAM cost, and SQLite writes from N workers would need cross-process locking. Defeats the single-writer invariant the storage layer relies on (memory.md). |
+| Tokio runtime for the timer + handlers | The daemon already uses `std::thread` everywhere (GC, dashboard); adding a runtime just to drive a 5-minute timer is the wrong tool. The future MCP server (sub-issue #259) may pull tokio in, but it can contain it inside its own thread; this PR doesn't preempt that choice. |
+
+**Consequences:**
+- Daemon startup runs the embedder load — first run pays the model download (~80 MB MiniLM ONNX); subsequent runs hit the on-disk cache. Logged but not fatal.
+- `DaemonInfo.memory_mcp_port` is reserved as `Option<u16>` so issue #259 can populate it without a wire-format break.
+- The consolidation timer holds the SQLite + lexical locks for the duration of one tick. Saves and searches are blocked for the tick's duration — typically tens of ms on a small store, bounded by `O(N)` in the worst case where the entire Working tier is being promoted in one round. Acceptable for v1; if it bites, future work can split the lock or batch the apply.
+- The reconciliation pass on startup is `O(N)` upserts plus one tantivy commit; bounded by row count and cheap on a clean daemon. Documents the cost in `crates/clud-bin/src/daemon/memory_service.rs` so future readers know the bound.
+- The HTTP `/memory/*` route bodies are stubs in this PR (#261); the real implementations land in #263. The seam is `MemoryService` references in each handler — no new IPC needs to be added when #263 lands.

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -225,16 +225,106 @@ Env-var knobs (read by `TierConfig::from_env`):
 - `CLUD_MEMORY_PROMOTE_DWELL_MS` (default 3_600_000)
 - `CLUD_MEMORY_DECAY_HALF_LIFE_MS` (default 604_800_000)
 
+## Daemon integration (issue #261)
+
+The memory subsystem runs **in-process** inside the existing `clud`
+daemon, not as a sidecar. One daemon owns the whole subsystem; the GC
+service and dashboard listener already established that pattern
+([DD-017](../DESIGN_DECISIONS.md#dd-017-memory-service-runs-in-process-inside-the-existing-clud-daemon)).
+
+`daemon::memory_service::spawn_memory_service(state_dir)` opens every
+resource the rest of the daemon needs:
+
+1. Resolve `<state_dir>/memory/{memory.db, tantivy/}` and create the
+   directories if missing.
+2. Resolve the embedder via `embedder_from_env()`. The embedder's `dim`
+   drives the SQLite vec0 column width on first open; on subsequent
+   opens a mismatch is logged as a warning and the daemon keeps going
+   (`clud memory reembed` — #262 — is the manual fix).
+3. Open `SqliteStore` (runs schema migrations to user_version 2) and
+   run `PRAGMA wal_checkpoint(TRUNCATE)` for WAL recovery on every
+   start.
+4. Open `LexicalIndex` (tantivy half-segments from a crash are dropped
+   on open).
+5. **Reconciliation pass**: walk every SQLite row by tier and re-upsert
+   it into tantivy. Bounded by row count; cheap on a clean daemon. The
+   pass self-heals the eventual-consistency window between SQLite
+   commit and tantivy commit so a daemon kill mid-write doesn't leave
+   BM25 permanently missing the row.
+6. Wrap `SqliteStore` and `LexicalIndex` in `Arc<Mutex<...>>`; wrap
+   `Embedder` in `Arc<_>` (no internal mutex — `Embedder` is
+   `Send + Sync`). Resolve `TierConfig::from_env`. Return
+   `MemoryService { store, lexical, embedder, tier_config,
+   consolidate_interval_ms }`.
+
+### Consolidation timer
+
+A named thread `clud-memory-consolidate` ticks every
+`CLUD_MEMORY_CONSOLIDATE_INTERVAL_MS` (default 300_000 = 5 min). Per
+tick:
+
+1. `promote_candidates(&store, now_ms, &cfg)`.
+2. `apply_promotions(&mut store, &mut lexical, &promotions, now_ms)`.
+3. `forget_expired(&mut store, &mut lexical, now_ms, &cfg)`.
+4. Every `CLUD_MEMORY_CHECKPOINT_EVERY_N_TICKS` ticks (default 12 = 1
+   hour at the default cadence), `store.checkpoint_truncate()` to
+   truncate the WAL.
+5. Log a structured one-liner with promoted / forgotten counts and the
+   checkpoint flag.
+
+The orchestration loop polls the shared shutdown flag at one-tenth the
+interval so cooperative shutdown wakes within seconds. The
+`run_one_consolidation_tick` helper is `pub(crate)` so tests can drive
+the lifecycle math with a deterministic `now_ms`.
+
+### Concurrency
+
+| Resource | Lock kind | Writers | Readers |
+|---|---|---|---|
+| `SqliteStore` | `Arc<Mutex<...>>` | one at a time (the timer thread + HTTP save handler) | through the same mutex; WAL still allows multi-reader inside the same process |
+| `LexicalIndex` | `Arc<Mutex<...>>` | one `IndexWriter` per process | reader is materialized inside the lock |
+| `Embedder` | `Arc<...>` | none — no internal mutex | shared across the timer + every HTTP handler |
+
+Order matters on a save: take SQLite first, commit, drop, then take
+tantivy. The reconciliation pass on next boot covers the eventual-
+consistency window if a crash happens between the two commits.
+
+### HTTP route scaffolding
+
+The dashboard's existing `tiny_http` server (issue #183) carries five
+new routes wired to the live `Arc<MemoryService>`:
+
+- `GET /memory/recent` — returns `[]` (stub for #263).
+- `GET /memory/search?q=` — returns `[]` (stub for #263).
+- `GET /memory/stats` — returns `{tier_counts, embedder_status,
+  consolidate_interval_ms}`. The embedder name is real; counts stay at
+  0 until #263.
+- `POST /memory/save` — 501 until #263.
+- `POST /memory/forget/<id>` — 501 until #263.
+
+When `MemoryService` is `None` (subsystem failed to start) every route
+returns 503 with a JSON error body. The daemon keeps serving sessions
+and GC traffic.
+
+The MCP server itself (`#259`) and the hook subcommands (`#260`) plug
+into `MemoryService` from outside; this PR just shares the four handles
+the way #135 shared the GC mpsc channel.
+
+`DaemonInfo.memory_mcp_port` is reserved as `Option<u16>` so #259 can
+populate the field without a wire-format break.
+
 ## Sibling sub-issues (META #255)
 
-- ~~Embeddings (local + remote + Windows-ARM strategy)~~ — #257 (this PR).
-- Tier lifecycle (Working / Episodic / Semantic + decay + promotion)
-- MCP server in daemon + `clud mcp` stdio bridge
-- Daemon HTTP/IPC routes for memory ops
+- ~~Embeddings (local + remote + Windows-ARM strategy)~~ — #257.
+- ~~Tier lifecycle (Working / Episodic / Semantic + decay + promotion)~~ — #258.
+- ~~Daemon integration (lifecycle, consolidation timer, HTTP route stubs)~~ — #261 (this PR).
+- MCP server in daemon + `clud mcp` stdio bridge — #259.
+- Hook subcommands — #260.
 - `clud memory search` / `save` CLI verbs (including
-  `clud memory branch-isolate`)
-- Cross-process persistence test
-- Knowledge graph (deferred past v1)
+  `clud memory branch-isolate`) — #262.
+- Dashboard JS for the `/memory/*` routes — #263.
+- Cross-process persistence test.
+- Knowledge graph (deferred past v1).
 
 Each sub-issue lands on top of the public surface this PR exposes from
 [`memory/mod.rs`](../../crates/clud-bin/src/memory/mod.rs); none of


### PR DESCRIPTION
## Summary
- Add `crates/clud-bin/src/daemon/memory_service.rs` exposing `spawn_memory_service` + `MemoryService { store, lexical, embedder, tier_config }`.
- Daemon spawn now starts the memory service alongside the GC worker; reconciliation pass on startup re-indexes any rows missing from tantivy.
- Consolidation timer ticks every 5 min (env-tunable): runs `promote_candidates` -> `apply_promotions` -> `forget_expired`; checkpoints WAL hourly.
- `Arc<Embedder>` loaded once, shared across the service.
- Stub `/memory/*` HTTP routes on the daemon's existing `tiny_http` server; bodies land in #263.
- `DaemonInfo.memory_mcp_port` field reserved for #259.

Closes #261. Part of meta #255.

## Test plan
- [x] `soldr cargo test -p clud --lib --no-default-features daemon::memory_service::` -- green (6 tests).
- [x] `soldr cargo test -p clud --lib --no-default-features daemon::` -- green (96 daemon tests including 2 new HTTP route tests).
- [x] Full lib test suite -- 813 passed, 0 failed.
- [x] `soldr cargo fmt --all --check`, `soldr cargo clippy --workspace --all-targets -- -D warnings`, `python -m ruff check src tests ci`, `python ci/banned_imports.py` -- all clean.
- [x] `soldr cargo build -p clud --no-default-features` -- clean (Windows-ARM compatibility).
- [ ] `soldr cargo build -p clud --features memory_local_embed` -- known `ort` MSVC link issue on this host (pre-existing, also affects `bash lint` wheel build). CI is authority.
- [ ] CI green on all 6 platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)