### PR TITLE
chore: release 2.0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "base64",
  "clap",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "libc",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.18"
+version = "2.0.19"
 edition = "2021"
 rust-version = "1.85"
 license-file = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.18"
+version = "2.0.19"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- First memory-free release after #283 (the 12-commit revert of the agent-memory feature, merged 2026-06-07).
- Bumps `[workspace.package].version` and `[project].version` from `2.0.18` → `2.0.19` and updates the two workspace member entries in `Cargo.lock` (`clud`, `mock-agent`). No code changes.

## Why 2.0.19 and not "delete the 2.0.18 wheel"

`2.0.18` was published *with* the memory feature included. Yanking and re-publishing the same version number is destructive to anyone who already installed it. Bumping forward is the safer, conventional path; downstream consumers will pick up the memory-free build on next upgrade.

## Test plan

- [ ] CI green on all 6 platforms.
- [ ] After merge, run `/clud-tag-release` to push the `2.0.19` tag and let the auto-release workflow publish.