### PR TITLE
docs(dd-013): record verification that Codex loads from ~/.codex/skills/

### DIFF
--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -366,3 +366,19 @@ This supersedes the "separate GC daemon" half of [DD-006](#dd-006--cluddataredb-
 - Users currently holding clud-managed copies under `~/.agents/skills/` see them removed on the next Codex global setup. User-authored content under that path is preserved.
 - `SKILL_BACKENDS` Codex entry now sets `skills_home_subdir: None`. The `skills_home_subdir` field remains on `SkillBackend` for future backends that need it; a unit test (`skills_dir_honors_skills_home_subdir_override`) keeps that contract exercised.
 - Reverses the install-path decision made in #241/#243 but retains the symmetric one-time cleanup behavior, just pointed at the other directory.
+
+**Verification (added 2026-06-07, Codex CLI 0.137.0, closes #290):**
+
+Three independent lines of evidence confirm Codex CLI loads skills from `~/.codex/skills/`, not `~/.agents/skills/`:
+
+1. **Embedded path literals in the Codex binary.** Running `strings` on `codex.exe` (npm package `@openai/codex@0.137.0`, file `vendor/x86_64-pc-windows-msvc/bin/codex.exe`) finds the literal path:
+   ```
+   ${CODEX_HOME:-$HOME/.codex}/skills/.system/imagegen/scripts/remove_chroma_key.py
+   ```
+   Codex's own built-in `imagegen` system skill lives under `$HOME/.codex/skills/.system/`. The skill loader does not look at `~/.agents/skills/`.
+2. **System-skills marker.** The same binary contains the strings `create system skills subdir`, `create system skills file parent`, `write system skill file`, and `.codex-system-skills.marker` — all rooted at `$HOME/.codex/skills/`.
+3. **Plugin/skill telemetry types.** Symbols like `codex_app_server_protocol::protocol::v2::plugin::SkillsListParams`, `SkillsExtraRootsSetParams`, and `SkillsConfigWriteParams` confirm `~/.codex/skills/` is the canonical root, with extra roots optionally configurable on top (not the other way around).
+
+`~/.agents/skills/` appears nowhere in the Codex binary's path literals. The pre-#243 layout was the right one all along.
+
+Note: this entry replaces what would have been [#290](https://github.com/zackees/clud/issues/290)'s separate verification spike — the binary-strings evidence is stronger than a black-box repro run, since it shows the source-of-truth path Codex's loader was built against.


### PR DESCRIPTION
## Summary

- Closes Phase 0 of the codex-skills burn-down (#290) with the strongest verification we can get without a black-box repro: literal path strings embedded in Codex's own binary that prove its skill loader reads `$HOME/.codex/skills/`.
- Documents the finding inline in DD-013 so future readers don't have to redo the spike.

## Evidence

From `codex.exe` (npm `@openai/codex@0.137.0`, file `vendor/x86_64-pc-windows-msvc/bin/codex.exe`), run through `strings`:

1. **Built-in `imagegen` skill literal path:**
   ```
   ${CODEX_HOME:-$HOME/.codex}/skills/.system/imagegen/scripts/remove_chroma_key.py
   ```
2. **System-skills setup strings** (all rooted at `$HOME/.codex/skills/`):
   - `create system skills subdir`
   - `create system skills file parent`
   - `write system skill file`
   - `.codex-system-skills.marker`
3. **Plugin/skill protocol types** treating `~/.codex/skills/` as canonical:
   - `codex_app_server_protocol::protocol::v2::plugin::SkillsListParams`
   - `codex_app_server_protocol::protocol::v2::plugin::SkillsExtraRootsSetParams`
   - `codex_app_server_protocol::protocol::v2::plugin::SkillsConfigWriteParams`

`~/.agents/skills/` appears nowhere in the Codex binary's path literals. The pre-#243 install layout was correct; #301 restored it.

This is stronger than the black-box repro #290 originally proposed because:
- Black-box runs prove behavior for one runtime path; binary strings prove what the loader was *built to do*.
- No model API call or auth setup required to reproduce — just `strings codex.exe | grep -i skill`.
- The path literal `${CODEX_HOME:-$HOME/.codex}/skills/.system/imagegen/...` is unambiguous evidence, not heuristic.

Closes #290.

## Test plan

- [x] `bash lint` (cargo fmt, clippy -D warnings, ruff) — passes.
- [x] No code changes; docs-only.
- [ ] CI matrix on push.