### PR TITLE
feat(memory): clud memory verb tree + daemon HTTP route bodies (#262)

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -249,6 +249,14 @@ pub enum Command {
         #[command(subcommand)]
         subcommand: DaemonSubcommand,
     },
+    /// Issue #262: agent-memory CLI verbs. The daemon owns the on-disk
+    /// SQLite + tantivy + embedder; the CLI proxies mutating ops through
+    /// the daemon's HTTP routes so there's exactly one SQLite writer per
+    /// process. Bare `clud memory` prints help.
+    Memory {
+        #[command(subcommand)]
+        subcommand: Option<MemorySubcommand>,
+    },
     #[command(name = "__daemon", hide = true)]
     InternalDaemon {
         #[arg(long = "state-dir")]
@@ -272,6 +280,86 @@ pub enum Command {
 pub enum DaemonSubcommand {
     /// Restart the daemon process so the next CLI call uses the current binary.
     Restart,
+}
+
+/// Subcommands under `clud memory`. See `crates/clud-bin/src/memory/cli.rs`.
+#[derive(Subcommand, Debug, Clone)]
+pub enum MemorySubcommand {
+    /// One-time schema init + best-effort embedder warm. Prints resolved
+    /// paths, embed_dim, and embedder name.
+    Init,
+    /// Print tier row counts, embedder status, schema user_version, db path,
+    /// and the daemon's consolidation cadence.
+    Status {
+        #[arg(long = "json")]
+        json: bool,
+    },
+    /// Hybrid (BM25 + KNN) search via RRF. `--tier-floor` filters out
+    /// rows below the requested tier.
+    Search {
+        query: String,
+        #[arg(short = 'k', long = "k", default_value = "10")]
+        k: u32,
+        #[arg(long = "session-id", value_name = "SID")]
+        session_id: Option<String>,
+        #[arg(long = "tier-floor", value_name = "TIER")]
+        tier_floor: Option<String>,
+        #[arg(long = "scope-key", value_name = "KEY")]
+        scope_key: Option<String>,
+        #[arg(long = "json")]
+        json: bool,
+    },
+    /// Embed and insert a new memory row.
+    Save {
+        content: String,
+        #[arg(long = "tier", default_value = "working")]
+        tier: String,
+        #[arg(long = "session-id", value_name = "SID")]
+        session_id: Option<String>,
+        #[arg(long = "metadata", value_name = "JSON")]
+        metadata: Option<String>,
+        #[arg(long = "json")]
+        json: bool,
+    },
+    /// Delete one memory by id (cascades to memory_vec + tantivy).
+    Forget {
+        id: String,
+        #[arg(long = "json")]
+        json: bool,
+    },
+    /// Export rows as JSON-lines. Default destination is stdout;
+    /// `--to-disk` stubs to #264.
+    Export {
+        #[arg(long = "to-disk", conflicts_with = "to_stdout")]
+        to_disk: bool,
+        #[arg(long = "to-stdout")]
+        to_stdout: bool,
+    },
+    /// Import rows from JSON-lines. `--from-stdin` reads JSON-lines from
+    /// stdin; `--from-disk` stubs to #264.
+    Import {
+        #[arg(long = "from-disk", conflicts_with = "from_stdin")]
+        from_disk: bool,
+        #[arg(long = "from-stdin")]
+        from_stdin: bool,
+    },
+    /// Open the dashboard in a browser at the `#memory` anchor.
+    Ui {
+        #[arg(long = "no-open")]
+        no_open: bool,
+    },
+    /// Re-embed every stored row using the currently-configured embedder.
+    Reembed {
+        #[arg(long = "model", value_name = "NAME")]
+        model: Option<String>,
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+    },
+    /// Write the branch-isolate marker so this branch keeps memories
+    /// private from main.
+    BranchIsolate,
+    /// Remove the branch-isolate marker.
+    BranchUnisolate,
 }
 
 /// Subcommands under `clud gc`. See `crates/clud-bin/src/gc.rs`.
@@ -343,8 +431,14 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--stale-after",
         "--daemon",
         "--state-dir",
+        "--session-id",
+        "--tier",
+        "--tier-floor",
+        "--scope-key",
+        "--metadata",
+        "--k",
     ];
-    let short_value_flags: &[&str] = &["-p", "-m", "-r"];
+    let short_value_flags: &[&str] = &["-p", "-m", "-r", "-k"];
     let bool_flags: &[&str] = &[
         "--continue",
         "--claude",
@@ -372,13 +466,17 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--json",
         "--no-open",
         "--demo-gfx-sixel",
+        "--to-disk",
+        "--to-stdout",
+        "--from-disk",
+        "--from-stdin",
         "--help",
         "--version",
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
         "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "ui", "mcp",
-        "trash", "daemon", "__daemon", "__worker",
+        "memory", "trash", "daemon", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/args_tests.rs
+++ b/crates/clud-bin/src/args_tests.rs
@@ -885,3 +885,171 @@ fn test_daemon_restart_subcommand_parses() {
         other => panic!("expected Daemon::Restart, got {other:?}"),
     }
 }
+
+// ---------- issue #262: clud memory verb parsing ----------
+
+#[test]
+fn memory_save_parses_basic() {
+    let args = parse(&["clud", "memory", "save", "hello world"]);
+    match args.command {
+        Some(Command::Memory {
+            subcommand:
+                Some(MemorySubcommand::Save {
+                    content,
+                    tier,
+                    session_id,
+                    metadata,
+                    json,
+                }),
+        }) => {
+            assert_eq!(content, "hello world");
+            assert_eq!(tier, "working");
+            assert!(session_id.is_none());
+            assert!(metadata.is_none());
+            assert!(!json);
+        }
+        other => panic!("expected Memory::Save, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_save_parses_tier_and_session() {
+    let args = parse(&[
+        "clud",
+        "memory",
+        "save",
+        "fact",
+        "--tier",
+        "semantic",
+        "--session-id",
+        "abc",
+    ]);
+    match args.command {
+        Some(Command::Memory {
+            subcommand:
+                Some(MemorySubcommand::Save {
+                    content,
+                    tier,
+                    session_id,
+                    ..
+                }),
+        }) => {
+            assert_eq!(content, "fact");
+            assert_eq!(tier, "semantic");
+            assert_eq!(session_id.as_deref(), Some("abc"));
+        }
+        other => panic!("expected Memory::Save with filters, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_search_parses_filters() {
+    let args = parse(&[
+        "clud",
+        "memory",
+        "search",
+        "needle",
+        "-k",
+        "5",
+        "--tier-floor",
+        "episodic",
+        "--scope-key",
+        "repo://x",
+        "--json",
+    ]);
+    match args.command {
+        Some(Command::Memory {
+            subcommand:
+                Some(MemorySubcommand::Search {
+                    query,
+                    k,
+                    session_id,
+                    tier_floor,
+                    scope_key,
+                    json,
+                }),
+        }) => {
+            assert_eq!(query, "needle");
+            assert_eq!(k, 5);
+            assert!(session_id.is_none());
+            assert_eq!(tier_floor.as_deref(), Some("episodic"));
+            assert_eq!(scope_key.as_deref(), Some("repo://x"));
+            assert!(json);
+        }
+        other => panic!("expected Memory::Search, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_reembed_parses_dry_run() {
+    let args = parse(&["clud", "memory", "reembed", "--dry-run"]);
+    match args.command {
+        Some(Command::Memory {
+            subcommand: Some(MemorySubcommand::Reembed { model, dry_run }),
+        }) => {
+            assert!(model.is_none());
+            assert!(dry_run);
+        }
+        other => panic!("expected Memory::Reembed, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_branch_isolate_parses() {
+    let args = parse(&["clud", "memory", "branch-isolate"]);
+    match args.command {
+        Some(Command::Memory {
+            subcommand: Some(MemorySubcommand::BranchIsolate),
+        }) => {}
+        other => panic!("expected Memory::BranchIsolate, got {other:?}"),
+    }
+
+    let args = parse(&["clud", "memory", "branch-unisolate"]);
+    match args.command {
+        Some(Command::Memory {
+            subcommand: Some(MemorySubcommand::BranchUnisolate),
+        }) => {}
+        other => panic!("expected Memory::BranchUnisolate, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_bare_parses_to_help_variant() {
+    let args = parse(&["clud", "memory"]);
+    match args.command {
+        Some(Command::Memory { subcommand: None }) => {}
+        other => panic!("expected Memory with no subcommand, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_forget_parses() {
+    let args = parse(&[
+        "clud",
+        "memory",
+        "forget",
+        "0190abcd-0000-7000-8000-000000000000",
+    ]);
+    match args.command {
+        Some(Command::Memory {
+            subcommand: Some(MemorySubcommand::Forget { id, json }),
+        }) => {
+            assert_eq!(id, "0190abcd-0000-7000-8000-000000000000");
+            assert!(!json);
+        }
+        other => panic!("expected Memory::Forget, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_status_parses_json_flag() {
+    let args = parse(&["clud", "memory", "status", "--json"]);
+    match args.command {
+        Some(Command::Memory {
+            subcommand: Some(MemorySubcommand::Status { json }),
+        }) => {
+            assert!(json);
+        }
+        other => panic!("expected Memory::Status, got {other:?}"),
+    }
+}

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -138,6 +138,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         | Some(Command::Gc { .. })
         | Some(Command::Ui { .. })
         | Some(Command::Mcp)
+        | Some(Command::Memory { .. })
         | Some(Command::Trash { .. })
         | Some(Command::Daemon { .. })
         | Some(Command::InternalDaemon { .. })

--- a/crates/clud-bin/src/daemon/http.rs
+++ b/crates/clud-bin/src/daemon/http.rs
@@ -34,6 +34,7 @@ use super::types::{
 };
 use crate::ctrl_c_track::{self, CtrlCEvent};
 use crate::memory::embedder::EmbedderTrait;
+use crate::memory::{rrf_fuse, HybridSearchConfig, MemoryId, MemoryRow, SqliteStore, Tier};
 use crate::session_registry::LiveSession;
 
 /// Supplier of live session-registry rows. Injected at the dashboard
@@ -384,40 +385,266 @@ fn respond_purge_reply(request: Request, reply: GcReply) {
     }
 }
 
-// ---------- memory route stubs (issue #261) ----------
+// ---------- memory routes (issue #262) ----------
 //
-// All five routes are wired to the live `Arc<MemoryService>` so #263 can
-// fill in the bodies in a follow-up without touching this file's match
-// arms. On `memory.is_none()` (memory subsystem failed to start) every
-// route returns 503 — the daemon keeps serving session + GC traffic.
+// All five routes are wired to the live `Arc<MemoryService>`. The CLI's
+// `clud memory *` verbs proxy mutating ops (save / forget / reembed)
+// through these routes so there is exactly one SQLite writer per process
+// (DD-018). On `memory.is_none()` (memory subsystem failed to start)
+// every route returns 503 with a JSON error body — the daemon keeps
+// serving session + GC traffic.
+
+/// Wire payload for `POST /memory/save`.
+#[derive(Debug, Default, Deserialize)]
+pub struct MemorySaveRequest {
+    pub content: String,
+    #[serde(default)]
+    pub tier: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub scope_key: Option<String>,
+    #[serde(default)]
+    pub metadata_json: Option<String>,
+}
+
+/// Wire shape for one memory row in HTTP responses.
+#[derive(Debug, Serialize)]
+pub struct MemoryRowView {
+    pub id: String,
+    pub tier: String,
+    pub content: String,
+    pub session_id: Option<String>,
+    pub scope_key: Option<String>,
+    pub created_at_ms: u64,
+    pub access_count: u32,
+}
+
+impl MemoryRowView {
+    fn from_row(row: &MemoryRow) -> Self {
+        Self {
+            id: row.id.as_str().to_string(),
+            tier: tier_name(row.tier).to_string(),
+            content: row.content.clone(),
+            session_id: row.session_id.clone(),
+            scope_key: row.scope_key.clone(),
+            created_at_ms: row.created_at_ms,
+            access_count: row.access_count,
+        }
+    }
+}
+
+fn tier_name(t: Tier) -> &'static str {
+    match t {
+        Tier::Working => "working",
+        Tier::Episodic => "episodic",
+        Tier::Semantic => "semantic",
+    }
+}
+
+fn parse_tier(s: &str) -> Option<Tier> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "working" => Some(Tier::Working),
+        "episodic" => Some(Tier::Episodic),
+        "semantic" => Some(Tier::Semantic),
+        _ => None,
+    }
+}
+
+fn parse_query_string(url: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let Some(qs) = url.split_once('?').map(|(_, q)| q) else {
+        return out;
+    };
+    for piece in qs.split('&') {
+        if piece.is_empty() {
+            continue;
+        }
+        let (k, v) = piece.split_once('=').unwrap_or((piece, ""));
+        out.insert(url_decode(k), url_decode(v));
+    }
+    out
+}
+
+fn url_decode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                match (hi, lo) {
+                    (Some(h), Some(l)) => {
+                        out.push((h * 16 + l) as u8 as char);
+                        i += 3;
+                    }
+                    _ => {
+                        out.push(bytes[i] as char);
+                        i += 1;
+                    }
+                }
+            }
+            b => {
+                out.push(b as char);
+                i += 1;
+            }
+        }
+    }
+    out
+}
 
 fn handle_memory_recent(request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
-    if memory.is_none() {
+    let Some(svc) = memory else {
         respond_json(
             request,
             503,
             json_error_bytes("memory subsystem unavailable").as_slice(),
         );
         return;
-    }
-    // TODO(#263): pull recent rows from `MemoryService::store` and
-    // render them as `[{id, tier, content, created_at_ms}]`. Empty array
-    // until then so the dashboard's JS can already poll the route.
-    respond_json(request, 200, b"[]");
+    };
+    let qs = parse_query_string(request.url());
+    let limit: usize = qs
+        .get("limit")
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(25);
+
+    let rows: Vec<MemoryRowView> = match svc.store.lock() {
+        Ok(store) => match store.list_recent(limit) {
+            Ok(rows) => rows.iter().map(MemoryRowView::from_row).collect(),
+            Err(err) => {
+                respond_json(
+                    request,
+                    500,
+                    json_error_bytes(&format!("list_recent failed: {err}")).as_slice(),
+                );
+                return;
+            }
+        },
+        Err(_) => {
+            respond_json(
+                request,
+                500,
+                json_error_bytes("memory store mutex poisoned").as_slice(),
+            );
+            return;
+        }
+    };
+    let body = serde_json::to_vec(&rows).unwrap_or_else(|_| b"[]".to_vec());
+    respond_json(request, 200, &body);
 }
 
 fn handle_memory_search(request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
-    if memory.is_none() {
+    let Some(svc) = memory else {
         respond_json(
             request,
             503,
             json_error_bytes("memory subsystem unavailable").as_slice(),
         );
         return;
+    };
+    let qs = parse_query_string(request.url());
+    let Some(query) = qs.get("q").cloned() else {
+        respond_json(
+            request,
+            400,
+            json_error_bytes("missing required query parameter `q`").as_slice(),
+        );
+        return;
+    };
+    if query.is_empty() {
+        respond_json(
+            request,
+            400,
+            json_error_bytes("query parameter `q` must not be empty").as_slice(),
+        );
+        return;
     }
-    // TODO(#263): parse `?q=` + `?k=`, run hybrid search via embedder +
-    // store + lexical, return `[{id, tier, content, score}]`.
-    respond_json(request, 200, b"[]");
+    let k: usize = qs
+        .get("k")
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(10);
+    let session_id = qs.get("session_id").map(String::as_str);
+    let tier_floor = qs.get("tier_floor").and_then(|s| parse_tier(s));
+    let scope_key = qs.get("scope_key").map(String::as_str);
+
+    let body = match run_hybrid_search(svc, &query, k, session_id, tier_floor, scope_key) {
+        Ok(b) => b,
+        Err(err) => {
+            respond_json(
+                request,
+                500,
+                json_error_bytes(&format!("search failed: {err}")).as_slice(),
+            );
+            return;
+        }
+    };
+    respond_json(request, 200, &body);
+}
+
+/// Shared body for `/memory/search` and the in-process daemon test paths.
+fn run_hybrid_search(
+    svc: &std::sync::Arc<MemoryService>,
+    query: &str,
+    k: usize,
+    session_id: Option<&str>,
+    tier_floor: Option<Tier>,
+    scope_key: Option<&str>,
+) -> Result<Vec<u8>, String> {
+    // BM25 first — does not require the embedder.
+    let lex_hits = {
+        let lex = svc
+            .lexical
+            .lock()
+            .map_err(|_| "memory lexical mutex poisoned".to_string())?;
+        lex.search(query, k, session_id, tier_floor, scope_key)
+            .map_err(|e| e.to_string())?
+    };
+
+    // KNN: only attempt if the embedder is live and dims match.
+    let vec_hits = match svc.embedder.embed(query) {
+        Ok(emb) => {
+            let store = svc
+                .store
+                .lock()
+                .map_err(|_| "memory store mutex poisoned".to_string())?;
+            store
+                .knn(&emb, k, session_id, tier_floor, scope_key)
+                .map_err(|e| e.to_string())?
+        }
+        Err(_) => Vec::new(),
+    };
+
+    let fused = rrf_fuse(&lex_hits, &vec_hits, &HybridSearchConfig::default());
+
+    let mut out: Vec<serde_json::Value> = Vec::with_capacity(fused.len());
+    if !fused.is_empty() {
+        let store = svc
+            .store
+            .lock()
+            .map_err(|_| "memory store mutex poisoned".to_string())?;
+        for hit in fused {
+            if let Ok(Some(row)) = store.fetch(&hit.id) {
+                out.push(serde_json::json!({
+                    "id": row.id.as_str(),
+                    "tier": tier_name(row.tier),
+                    "content": row.content,
+                    "score": hit.score,
+                    "session_id": row.session_id,
+                    "scope_key": row.scope_key,
+                    "created_at_ms": row.created_at_ms,
+                }));
+            }
+        }
+    }
+    serde_json::to_vec(&out).map_err(|e| e.to_string())
 }
 
 fn handle_memory_stats(request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
@@ -429,63 +656,230 @@ fn handle_memory_stats(request: Request, memory: Option<&std::sync::Arc<MemorySe
         );
         return;
     };
-    // The embedder name is cheap and useful even before #263 ships, so
-    // populate it now. Counts stay at 0 until #263 wires them up.
     let embedder_status =
         <crate::memory::Embedder as EmbedderTrait>::name(svc.embedder.as_ref()).to_string();
+    let embedder_dim = <crate::memory::Embedder as EmbedderTrait>::dim(svc.embedder.as_ref());
+
+    let (working, episodic, semantic, user_version, embed_dim) = match svc.store.lock() {
+        Ok(store) => {
+            let counts = store.count_by_tier().unwrap_or((0, 0, 0));
+            let uv = store.user_version().unwrap_or(0);
+            (counts.0, counts.1, counts.2, uv, store.embed_dim())
+        }
+        Err(_) => (0, 0, 0, 0, 0),
+    };
     let body = serde_json::json!({
         "tier_counts": {
-            "working": 0,
-            "episodic": 0,
-            "semantic": 0,
+            "working": working,
+            "episodic": episodic,
+            "semantic": semantic,
         },
         "embedder_status": embedder_status,
+        "embedder_dim": embedder_dim,
+        "store_embed_dim": embed_dim,
+        "schema_user_version": user_version,
         "consolidate_interval_ms": svc.consolidate_interval_ms,
     });
     let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
     respond_json(request, 200, &bytes);
 }
 
-fn handle_memory_save(request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
-    if memory.is_none() {
+fn handle_memory_save(mut request: Request, memory: Option<&std::sync::Arc<MemoryService>>) {
+    let Some(svc) = memory else {
         respond_json(
             request,
             503,
             json_error_bytes("memory subsystem unavailable").as_slice(),
         );
         return;
+    };
+    let body_bytes = match read_body(&mut request) {
+        Ok(b) => b,
+        Err(err) => {
+            respond_json(
+                request,
+                400,
+                json_error_bytes(&format!("read body failed: {err}")).as_slice(),
+            );
+            return;
+        }
+    };
+    let payload: MemorySaveRequest = match serde_json::from_slice(&body_bytes) {
+        Ok(p) => p,
+        Err(err) => {
+            respond_json(
+                request,
+                400,
+                json_error_bytes(&format!("invalid JSON: {err}")).as_slice(),
+            );
+            return;
+        }
+    };
+    if payload.content.is_empty() {
+        respond_json(
+            request,
+            400,
+            json_error_bytes("`content` must not be empty").as_slice(),
+        );
+        return;
     }
-    // TODO(#263): parse `{content, tier, session_id?, scope_key?}`,
-    // embed, store, lexical-upsert, return `{id}`. Stub returns 501 so
-    // the dashboard's save form gets a deterministic error until then.
-    respond_json(
-        request,
-        501,
-        json_error_bytes("memory save not implemented in this build (see #263)").as_slice(),
-    );
+    let tier = payload
+        .tier
+        .as_deref()
+        .map(parse_tier)
+        .unwrap_or(Some(Tier::Working));
+    let Some(tier) = tier else {
+        respond_json(
+            request,
+            400,
+            json_error_bytes("`tier` must be one of working|episodic|semantic").as_slice(),
+        );
+        return;
+    };
+
+    let embedding = match svc.embedder.embed(&payload.content) {
+        Ok(v) => v,
+        Err(err) => {
+            respond_json(
+                request,
+                500,
+                json_error_bytes(&format!("embedder failed: {err}")).as_slice(),
+            );
+            return;
+        }
+    };
+    let id = MemoryId::new_v7();
+    let now_ms = current_unix_ms();
+    let row = MemoryRow {
+        id: id.clone(),
+        session_id: payload.session_id.clone(),
+        scope_key: payload.scope_key.clone(),
+        branch_name: None,
+        is_orphan: false,
+        tier,
+        content: payload.content.clone(),
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+        tier_change_at_ms: now_ms,
+        access_count: 0,
+        last_access_at_ms: now_ms,
+        metadata_json: payload.metadata_json.clone(),
+    };
+    if let Err(err) = insert_with_lexical(svc, &row, &embedding) {
+        respond_json(
+            request,
+            500,
+            json_error_bytes(&format!("save failed: {err}")).as_slice(),
+        );
+        return;
+    }
+    let body = serde_json::json!({
+        "id": id.as_str(),
+        "tier": tier_name(tier),
+        "created_at_ms": now_ms,
+    });
+    let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
+    respond_json(request, 200, &bytes);
+}
+
+fn insert_with_lexical(
+    svc: &std::sync::Arc<MemoryService>,
+    row: &MemoryRow,
+    embedding: &[f32],
+) -> Result<(), String> {
+    {
+        let mut store = svc
+            .store
+            .lock()
+            .map_err(|_| "memory store mutex poisoned".to_string())?;
+        store.insert(row, embedding).map_err(|e| e.to_string())?;
+    }
+    let mut lex = svc
+        .lexical
+        .lock()
+        .map_err(|_| "memory lexical mutex poisoned".to_string())?;
+    lex.upsert(
+        &row.id,
+        row.session_id.as_deref(),
+        row.scope_key.as_deref(),
+        row.tier,
+        &row.content,
+    )
+    .map_err(|e| e.to_string())?;
+    lex.commit().map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 fn handle_memory_forget(
     request: Request,
-    _id: &str,
+    id_str: &str,
     memory: Option<&std::sync::Arc<MemoryService>>,
 ) {
-    if memory.is_none() {
+    let Some(svc) = memory else {
         respond_json(
             request,
             503,
             json_error_bytes("memory subsystem unavailable").as_slice(),
         );
         return;
+    };
+    let id = match MemoryId::parse(id_str) {
+        Ok(id) => id,
+        Err(err) => {
+            respond_json(
+                request,
+                400,
+                json_error_bytes(&format!("invalid id: {err}")).as_slice(),
+            );
+            return;
+        }
+    };
+    let removed = match svc.store.lock() {
+        Ok(mut store) => match store.delete(&id) {
+            Ok(b) => b,
+            Err(err) => {
+                respond_json(
+                    request,
+                    500,
+                    json_error_bytes(&format!("delete failed: {err}")).as_slice(),
+                );
+                return;
+            }
+        },
+        Err(_) => {
+            respond_json(
+                request,
+                500,
+                json_error_bytes("memory store mutex poisoned").as_slice(),
+            );
+            return;
+        }
+    };
+    if removed {
+        if let Ok(mut lex) = svc.lexical.lock() {
+            let _ = lex.delete(&id);
+            let _ = lex.commit();
+        }
     }
-    // TODO(#263): validate id, call `SqliteStore::delete` +
-    // `LexicalIndex::delete`, return `{deleted: true}`.
-    respond_json(
-        request,
-        501,
-        json_error_bytes("memory forget not implemented in this build (see #263)").as_slice(),
-    );
+    let body = serde_json::json!({
+        "id": id.as_str(),
+        "forgotten": removed,
+    });
+    let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
+    respond_json(request, 200, &bytes);
 }
+
+fn current_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Drop dead-code lint warning when `SqliteStore` import is used only
+/// via helper paths above on some cfg combinations.
+#[allow(dead_code)]
+fn _force_sqlitestore_use(_s: &SqliteStore) {}
 
 // ---------- state aggregation ----------
 
@@ -1334,12 +1728,13 @@ mod tests {
         assert_eq!(status, 503);
     }
 
-    /// With a live `MemoryService`, the stub bodies #263 will replace
-    /// are wired through: stats returns 200 with the documented JSON
-    /// shape; recent/search return 200 with an empty array; save/forget
-    /// return 501 until #263 implements them.
+    /// With a live `MemoryService`, the memory routes now serve real
+    /// bodies (#262): stats returns 200 with tier counts, recent/search
+    /// return 200 with an empty array on a fresh store, save validates
+    /// payloads and returns 400 on empty body, forget rejects ill-formed
+    /// ids with 400.
     #[test]
-    fn memory_routes_serve_stubs_when_subsystem_present() {
+    fn memory_routes_serve_real_bodies_when_subsystem_present() {
         // Force the embedder to `Disabled` so the test doesn't try to
         // download a fastembed model.
         let saved: Vec<(&str, Option<String>)> = [
@@ -1393,19 +1788,87 @@ mod tests {
         assert_eq!(status, 200);
         assert_eq!(body.trim(), "[]");
 
+        // Save with empty content is rejected as a 400.
         let (status, _) =
             fetch_path_with_status(port, "POST", "/memory/save", Some("{}".to_string()))
                 .expect("save");
-        assert_eq!(status, 501);
+        assert_eq!(status, 400);
 
+        // Forget with a non-uuid id is rejected as a 400.
         let (status, _) =
             fetch_path_with_status(port, "POST", "/memory/forget/abc", Some("{}".to_string()))
                 .expect("forget");
-        assert_eq!(status, 501);
+        assert_eq!(status, 400);
+
+        // /memory/stats now exposes embedder_dim, store_embed_dim,
+        // and schema_user_version on top of the original three fields.
+        let (status, body) =
+            fetch_path_with_status(port, "GET", "/memory/stats", None).expect("stats v2");
+        assert_eq!(status, 200);
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("json");
+        assert!(parsed.get("embedder_dim").is_some(), "body={body}");
+        assert!(parsed.get("store_embed_dim").is_some(), "body={body}");
+        assert!(parsed.get("schema_user_version").is_some(), "body={body}");
 
         svc.shutdown();
 
         // Restore env.
+        for (k, v) in saved {
+            match v {
+                Some(val) => unsafe { std::env::set_var(k, val) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+    }
+
+    /// Issue #262: save without `q` parameter is rejected. Empty `q` is
+    /// also rejected. These are the validation seams the CLI relies on
+    /// for its `clud memory search` exit codes.
+    #[test]
+    fn memory_search_rejects_missing_and_empty_q() {
+        let saved: Vec<(&str, Option<String>)> = [
+            "CLUD_MEMORY_EMBEDDER",
+            "CLUD_MEMORY_EMBEDDER_PROVIDER",
+            "CLUD_MEMORY_EMBEDDER_URL",
+            "CLUD_MEMORY_EMBEDDER_API_KEY",
+            "CLUD_MEMORY_EMBEDDER_MODEL",
+        ]
+        .iter()
+        .map(|k| (*k, std::env::var(*k).ok()))
+        .collect();
+        for (k, _) in &saved {
+            unsafe {
+                std::env::remove_var(k);
+            }
+        }
+        unsafe {
+            std::env::set_var("CLUD_MEMORY_EMBEDDER", "disabled");
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let svc = crate::daemon::memory_service::spawn_memory_service(dir.path())
+            .expect("memory service");
+        let svc = std::sync::Arc::new(svc);
+
+        let port = spawn_dashboard(
+            dir.path().to_path_buf(),
+            None,
+            9999,
+            100,
+            empty_live_provider(),
+            Some(svc.clone()),
+        )
+        .expect("dashboard spawned");
+
+        let (status, _) =
+            fetch_path_with_status(port, "GET", "/memory/search", None).expect("missing q");
+        assert_eq!(status, 400);
+
+        let (status, _) =
+            fetch_path_with_status(port, "GET", "/memory/search?q=", None).expect("empty q");
+        assert_eq!(status, 400);
+
+        svc.shutdown();
         for (k, v) in saved {
             match v {
                 Some(val) => unsafe { std::env::set_var(k, val) },

--- a/crates/clud-bin/src/daemon/memory_client.rs
+++ b/crates/clud-bin/src/daemon/memory_client.rs
@@ -1,0 +1,161 @@
+//! Issue #262: HTTP client used by the `clud memory *` CLI verbs.
+//!
+//! Talks to the dashboard's `/memory/*` routes (loopback, no auth). All
+//! calls go through the daemon so there is exactly one SQLite writer per
+//! process (DD-018). Each helper returns a tuple of `(status, body)` —
+//! callers map status → exit code and decode the JSON body.
+
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::time::Duration;
+
+use super::http::read_dashboard_port;
+
+const READ_WRITE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Result of one HTTP call against the dashboard's memory routes.
+pub struct MemoryHttpResponse {
+    pub status: u16,
+    pub body: String,
+}
+
+/// `GET /memory/stats`.
+pub fn http_stats(state_dir: &Path) -> io::Result<MemoryHttpResponse> {
+    fetch(state_dir, "GET", "/memory/stats", None)
+}
+
+/// `GET /memory/recent?limit=<n>`.
+pub fn http_recent(state_dir: &Path, limit: usize) -> io::Result<MemoryHttpResponse> {
+    let path = format!("/memory/recent?limit={limit}");
+    fetch(state_dir, "GET", &path, None)
+}
+
+/// `GET /memory/search?q=...&k=...&...`.
+pub fn http_search(
+    state_dir: &Path,
+    query: &str,
+    k: u32,
+    session_id: Option<&str>,
+    tier_floor: Option<&str>,
+    scope_key: Option<&str>,
+) -> io::Result<MemoryHttpResponse> {
+    let mut path = format!("/memory/search?q={}&k={}", url_encode(query), k.max(1));
+    if let Some(s) = session_id {
+        path.push_str("&session_id=");
+        path.push_str(&url_encode(s));
+    }
+    if let Some(t) = tier_floor {
+        path.push_str("&tier_floor=");
+        path.push_str(&url_encode(t));
+    }
+    if let Some(sk) = scope_key {
+        path.push_str("&scope_key=");
+        path.push_str(&url_encode(sk));
+    }
+    fetch(state_dir, "GET", &path, None)
+}
+
+/// `POST /memory/save` with a JSON body.
+pub fn http_save(state_dir: &Path, payload: &str) -> io::Result<MemoryHttpResponse> {
+    fetch(state_dir, "POST", "/memory/save", Some(payload))
+}
+
+/// `POST /memory/forget/<id>`.
+pub fn http_forget(state_dir: &Path, id: &str) -> io::Result<MemoryHttpResponse> {
+    let path = format!("/memory/forget/{}", url_encode(id));
+    fetch(state_dir, "POST", &path, Some("{}"))
+}
+
+fn fetch(
+    state_dir: &Path,
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+) -> io::Result<MemoryHttpResponse> {
+    let port = read_dashboard_port(state_dir)?
+        .ok_or_else(|| io::Error::other("daemon has no dashboard listener"))?;
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(READ_WRITE_TIMEOUT))?;
+    stream.set_write_timeout(Some(READ_WRITE_TIMEOUT))?;
+
+    let mut req = format!("{method} {path} HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n");
+    if let Some(b) = body {
+        req.push_str(&format!(
+            "Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            b.len(),
+            b
+        ));
+    } else {
+        req.push_str("\r\n");
+    }
+    stream.write_all(req.as_bytes())?;
+    stream.flush()?;
+
+    let mut buf = Vec::with_capacity(4096);
+    stream.read_to_end(&mut buf)?;
+    let status_line_end = buf
+        .windows(2)
+        .position(|w| w == b"\r\n")
+        .or_else(|| buf.windows(1).position(|w| w == b"\n"))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no status line"))?;
+    let status_line = std::str::from_utf8(&buf[..status_line_end])
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no status code"))?;
+    let body_start = find_body_start(&buf)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no header terminator"))?;
+    let body = String::from_utf8(buf[body_start..].to_vec())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    Ok(MemoryHttpResponse { status, body })
+}
+
+fn find_body_start(buf: &[u8]) -> Option<usize> {
+    buf.windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|i| i + 4)
+        .or_else(|| buf.windows(2).position(|w| w == b"\n\n").map(|i| i + 2))
+}
+
+fn url_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '~') {
+            out.push(c);
+        } else {
+            let mut buf = [0u8; 4];
+            let bytes = c.encode_utf8(&mut buf).as_bytes();
+            for b in bytes {
+                out.push_str(&format!("%{:02X}", b));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_encode_passes_unreserved() {
+        assert_eq!(url_encode("abc123_-.~"), "abc123_-.~");
+    }
+
+    #[test]
+    fn url_encode_escapes_spaces_and_quotes() {
+        assert_eq!(url_encode("hello world"), "hello%20world");
+        assert_eq!(url_encode("a&b=c"), "a%26b%3Dc");
+    }
+
+    #[test]
+    fn find_body_start_picks_crlf_or_lf() {
+        let crlf = b"HTTP/1.0 200 OK\r\n\r\nbody";
+        let lf = b"HTTP/1.0 200 OK\n\nbody";
+        assert_eq!(&crlf[find_body_start(crlf).unwrap()..], b"body");
+        assert_eq!(&lf[find_body_start(lf).unwrap()..], b"body");
+    }
+}

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -6,6 +6,7 @@ mod gc_service;
 mod http;
 mod io_helpers;
 mod keys;
+mod memory_client;
 pub(crate) mod memory_mcp;
 mod memory_service;
 mod paths;
@@ -24,6 +25,9 @@ pub use entry::{experimental_enabled, handle_special_command, run_centralized_se
 pub use http::{
     dashboard_url_from_info, fetch_state_json, read_dashboard_info, read_dashboard_port,
     DashboardInfo,
+};
+pub use memory_client::{
+    http_forget, http_recent, http_save, http_search, http_stats, MemoryHttpResponse,
 };
 pub use paths::{default_state_dir, default_trash_dir};
 pub use types::{ListRow, RepoVisit, ENV_NO_DAEMON};

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,7 @@
 use clud::{
     args, backend, backend_bootstrap, command, console_setup, console_title, ctrl_c_track, daemon,
     gc, graphics, hook_health, large_file_guard, launch_setup, loop_artifacts, loop_spec,
-    mcp_bridge, runner, startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
+    mcp_bridge, memory, runner, startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -83,6 +83,13 @@ fn main() {
     // frames to the daemon's memory_mcp_port.
     if let Some(args::Command::Mcp) = &args.command {
         std::process::exit(mcp_bridge::run());
+    }
+
+    // Issue #262: `clud memory <sub>` is self-contained maintenance.
+    // Never launches a backend; talks to the daemon's HTTP routes for
+    // mutating ops (single SQLite writer per process).
+    if let Some(args::Command::Memory { subcommand }) = &args.command {
+        std::process::exit(memory::cli::run(&args, subcommand.clone()));
     }
 
     // Issue #182: `clud trash` is self-contained maintenance. Dispatch

--- a/crates/clud-bin/src/memory/README.md
+++ b/crates/clud-bin/src/memory/README.md
@@ -203,3 +203,32 @@ args = ["mcp"]
 `clud mcp` calls `daemon::ensure_daemon` so a cold first launch
 transparently brings the clud daemon up; subsequent connects are
 loopback TCP only.
+
+## CLI surface (#262)
+
+`cli.rs` dispatches `clud memory <verb>` to thin handlers that proxy
+through the daemon's `/memory/*` HTTP routes. The daemon owns the
+single SQLite writer per process; the CLI's job is to embed the user's
+text where needed, hit HTTP, and pretty-print the JSON response. See
+[DD-018](../../../../docs/DESIGN_DECISIONS.md#dd-018-clud-memory-cli-verbs-proxy-mutating-ops-through-the-daemon).
+
+| Verb | Action | Daemon route |
+|---|---|---|
+| `init` | Best-effort embedder warm; prints resolved paths + embed_dim | `GET /memory/stats` |
+| `status [--json]` | Tier counts, embedder name + dim, schema user_version | `GET /memory/stats` |
+| `search <q> [-k N] [--session-id] [--tier-floor] [--scope-key] [--json]` | RRF hybrid BM25 + KNN search | `GET /memory/search?q=&k=&...` |
+| `save <content> [--tier] [--session-id] [--metadata] [--json]` | Embed + insert | `POST /memory/save` |
+| `forget <id> [--json]` | Delete row, cascade to vec + tantivy | `POST /memory/forget/<id>` |
+| `export [--to-stdout]` | Dump recent rows as JSON-lines | `GET /memory/recent?limit=100000` |
+| `export --to-disk` | Stub — deferred to #264 | (none) |
+| `import --from-stdin` | Read JSON-lines from stdin, re-save each | `POST /memory/save` per line |
+| `import --from-disk` | Stub — deferred to #264 | (none) |
+| `ui [--no-open]` | Open dashboard at `#memory` | reads daemon-info |
+| `reembed [--model] [--dry-run]` | Count rows (dry-run) or note that live reembed needs the daemon stopped | `GET /memory/stats` |
+| `branch-isolate` | Write `<common-dir>/.clud/memory-branch-isolate` | none — local fs |
+| `branch-unisolate` | Remove the marker | none — local fs |
+
+Exit codes: `0` success, `1` user error (validation / missing query /
+empty content), `2` internal error (HTTP 5xx / JSON decode failure /
+non-git repo for branch-isolate), `3` daemon unavailable (including
+`--no-daemon`).

--- a/crates/clud-bin/src/memory/cli.rs
+++ b/crates/clud-bin/src/memory/cli.rs
@@ -1,0 +1,659 @@
+//! Issue #262: `clud memory *` CLI verb dispatch.
+//!
+//! All mutating verbs proxy through the daemon's `/memory/*` HTTP routes
+//! (single SQLite writer per process — DD-018). Read-only verbs that
+//! only inspect the daemon's view of the store (`status`, `search`) also
+//! use HTTP. The two verbs that touch the local working tree directly
+//! (`branch-isolate` / `branch-unisolate`) call the library functions
+//! `memory::identity::branch_isolate` / `branch_unisolate` against the
+//! current repo's `git common-dir`.
+//!
+//! Exit codes:
+//! - `0` success.
+//! - `1` user error (validation, unknown id, missing query).
+//! - `2` internal error (HTTP 5xx, JSON decode failure, IO error).
+//! - `3` daemon unavailable / `--no-daemon`.
+
+use std::io::{self, BufRead, Write};
+use std::path::Path;
+
+use clap::CommandFactory;
+use serde_json::json;
+
+use crate::args::{Args, MemorySubcommand};
+use crate::daemon::{self, MemoryHttpResponse};
+use crate::memory::identity;
+
+/// Dispatch a `clud memory <sub>` invocation. Returns the process exit
+/// code.
+pub fn run(args: &Args, sub: Option<MemorySubcommand>) -> i32 {
+    // Bare `clud memory` prints help.
+    let Some(sub) = sub else {
+        return print_help_and_exit_zero();
+    };
+
+    // Verbs that touch local working-tree state and never need the
+    // daemon. `--to-disk` / `--from-disk` are #264 stubs and exit
+    // cleanly without contacting the daemon.
+    match &sub {
+        MemorySubcommand::BranchIsolate => return cmd_branch_isolate(),
+        MemorySubcommand::BranchUnisolate => return cmd_branch_unisolate(),
+        MemorySubcommand::Export { to_disk, .. } if *to_disk => return cmd_export_to_disk_stub(),
+        MemorySubcommand::Import { from_disk, .. } if *from_disk => {
+            return cmd_import_from_disk_stub();
+        }
+        _ => {}
+    }
+
+    // The rest require the daemon.
+    if args.no_daemon {
+        eprintln!("error: memory operations require the clud daemon; remove --no-daemon");
+        return 3;
+    }
+    let state_dir = match daemon::default_state_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: cannot resolve clud state dir: {e}");
+            return 2;
+        }
+    };
+    if let Err(e) = daemon::ensure_daemon(&state_dir) {
+        eprintln!("error: daemon unavailable: {e}");
+        return 3;
+    }
+
+    match sub {
+        MemorySubcommand::Init => cmd_init(&state_dir),
+        MemorySubcommand::Status { json } => cmd_status(&state_dir, json),
+        MemorySubcommand::Search {
+            query,
+            k,
+            session_id,
+            tier_floor,
+            scope_key,
+            json,
+        } => cmd_search(
+            &state_dir,
+            &query,
+            k,
+            session_id.as_deref(),
+            tier_floor.as_deref(),
+            scope_key.as_deref(),
+            json,
+        ),
+        MemorySubcommand::Save {
+            content,
+            tier,
+            session_id,
+            metadata,
+            json,
+        } => cmd_save(
+            &state_dir,
+            &content,
+            &tier,
+            session_id.as_deref(),
+            metadata.as_deref(),
+            json,
+        ),
+        MemorySubcommand::Forget { id, json } => cmd_forget(&state_dir, &id, json),
+        MemorySubcommand::Export { .. } => cmd_export_to_stdout(&state_dir),
+        MemorySubcommand::Import { from_stdin, .. } if from_stdin => {
+            cmd_import_from_stdin(&state_dir)
+        }
+        MemorySubcommand::Import { .. } => cmd_import_default(),
+        MemorySubcommand::Ui { no_open } => cmd_ui(&state_dir, no_open),
+        MemorySubcommand::Reembed { model, dry_run } => {
+            cmd_reembed(&state_dir, model.as_deref(), dry_run)
+        }
+        MemorySubcommand::BranchIsolate | MemorySubcommand::BranchUnisolate => {
+            // Already handled above; unreachable.
+            0
+        }
+    }
+}
+
+fn print_help_and_exit_zero() -> i32 {
+    let mut top = Args::command();
+    match top.find_subcommand_mut("memory") {
+        Some(mem) => {
+            let _ = mem.print_help();
+            println!();
+            0
+        }
+        None => {
+            eprintln!("error: memory subcommand definition missing (internal bug)");
+            2
+        }
+    }
+}
+
+// ---------- handlers ----------
+
+fn cmd_init(state_dir: &Path) -> i32 {
+    // `ensure_daemon` already ran. Touch the stats endpoint to confirm
+    // the memory service is alive and surface the resolved paths +
+    // embedder name.
+    match daemon::http_stats(state_dir) {
+        Ok(resp) if resp.status == 200 => {
+            let memory_dir = state_dir.join("memory");
+            println!("memory: initialized");
+            println!("  state dir       : {}", state_dir.display());
+            println!(
+                "  db path         : {}",
+                memory_dir.join("memory.db").display()
+            );
+            println!(
+                "  tantivy dir     : {}",
+                memory_dir.join("tantivy").display()
+            );
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&resp.body) {
+                if let Some(name) = parsed.get("embedder_status").and_then(|v| v.as_str()) {
+                    println!("  embedder        : {name}");
+                }
+                if let Some(dim) = parsed.get("embedder_dim").and_then(|v| v.as_u64()) {
+                    println!("  embedder dim    : {dim}");
+                }
+                if let Some(dim) = parsed.get("store_embed_dim").and_then(|v| v.as_u64()) {
+                    println!("  store embed dim : {dim}");
+                }
+                if let Some(uv) = parsed.get("schema_user_version").and_then(|v| v.as_u64()) {
+                    println!("  schema version  : {uv}");
+                }
+            }
+            0
+        }
+        Ok(resp) if resp.status == 503 => {
+            eprintln!("error: memory subsystem unavailable on running daemon");
+            eprintln!("note: try `clud daemon restart` to retry the embedder load");
+            2
+        }
+        Ok(resp) => {
+            eprintln!("error: init failed ({}): {}", resp.status, resp.body);
+            2
+        }
+        Err(e) => {
+            eprintln!("error: init failed: {e}");
+            2
+        }
+    }
+}
+
+fn cmd_status(state_dir: &Path, want_json: bool) -> i32 {
+    match daemon::http_stats(state_dir) {
+        Ok(resp) if resp.status == 200 => {
+            if want_json {
+                println!("{}", resp.body);
+                return 0;
+            }
+            let parsed: serde_json::Value =
+                serde_json::from_str(&resp.body).unwrap_or(serde_json::Value::Null);
+            let counts = parsed.get("tier_counts").cloned().unwrap_or_default();
+            let working = counts.get("working").and_then(|v| v.as_u64()).unwrap_or(0);
+            let episodic = counts.get("episodic").and_then(|v| v.as_u64()).unwrap_or(0);
+            let semantic = counts.get("semantic").and_then(|v| v.as_u64()).unwrap_or(0);
+            let embedder = parsed
+                .get("embedder_status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let edim = parsed
+                .get("embedder_dim")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let sdim = parsed
+                .get("store_embed_dim")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let uv = parsed
+                .get("schema_user_version")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let interval = parsed
+                .get("consolidate_interval_ms")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let total = working + episodic + semantic;
+            println!("clud memory  ({total} rows)");
+            println!(
+                "  db path        : {}",
+                state_dir.join("memory").join("memory.db").display()
+            );
+            println!("  embedder       : {embedder} (dim={edim}, store_dim={sdim})");
+            println!("  schema version : {uv}");
+            println!(
+                "  by tier        : working {working}  episodic {episodic}  semantic {semantic}"
+            );
+            println!("  consolidate    : every {interval} ms");
+            0
+        }
+        Ok(resp) if resp.status == 503 => {
+            eprintln!("error: memory subsystem unavailable");
+            2
+        }
+        Ok(resp) => {
+            eprintln!("error: status failed ({}): {}", resp.status, resp.body);
+            2
+        }
+        Err(e) => {
+            eprintln!("error: status request failed: {e}");
+            2
+        }
+    }
+}
+
+fn cmd_search(
+    state_dir: &Path,
+    query: &str,
+    k: u32,
+    session_id: Option<&str>,
+    tier_floor: Option<&str>,
+    scope_key: Option<&str>,
+    want_json: bool,
+) -> i32 {
+    if query.is_empty() {
+        eprintln!("error: query must not be empty");
+        return 1;
+    }
+    match daemon::http_search(state_dir, query, k, session_id, tier_floor, scope_key) {
+        Ok(resp) if resp.status == 200 => {
+            if want_json {
+                println!("{}", resp.body);
+                return 0;
+            }
+            let parsed: serde_json::Value =
+                serde_json::from_str(&resp.body).unwrap_or(serde_json::Value::Null);
+            let empty = Vec::new();
+            let hits = parsed.as_array().unwrap_or(&empty);
+            if hits.is_empty() {
+                println!("(no matches)");
+                return 0;
+            }
+            for hit in hits {
+                let id = hit.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+                let tier = hit.get("tier").and_then(|v| v.as_str()).unwrap_or("?");
+                let score = hit.get("score").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                let content = hit.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                let trimmed = excerpt(content, 80);
+                println!("{id}  [{tier}]  score={score:.4}  {trimmed}");
+            }
+            0
+        }
+        Ok(resp) if resp.status == 400 => {
+            eprintln!("error: invalid search request: {}", resp.body);
+            1
+        }
+        Ok(resp) if resp.status == 503 => {
+            eprintln!("error: memory subsystem unavailable");
+            2
+        }
+        Ok(resp) => {
+            eprintln!("error: search failed ({}): {}", resp.status, resp.body);
+            2
+        }
+        Err(e) => {
+            eprintln!("error: search request failed: {e}");
+            2
+        }
+    }
+}
+
+fn cmd_save(
+    state_dir: &Path,
+    content: &str,
+    tier: &str,
+    session_id: Option<&str>,
+    metadata: Option<&str>,
+    want_json: bool,
+) -> i32 {
+    if content.is_empty() {
+        eprintln!("error: content must not be empty");
+        return 1;
+    }
+    let payload = json!({
+        "content": content,
+        "tier": tier,
+        "session_id": session_id,
+        "metadata_json": metadata,
+    })
+    .to_string();
+    match daemon::http_save(state_dir, &payload) {
+        Ok(resp) if resp.status == 200 => {
+            if want_json {
+                println!("{}", resp.body);
+                return 0;
+            }
+            let parsed: serde_json::Value =
+                serde_json::from_str(&resp.body).unwrap_or(serde_json::Value::Null);
+            let id = parsed.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+            let saved_tier = parsed.get("tier").and_then(|v| v.as_str()).unwrap_or(tier);
+            println!("saved id={id}  tier={saved_tier}");
+            0
+        }
+        Ok(resp) if resp.status == 400 => {
+            eprintln!("error: invalid save request: {}", resp.body);
+            1
+        }
+        Ok(resp) if resp.status == 503 => {
+            eprintln!("error: memory subsystem unavailable");
+            2
+        }
+        Ok(resp) => {
+            eprintln!("error: save failed ({}): {}", resp.status, resp.body);
+            2
+        }
+        Err(e) => {
+            eprintln!("error: save request failed: {e}");
+            2
+        }
+    }
+}
+
+fn cmd_forget(state_dir: &Path, id: &str, want_json: bool) -> i32 {
+    if id.is_empty() {
+        eprintln!("error: id must not be empty");
+        return 1;
+    }
+    match daemon::http_forget(state_dir, id) {
+        Ok(resp) if resp.status == 200 => {
+            if want_json {
+                println!("{}", resp.body);
+                return 0;
+            }
+            let parsed: serde_json::Value =
+                serde_json::from_str(&resp.body).unwrap_or(serde_json::Value::Null);
+            let forgotten = parsed
+                .get("forgotten")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if forgotten {
+                println!("forgot id={id}");
+            } else {
+                println!("(no row with id={id})");
+            }
+            0
+        }
+        Ok(resp) if resp.status == 400 => {
+            eprintln!("error: invalid forget request: {}", resp.body);
+            1
+        }
+        Ok(resp) if resp.status == 503 => {
+            eprintln!("error: memory subsystem unavailable");
+            2
+        }
+        Ok(resp) => {
+            eprintln!("error: forget failed ({}): {}", resp.status, resp.body);
+            2
+        }
+        Err(e) => {
+            eprintln!("error: forget request failed: {e}");
+            2
+        }
+    }
+}
+
+fn cmd_export_to_stdout(state_dir: &Path) -> i32 {
+    // Dump the recent list as JSON-lines. The daemon's `/memory/recent`
+    // route is the seam; we cap at a generous limit so a daemon with N
+    // rows can be exported in one pull.
+    match daemon::http_recent(state_dir, 100_000) {
+        Ok(resp) if resp.status == 200 => {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&resp.body).unwrap_or(serde_json::Value::Null);
+            let empty = Vec::new();
+            let rows = parsed.as_array().unwrap_or(&empty);
+            let mut out = io::stdout().lock();
+            for row in rows {
+                let line = serde_json::to_string(row).unwrap_or_default();
+                if writeln!(out, "{line}").is_err() {
+                    return 2;
+                }
+            }
+            0
+        }
+        Ok(resp) => {
+            eprintln!("error: export failed ({}): {}", resp.status, resp.body);
+            2
+        }
+        Err(e) => {
+            eprintln!("error: export request failed: {e}");
+            2
+        }
+    }
+}
+
+fn cmd_export_to_disk_stub() -> i32 {
+    println!("memory export --to-disk: deferred; see #264 for git-artifact serialization");
+    0
+}
+
+fn cmd_import_default() -> i32 {
+    eprintln!("error: pass --from-stdin to import JSON-lines, or --from-disk (see #264)");
+    1
+}
+
+fn cmd_import_from_stdin(state_dir: &Path) -> i32 {
+    let stdin = io::stdin();
+    let mut imported = 0usize;
+    let mut errored = 0usize;
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else {
+            errored += 1;
+            continue;
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let parsed: serde_json::Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(err) => {
+                eprintln!("warn: skipping malformed JSON line: {err}");
+                errored += 1;
+                continue;
+            }
+        };
+        let content = parsed.get("content").and_then(|v| v.as_str()).unwrap_or("");
+        if content.is_empty() {
+            eprintln!("warn: skipping row with empty content");
+            errored += 1;
+            continue;
+        }
+        let tier = parsed
+            .get("tier")
+            .and_then(|v| v.as_str())
+            .unwrap_or("working");
+        let session_id = parsed.get("session_id").and_then(|v| v.as_str());
+        let payload = json!({
+            "content": content,
+            "tier": tier,
+            "session_id": session_id,
+        })
+        .to_string();
+        match daemon::http_save(state_dir, &payload) {
+            Ok(resp) if resp.status == 200 => imported += 1,
+            Ok(resp) => {
+                eprintln!("warn: save failed ({}): {}", resp.status, resp.body);
+                errored += 1;
+            }
+            Err(e) => {
+                eprintln!("warn: save request failed: {e}");
+                errored += 1;
+            }
+        }
+    }
+    println!("imported: {imported}  skipped: {errored}");
+    if errored > 0 && imported == 0 {
+        2
+    } else {
+        0
+    }
+}
+
+fn cmd_import_from_disk_stub() -> i32 {
+    println!("memory import --from-disk: deferred; see #264 for git-artifact serialization");
+    0
+}
+
+fn cmd_ui(state_dir: &Path, no_open: bool) -> i32 {
+    let info = match daemon::read_dashboard_info(state_dir) {
+        Ok(info) => info,
+        Err(e) => {
+            eprintln!("error: cannot read daemon info: {e}");
+            return 2;
+        }
+    };
+    let Some(port) = info.dashboard_port else {
+        eprintln!(
+            "error: daemon (pid {}) has no dashboard listener; restart it via `clud daemon restart`",
+            info.pid
+        );
+        return 2;
+    };
+    let url = format!("{}#memory", daemon::dashboard_url_from_info(port));
+    println!("{url}");
+    if no_open {
+        return 0;
+    }
+    if let Err(e) = open::that_detached(&url) {
+        eprintln!("note: could not auto-open browser ({e}); paste the URL above");
+        return 1;
+    }
+    0
+}
+
+fn cmd_reembed(state_dir: &Path, model: Option<&str>, dry_run: bool) -> i32 {
+    if let Some(m) = model {
+        eprintln!("note: --model {m} is not honored in v1; daemon uses CLUD_MEMORY_EMBEDDER_*");
+    }
+    // The cheap path: count rows via /memory/stats, then either report
+    // (dry-run) or call reembed_all in-process against the daemon's
+    // SQLite handle. Because the daemon owns the writer, a true reembed
+    // would need a `POST /memory/reembed` route. For v1 we offer
+    // dry-run-only against the running daemon and call out the
+    // requirement to stop the daemon before a real reembed.
+    match daemon::http_stats(state_dir) {
+        Ok(resp) if resp.status == 200 => {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&resp.body).unwrap_or(serde_json::Value::Null);
+            let counts = parsed.get("tier_counts").cloned().unwrap_or_default();
+            let working = counts.get("working").and_then(|v| v.as_u64()).unwrap_or(0);
+            let episodic = counts.get("episodic").and_then(|v| v.as_u64()).unwrap_or(0);
+            let semantic = counts.get("semantic").and_then(|v| v.as_u64()).unwrap_or(0);
+            let total = working + episodic + semantic;
+            println!("reembed: {total} rows would be re-embedded ({working} working, {episodic} episodic, {semantic} semantic)");
+            if dry_run {
+                return 0;
+            }
+            eprintln!("note: live reembed requires a dedicated daemon route; for now stop the daemon and rerun with --dry-run to plan");
+            0
+        }
+        Ok(resp) => {
+            eprintln!("error: reembed failed ({}): {}", resp.status, resp.body);
+            2
+        }
+        Err(e) => {
+            eprintln!("error: reembed request failed: {e}");
+            2
+        }
+    }
+}
+
+fn cmd_branch_isolate() -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: cannot resolve cwd: {e}");
+            return 2;
+        }
+    };
+    let scope = match identity::resolve_repo_scope(&cwd) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: not a git repo: {e}");
+            return 1;
+        }
+    };
+    if let Err(e) = identity::branch_isolate(&scope.common_dir) {
+        eprintln!("error: branch-isolate failed: {e}");
+        return 2;
+    }
+    let updated = match identity::resolve_repo_scope(&cwd) {
+        Ok(s) => s,
+        Err(_) => scope,
+    };
+    println!("branch isolated.");
+    println!("  scope_key : {}", updated.key);
+    println!(
+        "  marker    : {}",
+        updated
+            .common_dir
+            .join(identity::BRANCH_ISOLATE_MARKER)
+            .display()
+    );
+    0
+}
+
+fn cmd_branch_unisolate() -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: cannot resolve cwd: {e}");
+            return 2;
+        }
+    };
+    let scope = match identity::resolve_repo_scope(&cwd) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: not a git repo: {e}");
+            return 1;
+        }
+    };
+    if let Err(e) = identity::branch_unisolate(&scope.common_dir) {
+        eprintln!("error: branch-unisolate failed: {e}");
+        return 2;
+    }
+    let updated = identity::resolve_repo_scope(&cwd).unwrap_or(scope);
+    println!("branch un-isolated.");
+    println!("  scope_key : {}", updated.key);
+    0
+}
+
+fn excerpt(s: &str, max: usize) -> String {
+    let collapsed: String = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= max {
+        collapsed
+    } else {
+        let truncated: String = collapsed.chars().take(max.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    }
+}
+
+// Re-export so the `print_help_and_exit_zero` call site can use it
+// through the existing `Args::command()` factory; the trait import lives
+// here intentionally so consumers of `memory::cli` get the full surface.
+#[allow(dead_code)]
+fn _ensure_response_used(r: &MemoryHttpResponse) -> u16 {
+    r.status
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn excerpt_collapses_whitespace_and_truncates() {
+        let long = "a".repeat(200);
+        let trimmed = excerpt(&long, 80);
+        // One leading ellipsis byte is added when truncation happens.
+        assert!(trimmed.chars().count() <= 80);
+    }
+
+    #[test]
+    fn excerpt_passes_short_input_unchanged() {
+        assert_eq!(excerpt("hello world", 80), "hello world");
+    }
+
+    #[test]
+    fn excerpt_collapses_internal_whitespace() {
+        assert_eq!(excerpt("hello\n\tworld", 80), "hello world");
+    }
+}

--- a/crates/clud-bin/src/memory/mod.rs
+++ b/crates/clud-bin/src/memory/mod.rs
@@ -7,6 +7,7 @@
 //! `LexicalIndex::upsert` accepts an explicit `Tier` instead of inferring
 //! one.
 
+pub mod cli;
 pub mod embedder;
 pub mod error;
 pub mod identity;

--- a/crates/clud-bin/src/memory/store.rs
+++ b/crates/clud-bin/src/memory/store.rs
@@ -269,6 +269,57 @@ impl SqliteStore {
         Ok(n > 0)
     }
 
+    /// Count rows by tier. Cheap aggregate query used by the CLI's
+    /// `clud memory status` verb and the daemon's `/memory/stats`
+    /// dashboard route.
+    pub fn count_by_tier(&self) -> Result<(usize, usize, usize), MemoryError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT tier, COUNT(*) FROM memories GROUP BY tier")?;
+        let mut working = 0usize;
+        let mut episodic = 0usize;
+        let mut semantic = 0usize;
+        let mut rows = stmt.query([])?;
+        while let Some(r) = rows.next()? {
+            let tier_i: i64 = r.get(0)?;
+            let count: i64 = r.get(1)?;
+            match Tier::from_i64(tier_i)? {
+                Tier::Working => working = count as usize,
+                Tier::Episodic => episodic = count as usize,
+                Tier::Semantic => semantic = count as usize,
+            }
+        }
+        Ok((working, episodic, semantic))
+    }
+
+    /// Schema `user_version`. Surfaced by `clud memory status`.
+    pub fn user_version(&self) -> Result<i32, MemoryError> {
+        let v: i32 = self
+            .conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))?;
+        Ok(v)
+    }
+
+    /// Newest-first list across all tiers, capped at `limit`. Used by
+    /// `/memory/recent` and the CLI's `clud memory export` verb.
+    pub fn list_recent(&self, limit: usize) -> Result<Vec<MemoryRow>, MemoryError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, session_id, tier, content,
+                    created_at_ms, updated_at_ms, tier_change_at_ms,
+                    access_count, last_access_at_ms, metadata_json,
+                    scope_key, branch_name, is_orphan
+               FROM memories
+              ORDER BY created_at_ms DESC
+              LIMIT ?1",
+        )?;
+        let mut rows = stmt.query(params![limit as i64])?;
+        let mut out = Vec::new();
+        while let Some(r) = rows.next()? {
+            out.push(row_from_sqlite(r)?);
+        }
+        Ok(out)
+    }
+
     pub fn list_by_tier(&self, tier: Tier) -> Result<Vec<MemoryRow>, MemoryError> {
         let mut stmt = self.conn.prepare(
             "SELECT id, session_id, tier, content,

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -519,3 +519,35 @@ This supersedes the "separate GC daemon" half of [DD-006](#dd-006--cluddataredb-
 - We carry the JSON-RPC wire protocol ourselves. Cheap (single file, fully unit-tested) but it does mean tracking the MCP protocol version manually. The advertised version (`2024-11-05`) is the one Claude Code's MCP host currently negotiates.
 - Adopting `rmcp` later is non-breaking — the file is self-contained and the wire shape (`{ content: [{type: "text", text: "<json>"}] }`) is exactly what `rmcp` emits. A future migration is a behind-the-curtain rewrite, not a public-API change.
 - `memory_reflect` ships as a documented stub returning a `-32603` internal error with a `v0.5` note. The reflect tool depends on knowledge graph (deferred past v1 per META #255) and an LLM provider (#257 v0.5 ladder), neither of which is on main yet. The stub means MCP hosts get a clean error today instead of a missing-tool error.
+
+---
+
+## DD-019: `clud memory` CLI verbs proxy mutating ops through the daemon
+
+**Context:** The `clud memory` CLI surface (issue #262) needs to talk to the SQLite + tantivy + embedder stack that lives inside the always-on `clud` daemon ([DD-017](#dd-017-memory-service-runs-in-process-inside-the-existing-clud-daemon)). The CLI is a separate short-lived process; the daemon is the long-lived process that holds the `Arc<Mutex<SqliteStore>>` and `Arc<Mutex<LexicalIndex>>`. There are two ways the CLI can perform a save / forget / reembed: (A) open the on-disk files itself and write through, or (B) round-trip the request through the daemon's existing `tiny_http` loopback listener.
+
+**Decision:** Every mutating `clud memory` verb (and the read-only `status` / `search` / `recent` verbs) talks to the daemon via the dashboard's `/memory/*` HTTP routes. `branch-isolate` / `branch-unisolate` are the only verbs that bypass the daemon — they write a marker file under the working tree's git common-dir and never touch the SQLite or tantivy state. The `--to-disk` / `--from-disk` flags on `export` / `import` are stubs that defer to #264.
+
+**Rationale:**
+- **Single SQLite writer per process.** rusqlite holds a process-global lock per opened connection. If the CLI also opened `memory.db` while the daemon held it, the second open would either fail outright (WAL with `EXCLUSIVE` mode) or succeed and race with the daemon's `BEGIN IMMEDIATE` calls. Daemons are notoriously bad at recovering from the resulting `SQLITE_BUSY` / `SQLITE_LOCKED` errors when the conflicting writer is in another process. Routing through the daemon collapses both writes onto the daemon's single mutex.
+- **tantivy `IndexWriter` is per-directory exclusive.** Two `IndexWriter`s against the same directory return `LockBusy`. Same failure mode as SQLite, same fix.
+- **Embedder is already loaded in the daemon.** The CLI saving a row has to embed it. The daemon already paid the embedder cold-start (#257); making the CLI load its own embedder would double the cost on every save (and would race against the daemon's local model cache directory on Windows).
+- **HTTP routes were 95% wired up by #261.** The `tiny_http` server already had the routes registered as stubs. Replacing the stub bodies with real implementations is a smaller change than introducing a new IPC channel just for memory ops.
+- **Read-only ops go through HTTP too for consistency.** A `clud memory status` that opened the SQLite file read-only would work, but it's one more code path to maintain and one more way the on-disk schema version can drift from what the daemon thinks. HTTP keeps `status` aligned with whatever the daemon is currently serving.
+- **`branch-isolate` is a marker-file write only.** No SQLite, no tantivy. Forcing it through the daemon would mean another route and a daemon round-trip for a `fs::write` call. The marker semantics are entirely local to the git common-dir.
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| CLI opens SQLite + tantivy directly | Races against the daemon's writer; two `IndexWriter`s on tantivy hit `LockBusy`; two `BEGIN IMMEDIATE` SQL writers hit `SQLITE_BUSY`. The user's failure mode is "save succeeds half the time." |
+| CLI uses the daemon's existing JSON-line IPC (the GC channel) | The IPC channel is single-threaded and already serializes session + GC ops. Adding memory ops would stall on the GC worker thread. HTTP has its own threadpool inside `tiny_http`. |
+| CLI talks to an MCP server | The MCP server (#259) doesn't exist yet at the time #262 ships. Building #262 on top of #259 would reverse the dependency order and block #262 on the MCP wire-format design. |
+| Make every CLI verb an in-process `--daemon-state-dir` sub-mode (`__memory`-style hidden command) that the daemon shells out to | Doubles startup latency on every verb (Rust binary startup + linker time) and the in-process variant of `MemoryService` is what we built in #261 already — HTTP is the documented seam. |
+
+**Consequences:**
+- The CLI is now a thin shell around HTTP requests. Each verb is ~50 LOC of validation + pretty-printing.
+- `daemon::http_save` / `http_forget` / `http_search` / `http_stats` / `http_recent` are the public seam (`crates/clud-bin/src/daemon/memory_client.rs`). Future sub-issues (MCP, hooks) can call them too, or use the in-process `MemoryService` Arc directly when running inside the daemon process.
+- The dashboard's `/memory/*` route bodies are no longer stubs — they delegate to the live `MemoryService` they already received. #261's `MemoryService` parameter is now load-bearing.
+- `--no-daemon memory <verb>` exits 3 with a clear message; there is no "offline" mode for the memory CLI. The two verbs that don't need the daemon (`branch-isolate`, `branch-unisolate`) handle `--no-daemon` implicitly by never calling `ensure_daemon`.
+- Live `clud memory reembed` against a running daemon is intentionally not implemented in v1 — the route would need to hold the SQLite mutex for the duration of an O(N) walk and would starve other ops. The CLI's `reembed --dry-run` reports counts, and the user is pointed at stopping the daemon for the real rewrite. A dedicated `POST /memory/reembed` with batching is future work.

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -289,22 +289,47 @@ Order matters on a save: take SQLite first, commit, drop, then take
 tantivy. The reconciliation pass on next boot covers the eventual-
 consistency window if a crash happens between the two commits.
 
-### HTTP route scaffolding
+### HTTP routes (live as of #262)
 
 The dashboard's existing `tiny_http` server (issue #183) carries five
 new routes wired to the live `Arc<MemoryService>`:
 
-- `GET /memory/recent` — returns `[]` (stub for #263).
-- `GET /memory/search?q=` — returns `[]` (stub for #263).
+- `GET /memory/recent?limit=N` — returns newest-first rows as
+  `[{id, tier, content, session_id, scope_key, created_at_ms, access_count}]`.
+- `GET /memory/search?q=…&k=…&session_id=…&tier_floor=…&scope_key=…`
+  — embeds the query (if the embedder is live), runs BM25 + KNN, RRF-
+  fuses, and returns `[{id, tier, content, score, ...}]`. When the
+  embedder is `Disabled`, the route degrades to BM25-only.
 - `GET /memory/stats` — returns `{tier_counts, embedder_status,
-  consolidate_interval_ms}`. The embedder name is real; counts stay at
-  0 until #263.
-- `POST /memory/save` — 501 until #263.
-- `POST /memory/forget/<id>` — 501 until #263.
+  embedder_dim, store_embed_dim, schema_user_version,
+  consolidate_interval_ms}`.
+- `POST /memory/save` — body `{content, tier?, session_id?, scope_key?,
+  metadata_json?}`; embeds + inserts + commits the lexical writer in
+  the documented SQLite-first order; returns `{id, tier, created_at_ms}`.
+- `POST /memory/forget/<id>` — deletes the row from both `memories` +
+  `memory_vec` (one transaction) and the tantivy index; returns
+  `{id, forgotten: bool}`.
 
-When `MemoryService` is `None` (subsystem failed to start) every route
-returns 503 with a JSON error body. The daemon keeps serving sessions
-and GC traffic.
+Validation: missing/empty `q`, empty `content`, unknown tier name, or
+ill-formed id return 400 with a JSON error body. When `MemoryService`
+is `None` (subsystem failed to start) every route returns 503 with a
+JSON error body. The daemon keeps serving sessions and GC traffic.
+
+### CLI surface (#262)
+
+`crates/clud-bin/src/memory/cli.rs::run` dispatches `clud memory <verb>`.
+See [`crates/clud-bin/src/memory/README.md`](../../crates/clud-bin/src/memory/README.md#cli-surface-262)
+for the verb-to-route table. The CLI proxies **all mutating ops through
+the daemon** so there is exactly one SQLite writer per process
+([DD-018](../DESIGN_DECISIONS.md#dd-018-clud-memory-cli-verbs-proxy-mutating-ops-through-the-daemon)).
+`branch-isolate` and `branch-unisolate` are the two verbs that
+**don't** touch the daemon — they write/remove a marker file under
+`<git common-dir>/.clud/memory-branch-isolate`. The `--to-disk` /
+`--from-disk` flags on `export` and `import` are stubs that point
+users at #264.
+
+Exit codes: `0` success, `1` user error, `2` internal error
+(HTTP 5xx / decode), `3` daemon unavailable.
 
 The MCP server itself (`#259`) and the hook subcommands (`#260`) plug
 into `MemoryService` from outside; this PR just shares the four handles

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,0 +1,186 @@
+"""Issue #262: surface-level subprocess tests for `clud memory <verb>`.
+
+These tests cover only the argv parser + dispatcher entry points. The
+full save/recall/forget loop exercises real SQLite + tantivy + an
+embedder and is covered by the rust-side `daemon::http::tests`
+integration tests in `crates/clud-bin/src/daemon/http.rs`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _cargo_argv(subcommand: list[str]) -> list[str]:
+    if sys.platform == "win32":
+        try:
+            from ci.env import build_env, cargo_argv
+
+            return cargo_argv(subcommand, env=build_env())
+        except Exception:
+            pass
+        soldr = shutil.which("soldr")
+        if soldr:
+            return [soldr, "cargo", *subcommand]
+    return ["cargo", *subcommand]
+
+
+def _clud_binary() -> str:
+    env_binary = os.environ.get("CLUD_TEST_BINARY")
+    if env_binary and Path(env_binary).is_file():
+        return env_binary
+
+    import json as _json
+
+    result = subprocess.run(
+        _cargo_argv(["build", "-p", "clud", "--no-default-features", "--message-format=json"]),
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to build clud:\n{result.stderr}")
+
+    for line in result.stdout.splitlines():
+        try:
+            msg = _json.loads(line)
+        except _json.JSONDecodeError:
+            continue
+        if (
+            msg.get("reason") == "compiler-artifact"
+            and msg.get("target", {}).get("name") == "clud"
+            and msg.get("executable")
+        ):
+            return msg["executable"]
+
+    ext = ".exe" if sys.platform == "win32" else ""
+    for fallback in (
+        ROOT / "target" / "x86_64-pc-windows-msvc" / "debug" / f"clud{ext}",
+        ROOT / "target" / "aarch64-pc-windows-msvc" / "debug" / f"clud{ext}",
+        ROOT / "target" / "debug" / f"clud{ext}",
+    ):
+        if fallback.is_file():
+            return str(fallback)
+    raise RuntimeError("clud binary not found after build")
+
+
+CLUD = _clud_binary()
+
+
+def _run(
+    *args: str, env_overrides: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run clud in a tempdir with copied binary; mirror tests/test_hello.py."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source = Path(CLUD)
+        launch = Path(temp_dir) / source.name
+        shutil.copy2(source, launch)
+        env = os.environ.copy()
+        if env_overrides:
+            env.update(env_overrides)
+        return subprocess.run(
+            [str(launch), *args],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=env,
+        )
+
+
+def test_memory_bare_prints_help() -> None:
+    result = _run("memory")
+    assert result.returncode == 0, result.stderr
+    combined = (result.stdout + result.stderr).lower()
+    assert "memory" in combined
+    assert "init" in combined or "save" in combined or "search" in combined
+
+
+def test_memory_help_lists_verbs() -> None:
+    result = _run("memory", "--help")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout + result.stderr
+    for verb in ("init", "status", "search", "save", "forget", "reembed", "branch-isolate"):
+        assert verb in out, f"missing {verb} in help output:\n{out}"
+
+
+def test_memory_export_to_disk_is_stub() -> None:
+    # --to-disk is the #264 stub; should exit 0 with a pointer to #264.
+    result = _run("memory", "export", "--to-disk")
+    assert result.returncode == 0, result.stderr
+    assert "#264" in result.stdout, result.stdout
+
+
+def test_memory_import_from_disk_is_stub() -> None:
+    result = _run("memory", "import", "--from-disk")
+    assert result.returncode == 0, result.stderr
+    assert "#264" in result.stdout, result.stdout
+
+
+def test_memory_status_no_daemon_exits_3() -> None:
+    # `--no-daemon memory status` short-circuits with the daemon-unavailable
+    # exit code (3) before attempting any HTTP call.
+    result = _run("--no-daemon", "memory", "status")
+    assert result.returncode == 3, (
+        f"expected exit 3, got rc={result.returncode}; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "daemon" in result.stderr.lower()
+
+
+def test_memory_search_no_daemon_exits_3() -> None:
+    result = _run("--no-daemon", "memory", "search", "foo")
+    assert result.returncode == 3
+    assert "daemon" in result.stderr.lower()
+
+
+def test_memory_save_no_daemon_exits_3() -> None:
+    result = _run("--no-daemon", "memory", "save", "hello")
+    assert result.returncode == 3
+    assert "daemon" in result.stderr.lower()
+
+
+def test_memory_search_help_smoke() -> None:
+    # Every verb's --help must exit 0 and mention its own name. Probe the
+    # heaviest verb (with the most flags) as a smoke test.
+    result = _run("memory", "search", "--help")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout + result.stderr
+    for opt in ("--k", "--session-id", "--tier-floor", "--scope-key", "--json"):
+        assert opt in out, f"missing {opt} in search --help:\n{out}"
+
+
+def test_memory_save_help_smoke() -> None:
+    result = _run("memory", "save", "--help")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout + result.stderr
+    for opt in ("--tier", "--session-id", "--metadata", "--json"):
+        assert opt in out, f"missing {opt} in save --help:\n{out}"
+
+
+def test_memory_branch_isolate_outside_git_repo_reports_error() -> None:
+    # branch-isolate touches the local working tree and never needs the
+    # daemon; run it in a non-git tempdir and assert the error path.
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source = Path(CLUD)
+        launch = Path(temp_dir) / source.name
+        shutil.copy2(source, launch)
+        not_a_repo = Path(temp_dir) / "not-a-repo"
+        not_a_repo.mkdir()
+        result = subprocess.run(
+            [str(launch), "memory", "branch-isolate"],
+            cwd=not_a_repo,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=os.environ.copy(),
+        )
+    assert result.returncode == 1
+    assert "git" in result.stderr.lower() or "not a git" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- Add `Command::Memory(MemoryCommand)` to args, dispatched from main.
- Verbs: init, status, search, save, forget, export (stdout; --to-disk → #264), import (stdin; --from-disk → #264), ui, reembed, branch-isolate, branch-unisolate.
- Daemon HTTP route bodies (`/memory/{recent,search,stats,save,forget/<id>}`) are no longer stubs — they delegate to the live `MemoryService`. The CLI proxies all mutating ops through the daemon to keep a single SQLite writer (DD-018).

Closes #262. Part of meta #255.

## Test plan
- [x] `soldr cargo test -p clud --lib --no-default-features` — green (828 tests, +8 new args tests).
- [x] Python subprocess tests for help/parse/no-daemon paths (`tests/test_memory_cli.py`, 10 tests).
- [x] `soldr cargo clippy --workspace --all-targets --no-default-features -- -D warnings` clean.
- [x] `soldr cargo fmt --all --check` clean.
- [x] `ruff check src tests ci` clean.
- [ ] CI green on all 6 platforms.

## Notes on scope deviations
- `reembed` against a running daemon would need a dedicated route that holds the SQLite mutex for an O(N) walk. v1 ships `--dry-run` (reports counts via `/memory/stats`) and points the user at stopping the daemon for a live rewrite. Future work: dedicated `POST /memory/reembed` with batching.
- `import` and `export` against disk are intentionally stubs that point at #264 (git-artifact serialization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)