### PR TITLE
feat(memory): MCP server in daemon + clud mcp stdio bridge (#259)

### DIFF
--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -154,6 +154,8 @@ Quick lookup, which file owns a given subcommand:
   `daemon/gc_service.rs` (registry owner inside the always-on `__daemon`).
 - `clud --clean-worktrees` -> `worktrees.rs`.
 - `clud --fix-hooks` -> `hook_health.rs`.
+- `clud mcp` -> `mcp_bridge.rs` (stdio↔TCP proxy) -> `daemon/memory_mcp.rs`
+  (in-process MCP server, issue #259).
 
 ## Cross-Cutting Subsystems
 

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -230,6 +230,11 @@ pub enum Command {
         #[arg(long = "no-open")]
         no_open: bool,
     },
+    /// Issue #259: MCP stdio bridge for Claude Code / Codex. Forwards
+    /// JSON-RPC frames between stdio and the in-daemon memory MCP
+    /// server's loopback TCP port. Transparently brings up the daemon if
+    /// it isn't running.
+    Mcp,
     /// Quarantine paths under ~/.clud/trash and let daemon GC reap them.
     Trash {
         /// Allow copy + best-effort source removal when source and trash
@@ -372,7 +377,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
-        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "ui",
+        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "ui", "mcp",
         "trash", "daemon", "__daemon", "__worker",
     ];
 

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -137,6 +137,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         | Some(Command::Logs { .. })
         | Some(Command::Gc { .. })
         | Some(Command::Ui { .. })
+        | Some(Command::Mcp)
         | Some(Command::Trash { .. })
         | Some(Command::Daemon { .. })
         | Some(Command::InternalDaemon { .. })

--- a/crates/clud-bin/src/daemon/README.md
+++ b/crates/clud-bin/src/daemon/README.md
@@ -19,6 +19,7 @@ Internal helper subcommands `__daemon` and `__worker` re-enter the same binary i
 - `server.rs` — daemon-process entry: binds the loopback listener, spawns the GC registry worker, accepts `Create`/`Session`/`Terminate`/`Gc` requests, spawns worker subprocesses, reaps them.
 - `gc_service.rs` — single-owner registry worker thread (issue #135): opens `~/.clud/data.redb` once, serializes every `gc.*` op through an `mpsc::Receiver<GcRequestMsg>`. Replaces the standalone `gc_daemon` process that shipped in Phase 1.
 - `memory_service.rs` — agent-memory service running in-process (issue #261). Owns `Arc<Mutex<SqliteStore>>`, `Arc<Mutex<LexicalIndex>>`, `Arc<Embedder>`, and `TierConfig`. Runs a consolidation timer thread (`promote_candidates` → `apply_promotions` → `forget_expired` every 5 min, env-tunable) and an hourly `PRAGMA wal_checkpoint(TRUNCATE)`. Reconciliation pass on startup re-upserts every SQLite row into tantivy so a crash between SQLite commit and tantivy commit self-heals on next boot. Loaded by `server::run_daemon` alongside the GC service and the dashboard.
+- `memory_mcp.rs` — in-daemon MCP server (issue #259). Binds an ephemeral loopback TCP port, exposes the 8 ESSENTIAL_TOOLS as line-delimited JSON-RPC 2.0. Pure `std::net` + one accept thread + per-connection thread. The bound port is written into `DaemonInfo.memory_mcp_port` for the `clud mcp` bridge to discover. See [DD-018](../../../../docs/DESIGN_DECISIONS.md#dd-018-mcp-server-embedded-in-clud-daemon-vs-sidecar-binary).
 - `worker.rs` — worker-process entry: starts the backend (subprocess or PTY), serves attach connections, runs the repeat-job loop.
 - `worker_shared.rs` — per-worker shared state: snapshot, in-memory backlog, optional `TerminalCapture` for PTY attach-replay, log file rotation, single-client attach gate.
 - `attach.rs` — interactive client-side attach loop: handshake, raw-terminal keyboard forwarding, Ctrl-C → background-prompt flow, exit-code propagation.
@@ -48,6 +49,9 @@ Internal helper subcommands `__daemon` and `__worker` re-enter the same binary i
 - `fn run_daemon(&Path) -> i32` — `server.rs:23`
 - `pub fn spawn_memory_service(&Path) -> Result<MemoryService, MemoryError>` — `memory_service.rs:114`
 - `pub struct MemoryService { store, lexical, embedder, tier_config, consolidate_interval_ms }` — `memory_service.rs:52`
+- `pub fn spawn_mcp_server(Arc<MemoryService>) -> Result<McpServer, MemoryError>` — `memory_mcp.rs`
+- `pub struct McpServer { pub port: u16, shutdown }` — `memory_mcp.rs`
+- `pub fn read_memory_mcp_port(&Path) -> io::Result<Option<u16>>` — `mod.rs` (re-export for the `clud mcp` bridge)
 - `fn run_worker(&Path, &str, u32, &Path) -> i32` — `worker.rs:28`
 - `fn ensure_daemon(&Path) -> io::Result<()>` — `client.rs:18`
 - `fn send_daemon_request(&Path, &DaemonRequest)` — `client.rs:51`

--- a/crates/clud-bin/src/daemon/memory_mcp.rs
+++ b/crates/clud-bin/src/daemon/memory_mcp.rs
@@ -1,0 +1,1101 @@
+//! Issue #259: agent-memory MCP server, embedded in the clud daemon.
+//!
+//! Exposes the 8 ESSENTIAL_TOOLS (`memory_save`, `memory_recall`,
+//! `memory_smart_search`, `memory_sessions`, `memory_consolidate`,
+//! `memory_diagnose`, `memory_lesson_save`, `memory_reflect`) over
+//! line-delimited JSON-RPC 2.0 on a loopback TCP port. The `clud mcp`
+//! subcommand bridges Claude Code / Codex stdio to this listener so MCP
+//! clients can save and recall memories across sessions.
+//!
+//! Protocol: each TCP connection is a JSON-RPC 2.0 channel. Requests and
+//! responses are NDJSON (one JSON object per line). Supported methods:
+//! `initialize`, `tools/list`, `tools/call`. Tool results return the
+//! `{ content: [{type: "text", text: "<json-string>"}] }` shape mandated
+//! by the MCP spec.
+//!
+//! Concurrency: one `std::thread` per connection (matches the rest of the
+//! daemon's std::thread model — see DD-017 and DD-018). The
+//! `Arc<MemoryService>` is cheap to clone; per-resource access is gated
+//! by its existing `Mutex`es.
+//!
+//! Out of scope here: auto-registration of `~/.claude.json` /
+//! `~/.codex/config.toml` (#265). Dashboard JS (#263). PreToolUse hook
+//! capture path (#260).
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+#[cfg(test)]
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::memory::embedder::EmbedderTrait;
+use crate::memory::ids::MemoryId;
+use crate::memory::store::{MemoryRow, Tier};
+use crate::memory::{rrf_fuse, HybridSearchConfig, MemoryError};
+
+use super::memory_service::{run_one_consolidation_tick, MemoryService};
+
+/// JSON-RPC 2.0 error codes — match the values agentmemory ships with.
+const JSONRPC_PARSE_ERROR: i64 = -32700;
+const JSONRPC_INVALID_REQUEST: i64 = -32600;
+const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
+const JSONRPC_INVALID_PARAMS: i64 = -32602;
+const JSONRPC_INTERNAL_ERROR: i64 = -32603;
+/// Spec-mentioned "daemon unavailable" code used by the bridge when
+/// `DaemonInfo.memory_mcp_port` is `None`.
+pub const JSONRPC_DAEMON_UNAVAILABLE: i64 = -32099;
+
+/// MCP protocol version we advertise. Matches the version Claude Code's
+/// MCP host currently uses for negotiation.
+const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// Public handle returned by [`spawn_mcp_server`]. The port is what gets
+/// written into `DaemonInfo.memory_mcp_port`.
+pub struct McpServer {
+    pub port: u16,
+    /// Set to `true` to ask the accept loop to exit between connections.
+    /// Tests use this for clean shutdown; production daemons just exit
+    /// the process (the OS reclaims the listener).
+    shutdown: Arc<AtomicBool>,
+}
+
+#[allow(dead_code)]
+impl McpServer {
+    pub fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+}
+
+/// Spawn the MCP server on an ephemeral loopback TCP port. The accept
+/// loop runs on a single `std::thread`; each accepted connection spawns
+/// its own per-connection thread. Returns the bound port (or a
+/// `MemoryError::Io` if the bind itself failed).
+pub fn spawn_mcp_server(memory: Arc<MemoryService>) -> Result<McpServer, MemoryError> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    listener.set_nonblocking(true)?;
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_for_thread = Arc::clone(&shutdown);
+
+    thread::Builder::new()
+        .name("clud-memory-mcp".to_string())
+        .spawn(move || accept_loop(listener, memory, shutdown_for_thread))
+        .map_err(|err| {
+            MemoryError::Io(std::io::Error::other(format!(
+                "memory mcp accept loop spawn failed: {err}"
+            )))
+        })?;
+
+    Ok(McpServer { port, shutdown })
+}
+
+fn accept_loop(listener: TcpListener, memory: Arc<MemoryService>, shutdown: Arc<AtomicBool>) {
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            break;
+        }
+        match listener.accept() {
+            Ok((stream, _addr)) => {
+                let memory = Arc::clone(&memory);
+                let _ = thread::Builder::new()
+                    .name("clud-memory-mcp-conn".to_string())
+                    .spawn(move || {
+                        if let Err(err) = handle_connection(stream, memory) {
+                            eprintln!("[clud] memory mcp connection error: {err}");
+                        }
+                    });
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(err) => {
+                eprintln!("[clud] memory mcp accept failed: {err}");
+                thread::sleep(std::time::Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+fn handle_connection(
+    stream: std::net::TcpStream,
+    memory: Arc<MemoryService>,
+) -> std::io::Result<()> {
+    let read_stream = stream.try_clone()?;
+    let mut reader = BufReader::new(read_stream);
+    let mut writer = stream;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            return Ok(());
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let response = process_request_line(trimmed, &memory);
+        if let Some(resp) = response {
+            let mut out = serde_json::to_vec(&resp)?;
+            out.push(b'\n');
+            writer.write_all(&out)?;
+            writer.flush()?;
+        }
+    }
+}
+
+/// Parse one NDJSON request line and produce one NDJSON response value
+/// (or `None` for notifications which intentionally have no response).
+fn process_request_line(line: &str, memory: &Arc<MemoryService>) -> Option<Value> {
+    let request: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(err) => {
+            return Some(json_error(
+                Value::Null,
+                JSONRPC_PARSE_ERROR,
+                format!("parse error: {err}"),
+            ));
+        }
+    };
+    let id = request.get("id").cloned().unwrap_or(Value::Null);
+    let is_notification = request.get("id").is_none();
+
+    let method = match request.get("method").and_then(|v| v.as_str()) {
+        Some(m) => m.to_string(),
+        None => {
+            if is_notification {
+                return None;
+            }
+            return Some(json_error(
+                id,
+                JSONRPC_INVALID_REQUEST,
+                "missing method".to_string(),
+            ));
+        }
+    };
+    let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
+
+    let result = dispatch_method(&method, params, memory);
+    if is_notification {
+        return None;
+    }
+    Some(match result {
+        Ok(value) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": value,
+        }),
+        Err(McpError { code, message }) => json_error(id, code, message),
+    })
+}
+
+fn json_error(id: Value, code: i64, message: String) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message },
+    })
+}
+
+#[derive(Debug)]
+struct McpError {
+    code: i64,
+    message: String,
+}
+
+impl McpError {
+    fn invalid_params(msg: impl Into<String>) -> Self {
+        Self {
+            code: JSONRPC_INVALID_PARAMS,
+            message: msg.into(),
+        }
+    }
+
+    fn internal(msg: impl Into<String>) -> Self {
+        Self {
+            code: JSONRPC_INTERNAL_ERROR,
+            message: msg.into(),
+        }
+    }
+}
+
+impl From<MemoryError> for McpError {
+    fn from(err: MemoryError) -> Self {
+        Self::internal(format!("memory error: {err}"))
+    }
+}
+
+fn dispatch_method(
+    method: &str,
+    params: Value,
+    memory: &Arc<MemoryService>,
+) -> Result<Value, McpError> {
+    match method {
+        "initialize" => Ok(initialize_response()),
+        "tools/list" => Ok(tools_list_response()),
+        "tools/call" => dispatch_tool_call(params, memory),
+        // Notifications (no `id`) are handled upstream; unknown
+        // request methods come through here.
+        _ => Err(McpError {
+            code: JSONRPC_METHOD_NOT_FOUND,
+            message: format!("unknown method: {method}"),
+        }),
+    }
+}
+
+fn initialize_response() -> Value {
+    json!({
+        "protocolVersion": MCP_PROTOCOL_VERSION,
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": "clud-memory",
+            "version": env!("CARGO_PKG_VERSION"),
+        }
+    })
+}
+
+fn tools_list_response() -> Value {
+    json!({ "tools": tool_descriptors() })
+}
+
+fn dispatch_tool_call(params: Value, memory: &Arc<MemoryService>) -> Result<Value, McpError> {
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| McpError::invalid_params("missing tool name"))?
+        .to_string();
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let body = match name.as_str() {
+        "memory_save" => tool_memory_save(arguments, memory)?,
+        "memory_recall" => tool_memory_recall(arguments, memory)?,
+        "memory_smart_search" => tool_memory_smart_search(arguments, memory)?,
+        "memory_sessions" => tool_memory_sessions(memory)?,
+        "memory_consolidate" => tool_memory_consolidate(memory)?,
+        "memory_diagnose" => tool_memory_diagnose(memory)?,
+        "memory_lesson_save" => tool_memory_lesson_save(arguments, memory)?,
+        "memory_reflect" => tool_memory_reflect()?,
+        other => {
+            return Err(McpError::invalid_params(format!("unknown tool: {other}")));
+        }
+    };
+    let text = serde_json::to_string(&body)
+        .map_err(|err| McpError::internal(format!("tool result serialization: {err}")))?;
+    Ok(json!({
+        "content": [{ "type": "text", "text": text }]
+    }))
+}
+
+// ------------------------------------------------------------------
+// Tool descriptors — 1:1 with agentmemory's ESSENTIAL_TOOLS schemas.
+// ------------------------------------------------------------------
+
+fn tool_descriptors() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "memory_save",
+            "description": "Explicitly save an important insight, decision, or pattern to long-term memory.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["content"],
+                "properties": {
+                    "content": { "type": "string" },
+                    "tier": { "type": "string", "enum": ["working", "episodic", "semantic"] },
+                    "session_id": { "type": ["string", "null"] },
+                    "metadata": { "type": ["object", "null"] }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "memory_recall",
+            "description": "Fetch a single memory row by id.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": { "type": "string" }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "memory_smart_search",
+            "description": "Hybrid RRF search over BM25 (tantivy) + vector (sqlite-vec).",
+            "inputSchema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {
+                    "query": { "type": "string" },
+                    "k": { "type": "integer", "minimum": 1, "maximum": 100 },
+                    "session_id": { "type": ["string", "null"] },
+                    "tier_floor": { "type": ["string", "null"], "enum": ["working", "episodic", "semantic", null] },
+                    "scope_key": { "type": ["string", "null"] }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "memory_sessions",
+            "description": "List distinct session_ids found in the memory store.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "memory_consolidate",
+            "description": "Run the tier consolidation pipeline once and report the counts.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "memory_diagnose",
+            "description": "Report basic memory subsystem health (embedder, db path, dim, row count, schema version).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "memory_lesson_save",
+            "description": "Save a lesson learned from this session. Optionally link to a memory row.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["content"],
+                "properties": {
+                    "content": { "type": "string" },
+                    "summary": { "type": ["string", "null"] },
+                    "memory_id": { "type": ["string", "null"] }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "memory_reflect",
+            "description": "Knowledge-graph reflection — documented stub in v0.1; lands fully in v0.5.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }
+        }),
+    ]
+}
+
+// ------------------------------------------------------------------
+// Tool handlers.
+// ------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct SaveArgs {
+    content: String,
+    #[serde(default)]
+    tier: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    metadata: Option<Value>,
+}
+
+fn parse_tier(s: &str) -> Result<Tier, McpError> {
+    match s.to_ascii_lowercase().as_str() {
+        "working" => Ok(Tier::Working),
+        "episodic" => Ok(Tier::Episodic),
+        "semantic" => Ok(Tier::Semantic),
+        other => Err(McpError::invalid_params(format!(
+            "invalid tier `{other}`: expected one of working|episodic|semantic"
+        ))),
+    }
+}
+
+fn tool_memory_save(args: Value, memory: &Arc<MemoryService>) -> Result<Value, McpError> {
+    let parsed: SaveArgs = serde_json::from_value(args)
+        .map_err(|err| McpError::invalid_params(format!("invalid arguments: {err}")))?;
+    if parsed.content.trim().is_empty() {
+        return Err(McpError::invalid_params("content is required"));
+    }
+    let tier = match parsed.tier.as_deref() {
+        Some(t) => parse_tier(t)?,
+        None => Tier::Working,
+    };
+    let metadata_json = parsed
+        .metadata
+        .as_ref()
+        .map(|m| {
+            serde_json::to_string(m)
+                .map_err(|err| McpError::internal(format!("metadata serialize: {err}")))
+        })
+        .transpose()?;
+    let now_ms = unix_millis_now();
+    let id = MemoryId::new_v7();
+    let row = MemoryRow {
+        id: id.clone(),
+        session_id: parsed.session_id.clone(),
+        tier,
+        content: parsed.content.clone(),
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+        tier_change_at_ms: now_ms,
+        access_count: 0,
+        last_access_at_ms: now_ms,
+        metadata_json,
+        scope_key: None,
+        branch_name: None,
+        is_orphan: false,
+    };
+
+    let vec = match memory.embedder.embed(&parsed.content) {
+        Ok(v) => v,
+        Err(MemoryError::EmbedderDisabled(_)) => {
+            // Embedder disabled: write a zero vector of the stored dim so
+            // the lexical index still picks the row up. KNN won't surface
+            // it usefully, but smart_search's BM25 leg will.
+            let dim = {
+                let s = memory
+                    .store
+                    .lock()
+                    .map_err(|_| McpError::internal("memory store mutex poisoned"))?;
+                s.embed_dim()
+            };
+            vec![0.0_f32; dim]
+        }
+        Err(err) => return Err(McpError::from(err)),
+    };
+
+    {
+        let mut s = memory
+            .store
+            .lock()
+            .map_err(|_| McpError::internal("memory store mutex poisoned"))?;
+        s.insert(&row, &vec)?;
+    }
+    {
+        let mut l = memory
+            .lexical
+            .lock()
+            .map_err(|_| McpError::internal("memory lexical mutex poisoned"))?;
+        l.upsert(
+            &row.id,
+            row.session_id.as_deref(),
+            row.scope_key.as_deref(),
+            row.tier,
+            &row.content,
+        )?;
+        l.commit()?;
+    }
+    Ok(json!({ "id": id.as_str() }))
+}
+
+#[derive(Debug, Deserialize)]
+struct RecallArgs {
+    id: String,
+}
+
+fn tool_memory_recall(args: Value, memory: &Arc<MemoryService>) -> Result<Value, McpError> {
+    let parsed: RecallArgs = serde_json::from_value(args)
+        .map_err(|err| McpError::invalid_params(format!("invalid arguments: {err}")))?;
+    let id = MemoryId::parse(&parsed.id)
+        .map_err(|err| McpError::invalid_params(format!("invalid id: {err}")))?;
+    let row = {
+        let s = memory
+            .store
+            .lock()
+            .map_err(|_| McpError::internal("memory store mutex poisoned"))?;
+        s.fetch(&id)?
+    };
+    match row {
+        Some(r) => Ok(memory_row_to_json(&r)),
+        None => Err(McpError {
+            code: JSONRPC_INVALID_PARAMS,
+            message: format!("memory `{}` not found", parsed.id),
+        }),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchArgs {
+    query: String,
+    #[serde(default)]
+    k: Option<usize>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    tier_floor: Option<String>,
+    #[serde(default)]
+    scope_key: Option<String>,
+}
+
+fn tool_memory_smart_search(args: Value, memory: &Arc<MemoryService>) -> Result<Value, McpError> {
+    let parsed: SearchArgs = serde_json::from_value(args)
+        .map_err(|err| McpError::invalid_params(format!("invalid arguments: {err}")))?;
+    if parsed.query.trim().is_empty() {
+        return Err(McpError::invalid_params("query is required"));
+    }
+    let k = parsed.k.unwrap_or(10).clamp(1, 100);
+    let tier_floor = parsed.tier_floor.as_deref().map(parse_tier).transpose()?;
+
+    let bm25_hits = {
+        let l = memory
+            .lexical
+            .lock()
+            .map_err(|_| McpError::internal("memory lexical mutex poisoned"))?;
+        // Tantivy's QueryParser can choke on punctuation-heavy inputs; if
+        // the parse fails, treat as zero BM25 hits rather than aborting
+        // the whole search.
+        l.search(
+            &parsed.query,
+            k,
+            parsed.session_id.as_deref(),
+            tier_floor,
+            parsed.scope_key.as_deref(),
+        )
+        .unwrap_or_default()
+    };
+
+    let vec_hits = match memory.embedder.embed(&parsed.query) {
+        Ok(v) => {
+            let s = memory
+                .store
+                .lock()
+                .map_err(|_| McpError::internal("memory store mutex poisoned"))?;
+            // Dim drift between the embedder and the stored vec0 column
+            // is a soft error here — fall back to lexical-only ranking.
+            if v.len() == s.embed_dim() {
+                s.knn(
+                    &v,
+                    k,
+                    parsed.session_id.as_deref(),
+                    tier_floor,
+                    parsed.scope_key.as_deref(),
+                )
+                .unwrap_or_default()
+            } else {
+                Vec::new()
+            }
+        }
+        Err(_) => Vec::new(),
+    };
+
+    let fused = rrf_fuse(&bm25_hits, &vec_hits, &HybridSearchConfig::from_env());
+
+    let ids: Vec<MemoryId> = fused.iter().take(k).map(|h| h.id.clone()).collect();
+    let rows = {
+        let s = memory
+            .store
+            .lock()
+            .map_err(|_| McpError::internal("memory store mutex poisoned"))?;
+        s.fetch_many(&ids)?
+    };
+
+    let results: Vec<Value> = rows.iter().map(memory_row_to_json).collect();
+    Ok(json!({
+        "results": results,
+        "total": results.len(),
+    }))
+}
+
+fn tool_memory_sessions(memory: &Arc<MemoryService>) -> Result<Value, McpError> {
+    let s = memory
+        .store
+        .lock()
+        .map_err(|_| McpError::internal("memory store mutex poisoned"))?;
+    let conn = s.conn_ref();
+    let mut stmt = conn
+        .prepare(
+            "SELECT DISTINCT session_id FROM memories \
+             WHERE session_id IS NOT NULL ORDER BY session_id",
+        )
+        .map_err(|err| McpError::internal(format!("prepare: {err}")))?;
+    let rows: Vec<String> = stmt
+        .query_map([], |r| r.get::<_, String>(0))
+        .map_err(|err| McpError::internal(format!("query: {err}")))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(json!({ "sessions": rows }))
+}
+
+fn tool_memory_consolidate(memory: &Arc<MemoryService>) -> Result<Value, McpError> {
+    let now_ms = unix_millis_now();
+    let report =
+        run_one_consolidation_tick(&memory.store, &memory.lexical, &memory.tier_config, now_ms)?;
+    Ok(json!({
+        "promoted": report.promoted,
+        "forgotten": report.forgotten,
+    }))
+}
+
+fn tool_memory_diagnose(memory: &Arc<MemoryService>) -> Result<Value, McpError> {
+    let embed_dim = <crate::memory::Embedder as EmbedderTrait>::dim(memory.embedder.as_ref());
+    let embedder_name =
+        <crate::memory::Embedder as EmbedderTrait>::name(memory.embedder.as_ref()).to_string();
+    let s = memory
+        .store
+        .lock()
+        .map_err(|_| McpError::internal("memory store mutex poisoned"))?;
+    let stored_dim = s.embed_dim();
+    let conn = s.conn_ref();
+    let row_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .unwrap_or(0);
+    let schema_user_version: i64 = conn
+        .query_row("PRAGMA user_version", [], |r| r.get(0))
+        .unwrap_or(0);
+    Ok(json!({
+        "embedder": embedder_name,
+        "embed_dim": embed_dim,
+        "stored_embed_dim": stored_dim,
+        "row_count": row_count,
+        "schema_user_version": schema_user_version,
+        "notes": "v0.1 diagnose surface — extended subsystem checks land later",
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct LessonSaveArgs {
+    content: String,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    memory_id: Option<String>,
+}
+
+fn tool_memory_lesson_save(args: Value, memory: &Arc<MemoryService>) -> Result<Value, McpError> {
+    let parsed: LessonSaveArgs = serde_json::from_value(args)
+        .map_err(|err| McpError::invalid_params(format!("invalid arguments: {err}")))?;
+    if parsed.content.trim().is_empty() {
+        return Err(McpError::invalid_params("content is required"));
+    }
+    let id = MemoryId::new_v7();
+    let now_ms = unix_millis_now();
+    let summary = parsed.summary.unwrap_or_else(|| parsed.content.clone());
+    let s = memory
+        .store
+        .lock()
+        .map_err(|_| McpError::internal("memory store mutex poisoned"))?;
+    s.conn_ref()
+        .execute(
+            "INSERT INTO lessons(id, memory_id, summary, created_at_ms, metadata_json) \
+             VALUES (?1, ?2, ?3, ?4, NULL)",
+            rusqlite::params![id.as_str(), parsed.memory_id, summary, now_ms as i64],
+        )
+        .map_err(|err| McpError::internal(format!("insert lesson: {err}")))?;
+    Ok(json!({ "id": id.as_str() }))
+}
+
+fn tool_memory_reflect() -> Result<Value, McpError> {
+    // Spec calls this out as a documented stub in v0.1; the full
+    // implementation lands in v0.5 (knowledge-graph + LLM provider).
+    Err(McpError {
+        code: JSONRPC_INTERNAL_ERROR,
+        message: "memory_reflect is not yet implemented (lands in v0.5)".to_string(),
+    })
+}
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+fn memory_row_to_json(row: &MemoryRow) -> Value {
+    json!({
+        "id": row.id.as_str(),
+        "session_id": row.session_id,
+        "tier": tier_label(row.tier),
+        "content": row.content,
+        "created_at_ms": row.created_at_ms,
+        "updated_at_ms": row.updated_at_ms,
+        "tier_change_at_ms": row.tier_change_at_ms,
+        "access_count": row.access_count,
+        "last_access_at_ms": row.last_access_at_ms,
+        "metadata_json": row.metadata_json,
+        "scope_key": row.scope_key,
+        "branch_name": row.branch_name,
+        "is_orphan": row.is_orphan,
+    })
+}
+
+fn tier_label(t: Tier) -> &'static str {
+    match t {
+        Tier::Working => "working",
+        Tier::Episodic => "episodic",
+        Tier::Semantic => "semantic",
+    }
+}
+
+fn unix_millis_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+// ------------------------------------------------------------------
+// Wire-level helpers used by the bridge + tests
+// ------------------------------------------------------------------
+
+/// A minimal JSON-RPC 2.0 request struct used by the in-process tests.
+#[cfg(test)]
+#[derive(Debug, Serialize)]
+pub(crate) struct JsonRpcRequest<'a> {
+    pub jsonrpc: &'static str,
+    pub id: u64,
+    pub method: &'a str,
+    pub params: Value,
+}
+
+#[cfg(test)]
+impl<'a> JsonRpcRequest<'a> {
+    pub fn new(id: u64, method: &'a str, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            method,
+            params,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::memory_service::spawn_memory_service;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    struct EnvGuard {
+        keys: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn clear(keys: &[&'static str]) -> Self {
+            let saved: Vec<(&'static str, Option<String>)> =
+                keys.iter().map(|k| (*k, std::env::var(*k).ok())).collect();
+            for k in keys {
+                unsafe {
+                    std::env::remove_var(k);
+                }
+            }
+            Self { keys: saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.keys {
+                match v {
+                    Some(val) => unsafe { std::env::set_var(k, val) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+            }
+        }
+    }
+
+    fn disabled_embedder_guard() -> EnvGuard {
+        let g = EnvGuard::clear(&[
+            crate::memory::embedder::ENV_EMBEDDER_KIND,
+            crate::memory::embedder::ENV_EMBEDDER_PROVIDER,
+            crate::memory::embedder::ENV_EMBEDDER_URL,
+            crate::memory::embedder::ENV_EMBEDDER_API_KEY,
+            crate::memory::embedder::ENV_EMBEDDER_MODEL,
+        ]);
+        unsafe {
+            std::env::set_var(crate::memory::embedder::ENV_EMBEDDER_KIND, "disabled");
+        }
+        g
+    }
+
+    fn spawn_service_and_server() -> (tempfile::TempDir, Arc<MemoryService>, McpServer) {
+        let _g = disabled_embedder_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = Arc::new(spawn_memory_service(tmp.path()).unwrap());
+        let server = spawn_mcp_server(Arc::clone(&svc)).unwrap();
+        // give the accept loop a beat to enter `listener.accept`.
+        std::thread::sleep(Duration::from_millis(20));
+        (tmp, svc, server)
+    }
+
+    fn send_request(port: u16, req: &Value) -> Value {
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let line = format!("{}\n", req);
+        stream.write_all(line.as_bytes()).unwrap();
+        stream.flush().unwrap();
+        let mut reader = BufReader::new(stream);
+        let mut buf = String::new();
+        reader.read_line(&mut buf).unwrap();
+        serde_json::from_str(&buf).unwrap()
+    }
+
+    fn call_tool(port: u16, id: u64, name: &str, arguments: Value) -> Value {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": { "name": name, "arguments": arguments },
+        });
+        send_request(port, &req)
+    }
+
+    /// Acceptance #1: `spawn_mcp_server` binds a real loopback port.
+    #[test]
+    fn spawn_mcp_server_binds_loopback_port() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        assert!(server.port > 0);
+        // Connect with no payload — must not hang.
+        let stream = TcpStream::connect(("127.0.0.1", server.port)).unwrap();
+        drop(stream);
+        server.shutdown();
+    }
+
+    /// `tools/list` returns the 8 ESSENTIAL_TOOLS.
+    #[test]
+    fn tools_list_returns_eight_tools() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let resp = send_request(
+            server.port,
+            &json!({"jsonrpc":"2.0","id":1,"method":"tools/list"}),
+        );
+        let tools = resp["result"]["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 8, "got {:?}", tools);
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        for required in [
+            "memory_save",
+            "memory_recall",
+            "memory_smart_search",
+            "memory_sessions",
+            "memory_consolidate",
+            "memory_diagnose",
+            "memory_lesson_save",
+            "memory_reflect",
+        ] {
+            assert!(names.contains(&required), "missing {required}: {names:?}");
+        }
+        server.shutdown();
+    }
+
+    /// `memory_save` returns a uuidv7-shaped id.
+    #[test]
+    fn memory_save_returns_uuidv7_id() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let resp = call_tool(
+            server.port,
+            1,
+            "memory_save",
+            json!({ "content": "hello world" }),
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let body: Value = serde_json::from_str(text).unwrap();
+        let id = body["id"].as_str().unwrap().to_string();
+        let parsed = MemoryId::parse(&id).expect("uuid parse");
+        // round-tripping via parse keeps it canonical, but we also want
+        // to assert v7-ness directly.
+        let uuid_parsed = uuid::Uuid::parse_str(parsed.as_str()).unwrap();
+        assert_eq!(uuid_parsed.get_version_num(), 7);
+        server.shutdown();
+    }
+
+    /// `memory_recall` returns the saved content for a known id.
+    #[test]
+    fn memory_recall_returns_saved_content() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let saved = call_tool(
+            server.port,
+            1,
+            "memory_save",
+            json!({ "content": "bcrypt is fine; argon2id is better" }),
+        );
+        let saved_text = saved["result"]["content"][0]["text"].as_str().unwrap();
+        let saved_body: Value = serde_json::from_str(saved_text).unwrap();
+        let id = saved_body["id"].as_str().unwrap().to_string();
+        let recalled = call_tool(server.port, 2, "memory_recall", json!({ "id": id }));
+        let body_text = recalled["result"]["content"][0]["text"].as_str().unwrap();
+        let body: Value = serde_json::from_str(body_text).unwrap();
+        assert_eq!(body["id"], id);
+        assert_eq!(body["content"], "bcrypt is fine; argon2id is better");
+        server.shutdown();
+    }
+
+    /// `memory_smart_search` ranks the matching row first.
+    #[test]
+    fn memory_smart_search_returns_relevant_hit() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        call_tool(
+            server.port,
+            1,
+            "memory_save",
+            json!({ "content": "Use bcrypt for password hashing" }),
+        );
+        call_tool(
+            server.port,
+            2,
+            "memory_save",
+            json!({ "content": "Cats love sunny windowsills" }),
+        );
+        let resp = call_tool(
+            server.port,
+            3,
+            "memory_smart_search",
+            json!({ "query": "bcrypt" }),
+        );
+        let body_text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let body: Value = serde_json::from_str(body_text).unwrap();
+        let results = body["results"].as_array().expect("results");
+        assert!(!results.is_empty(), "expected at least one hit");
+        let top = results[0]["content"].as_str().unwrap();
+        assert!(
+            top.contains("bcrypt"),
+            "top hit should be the bcrypt row, got: {top}"
+        );
+        server.shutdown();
+    }
+
+    /// `memory_sessions` returns the distinct session ids we've stored.
+    #[test]
+    fn memory_sessions_returns_distinct_session_ids() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        call_tool(
+            server.port,
+            1,
+            "memory_save",
+            json!({ "content": "a", "session_id": "sess-A" }),
+        );
+        call_tool(
+            server.port,
+            2,
+            "memory_save",
+            json!({ "content": "b", "session_id": "sess-B" }),
+        );
+        call_tool(
+            server.port,
+            3,
+            "memory_save",
+            json!({ "content": "a2", "session_id": "sess-A" }),
+        );
+        let resp = call_tool(server.port, 4, "memory_sessions", json!({}));
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let body: Value = serde_json::from_str(text).unwrap();
+        let mut sessions: Vec<String> = body["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        sessions.sort();
+        assert_eq!(sessions, vec!["sess-A".to_string(), "sess-B".to_string()]);
+        server.shutdown();
+    }
+
+    /// `memory_diagnose` returns the basics: embedder name, dim, row count,
+    /// schema user_version.
+    #[test]
+    fn memory_diagnose_returns_basics() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let resp = call_tool(server.port, 1, "memory_diagnose", json!({}));
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let body: Value = serde_json::from_str(text).unwrap();
+        assert!(body["embedder"].is_string());
+        assert!(body["embed_dim"].is_number());
+        assert!(body["row_count"].is_number());
+        assert!(body["schema_user_version"].is_number());
+        server.shutdown();
+    }
+
+    /// `memory_reflect` is a documented stub in v0.1.
+    #[test]
+    fn memory_reflect_returns_unimplemented_error() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let resp = call_tool(server.port, 1, "memory_reflect", json!({}));
+        let err = resp["error"].as_object().expect("error reply");
+        let msg = err["message"].as_str().unwrap();
+        assert!(
+            msg.contains("v0.5") || msg.to_lowercase().contains("not yet"),
+            "expected v0.5/not-yet stub message, got: {msg}"
+        );
+        server.shutdown();
+    }
+
+    /// `memory_lesson_save` writes into the lessons table and returns an id.
+    #[test]
+    fn memory_lesson_save_returns_id() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let resp = call_tool(
+            server.port,
+            1,
+            "memory_lesson_save",
+            json!({ "content": "Don't unwrap on user input." }),
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let body: Value = serde_json::from_str(text).unwrap();
+        let id = body["id"].as_str().unwrap();
+        assert!(uuid::Uuid::parse_str(id).is_ok());
+        server.shutdown();
+    }
+
+    /// Invalid params should produce a JSON-RPC error response.
+    #[test]
+    fn memory_save_rejects_missing_content() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let resp = call_tool(server.port, 1, "memory_save", json!({}));
+        let err = resp["error"].as_object().expect("error reply");
+        assert_eq!(err["code"].as_i64().unwrap(), JSONRPC_INVALID_PARAMS);
+        server.shutdown();
+    }
+
+    /// Parse errors propagate as JSON-RPC -32700.
+    #[test]
+    fn malformed_request_returns_parse_error() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let mut stream = TcpStream::connect(("127.0.0.1", server.port)).unwrap();
+        stream.write_all(b"not-json-at-all\n").unwrap();
+        stream.flush().unwrap();
+        let mut reader = BufReader::new(stream);
+        let mut buf = String::new();
+        reader.read_line(&mut buf).unwrap();
+        let resp: Value = serde_json::from_str(&buf).unwrap();
+        assert_eq!(resp["error"]["code"].as_i64().unwrap(), JSONRPC_PARSE_ERROR);
+        server.shutdown();
+    }
+
+    /// JsonRpcRequest helper roundtrips its shape unchanged.
+    #[test]
+    fn jsonrpc_request_roundtrips() {
+        let req = JsonRpcRequest::new(7, "tools/list", json!({}));
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains(r#""jsonrpc":"2.0""#));
+        assert!(s.contains(r#""id":7"#));
+        assert!(s.contains(r#""method":"tools/list""#));
+    }
+
+    /// `initialize` returns the MCP protocol shape Claude Code expects.
+    #[test]
+    fn initialize_returns_capabilities() {
+        let (_tmp, _svc, server) = spawn_service_and_server();
+        let resp = send_request(
+            server.port,
+            &json!({"jsonrpc":"2.0","id":1,"method":"initialize"}),
+        );
+        assert_eq!(resp["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert!(resp["result"]["capabilities"]["tools"].is_object());
+        assert_eq!(resp["result"]["serverInfo"]["name"], "clud-memory");
+        server.shutdown();
+    }
+}

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -6,6 +6,7 @@ mod gc_service;
 mod http;
 mod io_helpers;
 mod keys;
+pub(crate) mod memory_mcp;
 mod memory_service;
 mod paths;
 mod process_utils;
@@ -26,3 +27,13 @@ pub use http::{
 };
 pub use paths::{default_state_dir, default_trash_dir};
 pub use types::{ListRow, RepoVisit, ENV_NO_DAEMON};
+
+/// Issue #259: re-exported for the `clud mcp` stdio bridge. Reads
+/// `daemon.json` and returns the port the in-process MCP server is
+/// listening on (or `None` if the memory subsystem failed to start).
+pub fn read_memory_mcp_port(state_dir: &std::path::Path) -> std::io::Result<Option<u16>> {
+    use io_helpers::read_json_file;
+    use paths::daemon_info_path;
+    let info: types::DaemonInfo = read_json_file(&daemon_info_path(state_dir))?;
+    Ok(info.memory_mcp_port)
+}

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -19,6 +19,7 @@ use super::gc_service::{
 };
 use super::http::{default_live_sessions_provider, spawn_dashboard};
 use super::io_helpers::{new_session_id, read_json_file, write_json_file, write_json_line};
+use super::memory_mcp::spawn_mcp_server;
 use super::memory_service::{spawn_memory_service, MemoryService};
 use super::paths::{daemon_info_path, session_snapshot_path, sessions_dir, spec_path, specs_dir};
 use super::process_utils::{pid_is_alive, signal_process_tree};
@@ -80,6 +81,21 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
         }
     };
 
+    // Issue #259: agent-memory MCP server. Bound on a loopback port and
+    // surfaced via `daemon.json` so the `clud mcp` stdio bridge can find
+    // it. Bind failures are non-fatal — the rest of the daemon still
+    // works; `clud mcp` will print a clear error if the field is `None`.
+    let memory_mcp_port = match memory_service.as_ref() {
+        Some(svc) => match spawn_mcp_server(Arc::clone(svc)) {
+            Ok(server) => Some(server.port),
+            Err(err) => {
+                eprintln!("[clud] note: memory mcp server unavailable: {err}");
+                None
+            }
+        },
+        None => None,
+    };
+
     // Issue #183: in-process HTTP dashboard. Bind a second loopback port
     // alongside the IPC listener and run a `tiny_http` server on a worker
     // thread. The port is recorded in `daemon.json` so `clud ui` can
@@ -100,9 +116,7 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
         port,
         dashboard_port,
         version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        // The MCP server itself lands in #259; this PR ships the field
-        // as `None` so the wire format stays stable across the rollout.
-        memory_mcp_port: None,
+        memory_mcp_port,
     };
     if let Err(err) = write_json_file(&daemon_info_path(state_dir), &info) {
         eprintln!("[clud] failed to persist daemon info: {}", err);

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -24,6 +24,7 @@ pub mod launch_setup;
 pub mod loop_artifacts;
 pub mod loop_check;
 pub mod loop_spec;
+pub mod mcp_bridge;
 pub mod memory;
 pub mod process_tree;
 pub mod runner;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,7 @@
 use clud::{
     args, backend, backend_bootstrap, command, console_setup, console_title, ctrl_c_track, daemon,
-    gc, graphics, hook_health, large_file_guard, launch_setup, loop_artifacts, loop_spec, runner,
-    startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
+    gc, graphics, hook_health, large_file_guard, launch_setup, loop_artifacts, loop_spec,
+    mcp_bridge, runner, startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -75,6 +75,14 @@ fn main() {
     // never launches a backend.
     if let Some(args::Command::Ui { json, no_open }) = &args.command {
         std::process::exit(ui::run(*json, *no_open));
+    }
+
+    // Issue #259: `clud mcp` is the MCP stdio bridge for Claude Code /
+    // Codex. Self-contained; never launches a backend. Brings the
+    // always-on daemon up if it isn't running and proxies JSON-RPC
+    // frames to the daemon's memory_mcp_port.
+    if let Some(args::Command::Mcp) = &args.command {
+        std::process::exit(mcp_bridge::run());
     }
 
     // Issue #182: `clud trash` is self-contained maintenance. Dispatch

--- a/crates/clud-bin/src/mcp_bridge.rs
+++ b/crates/clud-bin/src/mcp_bridge.rs
@@ -1,0 +1,227 @@
+//! Issue #259: `clud mcp` — stdio↔TCP bridge for the in-daemon MCP server.
+//!
+//! Claude Code and Codex MCP hosts spawn this subcommand and treat its
+//! stdio as the MCP transport. This module:
+//!
+//! 1. Calls `daemon::ensure_daemon` (transparently bringing the daemon up
+//!    if it isn't running).
+//! 2. Reads `DaemonInfo.memory_mcp_port` from `daemon.json`.
+//! 3. If the port is unavailable, emits a single JSON-RPC error reply to
+//!    stdout and exits non-zero. (Better than hanging — MCP hosts that
+//!    just wait on stdout would block forever otherwise.)
+//! 4. Otherwise, connects to `127.0.0.1:<port>` and proxies bytes both
+//!    directions until either side closes.
+//!
+//! Pure `std::net` / `std::thread` — no tokio runtime is started by the
+//! bridge process. The two copy threads exit when one closes the
+//! connection.
+
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+
+use serde_json::json;
+
+use crate::daemon;
+use crate::daemon::memory_mcp::JSONRPC_DAEMON_UNAVAILABLE;
+
+/// CLI entry point for `clud mcp`. Returns the process exit code.
+pub fn run() -> i32 {
+    let state_dir = match daemon::default_state_dir() {
+        Ok(p) => p,
+        Err(err) => {
+            emit_bridge_error(&format!("cannot resolve daemon state dir: {err}"));
+            return 1;
+        }
+    };
+    if let Err(err) = daemon::ensure_daemon(&state_dir) {
+        emit_bridge_error(&format!("daemon unavailable: {err}"));
+        return 1;
+    }
+    let port = match daemon::read_memory_mcp_port(&state_dir) {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            emit_bridge_error(
+                "memory subsystem not running on this daemon; check `clud daemon status`",
+            );
+            return 1;
+        }
+        Err(err) => {
+            emit_bridge_error(&format!("read daemon.json: {err}"));
+            return 1;
+        }
+    };
+    proxy_stdio(port)
+}
+
+/// Connect to the daemon's loopback MCP port and forward bytes between
+/// stdio and the TCP socket until either side closes.
+fn proxy_stdio(port: u16) -> i32 {
+    let stream = match TcpStream::connect(("127.0.0.1", port)) {
+        Ok(s) => s,
+        Err(err) => {
+            emit_bridge_error(&format!("connect 127.0.0.1:{port}: {err}"));
+            return 1;
+        }
+    };
+    let stream_for_stdout = match stream.try_clone() {
+        Ok(s) => s,
+        Err(err) => {
+            emit_bridge_error(&format!("clone tcp stream: {err}"));
+            return 1;
+        }
+    };
+    let done = Arc::new(AtomicBool::new(false));
+    let done_a = Arc::clone(&done);
+    let done_b = Arc::clone(&done);
+
+    // stdin → tcp
+    let writer = stream;
+    let t_in = thread::Builder::new()
+        .name("clud-mcp-stdin".to_string())
+        .spawn(move || {
+            let stdin = io::stdin();
+            let mut reader = stdin.lock();
+            let mut writer = writer;
+            let mut buf = [0u8; 8192];
+            while !done_a.load(Ordering::SeqCst) {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if writer.write_all(&buf[..n]).is_err() {
+                            break;
+                        }
+                        let _ = writer.flush();
+                    }
+                    Err(_) => break,
+                }
+            }
+            done_a.store(true, Ordering::SeqCst);
+            // Half-close so the daemon sees EOF and tears down.
+            let _ = writer.shutdown(std::net::Shutdown::Write);
+        })
+        .expect("spawn clud-mcp-stdin");
+
+    // tcp → stdout
+    let mut reader = stream_for_stdout;
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                if out.write_all(&buf[..n]).is_err() {
+                    break;
+                }
+                let _ = out.flush();
+            }
+            Err(_) => break,
+        }
+    }
+    done_b.store(true, Ordering::SeqCst);
+    let _ = reader.shutdown(std::net::Shutdown::Both);
+    let _ = t_in.join();
+    0
+}
+
+/// Write a single JSON-RPC error envelope to stdout. Hosts that wait on
+/// the bridge's stdout will see the error and surface it instead of
+/// hanging forever.
+fn emit_bridge_error(message: &str) {
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "id": null,
+        "error": {
+            "code": JSONRPC_DAEMON_UNAVAILABLE,
+            "message": message,
+        }
+    });
+    let mut out = io::stdout().lock();
+    let _ = writeln!(out, "{payload}");
+    let _ = out.flush();
+    eprintln!("[clud mcp] {message}");
+}
+
+/// Issue #259 test helper: deterministic resolver factored out so unit
+/// tests can stub `read_memory_mcp_port` with a fake daemon state dir.
+#[cfg(test)]
+pub(crate) fn resolve_port_from(state_dir: &std::path::Path) -> Result<u16, String> {
+    match daemon::read_memory_mcp_port(state_dir) {
+        Ok(Some(p)) => Ok(p),
+        Ok(None) => Err("memory subsystem not running on this daemon".to_string()),
+        Err(err) => Err(format!("read daemon.json: {err}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    /// Acceptance: the bridge resolver returns a clear error when the
+    /// daemon's `daemon.json` doesn't carry a memory_mcp_port. Captures
+    /// the contract `clud mcp` relies on (without spawning a real daemon
+    /// or talking real stdio).
+    #[test]
+    fn bridge_errors_clearly_when_daemon_has_no_memory_port() {
+        let tmp = tempfile::tempdir().unwrap();
+        let info = json!({
+            "pid": 1u32,
+            "port": 12345u16,
+        });
+        std::fs::write(
+            tmp.path().join("daemon.json"),
+            serde_json::to_string(&info).unwrap(),
+        )
+        .unwrap();
+        let err = resolve_port_from(tmp.path()).unwrap_err();
+        assert!(err.to_lowercase().contains("memory subsystem"));
+    }
+
+    /// `daemon.json` carrying an explicit port resolves cleanly.
+    #[test]
+    fn bridge_resolves_port_from_daemon_info() {
+        let tmp = tempfile::tempdir().unwrap();
+        let info = json!({
+            "pid": 1u32,
+            "port": 12345u16,
+            "memory_mcp_port": 31415u16,
+        });
+        std::fs::write(
+            tmp.path().join("daemon.json"),
+            serde_json::to_string(&info).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(resolve_port_from(tmp.path()).unwrap(), 31415);
+    }
+
+    /// Missing `daemon.json` produces a clear, non-panicking error.
+    #[test]
+    fn bridge_errors_when_daemon_info_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_port_from(tmp.path()).unwrap_err();
+        assert!(err.to_lowercase().contains("read daemon.json"));
+    }
+
+    /// The emitted bridge-error envelope is a well-formed JSON-RPC error.
+    /// (Smoke-test the shape so MCP hosts can rely on it.)
+    #[test]
+    fn bridge_error_envelope_is_valid_jsonrpc() {
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "id": null,
+            "error": {
+                "code": JSONRPC_DAEMON_UNAVAILABLE,
+                "message": "test",
+            }
+        });
+        let s = payload.to_string();
+        let parsed: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert!(parsed["id"].is_null());
+        assert_eq!(parsed["error"]["code"], JSONRPC_DAEMON_UNAVAILABLE);
+    }
+}

--- a/crates/clud-bin/src/memory/README.md
+++ b/crates/clud-bin/src/memory/README.md
@@ -147,3 +147,59 @@ semantics).
 Out of scope for this directory; daemon-integration sub-issue wires
 `Mutex<SqliteStore>` lifetime inside `__daemon` and exposes
 `checkpoint_truncate` to the GC tick.
