### PR TITLE
chore: release codex skill path fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2.0.19 - 2026-06-07
+
+- `/clud-pr` and other bundled skills now install under `~/.codex/skills/`
+  for `clud --codex`, matching the skill path Codex itself loads from.
+- Old clud-managed bundled skill copies under `~/.agents/skills/` are removed
+  on first Codex global setup after upgrade. User-authored content and
+  unrelated skill directories are preserved.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "base64",
  "clap",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "libc",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.18"
+version = "2.0.19"
 edition = "2021"
 rust-version = "1.85"
 license-file = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.18"
+version = "2.0.19"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clud/__init__.py
+++ b/src/clud/__init__.py
@@ -1,3 +1,3 @@
 """clud — Fast Rust CLI for running Claude Code and Codex in YOLO mode."""
 
-__version__ = "2.0.16"
+__version__ = "2.0.19"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.18"
+version = "2.0.19"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- add the 2.0.19 changelog entry for the Codex skill-path migration landed in #301
- bump the Rust workspace, Python project, lockfiles, and Python shim versions to 2.0.19
- close the remaining #299 burn-down bookkeeping after the Phase 0 evidence comment on #290

PR #301 already landed the implementation phases for #289/#291-#296. Phase 0 evidence is recorded on #290: https://github.com/zackees/clud/issues/290#issuecomment-4644217087

## Verification

- `git diff --check`
- `soldr cargo fmt --check`
- `python -m ci.build_wheel --dev`
- built wheel metadata: `clud-2.0.19-py3-none-win_amd64.whl`, `Version: 2.0.19`
- installed Python package metadata reports `2.0.19`

Closes #290
Closes #298
Closes #299