### PR TITLE
feat(verbose): emit "[clud] ctrl-c received" on every Ctrl+C press

### DIFF
--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -161,7 +161,7 @@ fn main() {
         }
     }
 
-    let interrupted = startup::install_ctrl_c_flag();
+    let interrupted = startup::install_ctrl_c_flag(args.verbose);
     if let Some(exit_code) = daemon::handle_special_command(&args, interrupted.as_ref()) {
         flush_ctrl_c_exit_event(ctrl_c_track::InvocationKind::Attach, exit_code);
         std::process::exit(exit_code);

--- a/crates/clud-bin/src/startup.rs
+++ b/crates/clud-bin/src/startup.rs
@@ -156,20 +156,37 @@ pub fn enforce_session_cap() -> Option<ScopedSessionGuard> {
     }
 }
 
-pub fn install_ctrl_c_flag() -> Arc<AtomicBool> {
-    use std::sync::atomic::Ordering;
+pub fn install_ctrl_c_flag(verbose: bool) -> Arc<AtomicBool> {
     let interrupted = Arc::new(AtomicBool::new(false));
     let handler_flag = Arc::clone(&interrupted);
     if let Err(e) = ctrlc::set_handler(move || {
-        // Stamp the first-Ctrl+C wall-clock observation before we flip
-        // the flag the rest of the process polls, so the elapsed-time
-        // measurement covers everything from signal-delivery onward.
-        crate::ctrl_c_track::record_observed();
-        handler_flag.store(true, Ordering::SeqCst);
+        run_ctrl_c_handler(verbose, handler_flag.as_ref(), |msg| {
+            crate::verbose_log::log(msg)
+        });
     }) {
         eprintln!("[clud] warning: failed to install Ctrl+C handler: {}", e);
     }
     interrupted
+}
+
+/// Pure side-effecting body of the Ctrl+C handler closure, extracted so
+/// unit tests can assert the verbose-emit decision without installing a
+/// real signal handler (which would conflict with cargo's test runner).
+///
+/// The handler stamps `ctrl_c_track::OBSERVED_UNIX_MS`, optionally emits
+/// a timestamped marker through `verbose_log::log`, then flips the
+/// process-wide interrupted flag. The verbose marker is what lets the
+/// launch log show *when* the Ctrl+C arrived relative to the eventual
+/// `[clud] subprocess: exited code …` / `[clud] exit: code …` lines —
+/// without it the user only sees the *result* of an interrupt, never
+/// the *moment* it was delivered.
+fn run_ctrl_c_handler(verbose: bool, interrupted: &AtomicBool, emit_verbose: impl FnOnce(&str)) {
+    use std::sync::atomic::Ordering;
+    crate::ctrl_c_track::record_observed();
+    if verbose {
+        emit_verbose("[clud] ctrl-c received");
+    }
+    interrupted.store(true, Ordering::SeqCst);
 }
 
 #[cfg(test)]
@@ -238,5 +255,49 @@ mod tests {
         // it succeeds or fails, the function must return Option<Guard>
         // (never panic, never abort the process).
         let _result = super::try_register_console_drop_target_subprocess();
+    }
+
+    /// Verbose mode: every Ctrl+C press emits the `[clud] ctrl-c received`
+    /// marker so the launch log shows the moment of interrupt, not just
+    /// the eventual exit-code lines.
+    #[test]
+    fn ctrl_c_handler_emits_verbose_marker_when_verbose() {
+        use std::cell::Cell;
+        use std::sync::atomic::Ordering;
+        let interrupted = AtomicBool::new(false);
+        let captured: Cell<Option<String>> = Cell::new(None);
+        super::run_ctrl_c_handler(true, &interrupted, |msg| {
+            captured.set(Some(msg.to_string()));
+        });
+        assert_eq!(
+            captured.into_inner().as_deref(),
+            Some("[clud] ctrl-c received"),
+            "verbose handler must emit the ctrl-c marker"
+        );
+        assert!(
+            interrupted.load(Ordering::SeqCst),
+            "handler must flip the interrupted flag"
+        );
+    }
+
+    /// Non-verbose mode: the marker is suppressed so it doesn't clobber
+    /// a live TUI's screen state. The interrupted flag still flips.
+    #[test]
+    fn ctrl_c_handler_skips_verbose_marker_when_not_verbose() {
+        use std::cell::Cell;
+        use std::sync::atomic::Ordering;
+        let interrupted = AtomicBool::new(false);
+        let called = Cell::new(false);
+        super::run_ctrl_c_handler(false, &interrupted, |_| {
+            called.set(true);
+        });
+        assert!(
+            !called.into_inner(),
+            "non-verbose handler must not call the emit closure"
+        );
+        assert!(
+            interrupted.load(Ordering::SeqCst),
+            "handler must still flip the interrupted flag without verbose"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- In `--verbose` mode, stamp a `[clud] ctrl-c received` line through `verbose_log::log` from inside the ctrlc handler closure on every press. Without this, the launch log shows `[clud] subprocess: exited code …` and `[clud] exit: code …` but the user can't see the *moment* of interrupt, only its eventual consequences — so the time from "I pressed Ctrl+C" to "shell came back" is unreadable from the printout.
- Non-verbose mode is unchanged so the marker doesn't stamp over a live agent TUI ("Press Ctrl-C again to exit" etc.).
- Extracted the handler body into `run_ctrl_c_handler` so the verbose-emit decision is unit-testable without installing a real signal handler (which would conflict with cargo's test runner).

### Before / after (verbose output)

Before:
```
  Press Ctrl-C again to exit                                ◉ xhigh · /effort
3.61 [clud] subprocess: exited code 0
5.74 [clud] exit: code 0
```

After (sample):
```
  Press Ctrl-C again to exit                                ◉ xhigh · /effort
2.85 [clud] ctrl-c received
2.97 [clud] ctrl-c received
3.61 [clud] subprocess: exited code 0
5.74 [clud] exit: code 0
```

## Test plan

- [x] `bash lint` (cargo fmt, clippy, ruff) — clean
- [x] `bash test` — 738 Rust tests + 80 Python tests pass; 2 new tests added (`ctrl_c_handler_emits_verbose_marker_when_verbose`, `ctrl_c_handler_skips_verbose_marker_when_not_verbose`)
- [ ] Manual: run `clud -v -p hi`, press Ctrl+C during the agent run, confirm the new line appears in the verbose stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)