### PR TITLE
chore: release 2.0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "base64",
  "clap",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.18"
+version = "2.0.19"
 dependencies = [
  "libc",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.18"
+version = "2.0.19"
 edition = "2021"
 rust-version = "1.85"
 license-file = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.18"
+version = "2.0.19"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.18"
+version = "2.0.19"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Bumps workspace + Python wheel from `2.0.18` -> `2.0.19`.
- First release after #283 (agent-memory revert) and #301 (Codex skill install path fix).

## Why this supersedes #284

PR #284 was opened earlier today on `chore/release-2.0.19` (commit `a8d1b21`), but its branch is 3 commits behind main (it predates #301 by ~5 hours) and its release notes don't mention the Codex skill fix. Rather than force-push to the maintainer's branch, this PR opens a clean release from current main with both notable changes called out. Closing #284 as superseded.

## Release notes (commit body)

> Includes:
> - #283: revert agent-memory feature (12-commit series, no end-user functionality).
> - #301: Codex skill install path fix (`~/.agents/skills/` -> `~/.codex/skills/`), so `clud --codex -p "/clud-pr ..."` resolves the bundled skill. Stale clud-managed copies under `~/.agents/skills/` are cleaned up on first Codex global setup after upgrade. See DD-013 for rationale.

Closes #298.

## Test plan

- [x] `bash lint` (cargo fmt, clippy -D warnings, ruff) - clean.
- [ ] CI matrix on push (6 platforms x 4 job types).