+
+## MCP server
+
+The agent-memory subsystem is surfaced to Claude Code / Codex via an
+in-daemon MCP server (issue #259). Implementation lives in
+[`crates/clud-bin/src/daemon/memory_mcp.rs`](../daemon/memory_mcp.rs);
+the stdio bridge lives in
+[`crates/clud-bin/src/mcp_bridge.rs`](../mcp_bridge.rs).
+
+The 8 ESSENTIAL_TOOLS exposed (verbatim from agentmemory):
+
+- `memory_save` — embed + persist a memory row.
+- `memory_recall` — fetch one row by id.
+- `memory_smart_search` — hybrid RRF (BM25 + vector) search.
+- `memory_sessions` — distinct `session_id` values.
+- `memory_consolidate` — drive one consolidation tick on demand.
+- `memory_diagnose` — basic health (embedder, dim, row count, schema
+  user_version). Subsystem-level checks (actions/leases/sentinels/…)
+  land in a future PR.
+- `memory_lesson_save` — insert into the `lessons` table.
+- `memory_reflect` — **documented stub** until v0.5; returns an
+  `unimplemented` JSON-RPC error today. Knowledge-graph + LLM reflection
+  lands with the v0.5 release per META #255.
+
+Scope filter wiring (`scope_key` end-to-end) lands in #267 and is
+already on main; this MCP surface accepts the `scope_key` argument on
+`memory_smart_search` and forwards it to `SqliteStore::knn` and
+`LexicalIndex::search`.
+
+### Manual MCP registration (v0.1)
+
+Auto-registration of `~/.claude.json` / `~/.codex/config.toml` is owned
+by sibling #265. For v0.1 the user adds an entry by hand:
+
+```jsonc
+// ~/.claude.json
+{
+  "mcpServers": {
+    "clud-memory": {
+      "command": "clud",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+```toml
+# ~/.codex/config.toml
+[mcp_servers.clud-memory]
+command = "clud"
+args = ["mcp"]
+```
+
+`clud mcp` calls `daemon::ensure_daemon` so a cold first launch
+transparently brings the clud daemon up; subsequent connects are
+loopback TCP only.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -488,3 +488,34 @@ This supersedes the "separate GC daemon" half of [DD-006](#dd-006--cluddataredb-
 - The consolidation timer holds the SQLite + lexical locks for the duration of one tick. Saves and searches are blocked for the tick's duration — typically tens of ms on a small store, bounded by `O(N)` in the worst case where the entire Working tier is being promoted in one round. Acceptable for v1; if it bites, future work can split the lock or batch the apply.
 - The reconciliation pass on startup is `O(N)` upserts plus one tantivy commit; bounded by row count and cheap on a clean daemon. Documents the cost in `crates/clud-bin/src/daemon/memory_service.rs` so future readers know the bound.
 - The HTTP `/memory/*` route bodies are stubs in this PR (#261); the real implementations land in #263. The seam is `MemoryService` references in each handler — no new IPC needs to be added when #263 lands.
+
+---
+
+## DD-018: MCP server embedded in clud daemon vs sidecar binary
+
+**Context:** Issue #259 needed to expose the agent-memory subsystem to MCP clients (Claude Code, Codex). The choice was between (a) shipping a separate `clud-memory-mcp` sidecar binary that MCP hosts spawn directly and which opens its own SQLite/tantivy handles, and (b) folding the MCP server into the existing `clud` daemon next to the GC registry, the dashboard, and the memory consolidation timer. The MCP client integration is a thin `clud mcp` stdio bridge in either case; what differs is who owns the storage handles.
+
+**Decision:** Embed the MCP server in the clud daemon. `daemon::memory_mcp::spawn_mcp_server(memory: Arc<MemoryService>)` runs alongside `spawn_dashboard` and the consolidation timer from `daemon::server::run_daemon`, binds an ephemeral loopback TCP port, and writes that port into `DaemonInfo.memory_mcp_port`. The `clud mcp` subcommand is a thin stdio↔TCP bridge that calls `daemon::ensure_daemon` and proxies bytes to the loopback port.
+
+**Rationale:**
+- Single source of truth for `MemoryService`. The dashboard, the consolidation timer, the hook subcommands (#260), and the MCP server all share one `Arc<MemoryService>`. A sidecar would have to re-open SQLite (single-writer constraint! cross-process locking!), re-open tantivy (per-directory `LockBusy`), and re-load the embedder (the ~80 MB ONNX session at first run). Net: more code, slower cold-start, and a real concurrency problem to solve, with no upside.
+- Lifecycle is already solved. The daemon's `ensure_daemon` + bringup lock + version skew detection (DD-012) already handles "is there one of these per user, and is it the current version?". A sidecar would re-do all of that.
+- IPC overhead is already paid. The dashboard's `/memory/*` routes go through the same `MemoryService` Arc; a sidecar would need a second IPC path to call back into the dashboard's data, or the dashboard would have to learn to talk to the sidecar via TCP, doubling the surface area.
+- The `clud mcp` bridge is pure `std::net` + two `std::thread`s. No tokio runtime, no rmcp dependency churn. Adding 200 LOC of std-only bridge code is strictly cheaper than introducing async to the daemon process.
+- Failure isolation is preserved. If the memory subsystem fails to start, `memory_service: None`, and `memory_mcp_port` stays `None`. The bridge emits a clear JSON-RPC error (`-32099`) and exits 1 rather than hanging. Sessions, GC, and the dashboard keep running.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Sidecar `clud-memory-mcp` binary | Cross-process SQLite handle ownership is the actual blocker — sqlite-vec's single-writer rule means only one process can have the write handle. We'd either need IPC from the sidecar to the daemon for every write (defeating the sidecar) or move the daemon's writes into the sidecar (turning the daemon into the sidecar's IPC client). Lose-lose. |
+| In-process but on a tokio runtime via `rmcp` | rmcp 1.7 pulls in tokio + tokio-util + schemars + (transitively) hyper-bits. The MCP wire protocol is line-delimited JSON-RPC 2.0; it doesn't need any of that. A 350-line hand-rolled NDJSON dispatcher on `std::net::TcpListener` covers initialize / tools/list / tools/call. Saves ~50s of cold-build time × 6 CI targets and keeps the daemon's "no async runtime" property (DD-017). |
+| Defer MCP entirely; only ship CLI verbs | Forces every prompt-time memory access through `clud memory search` subprocess hops. MCP is what Claude Code and Codex already speak; missing it is a v0.1 regression. |
+| Streamable HTTP transport instead of TCP | MCP supports HTTP + SSE, useful for team-shared memory hosts later. Loopback TCP is simpler, has no auth surface, and matches the daemon's existing pattern. Streamable HTTP can be added in v0.5 without breaking the TCP transport. |
+
+**Consequences:**
+- Adding new MCP tools is a one-place edit in `daemon::memory_mcp` — no IPC schema to extend, no sidecar binary to rev.
+- The `clud mcp` bridge depends on `daemon::ensure_daemon` succeeding. A daemon-down case shows up as a stdout JSON-RPC error to the MCP host within ~5s (the `ensure_daemon` timeout); never silently hangs.
+- We carry the JSON-RPC wire protocol ourselves. Cheap (single file, fully unit-tested) but it does mean tracking the MCP protocol version manually. The advertised version (`2024-11-05`) is the one Claude Code's MCP host currently negotiates.
+- Adopting `rmcp` later is non-breaking — the file is self-contained and the wire shape (`{ content: [{type: "text", text: "<json>"}] }`) is exactly what `rmcp` emits. A future migration is a behind-the-curtain rewrite, not a public-API change.
+- `memory_reflect` ships as a documented stub returning a `-32603` internal error with a `v0.5` note. The reflect tool depends on knowledge graph (deferred past v1 per META #255) and an LLM provider (#257 v0.5 ladder), neither of which is on main yet. The stub means MCP hosts get a clean error today instead of a missing-tool error.

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -310,15 +310,75 @@ The MCP server itself (`#259`) and the hook subcommands (`#260`) plug
 into `MemoryService` from outside; this PR just shares the four handles
 the way #135 shared the GC mpsc channel.
 
-`DaemonInfo.memory_mcp_port` is reserved as `Option<u16>` so #259 can
-populate the field without a wire-format break.
+`DaemonInfo.memory_mcp_port` is now populated by #259 — see "MCP server"
+below.
+
+## MCP server
+
+Issue #259 surfaces the agent-memory subsystem as an MCP server,
+in-process with the rest of the daemon (see
+[DD-018](../DESIGN_DECISIONS.md#dd-018-mcp-server-embedded-in-clud-daemon-vs-sidecar-binary)
+for why we embed rather than ship a sidecar). The implementation is in
+[`crates/clud-bin/src/daemon/memory_mcp.rs`](../../crates/clud-bin/src/daemon/memory_mcp.rs);
+the `clud mcp` stdio↔TCP bridge is in
+[`crates/clud-bin/src/mcp_bridge.rs`](../../crates/clud-bin/src/mcp_bridge.rs).
+
+### Port allocation
+
+`spawn_mcp_server` binds `127.0.0.1:0` (ephemeral loopback) and writes
+the resolved port into `DaemonInfo.memory_mcp_port`. The accept loop is
+a single `std::thread`; each accepted TCP connection spawns its own
+per-connection thread. There is no tokio runtime in the daemon — the
+existing `Arc<Mutex<...>>` resources on `MemoryService` are reused
+unchanged.
+
+### The 8 tools (agentmemory `ESSENTIAL_TOOLS`)
+
+Names and argument schemas are 1:1 with the `rohitg00/agentmemory`
+TypeScript reference:
+
+| Tool | v0.1 status |
+|---|---|
+| `memory_save` | functional |
+| `memory_recall` | functional |
+| `memory_smart_search` | functional (BM25 + vec → RRF) |
+| `memory_sessions` | functional |
+| `memory_consolidate` | functional (manual tick) |
+| `memory_diagnose` | basics: embedder, dim, row count, schema user_version |
+| `memory_lesson_save` | functional (writes `lessons` table) |
+| `memory_reflect` | **documented stub** — returns an internal error until v0.5 (depends on knowledge graph + LLM provider) |
+
+### Wire protocol
+
+Line-delimited JSON-RPC 2.0 over TCP. Supported methods: `initialize`,
+`tools/list`, `tools/call`. Tool results return the
+`{ content: [{type: "text", text: "<json-string>"}] }` shape mandated
+by the MCP spec. Errors use the standard JSON-RPC codes plus `-32099`
+("daemon unavailable") emitted by the bridge when
+`DaemonInfo.memory_mcp_port` is `None`.
+
+### `clud mcp` stdio bridge
+
+Calls `daemon::ensure_daemon` first (transparently brings the daemon up
+if it isn't running), reads the port from `daemon.json`, then opens a
+loopback TCP socket and proxies bytes between stdio and the socket
+using two `std::thread`s. Closes when either side closes. On error
+(daemon unavailable, missing port, bad connect) the bridge emits a
+single JSON-RPC error envelope on stdout — never hangs.
+
+### Manual registration (v0.1)
+
+Auto-registration of `~/.claude.json` / `~/.codex/config.toml` is owned
+by sibling #265 and is not in #259. For v0.1 the user adds an entry by
+hand — see
+[`crates/clud-bin/src/memory/README.md`](../../crates/clud-bin/src/memory/README.md#manual-mcp-registration-v01).
 
 ## Sibling sub-issues (META #255)
 
 - ~~Embeddings (local + remote + Windows-ARM strategy)~~ — #257.
 - ~~Tier lifecycle (Working / Episodic / Semantic + decay + promotion)~~ — #258.
-- ~~Daemon integration (lifecycle, consolidation timer, HTTP route stubs)~~ — #261 (this PR).
-- MCP server in daemon + `clud mcp` stdio bridge — #259.
+- ~~Daemon integration (lifecycle, consolidation timer, HTTP route stubs)~~ — #261.
+- ~~MCP server in daemon + `clud mcp` stdio bridge~~ — #259 (this PR).
 - Hook subcommands — #260.
 - `clud memory search` / `save` CLI verbs (including
   `clud memory branch-isolate`) — #262.


### PR DESCRIPTION
## Summary
- Add `crates/clud-bin/src/daemon/memory_mcp.rs`: in-process JSON-RPC 2.0 dispatcher exposing the 8 agentmemory `ESSENTIAL_TOOLS` on a loopback TCP port. Pure `std::net` + `std::thread` — no tokio runtime, no rmcp dependency (see DD-018 for the rationale).
- New `clud mcp` subcommand: stdio↔TCP bridge that calls `daemon::ensure_daemon`, reads `DaemonInfo.memory_mcp_port`, and proxies bytes both directions. On error emits a single JSON-RPC `-32099` envelope on stdout instead of hanging.
- `DaemonInfo.memory_mcp_port` is now populated by `daemon::server::run_daemon` (was reserved as `None` in #261).
- Documented manual registration for Claude Code / Codex; auto-registration lands in #265.
- `memory_diagnose` ships with the basics (embedder, dim, row count, schema user_version); `memory_reflect` ships as a documented stub returning `-32603` with a v0.5 note per META #255.

Closes #259. **v0.1 MVP gate for meta #255** — Claude Code / Codex clients can save and recall memories across sessions.

## Test plan
- [x] `soldr cargo test -p clud --lib daemon::memory_mcp::` — green (13 tests).
- [x] `soldr cargo test -p clud --lib mcp_bridge::` — green (4 tests).
- [x] `soldr cargo fmt --all --check` — clean.
- [x] `soldr cargo clippy --workspace --all-targets --no-default-features -- -D warnings` — clean.
- [x] `python -m ruff check src tests ci` — clean.
- [x] `python ci/banned_imports.py` — clean.
- [x] `soldr cargo test -p clud --no-default-features` — 848 tests pass (lib + integration).
- [ ] CI green on all 6 platforms.

### Host quirk
`bash lint` / `bash test` / Python tests trip the pre-existing ort/MSVC link error on this Windows host (predates this PR; documented in the spec). All individual sub-steps green; CI should run cleanly on the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)