### PR TITLE
feat(memory): launch-setup integration -- MCP + hook config injection (#265)

### DIFF
--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -113,9 +113,11 @@ Platform glue:
   sites stay portable.
 - `large_file_guard.rs` - startup-time `ignore`-crate walker that warns about
   source files large enough to choke agents (issue #132); hard 1 s deadline.
-- `launch_setup.rs` - session-only/global setup selector plus
-  selected-backend persistent setup actions for skills and Codex hook
-  normalization.
+- `launch_setup.rs` - session-only/global/global+memory setup selector plus
+  selected-backend persistent setup actions for skills, Codex hook
+  normalization, and (issue #265) memory MCP+hook registration via
+  `memory::mcp_config`. The third selector row defaults on when memory is
+  not yet registered.
 
 Skills and hooks:
 

--- a/crates/clud-bin/src/launch_setup.rs
+++ b/crates/clud-bin/src/launch_setup.rs
@@ -3,6 +3,16 @@
 //! Session-only launches are the default for automation and one-shot prompt
 //! paths. Interactive TUI launches can opt into global setup before the backend
 //! starts.
+//!
+//! The selector exposes three rows: "Session only", "Globally", and
+//! "Globally + clud memory (recommended)". The third row is identical to
+//! "Globally" plus two extra setup actions ([`MemoryMcpRegistrationAction`]
+//! and [`MemoryHookRegistrationAction`]) that register the `clud-memory`
+//! MCP server and the four `clud hook` entries into the backend's user
+//! config files (`~/.claude.json`, `~/.codex/config.toml`,
+//! `~/.claude/settings.json`, `~/.codex/hooks.json`). Both actions are
+//! idempotent and refuse to clobber hand-edited user blocks; see
+//! [`crate::memory::mcp_config`] for the upsert primitives.
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -12,12 +22,18 @@ use crossterm::terminal;
 
 use crate::args::Args;
 use crate::backend::Backend;
+use crate::memory::mcp_config;
 use crate::{codex_hook_normalize, skill_install, skills};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LaunchSetupScope {
     SessionOnly,
     Global,
+    /// Global setup PLUS native-memory registration (issue #265).
+    /// Runs the same actions as `Global`, then registers the `clud-memory`
+    /// MCP server and the four `clud hook` entries into the selected
+    /// backend's user config files.
+    GlobalWithMemory,
 }
 
 impl LaunchSetupScope {
@@ -25,7 +41,19 @@ impl LaunchSetupScope {
         match self {
             LaunchSetupScope::SessionOnly => "session-only",
             LaunchSetupScope::Global => "global",
+            LaunchSetupScope::GlobalWithMemory => "global+memory",
         }
+    }
+
+    /// `true` for the two scopes that run the existing global actions
+    /// (`Global` and `GlobalWithMemory`). Existing actions can keep their
+    /// `matches!(scope, LaunchSetupScope::Global)` check by switching to
+    /// this helper to opt into both scopes.
+    pub fn runs_global_actions(self) -> bool {
+        matches!(
+            self,
+            LaunchSetupScope::Global | LaunchSetupScope::GlobalWithMemory
+        )
     }
 }
 
@@ -36,43 +64,59 @@ pub enum SelectorEvent {
     Enter,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ScopeSelector {
-    selected: LaunchSetupScope,
-}
+const SELECTOR_ROWS: [LaunchSetupScope; 3] = [
+    LaunchSetupScope::SessionOnly,
+    LaunchSetupScope::Global,
+    LaunchSetupScope::GlobalWithMemory,
+];
 
-impl Default for ScopeSelector {
-    fn default() -> Self {
-        Self {
-            selected: LaunchSetupScope::SessionOnly,
-        }
-    }
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ScopeSelector {
+    index: usize,
 }
 
 impl ScopeSelector {
+    /// Build a selector that highlights "Globally + clud memory" by default
+    /// when memory is not yet registered, falling back to "Session only" once
+    /// memory is already configured. The memory check probes
+    /// `~/.claude.json` / `~/.codex/config.toml` via
+    /// [`mcp_config::memory_already_registered`].
+    pub fn for_home(home: &Path) -> Self {
+        if mcp_config::memory_already_registered(home) {
+            Self { index: 0 }
+        } else {
+            Self { index: 2 }
+        }
+    }
+
     pub fn selected(self) -> LaunchSetupScope {
-        self.selected
+        SELECTOR_ROWS[self.index]
     }
 
     pub fn handle(&mut self, event: SelectorEvent) -> Option<LaunchSetupScope> {
         match event {
-            SelectorEvent::Up => self.selected = LaunchSetupScope::SessionOnly,
-            SelectorEvent::Down => self.selected = LaunchSetupScope::Global,
-            SelectorEvent::Enter => return Some(self.selected),
+            SelectorEvent::Up => {
+                self.index = if self.index == 0 {
+                    SELECTOR_ROWS.len() - 1
+                } else {
+                    self.index - 1
+                };
+            }
+            SelectorEvent::Down => {
+                self.index = (self.index + 1) % SELECTOR_ROWS.len();
+            }
+            SelectorEvent::Enter => return Some(self.selected()),
         }
         None
     }
 
     pub fn render<W: Write>(&self, out: &mut W) -> io::Result<()> {
+        writeln!(out, "{} Session only", marker(self.index == 0))?;
+        writeln!(out, "{} Globally", marker(self.index == 1))?;
         writeln!(
             out,
-            "{} Session only",
-            marker(self.selected == LaunchSetupScope::SessionOnly)
-        )?;
-        writeln!(
-            out,
-            "{} Globally",
-            marker(self.selected == LaunchSetupScope::Global)
+            "{} Globally + clud memory (recommended)",
+            marker(self.index == 2)
         )?;
         out.flush()
     }
@@ -105,8 +149,12 @@ pub fn scope_for_non_prompting_launch(
 }
 
 pub fn prompt_scope<W: Write>(out: &mut W) -> io::Result<LaunchSetupScope> {
+    let home = home_dir();
     let _raw = RawModeGuard::enable()?;
-    let mut selector = ScopeSelector::default();
+    let mut selector = match home.as_deref() {
+        Some(h) => ScopeSelector::for_home(h),
+        None => ScopeSelector::default(),
+    };
     selector.render(out)?;
 
     loop {
@@ -124,7 +172,7 @@ pub fn prompt_scope<W: Write>(out: &mut W) -> io::Result<LaunchSetupScope> {
             out.flush()?;
             return Ok(scope);
         }
-        write!(out, "\x1b[2A")?;
+        write!(out, "\x1b[3A")?;
         selector.render(out)?;
     }
 }
@@ -149,6 +197,7 @@ pub enum SetupError {
     NoHomeDir,
     Skills(skills::InstallError),
     Io(io::Error),
+    MemoryConfig(mcp_config::Error),
 }
 
 impl std::fmt::Display for SetupError {
@@ -157,6 +206,7 @@ impl std::fmt::Display for SetupError {
             SetupError::NoHomeDir => write!(f, "could not resolve user home directory"),
             SetupError::Skills(error) => write!(f, "{error}"),
             SetupError::Io(error) => write!(f, "{error}"),
+            SetupError::MemoryConfig(error) => write!(f, "{error}"),
         }
     }
 }
@@ -175,6 +225,12 @@ impl From<io::Error> for SetupError {
     }
 }
 
+impl From<mcp_config::Error> for SetupError {
+    fn from(error: mcp_config::Error) -> Self {
+        SetupError::MemoryConfig(error)
+    }
+}
+
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SetupReport {
     pub ran: Vec<&'static str>,
@@ -190,6 +246,7 @@ pub trait HarnessSetupAction {
 pub struct SetupContext<'a> {
     pub home: &'a Path,
     pub verbose: bool,
+    pub dry_run: bool,
     pub out: &'a mut dyn Write,
 }
 
@@ -207,10 +264,13 @@ impl HarnessSetupAction for BundledSkillsAction {
     }
 
     fn supports(&self, scope: LaunchSetupScope) -> bool {
-        matches!(scope, LaunchSetupScope::Global)
+        scope.runs_global_actions()
     }
 
     fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError> {
+        if ctx.dry_run {
+            return Ok(());
+        }
         let _ = skills::ensure_installed_for_backend_at(ctx.home, self.backend)?;
         Ok(())
     }
@@ -228,10 +288,13 @@ impl HarnessSetupAction for ClaudeDriftSkillsAction {
     }
 
     fn supports(&self, scope: LaunchSetupScope) -> bool {
-        matches!(scope, LaunchSetupScope::Global)
+        scope.runs_global_actions()
     }
 
     fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError> {
+        if ctx.dry_run {
+            return Ok(());
+        }
         skill_install::ensure_installed_at(ctx.home);
         Ok(())
     }
@@ -249,10 +312,13 @@ impl HarnessSetupAction for CodexHookNormalizeAction {
     }
 
     fn supports(&self, scope: LaunchSetupScope) -> bool {
-        matches!(scope, LaunchSetupScope::Global)
+        scope.runs_global_actions()
     }
 
     fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError> {
+        if ctx.dry_run {
+            return Ok(());
+        }
         let clud_dir = ctx.home.join(".clud");
         let hooks_path = ctx.home.join(".codex").join("hooks.json");
         if let Err(error) =
@@ -266,6 +332,95 @@ impl HarnessSetupAction for CodexHookNormalizeAction {
     }
 }
 
+/// Issue #265: register the `clud-memory` MCP server in the selected
+/// backend's user config file. Only runs under
+/// [`LaunchSetupScope::GlobalWithMemory`] — opting into memory is its own
+/// scope, intentionally not folded into the existing `Global` row.
+struct MemoryMcpRegistrationAction {
+    backend: Backend,
+}
+
+impl HarnessSetupAction for MemoryMcpRegistrationAction {
+    fn name(&self) -> &'static str {
+        "memory-mcp-registration"
+    }
+
+    fn backend(&self) -> Backend {
+        self.backend
+    }
+
+    fn supports(&self, scope: LaunchSetupScope) -> bool {
+        matches!(scope, LaunchSetupScope::GlobalWithMemory)
+    }
+
+    fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError> {
+        if ctx.dry_run {
+            return Ok(());
+        }
+        let version = env!("CARGO_PKG_VERSION");
+        let result = match self.backend {
+            Backend::Claude => mcp_config::ensure_claude_mcp(ctx.home, version, ctx.out),
+            Backend::Codex => mcp_config::ensure_codex_mcp(ctx.home, version, ctx.out),
+        };
+        match result {
+            Ok(_) => Ok(()),
+            Err(mcp_config::Error::UserDefined { path, key }) => {
+                let _ = writeln!(
+                    ctx.out,
+                    "[clud] note: refusing to overwrite user-defined `{key}` in {}; re-run `clud --setup` after renaming the block",
+                    path.display()
+                );
+                Ok(())
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+/// Issue #265: register the four `clud hook` entries in the selected
+/// backend's user hook-config file (Claude: `~/.claude/settings.json`,
+/// Codex: `~/.codex/hooks.json`).
+struct MemoryHookRegistrationAction {
+    backend: Backend,
+}
+
+impl HarnessSetupAction for MemoryHookRegistrationAction {
+    fn name(&self) -> &'static str {
+        "memory-hook-registration"
+    }
+
+    fn backend(&self) -> Backend {
+        self.backend
+    }
+
+    fn supports(&self, scope: LaunchSetupScope) -> bool {
+        matches!(scope, LaunchSetupScope::GlobalWithMemory)
+    }
+
+    fn run(&self, ctx: &mut SetupContext<'_>) -> Result<(), SetupError> {
+        if ctx.dry_run {
+            return Ok(());
+        }
+        let version = env!("CARGO_PKG_VERSION");
+        let result = match self.backend {
+            Backend::Claude => mcp_config::ensure_claude_hooks(ctx.home, version, ctx.out),
+            Backend::Codex => mcp_config::ensure_codex_hooks(ctx.home, version, ctx.out),
+        };
+        match result {
+            Ok(_) => Ok(()),
+            Err(mcp_config::Error::UserDefined { path, key }) => {
+                let _ = writeln!(
+                    ctx.out,
+                    "[clud] note: refusing to overwrite user-defined `{key}` in {}; re-run `clud --setup` after renaming the block",
+                    path.display()
+                );
+                Ok(())
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
 pub fn setup_actions() -> Vec<Box<dyn HarnessSetupAction>> {
     vec![
         Box::new(BundledSkillsAction {
@@ -276,6 +431,18 @@ pub fn setup_actions() -> Vec<Box<dyn HarnessSetupAction>> {
         }),
         Box::new(ClaudeDriftSkillsAction),
         Box::new(CodexHookNormalizeAction),
+        Box::new(MemoryMcpRegistrationAction {
+            backend: Backend::Claude,
+        }),
+        Box::new(MemoryMcpRegistrationAction {
+            backend: Backend::Codex,
+        }),
+        Box::new(MemoryHookRegistrationAction {
+            backend: Backend::Claude,
+        }),
+        Box::new(MemoryHookRegistrationAction {
+            backend: Backend::Codex,
+        }),
     ]
 }
 
@@ -296,12 +463,33 @@ pub fn run_setup_at(
     verbose: bool,
     out: &mut dyn Write,
 ) -> Result<SetupReport, SetupError> {
+    run_setup_at_with_options(home, scope, backend, verbose, false, out)
+}
+
+/// Issue #265: dry-run variant — prints the four-file summary and skips all
+/// disk writes. Same return shape as [`run_setup_at`] so the caller can
+/// rely on `report.ran` to confirm which actions matched.
+pub fn run_setup_at_with_options(
+    home: &Path,
+    scope: LaunchSetupScope,
+    backend: Backend,
+    verbose: bool,
+    dry_run: bool,
+    out: &mut dyn Write,
+) -> Result<SetupReport, SetupError> {
     if matches!(scope, LaunchSetupScope::SessionOnly) {
         return Ok(SetupReport::default());
     }
-
+    if dry_run && matches!(scope, LaunchSetupScope::GlobalWithMemory) {
+        let _ = mcp_config::print_dry_run_summary(home, out);
+    }
     let mut report = SetupReport::default();
-    let mut ctx = SetupContext { home, verbose, out };
+    let mut ctx = SetupContext {
+        home,
+        verbose,
+        dry_run,
+        out,
+    };
     for action in setup_actions() {
         if action.backend() == backend && action.supports(scope) {
             action.run(&mut ctx)?;
@@ -348,7 +536,7 @@ mod tests {
         selector.render(&mut out).unwrap();
         assert_eq!(
             String::from_utf8(out).unwrap(),
-            "[x] Session only\n[ ] Globally\n"
+            "[x] Session only\n[ ] Globally\n[ ] Globally + clud memory (recommended)\n"
         );
     }
 
@@ -363,6 +551,140 @@ mod tests {
             selector.handle(SelectorEvent::Enter),
             Some(LaunchSetupScope::SessionOnly)
         );
+    }
+
+    #[test]
+    fn selector_renders_three_rows_when_memory_unconfigured() {
+        let home = tempdir().unwrap();
+        let selector = ScopeSelector::for_home(home.path());
+        let mut out = Vec::new();
+        selector.render(&mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("Session only"));
+        assert!(text.contains("Globally\n"));
+        assert!(text.contains("Globally + clud memory (recommended)"));
+    }
+
+    #[test]
+    fn selector_defaults_to_global_with_memory_when_memory_unconfigured() {
+        let home = tempdir().unwrap();
+        let selector = ScopeSelector::for_home(home.path());
+        assert_eq!(selector.selected(), LaunchSetupScope::GlobalWithMemory);
+    }
+
+    #[test]
+    fn selector_defaults_to_session_only_when_memory_already_registered() {
+        let home = tempdir().unwrap();
+        let mut out = Vec::new();
+        mcp_config::ensure_claude_mcp(home.path(), "0.0.0", &mut out).unwrap();
+        let selector = ScopeSelector::for_home(home.path());
+        assert_eq!(selector.selected(), LaunchSetupScope::SessionOnly);
+    }
+
+    #[test]
+    fn selector_wraps_up_from_row_zero_to_row_two() {
+        let mut selector = ScopeSelector::default();
+        assert_eq!(selector.selected(), LaunchSetupScope::SessionOnly);
+        selector.handle(SelectorEvent::Up);
+        assert_eq!(selector.selected(), LaunchSetupScope::GlobalWithMemory);
+    }
+
+    #[test]
+    fn selector_wraps_down_from_row_two_to_row_zero() {
+        let mut selector = ScopeSelector { index: 2 };
+        assert_eq!(selector.selected(), LaunchSetupScope::GlobalWithMemory);
+        selector.handle(SelectorEvent::Down);
+        assert_eq!(selector.selected(), LaunchSetupScope::SessionOnly);
+    }
+
+    #[test]
+    fn scope_selector_third_row_dispatches_both_actions() {
+        let home = tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(".claude")).unwrap();
+        std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+        let mut out = Vec::new();
+        let report = run_setup_at(
+            home.path(),
+            LaunchSetupScope::GlobalWithMemory,
+            Backend::Claude,
+            false,
+            &mut out,
+        )
+        .unwrap();
+
+        assert!(report.ran.contains(&"memory-mcp-registration"));
+        assert!(report.ran.contains(&"memory-hook-registration"));
+        assert!(home.path().join(".claude.json").is_file());
+        assert!(home.path().join(".claude/settings.json").is_file());
+    }
+
+    #[test]
+    fn scope_selector_third_row_does_codex_actions_too() {
+        let home = tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(".claude")).unwrap();
+        std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+        let mut out = Vec::new();
+        let report = run_setup_at(
+            home.path(),
+            LaunchSetupScope::GlobalWithMemory,
+            Backend::Codex,
+            false,
+            &mut out,
+        )
+        .unwrap();
+
+        assert!(report.ran.contains(&"memory-mcp-registration"));
+        assert!(report.ran.contains(&"memory-hook-registration"));
+        assert!(home.path().join(".codex/config.toml").is_file());
+        assert!(home.path().join(".codex/hooks.json").is_file());
+    }
+
+    #[test]
+    fn global_scope_skips_memory_actions() {
+        let home = tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(".claude")).unwrap();
+        std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+        let mut out = Vec::new();
+        let report = run_setup_at(
+            home.path(),
+            LaunchSetupScope::Global,
+            Backend::Claude,
+            false,
+            &mut out,
+        )
+        .unwrap();
+
+        assert!(!report.ran.contains(&"memory-mcp-registration"));
+        assert!(!report.ran.contains(&"memory-hook-registration"));
+        assert!(!home.path().join(".claude.json").exists());
+    }
+
+    #[test]
+    fn dry_run_emits_summary_and_does_not_write() {
+        let home = tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(".claude")).unwrap();
+        std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+        let mut out = Vec::new();
+        run_setup_at_with_options(
+            home.path(),
+            LaunchSetupScope::GlobalWithMemory,
+            Backend::Claude,
+            false,
+            true,
+            &mut out,
+        )
+        .unwrap();
+
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("would write to"), "{text}");
+        assert!(text.contains("mcpServers.clud-memory"), "{text}");
+        assert!(text.contains("hooks.SessionStart"), "{text}");
+        assert!(!home.path().join(".claude.json").exists());
+        assert!(!home.path().join(".claude/settings.json").exists());
     }
 
     #[test]

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -294,7 +294,7 @@ fn main() {
             }
         }
     };
-    if matches!(setup_scope, launch_setup::LaunchSetupScope::Global) {
+    if setup_scope.runs_global_actions() {
         let mut err = io::stderr().lock();
         if let Err(error) = launch_setup::run_setup(setup_scope, backend, args.verbose, &mut err) {
             eprintln!("[clud] note: global setup failed: {error}");

--- a/crates/clud-bin/src/memory/README.md
+++ b/crates/clud-bin/src/memory/README.md
@@ -179,10 +179,27 @@ already on main; this MCP surface accepts the `scope_key` argument on
 `memory_smart_search` and forwards it to `SqliteStore::knn` and
 `LexicalIndex::search`.
 
-### Manual MCP registration (v0.1)
+### Auto-registration via launch setup (#265)
 
-Auto-registration of `~/.claude.json` / `~/.codex/config.toml` is owned
-by sibling #265. For v0.1 the user adds an entry by hand:
+The recommended path is the third row of the launch-setup scope
+selector — `Globally + clud memory (recommended)` — which runs the
+`MemoryMcpRegistrationAction` for the selected backend. The action
+upserts the `clud-memory` block into `~/.claude.json` (JSON) or
+`~/.codex/config.toml` (TOML preserving comments via `toml_edit`).
+The block carries a managed-marker (`_clud_managed: true` in JSON, a
+`# managed-by: clud-memory` lead comment in TOML) so re-running is a
+no-op; a hand-edited `clud-memory` key without the marker is **not
+overwritten** — the action logs a `[clud] note: refusing to ...` line
+and skips. Implementation lives in
+[`mcp_config.rs`](mcp_config.rs); see
+[`docs/architecture/launch-setup.md`](../../../../docs/architecture/launch-setup.md)
+for the cross-cutting flow.
+
+### Manual MCP registration (escape hatch)
+
+If you have a custom `clud-memory` block that the action refuses to
+clobber, or you want to wire the MCP server without taking the rest of
+the global setup, you can hand-edit:
 
 ```jsonc
 // ~/.claude.json
@@ -378,9 +395,18 @@ invoke at session lifecycle events. Implementation lives in
 payload from stdin, talk HTTP to the daemon's `/memory/*` routes
 ([DD-019](../../../../docs/DESIGN_DECISIONS.md#dd-019-clud-memory-cli-verbs-proxy-mutating-ops-through-the-daemon)
 + DD-020), and **exit 0 unconditionally** — a hook failure must never
-block the agent. The handlers are hidden from `--help`; registration
-into `~/.claude/settings.json` / `~/.codex/hooks.json` is owned by
-sibling #265.
+block the agent. The handlers are hidden from `--help`.
+
+Registration of all four hook entries into `~/.claude/settings.json`
+and `~/.codex/hooks.json` happens via the
+`MemoryHookRegistrationAction` (issue #265), gated on the
+`GlobalWithMemory` launch-setup scope. The action is idempotent and
+refuses to clobber hand-edited `clud hook ...` commands — see
+[`mcp_config.rs`](mcp_config.rs) for the upsert primitives and
+[`docs/architecture/launch-setup.md`](../../../../docs/architecture/launch-setup.md)
+for the cross-cutting flow. Manual installation by hand-editing the
+JSON files is still supported as an escape hatch (the action will
+detect and preserve any user-defined entries).
 
 | Verb | Trigger | Reads stdin? | Writes stdout? |
 |---|---|---|---|

--- a/crates/clud-bin/src/memory/mcp_config.rs
+++ b/crates/clud-bin/src/memory/mcp_config.rs
@@ -1,0 +1,738 @@
+//! Issue #265: idempotent registration of the `clud-memory` MCP server and the
+//! `clud hook` entries into the user's Claude Code and Codex config files.
+//!
+//! Four files are written, all under `$HOME`:
+//!
+//! - `~/.claude.json`         (JSON)  — `mcpServers."clud-memory"` block.
+//! - `~/.codex/config.toml`   (TOML)  — `[mcp_servers.clud-memory]` table.
+//! - `~/.claude/settings.json`(JSON)  — four `hooks.<Event>[]` entries.
+//! - `~/.codex/hooks.json`    (JSON)  — same four entries (Codex hook file is
+//!   JSON; see `codex_hook_normalize.rs`).
+//!
+//! Idempotency: a managed block carries a marker (`_clud_managed: true` in
+//! JSON, a `# managed-by: clud-memory` lead comment in TOML). Re-running
+//! against an already-up-to-date file is a no-op.
+//!
+//! Refuse-to-clobber: when a `clud-memory` MCP key or a `clud hook ...`
+//! command exists *without* the managed marker, the helper returns
+//! `Error::UserDefined { .. }` so the caller can warn and skip. The user can
+//! rename their entry, hand-edit the marker in, or re-run `clud --setup` to
+//! reapply.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use fs4::fs_std::FileExt;
+use serde_json::{json, Value};
+use toml_edit::{value, DocumentMut, Item, Table};
+
+const MANAGED_MARKER: &str = "_clud_managed";
+const VERSION_MARKER: &str = "_clud_version";
+const MCP_SERVER_KEY: &str = "clud-memory";
+const TOML_MANAGED_COMMENT: &str = "managed-by: clud-memory";
+
+const HOOK_EVENTS: &[(&str, &str)] = &[
+    ("SessionStart", "clud hook session-start"),
+    ("UserPromptSubmit", "clud hook user-prompt-submit"),
+    ("PostToolUse", "clud hook post-tool-use"),
+    ("Stop", "clud hook stop"),
+];
+
+const HOOK_TIMEOUT_SECS: u64 = 30;
+
+/// Outcome of a single ensure_* / remove_* call. The `Wrote` / `AlreadyPresent`
+/// split lets the caller stay quiet on idempotent re-runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    Wrote,
+    AlreadyPresent,
+    Removed,
+    NotPresent,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Json(serde_json::Error),
+    Toml(toml_edit::TomlError),
+    /// The target key exists in the config without our managed marker. The
+    /// caller must surface a warning and skip the write.
+    UserDefined {
+        path: PathBuf,
+        key: String,
+    },
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Io(error) => write!(f, "{error}"),
+            Error::Json(error) => write!(f, "{error}"),
+            Error::Toml(error) => write!(f, "{error}"),
+            Error::UserDefined { path, key } => write!(
+                f,
+                "refusing to overwrite user-defined `{key}` in {}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Error::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Error::Json(error)
+    }
+}
+
+impl From<toml_edit::TomlError> for Error {
+    fn from(error: toml_edit::TomlError) -> Self {
+        Error::Toml(error)
+    }
+}
+
+fn claude_json_path(home: &Path) -> PathBuf {
+    home.join(".claude.json")
+}
+
+fn codex_config_path(home: &Path) -> PathBuf {
+    home.join(".codex").join("config.toml")
+}
+
+fn claude_settings_path(home: &Path) -> PathBuf {
+    home.join(".claude").join("settings.json")
+}
+
+fn codex_hooks_path(home: &Path) -> PathBuf {
+    home.join(".codex").join("hooks.json")
+}
+
+fn lock_path(home: &Path, name: &str) -> PathBuf {
+    home.join(".clud").join(name)
+}
+
+/// `true` iff the `clud-memory` MCP block is registered in either the Claude
+/// or the Codex config. Used by the scope selector to choose its default row.
+pub fn memory_already_registered(home: &Path) -> bool {
+    if let Ok(text) = std::fs::read_to_string(claude_json_path(home)) {
+        if let Ok(json) = serde_json::from_str::<Value>(&text) {
+            if let Some(block) = json
+                .get("mcpServers")
+                .and_then(|v| v.get(MCP_SERVER_KEY))
+                .and_then(|v| v.as_object())
+            {
+                if block
+                    .get(MANAGED_MARKER)
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    if let Ok(text) = std::fs::read_to_string(codex_config_path(home)) {
+        if let Ok(doc) = text.parse::<DocumentMut>() {
+            if doc
+                .get("mcp_servers")
+                .and_then(|i| i.as_table())
+                .and_then(|t| t.get(MCP_SERVER_KEY))
+                .is_some()
+            {
+                let header_managed = doc
+                    .get("mcp_servers")
+                    .and_then(|i| i.as_table())
+                    .and_then(|t| t.get(MCP_SERVER_KEY))
+                    .map(|item| {
+                        item.as_table()
+                            .map(|t| {
+                                let decor = t.decor();
+                                let prefix = decor.prefix().and_then(|s| s.as_str()).unwrap_or("");
+                                prefix.contains(TOML_MANAGED_COMMENT)
+                            })
+                            .unwrap_or(false)
+                    })
+                    .unwrap_or(false);
+                if header_managed {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+// ---------- Atomic-write + lock helpers ---------------------------------
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.write_all(bytes)?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+struct LockGuard {
+    _file: File,
+}
+
+fn acquire_lock(path: &Path) -> io::Result<LockGuard> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    FileExt::lock_exclusive(&file)
+        .map_err(|e| io::Error::other(format!("lock_exclusive {}: {e}", path.display())))?;
+    Ok(LockGuard { _file: file })
+}
+
+// ---------- Managed-block builders --------------------------------------
+
+fn managed_mcp_block(clud_version: &str) -> Value {
+    json!({
+        "command": "clud",
+        "args": ["mcp"],
+        MANAGED_MARKER: true,
+        VERSION_MARKER: clud_version,
+    })
+}
+
+fn mcp_block_matches(existing: &Value, clud_version: &str) -> bool {
+    existing
+        .get("command")
+        .and_then(|v| v.as_str())
+        .map(|s| s == "clud")
+        .unwrap_or(false)
+        && existing
+            .get("args")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.len() == 1 && arr[0].as_str() == Some("mcp"))
+            .unwrap_or(false)
+        && existing
+            .get(VERSION_MARKER)
+            .and_then(|v| v.as_str())
+            .map(|s| s == clud_version)
+            .unwrap_or(false)
+}
+
+fn hook_entry(command: &str) -> Value {
+    json!({
+        "hooks": [
+            {
+                "type": "command",
+                "command": command,
+                "timeout": HOOK_TIMEOUT_SECS,
+                MANAGED_MARKER: true,
+            }
+        ]
+    })
+}
+
+fn hook_array_is_user_defined(arr: &[Value], command: &str) -> bool {
+    arr.iter().any(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|v| v.as_array())
+            .map(|inner| {
+                inner.iter().any(|h| {
+                    h.get("command").and_then(|v| v.as_str()) == Some(command)
+                        && h.get(MANAGED_MARKER).and_then(|v| v.as_bool()) != Some(true)
+                })
+            })
+            .unwrap_or(false)
+    })
+}
+
+fn find_managed_index(arr: &[Value], command: &str) -> Option<usize> {
+    arr.iter().position(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|v| v.as_array())
+            .map(|inner| {
+                inner.iter().any(|h| {
+                    h.get("command").and_then(|v| v.as_str()) == Some(command)
+                        && h.get(MANAGED_MARKER).and_then(|v| v.as_bool()) == Some(true)
+                })
+            })
+            .unwrap_or(false)
+    })
+}
+
+// ---------- Claude MCP --------------------------------------------------
+
+pub fn ensure_claude_mcp(
+    home: &Path,
+    clud_version: &str,
+    out: &mut dyn Write,
+) -> Result<Outcome, Error> {
+    let path = claude_json_path(home);
+    let _lock = acquire_lock(&lock_path(home, "memory-claude-mcp.lock"))?;
+    let outcome = write_claude_mcp(&path, clud_version)?;
+    log_outcome(out, &path, "mcpServers.clud-memory", outcome);
+    Ok(outcome)
+}
+
+fn read_claude_json(path: &Path) -> Result<Value, Error> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    let text = std::fs::read_to_string(path)?;
+    if text.trim().is_empty() {
+        return Ok(json!({}));
+    }
+    Ok(serde_json::from_str(&text)?)
+}
+
+fn write_claude_mcp(path: &Path, clud_version: &str) -> Result<Outcome, Error> {
+    let mut json = read_claude_json(path)?;
+    if !json.is_object() {
+        json = json!({});
+    }
+    let root = json.as_object_mut().expect("root is object");
+    let servers = root
+        .entry("mcpServers".to_string())
+        .or_insert_with(|| json!({}));
+    if !servers.is_object() {
+        *servers = json!({});
+    }
+    let servers = servers.as_object_mut().expect("servers is object");
+    if let Some(existing) = servers.get(MCP_SERVER_KEY) {
+        let managed = existing
+            .get(MANAGED_MARKER)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !managed {
+            return Err(Error::UserDefined {
+                path: path.to_path_buf(),
+                key: format!("mcpServers.{MCP_SERVER_KEY}"),
+            });
+        }
+        if mcp_block_matches(existing, clud_version) {
+            return Ok(Outcome::AlreadyPresent);
+        }
+    }
+    servers.insert(MCP_SERVER_KEY.to_string(), managed_mcp_block(clud_version));
+    let mut serialized = serde_json::to_string_pretty(&json)?;
+    if !serialized.ends_with('\n') {
+        serialized.push('\n');
+    }
+    atomic_write(path, serialized.as_bytes())?;
+    Ok(Outcome::Wrote)
+}
+
+pub fn remove_claude_mcp(home: &Path) -> Result<Outcome, Error> {
+    let path = claude_json_path(home);
+    let _lock = acquire_lock(&lock_path(home, "memory-claude-mcp.lock"))?;
+    if !path.exists() {
+        return Ok(Outcome::NotPresent);
+    }
+    let mut json = read_claude_json(&path)?;
+    let Some(root) = json.as_object_mut() else {
+        return Ok(Outcome::NotPresent);
+    };
+    let Some(servers) = root.get_mut("mcpServers").and_then(|v| v.as_object_mut()) else {
+        return Ok(Outcome::NotPresent);
+    };
+    let Some(existing) = servers.get(MCP_SERVER_KEY) else {
+        return Ok(Outcome::NotPresent);
+    };
+    let managed = existing
+        .get(MANAGED_MARKER)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if !managed {
+        return Err(Error::UserDefined {
+            path,
+            key: format!("mcpServers.{MCP_SERVER_KEY}"),
+        });
+    }
+    servers.remove(MCP_SERVER_KEY);
+    let mut serialized = serde_json::to_string_pretty(&json)?;
+    if !serialized.ends_with('\n') {
+        serialized.push('\n');
+    }
+    atomic_write(&path, serialized.as_bytes())?;
+    Ok(Outcome::Removed)
+}
+
+// ---------- Codex MCP (TOML) -------------------------------------------
+
+pub fn ensure_codex_mcp(
+    home: &Path,
+    clud_version: &str,
+    out: &mut dyn Write,
+) -> Result<Outcome, Error> {
+    let path = codex_config_path(home);
+    let _lock = acquire_lock(&lock_path(home, "memory-codex-mcp.lock"))?;
+    let outcome = write_codex_mcp(&path, clud_version)?;
+    log_outcome(out, &path, "mcp_servers.clud-memory", outcome);
+    Ok(outcome)
+}
+
+fn read_codex_toml(path: &Path) -> Result<DocumentMut, Error> {
+    if !path.exists() {
+        return Ok(DocumentMut::new());
+    }
+    let text = std::fs::read_to_string(path)?;
+    if text.trim().is_empty() {
+        return Ok(DocumentMut::new());
+    }
+    Ok(text.parse::<DocumentMut>()?)
+}
+
+fn codex_block_table_is_managed(table: &Table) -> bool {
+    let decor = table.decor();
+    let prefix = decor.prefix().and_then(|s| s.as_str()).unwrap_or("");
+    prefix.contains(TOML_MANAGED_COMMENT)
+}
+
+fn codex_block_matches(table: &Table, clud_version: &str) -> bool {
+    let cmd_ok = table
+        .get("command")
+        .and_then(|i| i.as_str())
+        .map(|s| s == "clud")
+        .unwrap_or(false);
+    let args_ok = table
+        .get("args")
+        .and_then(|i| i.as_array())
+        .map(|arr| {
+            arr.len() == 1
+                && arr
+                    .get(0)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s == "mcp")
+                    .unwrap_or(false)
+        })
+        .unwrap_or(false);
+    let version_ok = table
+        .get(VERSION_MARKER)
+        .and_then(|i| i.as_str())
+        .map(|s| s == clud_version)
+        .unwrap_or(false);
+    cmd_ok && args_ok && version_ok
+}
+
+fn build_codex_mcp_table(clud_version: &str) -> Table {
+    let mut t = Table::new();
+    t.set_implicit(false);
+    t.insert("command", value("clud"));
+    let mut args = toml_edit::Array::new();
+    args.push("mcp");
+    t.insert("args", value(args));
+    t.insert(VERSION_MARKER, value(clud_version));
+    let decor = t.decor_mut();
+    decor.set_prefix(format!("\n# {TOML_MANAGED_COMMENT}\n"));
+    t
+}
+
+fn write_codex_mcp(path: &Path, clud_version: &str) -> Result<Outcome, Error> {
+    let mut doc = read_codex_toml(path)?;
+    let servers_item = doc
+        .entry("mcp_servers")
+        .or_insert_with(|| Item::Table(Table::new()));
+    if !servers_item.is_table() {
+        *servers_item = Item::Table(Table::new());
+    }
+    let servers = servers_item.as_table_mut().expect("table");
+    servers.set_implicit(true);
+
+    if let Some(existing) = servers.get(MCP_SERVER_KEY) {
+        let existing_table = match existing.as_table() {
+            Some(t) => t,
+            None => {
+                return Err(Error::UserDefined {
+                    path: path.to_path_buf(),
+                    key: format!("mcp_servers.{MCP_SERVER_KEY}"),
+                });
+            }
+        };
+        if !codex_block_table_is_managed(existing_table) {
+            return Err(Error::UserDefined {
+                path: path.to_path_buf(),
+                key: format!("mcp_servers.{MCP_SERVER_KEY}"),
+            });
+        }
+        if codex_block_matches(existing_table, clud_version) {
+            return Ok(Outcome::AlreadyPresent);
+        }
+    }
+    servers.insert(
+        MCP_SERVER_KEY,
+        Item::Table(build_codex_mcp_table(clud_version)),
+    );
+    atomic_write(path, doc.to_string().as_bytes())?;
+    Ok(Outcome::Wrote)
+}
+
+pub fn remove_codex_mcp(home: &Path) -> Result<Outcome, Error> {
+    let path = codex_config_path(home);
+    let _lock = acquire_lock(&lock_path(home, "memory-codex-mcp.lock"))?;
+    if !path.exists() {
+        return Ok(Outcome::NotPresent);
+    }
+    let mut doc = read_codex_toml(&path)?;
+    let Some(servers) = doc.get_mut("mcp_servers").and_then(|i| i.as_table_mut()) else {
+        return Ok(Outcome::NotPresent);
+    };
+    let managed = servers
+        .get(MCP_SERVER_KEY)
+        .and_then(|i| i.as_table())
+        .map(codex_block_table_is_managed)
+        .unwrap_or(false);
+    if servers.get(MCP_SERVER_KEY).is_none() {
+        return Ok(Outcome::NotPresent);
+    }
+    if !managed {
+        return Err(Error::UserDefined {
+            path,
+            key: format!("mcp_servers.{MCP_SERVER_KEY}"),
+        });
+    }
+    servers.remove(MCP_SERVER_KEY);
+    atomic_write(&path, doc.to_string().as_bytes())?;
+    Ok(Outcome::Removed)
+}
+
+// ---------- Claude hooks -------------------------------------------------
+
+pub fn ensure_claude_hooks(
+    home: &Path,
+    _clud_version: &str,
+    out: &mut dyn Write,
+) -> Result<Outcome, Error> {
+    let path = claude_settings_path(home);
+    let _lock = acquire_lock(&lock_path(home, "memory-claude-hooks.lock"))?;
+    let outcome = write_hooks_json(&path)?;
+    log_outcome(
+        out,
+        &path,
+        "hooks.{SessionStart,UserPromptSubmit,PostToolUse,Stop}",
+        outcome,
+    );
+    Ok(outcome)
+}
+
+pub fn ensure_codex_hooks(
+    home: &Path,
+    _clud_version: &str,
+    out: &mut dyn Write,
+) -> Result<Outcome, Error> {
+    let path = codex_hooks_path(home);
+    let _lock = acquire_lock(&lock_path(home, "memory-codex-hooks.lock"))?;
+    let outcome = write_hooks_json(&path)?;
+    log_outcome(
+        out,
+        &path,
+        "hooks.{SessionStart,UserPromptSubmit,PostToolUse,Stop}",
+        outcome,
+    );
+    Ok(outcome)
+}
+
+fn read_hooks_json(path: &Path) -> Result<Value, Error> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    let text = std::fs::read_to_string(path)?;
+    if text.trim().is_empty() {
+        return Ok(json!({}));
+    }
+    Ok(serde_json::from_str(&text)?)
+}
+
+fn write_hooks_json(path: &Path) -> Result<Outcome, Error> {
+    let mut json = read_hooks_json(path)?;
+    if !json.is_object() {
+        json = json!({});
+    }
+    let root = json.as_object_mut().expect("root is object");
+    let hooks = root.entry("hooks".to_string()).or_insert_with(|| json!({}));
+    if !hooks.is_object() {
+        *hooks = json!({});
+    }
+    let hooks = hooks.as_object_mut().expect("hooks is object");
+
+    let mut wrote_anything = false;
+    let mut already_all = true;
+
+    for (event, command) in HOOK_EVENTS {
+        let arr_item = hooks
+            .entry((*event).to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        if !arr_item.is_array() {
+            *arr_item = Value::Array(Vec::new());
+        }
+        let arr = arr_item.as_array_mut().expect("array");
+        if hook_array_is_user_defined(arr, command) {
+            return Err(Error::UserDefined {
+                path: path.to_path_buf(),
+                key: format!("hooks.{event}[].hooks[]"),
+            });
+        }
+        let want = hook_entry(command);
+        match find_managed_index(arr, command) {
+            Some(idx) => {
+                if arr[idx] != want {
+                    arr[idx] = want;
+                    wrote_anything = true;
+                    already_all = false;
+                }
+            }
+            None => {
+                arr.push(want);
+                wrote_anything = true;
+                already_all = false;
+            }
+        }
+    }
+
+    if !wrote_anything && already_all {
+        return Ok(Outcome::AlreadyPresent);
+    }
+    let mut serialized = serde_json::to_string_pretty(&json)?;
+    if !serialized.ends_with('\n') {
+        serialized.push('\n');
+    }
+    atomic_write(path, serialized.as_bytes())?;
+    Ok(Outcome::Wrote)
+}
+
+pub fn remove_claude_hooks(home: &Path) -> Result<Outcome, Error> {
+    let path = claude_settings_path(home);
+    let _lock = acquire_lock(&lock_path(home, "memory-claude-hooks.lock"))?;
+    remove_hooks_json(&path)
+}
+
+pub fn remove_codex_hooks(home: &Path) -> Result<Outcome, Error> {
+    let path = codex_hooks_path(home);
+    let _lock = acquire_lock(&lock_path(home, "memory-codex-hooks.lock"))?;
+    remove_hooks_json(&path)
+}
+
+fn remove_hooks_json(path: &Path) -> Result<Outcome, Error> {
+    if !path.exists() {
+        return Ok(Outcome::NotPresent);
+    }
+    let mut json = read_hooks_json(path)?;
+    let Some(root) = json.as_object_mut() else {
+        return Ok(Outcome::NotPresent);
+    };
+    let Some(hooks) = root.get_mut("hooks").and_then(|v| v.as_object_mut()) else {
+        return Ok(Outcome::NotPresent);
+    };
+
+    let mut removed_any = false;
+    for (event, command) in HOOK_EVENTS {
+        let Some(arr_item) = hooks.get_mut(*event) else {
+            continue;
+        };
+        let Some(arr) = arr_item.as_array_mut() else {
+            continue;
+        };
+        let before = arr.len();
+        arr.retain(|entry| {
+            entry
+                .get("hooks")
+                .and_then(|v| v.as_array())
+                .map(|inner| {
+                    !inner.iter().any(|h| {
+                        h.get("command").and_then(|v| v.as_str()) == Some(command)
+                            && h.get(MANAGED_MARKER).and_then(|v| v.as_bool()) == Some(true)
+                    })
+                })
+                .unwrap_or(true)
+        });
+        if arr.len() != before {
+            removed_any = true;
+        }
+    }
+    if !removed_any {
+        return Ok(Outcome::NotPresent);
+    }
+    let mut serialized = serde_json::to_string_pretty(&json)?;
+    if !serialized.ends_with('\n') {
+        serialized.push('\n');
+    }
+    atomic_write(path, serialized.as_bytes())?;
+    Ok(Outcome::Removed)
+}
+
+// ---------- Dry-run preview ---------------------------------------------
+
+/// Print a summary of what the four ensure_* helpers would do for `home`
+/// without actually writing. Caller is expected to gate this behind a
+/// `--dry-run` flag.
+pub fn print_dry_run_summary(home: &Path, out: &mut dyn Write) -> io::Result<()> {
+    writeln!(
+        out,
+        "[clud setup] would write to {}:",
+        claude_json_path(home).display()
+    )?;
+    writeln!(out, "  + mcpServers.clud-memory.{{command, args}}")?;
+    writeln!(
+        out,
+        "[clud setup] would write to {}:",
+        codex_config_path(home).display()
+    )?;
+    writeln!(out, "  + [mcp_servers.clud-memory] {{command, args}}")?;
+    writeln!(
+        out,
+        "[clud setup] would write to {}:",
+        claude_settings_path(home).display()
+    )?;
+    writeln!(out, "  + hooks.SessionStart[].hooks[]")?;
+    writeln!(out, "  + hooks.UserPromptSubmit[].hooks[]")?;
+    writeln!(out, "  + hooks.PostToolUse[].hooks[]")?;
+    writeln!(out, "  + hooks.Stop[].hooks[]")?;
+    writeln!(
+        out,
+        "[clud setup] would write to {}:",
+        codex_hooks_path(home).display()
+    )?;
+    writeln!(out, "  + hooks.SessionStart[].hooks[]")?;
+    writeln!(out, "  + hooks.UserPromptSubmit[].hooks[]")?;
+    writeln!(out, "  + hooks.PostToolUse[].hooks[]")?;
+    writeln!(out, "  + hooks.Stop[].hooks[]")?;
+    out.flush()
+}
+
+fn log_outcome(out: &mut dyn Write, path: &Path, key: &str, outcome: Outcome) {
+    match outcome {
+        Outcome::Wrote => {
+            let _ = writeln!(
+                out,
+                "[clud] registered {key} in {} (clud-memory)",
+                path.display()
+            );
+        }
+        Outcome::Removed => {
+            let _ = writeln!(out, "[clud] removed {key} from {}", path.display());
+        }
+        Outcome::AlreadyPresent | Outcome::NotPresent => {}
+    }
+}
+
+#[cfg(test)]
+#[path = "mcp_config_tests.rs"]
+mod tests;

--- a/crates/clud-bin/src/memory/mcp_config_tests.rs
+++ b/crates/clud-bin/src/memory/mcp_config_tests.rs
@@ -1,0 +1,439 @@
+use super::*;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const VERSION: &str = "1.2.3";
+
+fn run<F, R>(f: F) -> R
+where
+    F: FnOnce(&Path) -> R,
+{
+    let tmp = TempDir::new().unwrap();
+    f(tmp.path())
+}
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+}
+
+// ---------- Claude MCP --------------------------------------------------
+
+#[test]
+fn ensure_claude_mcp_writes_entry_on_empty_file() {
+    run(|home| {
+        std::fs::write(home.join(".claude.json"), "{}").unwrap();
+        let mut out = Vec::new();
+        let outcome = ensure_claude_mcp(home, VERSION, &mut out).unwrap();
+        assert_eq!(outcome, Outcome::Wrote);
+        let json = read_json(&home.join(".claude.json"));
+        let block = &json["mcpServers"]["clud-memory"];
+        assert_eq!(block["command"], "clud");
+        assert_eq!(block["args"], json!(["mcp"]));
+        assert_eq!(block["_clud_managed"], json!(true));
+        assert_eq!(block["_clud_version"], VERSION);
+    });
+}
+
+#[test]
+fn ensure_claude_mcp_works_on_missing_file() {
+    run(|home| {
+        let mut out = Vec::new();
+        let outcome = ensure_claude_mcp(home, VERSION, &mut out).unwrap();
+        assert_eq!(outcome, Outcome::Wrote);
+        assert!(home.join(".claude.json").is_file());
+    });
+}
+
+#[test]
+fn mcp_registration_writes_clud_memory_block_idempotently() {
+    run(|home| {
+        std::fs::write(home.join(".claude.json"), "{}").unwrap();
+        let mut out = Vec::new();
+        assert_eq!(
+            ensure_claude_mcp(home, VERSION, &mut out).unwrap(),
+            Outcome::Wrote
+        );
+        out.clear();
+        let outcome = ensure_claude_mcp(home, VERSION, &mut out).unwrap();
+        assert_eq!(outcome, Outcome::AlreadyPresent);
+    });
+}
+
+#[test]
+fn mcp_registration_refuses_to_clobber_user_block() {
+    run(|home| {
+        let user = json!({
+            "mcpServers": {
+                "clud-memory": {
+                    "command": "/usr/local/bin/clud-fork",
+                    "args": []
+                }
+            }
+        });
+        std::fs::write(
+            home.join(".claude.json"),
+            serde_json::to_string_pretty(&user).unwrap(),
+        )
+        .unwrap();
+        let before = std::fs::read_to_string(home.join(".claude.json")).unwrap();
+        let mut out = Vec::new();
+        let err = ensure_claude_mcp(home, VERSION, &mut out).unwrap_err();
+        assert!(matches!(err, Error::UserDefined { .. }));
+        let after = std::fs::read_to_string(home.join(".claude.json")).unwrap();
+        assert_eq!(before, after, "must not overwrite user-defined block");
+    });
+}
+
+#[test]
+fn ensure_claude_mcp_preserves_other_servers() {
+    run(|home| {
+        let user = json!({
+            "mcpServers": {
+                "gmail": { "command": "gmail-mcp", "args": ["--auth"] }
+            },
+            "otherKey": "value"
+        });
+        std::fs::write(
+            home.join(".claude.json"),
+            serde_json::to_string_pretty(&user).unwrap(),
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        assert_eq!(
+            ensure_claude_mcp(home, VERSION, &mut out).unwrap(),
+            Outcome::Wrote
+        );
+        let json = read_json(&home.join(".claude.json"));
+        assert_eq!(json["otherKey"], "value");
+        assert_eq!(json["mcpServers"]["gmail"]["command"], "gmail-mcp");
+        assert_eq!(json["mcpServers"]["clud-memory"]["command"], "clud");
+    });
+}
+
+#[test]
+fn ensure_claude_mcp_rewrites_version_drift() {
+    run(|home| {
+        std::fs::write(home.join(".claude.json"), "{}").unwrap();
+        let mut out = Vec::new();
+        ensure_claude_mcp(home, "0.0.1", &mut out).unwrap();
+        let outcome = ensure_claude_mcp(home, VERSION, &mut out).unwrap();
+        assert_eq!(outcome, Outcome::Wrote);
+        let json = read_json(&home.join(".claude.json"));
+        assert_eq!(json["mcpServers"]["clud-memory"]["_clud_version"], VERSION);
+    });
+}
+
+// ---------- Codex MCP (TOML) -------------------------------------------
+
+#[test]
+fn ensure_codex_mcp_writes_entry_on_empty_file() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let mut out = Vec::new();
+        assert_eq!(
+            ensure_codex_mcp(home, VERSION, &mut out).unwrap(),
+            Outcome::Wrote
+        );
+        let text = std::fs::read_to_string(home.join(".codex/config.toml")).unwrap();
+        assert!(text.contains("[mcp_servers.clud-memory]"), "{text}");
+        assert!(text.contains("managed-by: clud-memory"), "{text}");
+        assert!(text.contains("command = \"clud\""), "{text}");
+        assert!(text.contains("\"mcp\""), "{text}");
+    });
+}
+
+#[test]
+fn codex_toml_registration_preserves_existing_keys() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let body = r#"# user comment
+model = "gpt-5"
+
+[mcp_servers.foo]
+# this is a foo server
+command = "foo"
+args = ["a", "b"]
+"#;
+        std::fs::write(home.join(".codex/config.toml"), body).unwrap();
+        let mut out = Vec::new();
+        assert_eq!(
+            ensure_codex_mcp(home, VERSION, &mut out).unwrap(),
+            Outcome::Wrote
+        );
+        let text = std::fs::read_to_string(home.join(".codex/config.toml")).unwrap();
+        assert!(text.contains("# user comment"), "{text}");
+        assert!(text.contains("model = \"gpt-5\""), "{text}");
+        assert!(text.contains("[mcp_servers.foo]"), "{text}");
+        assert!(text.contains("# this is a foo server"), "{text}");
+        assert!(text.contains("[mcp_servers.clud-memory]"), "{text}");
+        assert!(text.contains("# managed-by: clud-memory"), "{text}");
+    });
+}
+
+#[test]
+fn ensure_codex_mcp_idempotent() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let mut out = Vec::new();
+        ensure_codex_mcp(home, VERSION, &mut out).unwrap();
+        let outcome = ensure_codex_mcp(home, VERSION, &mut out).unwrap();
+        assert_eq!(outcome, Outcome::AlreadyPresent);
+    });
+}
+
+#[test]
+fn ensure_codex_mcp_refuses_user_block() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let body = "[mcp_servers.clud-memory]\ncommand = \"other\"\nargs = []\n";
+        std::fs::write(home.join(".codex/config.toml"), body).unwrap();
+        let mut out = Vec::new();
+        let err = ensure_codex_mcp(home, VERSION, &mut out).unwrap_err();
+        assert!(matches!(err, Error::UserDefined { .. }));
+        let after = std::fs::read_to_string(home.join(".codex/config.toml")).unwrap();
+        assert_eq!(after, body);
+    });
+}
+
+// ---------- Claude hooks ------------------------------------------------
+
+#[test]
+fn hook_registration_writes_all_four_entries() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let mut out = Vec::new();
+        assert_eq!(
+            ensure_claude_hooks(home, VERSION, &mut out).unwrap(),
+            Outcome::Wrote
+        );
+        let json = read_json(&home.join(".claude/settings.json"));
+        let hooks = &json["hooks"];
+        for (event, command) in HOOK_EVENTS {
+            let arr = hooks[event].as_array().expect("event array");
+            assert_eq!(arr.len(), 1, "{event}");
+            assert_eq!(arr[0]["hooks"][0]["command"], *command);
+            assert_eq!(arr[0]["hooks"][0]["timeout"], json!(30));
+            assert_eq!(arr[0]["hooks"][0]["_clud_managed"], json!(true));
+        }
+    });
+}
+
+#[test]
+fn hook_registration_is_idempotent() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let mut out = Vec::new();
+        ensure_claude_hooks(home, VERSION, &mut out).unwrap();
+        let outcome = ensure_claude_hooks(home, VERSION, &mut out).unwrap();
+        assert_eq!(outcome, Outcome::AlreadyPresent);
+    });
+}
+
+#[test]
+fn hook_registration_refuses_to_clobber_user_entries() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let user = json!({
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "hooks": [
+                            { "type": "command", "command": "clud hook session-start", "timeout": 60 }
+                        ]
+                    }
+                ]
+            }
+        });
+        std::fs::write(
+            home.join(".claude/settings.json"),
+            serde_json::to_string_pretty(&user).unwrap(),
+        )
+        .unwrap();
+        let before = std::fs::read_to_string(home.join(".claude/settings.json")).unwrap();
+        let mut out = Vec::new();
+        let err = ensure_claude_hooks(home, VERSION, &mut out).unwrap_err();
+        assert!(matches!(err, Error::UserDefined { .. }));
+        let after = std::fs::read_to_string(home.join(".claude/settings.json")).unwrap();
+        assert_eq!(before, after);
+    });
+}
+
+#[test]
+fn hook_registration_appends_to_existing_user_hooks() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let user = json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            { "type": "command", "command": "echo pretool" }
+                        ]
+                    }
+                ]
+            }
+        });
+        std::fs::write(
+            home.join(".claude/settings.json"),
+            serde_json::to_string_pretty(&user).unwrap(),
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        ensure_claude_hooks(home, VERSION, &mut out).unwrap();
+        let json = read_json(&home.join(".claude/settings.json"));
+        assert_eq!(
+            json["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "echo pretool"
+        );
+        assert_eq!(
+            json["hooks"]["SessionStart"][0]["hooks"][0]["command"],
+            "clud hook session-start"
+        );
+    });
+}
+
+#[test]
+fn ensure_codex_hooks_writes_all_four_entries() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let mut out = Vec::new();
+        assert_eq!(
+            ensure_codex_hooks(home, VERSION, &mut out).unwrap(),
+            Outcome::Wrote
+        );
+        let json = read_json(&home.join(".codex/hooks.json"));
+        for (event, command) in HOOK_EVENTS {
+            let arr = json["hooks"][event].as_array().expect("event array");
+            assert_eq!(arr.len(), 1, "{event}");
+            assert_eq!(arr[0]["hooks"][0]["command"], *command);
+        }
+    });
+}
+
+// ---------- memory_already_registered ----------------------------------
+
+#[test]
+fn memory_already_registered_returns_true_after_ensure() {
+    run(|home| {
+        assert!(!memory_already_registered(home));
+        let mut out = Vec::new();
+        ensure_claude_mcp(home, VERSION, &mut out).unwrap();
+        assert!(memory_already_registered(home));
+    });
+}
+
+#[test]
+fn memory_already_registered_false_for_user_defined_block() {
+    run(|home| {
+        let user = json!({
+            "mcpServers": {
+                "clud-memory": { "command": "other", "args": [] }
+            }
+        });
+        std::fs::write(
+            home.join(".claude.json"),
+            serde_json::to_string_pretty(&user).unwrap(),
+        )
+        .unwrap();
+        assert!(!memory_already_registered(home));
+    });
+}
+
+// ---------- Remove helpers --------------------------------------------
+
+#[test]
+fn remove_claude_mcp_strips_managed_entry() {
+    run(|home| {
+        std::fs::write(home.join(".claude.json"), "{}").unwrap();
+        let mut out = Vec::new();
+        ensure_claude_mcp(home, VERSION, &mut out).unwrap();
+        assert_eq!(remove_claude_mcp(home).unwrap(), Outcome::Removed);
+        let json = read_json(&home.join(".claude.json"));
+        assert!(json["mcpServers"]
+            .as_object()
+            .map(|m| !m.contains_key("clud-memory"))
+            .unwrap_or(true));
+    });
+}
+
+#[test]
+fn remove_returns_not_present_on_missing() {
+    run(|home| {
+        assert_eq!(remove_claude_mcp(home).unwrap(), Outcome::NotPresent);
+        assert_eq!(remove_codex_mcp(home).unwrap(), Outcome::NotPresent);
+        assert_eq!(remove_claude_hooks(home).unwrap(), Outcome::NotPresent);
+        assert_eq!(remove_codex_hooks(home).unwrap(), Outcome::NotPresent);
+    });
+}
+
+#[test]
+fn remove_claude_hooks_strips_managed_entries_but_preserves_user_hooks() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let user = json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{ "type": "command", "command": "echo x" }]
+                    }
+                ]
+            }
+        });
+        std::fs::write(
+            home.join(".claude/settings.json"),
+            serde_json::to_string_pretty(&user).unwrap(),
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        ensure_claude_hooks(home, VERSION, &mut out).unwrap();
+        assert_eq!(remove_claude_hooks(home).unwrap(), Outcome::Removed);
+        let json = read_json(&home.join(".claude/settings.json"));
+        assert_eq!(
+            json["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "echo x"
+        );
+        assert!(json["hooks"]["SessionStart"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true));
+    });
+}
+
+// ---------- Codex hook integration -------------------------------------
+
+#[test]
+fn ensure_codex_hooks_appends_to_existing_user_hooks() {
+    run(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let user = json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{ "type": "command", "command": "do.sh", "timeout": 30 }]
+                    }
+                ]
+            }
+        });
+        std::fs::write(
+            home.join(".codex/hooks.json"),
+            serde_json::to_string_pretty(&user).unwrap(),
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        ensure_codex_hooks(home, VERSION, &mut out).unwrap();
+        let json = read_json(&home.join(".codex/hooks.json"));
+        assert_eq!(
+            json["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "do.sh"
+        );
+        for (event, command) in HOOK_EVENTS {
+            assert_eq!(
+                json["hooks"][event][0]["hooks"][0]["command"], *command,
+                "{event}"
+            );
+        }
+    });
+}

--- a/crates/clud-bin/src/memory/mod.rs
+++ b/crates/clud-bin/src/memory/mod.rs
@@ -14,6 +14,7 @@ pub mod git_artifact;
 pub mod identity;
 pub mod ids;
 pub mod lexical;
+pub mod mcp_config;
 pub mod paths;
 pub mod schema;
 pub mod search;

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -651,3 +651,38 @@ A new tab is the second-largest UI change the dashboard has ever taken (after th
 - Verbose stderr diagnostics are gated on `CLUD_MEMORY_DEBUG_HOOKS=1`. The default-off behavior keeps agent transcripts clean.
 - Auto-export of recalled rows to disk and tool-output classification are deferred to siblings #264 and v0.5 respectively; the `post-tool-use` hook ships as a logged no-op in v0.1, and the `stop` hook's consolidation path is wired but waits on a `/memory/consolidate` route.
 - Registration of `clud hook` calls into `~/.claude/settings.json` / `~/.codex/hooks.json` is owned by sibling #265; the four subcommands are `hide = true` in clap because they are not user-facing.
+
+---
+
+## DD-023: ScopeSelector third row enables memory MCP+hooks in one action; refuse-to-clobber semantics
+
+**Context:** Issue #265 (sub-issue 10 of META #255) wires the native agent-memory subsystem into the launch flow. The MCP server (`clud mcp`) and the four `clud hook <verb>` subcommands have already shipped (#259, #260) but need to be *registered* into the user's `~/.claude.json` / `~/.codex/config.toml` (MCP) and `~/.claude/settings.json` / `~/.codex/hooks.json` (hooks) for the backend to actually invoke them. Without registration, the subsystem is dark. Three questions had to be answered: (1) where in the UX does the opt-in live, (2) what happens when the user has already hand-edited a `clud-memory` block, (3) is the registration a one-shot migration or an idempotent pass that the launch flow can run every time.
+
+**Decision:** The existing two-row `ScopeSelector` ([`launch_setup.rs`](../crates/clud-bin/src/launch_setup.rs)) grows a third row — `Globally + clud memory (recommended)` — which is its own `LaunchSetupScope::GlobalWithMemory` variant. Selecting it runs the same actions as `Global` plus two new actions (`MemoryMcpRegistrationAction` and `MemoryHookRegistrationAction`) that upsert the MCP and hook entries idempotently into the *selected* backend's config files. The actions carry a managed marker (`_clud_managed: true` in JSON, `# managed-by: clud-memory` lead comment in TOML) and **refuse to overwrite** any `clud-memory` key that lacks the marker.
+
+**Rationale:**
+
+- **One toggle, not four.** Memory is *only* useful if both the MCP server and all four hooks are registered. Splitting them into separate scope-selector rows (`+ MCP`, `+ hooks`, `+ both`) would let users land in a half-configured state where the MCP server is wired but no rows ever land because the `user-prompt-submit` hook never fires the `remember:` directive. Bundling them into one row makes the failure mode "memory works or doesn't" rather than "memory silently swallows half the saves."
+- **Idempotent + refuse-to-clobber instead of one-shot migration.** A one-shot migration is hostile to upgrades — bumping `clud` would either silently skip the new entry shape or require a separate "did I migrate yet?" sentinel. Running every launch is cheap (one stat + one parse per file, all under a sibling `.lock`), and the managed marker lets the action distinguish its own writes from user writes. Re-running on an up-to-date file is a no-op (`Outcome::AlreadyPresent`); rerunning with a newer `clud` version rewrites the managed block in place; rerunning against a user-defined block surfaces a `[clud] note: refusing to ...` line and continues without touching the file.
+- **Selected-backend only, mirror the existing actions.** `BundledSkillsAction` is registered twice — `Backend::Claude` and `Backend::Codex` — and `setup_actions()` filters by `action.backend() == backend`. The two new memory actions follow the same shape: one Claude instance writes `~/.claude.json` + `~/.claude/settings.json`, one Codex instance writes `~/.codex/config.toml` + `~/.codex/hooks.json`. A user on Claude doesn't pay for a Codex config write they don't want, and the dispatch path stays uniform.
+- **Memory-aware default.** `ScopeSelector::for_home(home)` probes `mcp_config::memory_already_registered(home)` and starts the cursor on row 2 (recommended) when memory is not yet configured, row 0 (session-only) when it is. First-time users land on the row that does the right thing without reading the spec; repeat users keep muscle memory.
+- **`toml_edit::DocumentMut` over `toml::to_string`.** TOML round-trip via `toml::to_string` would re-serialize the entire `~/.codex/config.toml`, dropping user comments and reordering keys. `toml_edit` preserves trivia (comments, blank lines, key order) by design — the test `codex_toml_registration_preserves_existing_keys` is the regression guard.
+- **Atomic temp-file + rename writes.** A crash mid-write would leave an empty or half-written `~/.claude.json`, which Claude Code reads on every launch. `tempfile::NamedTempFile::new_in(parent)` + `persist(path)` keeps the rename on the same filesystem (so no `EXDEV`) and the rename is atomic on POSIX and on NTFS (`MoveFileExW` semantics behind `persist`).
+
+**Alternatives Considered:**
+
+| Approach | Why not |
+|---|---|
+| Add memory MCP/hook to the existing `Global` row | Existing users who pick `Globally` today don't expect new persistent edits to their config files. A separate row makes the opt-in explicit and the rollback path obvious (re-run, pick `Globally`). |
+| Silently overwrite user-edited `clud-memory` blocks | User picked a custom command (`/usr/local/bin/clud-fork`, a forked branch, a wrapper script) for a reason. Overwriting it on every launch would actively fight the user. The refuse-to-clobber + `[clud] note: ...` line surfaces the conflict without blocking the launch. |
+| One-shot migration gated by a sentinel file | Adds a "did I migrate yet?" state machine that the agent has to reason about on upgrade. The idempotent pass collapses to the same end state without the sentinel. |
+| Serialize TOML via `serde::Serialize` + `toml::to_string` | Drops user comments, reorders keys, loses inline trivia. The `toml_edit` round-trip preserves all of that and the regression test (`codex_toml_registration_preserves_existing_keys`) pins it. |
+| Register into every detected backend (mirror `BundledSkillsAction`) | Memory is more invasive than skills (permanently edits user MCP/hook config). Registering only into the currently selected backend minimizes blast radius; the user can rerun `clud --claude --setup` and `clud --codex --setup` if they want both. |
+
+**Consequences:**
+
+- The selector default flips between row 0 and row 2 based on `memory_already_registered`. First-time users get the recommended path; repeat users land on the row they last picked. The `for_home(home)` constructor is the test seam.
+- Four advisory locks under `~/.clud/memory-{claude,codex}-{mcp,hooks}.lock` serialize concurrent launches; `fs4` releases them on process exit. The `.lock` file itself stays on disk (cosmetic; same as `codex_hook_normalize`).
+- `clud --setup --dry-run` prints a four-file summary without writing — useful for users to preview what the action will touch.
+- The `MemoryConfig` variant added to `SetupError` is propagated through `main.rs`'s `[clud] note: global setup failed: ...` path, matching the existing skill/hook setup failure handling. Setup failures are non-fatal.
+- `clud memory uninstall` (a future verb under META #255) re-uses the symmetric `remove_*` helpers in `mcp_config.rs` to strip the managed entries while preserving any user-defined siblings — the lock pattern and atomic write keep the operation safe even mid-session.

--- a/docs/architecture/launch-setup.md
+++ b/docs/architecture/launch-setup.md
@@ -11,13 +11,17 @@ Interactive TUI launches that explicitly choose a backend with `--claude` or
 ```text
 [x] Session only
 [ ] Globally
+[ ] Globally + clud memory (recommended)
 ```
 
-The default is session-only. Enter accepts the highlighted option, Up selects
-session-only, and Down selects global. A bare `clud` invocation (no `--claude`
-or `--codex`), non-interactive launches, piped stdin, `--dry-run`, one-shot
-prompt launches (`-p` / `-m`), continuations, resumes, and maintenance commands
-do not prompt; they use session-only.
+The default is session-only when the `clud-memory` MCP block is already
+registered, and "Globally + clud memory (recommended)" when memory is not yet
+configured (probed via `mcp_config::memory_already_registered`). Enter accepts
+the highlighted option; Up/Down navigate (with wrap-around — Up from row 0
+selects row 2, Down from row 2 selects row 0). A bare `clud` invocation (no
+`--claude` or `--codex`), non-interactive launches, piped stdin, `--dry-run`,
+one-shot prompt launches (`-p` / `-m`), continuations, resumes, and maintenance
+commands do not prompt; they use session-only.
 
 Session-only launches skip persistent setup. They must not create or modify
 agent home setup files under `~/.claude`, `~/.codex`, `~/.agents`, or
@@ -25,17 +29,40 @@ agent home setup files under `~/.claude`, `~/.codex`, `~/.agents`, or
 
 ## Global Actions
 
-Global setup runs only the selected backend's registered actions:
+Global setup runs only the selected backend's registered actions. Actions whose
+`supports()` returns true for the current scope run in registration order;
+existing actions opt in via `LaunchSetupScope::runs_global_actions()`, while
+the two memory-registration actions intentionally gate on
+`LaunchSetupScope::GlobalWithMemory` only.
 
-| Backend | Action | Persistent paths |
-|---|---|---|
-| Claude | bundled skills | `~/.claude/skills/` |
-| Claude | Claude drift skills | `~/.claude/skills/` |
-| Codex | bundled skills | `~/.agents/skills/` gated by `~/.codex`; stale clud-managed `~/.codex/skills/` copies are purged |
-| Codex | hook timeout normalization | `~/.codex/hooks.json` and `~/.clud/settings.lock` / `settings.json` |
+| Scope | Backend | Action | Persistent paths |
+|---|---|---|---|
+| Global / GlobalWithMemory | Claude | bundled skills | `~/.claude/skills/` |
+| Global / GlobalWithMemory | Claude | Claude drift skills | `~/.claude/skills/` |
+| Global / GlobalWithMemory | Codex | bundled skills | `~/.agents/skills/` gated by `~/.codex`; stale clud-managed `~/.codex/skills/` copies are purged |
+| Global / GlobalWithMemory | Codex | hook timeout normalization | `~/.codex/hooks.json` and `~/.clud/settings.lock` / `settings.json` |
+| GlobalWithMemory only | Claude | memory MCP registration (#265) | `~/.claude.json` (`mcpServers.clud-memory`) |
+| GlobalWithMemory only | Codex | memory MCP registration (#265) | `~/.codex/config.toml` (`[mcp_servers.clud-memory]`) |
+| GlobalWithMemory only | Claude | memory hook registration (#265) | `~/.claude/settings.json` (`hooks.{SessionStart,UserPromptSubmit,PostToolUse,Stop}`) |
+| GlobalWithMemory only | Codex | memory hook registration (#265) | `~/.codex/hooks.json` (same four events) |
 
 All setup failures are non-fatal. `main.rs` logs a `[clud] note: ...` line and
 continues to build and run the backend `LaunchPlan`.
+
+### Memory registration idempotency
+
+The two memory-registration actions are **idempotent** and **refuse to clobber
+hand-edits**. The managed entries carry a `_clud_managed: true` field (JSON) or
+a `# managed-by: clud-memory` lead comment (TOML). Re-running on an up-to-date
+file is a no-op. When a `clud-memory` key exists *without* the marker, the
+helper returns `Error::UserDefined { path, key }`; the action surfaces a
+`[clud] note: refusing to overwrite ...` line and continues without writing.
+The user's escape hatch is to rename the conflicting block or hand-edit the
+marker in, then re-run `clud --setup`.
+
+Writes are atomic (temp-file + rename in the same directory) and serialized by
+a sibling `~/.clud/memory-{claude,codex}-{mcp,hooks}.lock` advisory file lock
+(same `fs4` pattern used by `codex_hook_normalize`).
 
 ## Adding an Action
 

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -568,6 +568,48 @@ Tests:
 - Python `tests/test_memory_dashboard.py` exercises both the served
   HTML and `/memory/stats` against a real daemon process.
 
+## Launch-setup integration (#265)
+
+The opt-in surface for native memory is the third row of the launch-setup
+scope selector — `Globally + clud memory (recommended)`. Selecting it runs
+the existing `Global` actions (bundled skills, drift skills, hook timeout
+normalization) AND two new actions registered for the selected backend only:
+
+- `MemoryMcpRegistrationAction` — upserts the `clud-memory` MCP block into
+  `~/.claude.json` (Claude) or `~/.codex/config.toml` (Codex).
+- `MemoryHookRegistrationAction` — upserts the four `clud hook <verb>`
+  entries into `~/.claude/settings.json` (Claude) or `~/.codex/hooks.json`
+  (Codex).
+
+Both actions live in `crates/clud-bin/src/launch_setup.rs` and delegate to
+the idempotent upsert helpers in
+[`crates/clud-bin/src/memory/mcp_config.rs`](../../crates/clud-bin/src/memory/mcp_config.rs):
+`ensure_claude_mcp` / `ensure_codex_mcp` / `ensure_claude_hooks` /
+`ensure_codex_hooks` (plus the four symmetric `remove_*` helpers used by
+`clud memory uninstall` once that verb lands). Each helper acquires an
+advisory `~/.clud/memory-{backend}-{kind}.lock` lock, parses the existing
+config with `serde_json` (JSON) or `toml_edit` (TOML, so user comments
+survive), upserts the managed block, and writes atomically via a temp
+file + rename in the same directory. JSON entries carry a sibling
+`_clud_managed: true` field; TOML entries carry a `# managed-by: clud-memory`
+lead comment. An existing `clud-memory` key without the managed marker is
+treated as user-defined: the helper returns `Error::UserDefined { path, key }`,
+the action surfaces a `[clud] note: refusing to ...` line and continues without
+writing.
+
+The selector default flips based on whether memory is already registered
+(`mcp_config::memory_already_registered(home)` — one stat + one parse), so a
+fresh install opens on row 2 (the recommended row) and a repeat launch opens on
+row 0. See
+[`docs/architecture/launch-setup.md`](launch-setup.md) for the row-level
+details and [DD-023](../DESIGN_DECISIONS.md#dd-023-scope-selector-third-row-enables-memory-mcphooks-in-one-action-refuse-to-clobber-semantics)
+for the rationale on refuse-to-clobber semantics.
+
+A `--dry-run` flag on `run_setup_at_with_options` emits a four-file preview
+without touching disk; the same flag is exposed to users via
+`clud --setup --dry-run` (no writes; prints the file paths and entries that
+would be added).
+
 ## Sibling sub-issues (META #255)
 
 - ~~Embeddings (local + remote + Windows-ARM strategy)~~ — #257.


### PR DESCRIPTION
## Summary
- ScopeSelector gains a third row: "Globally + clud memory (recommended)". Defaults to row 2 when memory is not yet configured, row 0 once it is.
- New `MemoryMcpRegistrationAction`: writes `clud-memory` entries into `~/.claude.json` and `~/.codex/config.toml`. Idempotent + refuses to clobber hand-edited blocks (managed marker: `_clud_managed: true` in JSON, `# managed-by: clud-memory` comment in TOML preserved via `toml_edit`).
- New `MemoryHookRegistrationAction`: writes 4 hook entries into `~/.claude/settings.json` and `~/.codex/hooks.json`. Same idempotency rules.
- `--dry-run` previews changes without writing.
- Atomic temp-file + rename writes serialized by sibling `~/.clud/memory-*.lock` files.

Closes #265. Part of meta #255.

## Test plan
- [x] `soldr cargo test -p clud --lib launch_setup::` -- 16 green (incl. new wrap-around / memory-aware default / both-actions-dispatch / dry-run tests).
- [x] `soldr cargo test -p clud --lib memory::mcp_config::` -- 21 green (idempotency, refuse-to-clobber, preserves user keys, version drift, hooks merge with user PreToolUse, etc.).
- [x] Full library test suite: 925 green (no regressions).
- [x] `soldr cargo clippy --workspace --no-default-features --all-targets -- -D warnings` clean.
- [x] `soldr cargo fmt --all --check` clean.
- [x] `python -m ruff check src tests ci` clean.
- [ ] CI green on all 6 platforms.

Robot Generated with [Claude Code](https://claude.com/claude-code)