### PR TITLE
feat(launch-setup): persist global setup preference per backend

### DIFF
--- a/crates/clud-bin/src/clud_settings.rs
+++ b/crates/clud-bin/src/clud_settings.rs
@@ -1,0 +1,242 @@
+//! User-level clud settings persisted under `~/.clud/settings.toml`.
+
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use fs4::fs_std::FileExt;
+use toml_edit::{table, value, DocumentMut, Item};
+
+use crate::backend::Backend;
+use crate::launch_setup::LaunchSetupScope;
+
+pub const CLUD_DIR_NAME: &str = ".clud";
+pub const SETTINGS_FILE_NAME: &str = "settings.toml";
+pub const LOCK_FILE_NAME: &str = "settings.lock";
+
+#[derive(Debug)]
+pub enum SettingsError {
+    NoHomeDir,
+    Io(io::Error),
+    Parse { path: PathBuf, error: String },
+}
+
+impl std::fmt::Display for SettingsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SettingsError::NoHomeDir => write!(f, "could not resolve user home directory"),
+            SettingsError::Io(error) => write!(f, "{error}"),
+            SettingsError::Parse { path, error } => {
+                write!(f, "malformed TOML in {}: {error}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for SettingsError {}
+
+impl From<io::Error> for SettingsError {
+    fn from(error: io::Error) -> Self {
+        SettingsError::Io(error)
+    }
+}
+
+pub fn settings_path_at(home: &Path) -> PathBuf {
+    home.join(CLUD_DIR_NAME).join(SETTINGS_FILE_NAME)
+}
+
+pub fn load_launch_setup_scope(
+    backend: Backend,
+) -> Result<Option<LaunchSetupScope>, SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    load_launch_setup_scope_at(&home, backend)
+}
+
+pub fn load_launch_setup_scope_at(
+    home: &Path,
+    backend: Backend,
+) -> Result<Option<LaunchSetupScope>, SettingsError> {
+    let path = settings_path_at(home);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let lock_path = home.join(CLUD_DIR_NAME).join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+    let text = fs::read_to_string(&path)?;
+    if text.trim().is_empty() {
+        return Ok(None);
+    }
+    let document = parse_settings(&path, &text)?;
+    let Some(scope) = document
+        .get("launch_setup")
+        .and_then(|item| item.get(backend_settings_key(backend)))
+        .and_then(|item| item.get("scope"))
+        .and_then(Item::as_str)
+    else {
+        return Ok(None);
+    };
+    Ok(LaunchSetupScope::from_settings_str(scope))
+}
+
+pub fn save_launch_setup_scope(
+    backend: Backend,
+    scope: LaunchSetupScope,
+) -> Result<(), SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    save_launch_setup_scope_at(&home, backend, scope)
+}
+
+pub fn save_launch_setup_scope_at(
+    home: &Path,
+    backend: Backend,
+    scope: LaunchSetupScope,
+) -> Result<(), SettingsError> {
+    let clud_dir = home.join(CLUD_DIR_NAME);
+    fs::create_dir_all(&clud_dir)?;
+    let lock_path = clud_dir.join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+
+    let path = settings_path_at(home);
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(SettingsError::Io(error)),
+    };
+    let mut document = if text.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        parse_settings(&path, &text)?
+    };
+
+    if document
+        .get("launch_setup")
+        .and_then(Item::as_table)
+        .is_none()
+    {
+        document["launch_setup"] = table();
+    }
+    let backend_key = backend_settings_key(backend);
+    if document["launch_setup"]
+        .get(backend_key)
+        .and_then(Item::as_table)
+        .is_none()
+    {
+        document["launch_setup"][backend_key] = table();
+    }
+    document["launch_setup"][backend_key]["scope"] = value(scope.as_str());
+
+    let mut body = document.to_string();
+    if !body.ends_with('\n') {
+        body.push('\n');
+    }
+    fs::write(path, body)?;
+    Ok(())
+}
+
+fn parse_settings(path: &Path, text: &str) -> Result<DocumentMut, SettingsError> {
+    text.parse::<DocumentMut>()
+        .map_err(|error| SettingsError::Parse {
+            path: path.to_path_buf(),
+            error: error.to_string(),
+        })
+}
+
+fn backend_settings_key(backend: Backend) -> &'static str {
+    backend.executable_name()
+}
+
+fn acquire_lock(path: &Path) -> io::Result<LockGuard> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    FileExt::lock_exclusive(&file)
+        .map_err(|error| io::Error::other(format!("lock {}: {error}", path.display())))?;
+    Ok(LockGuard { _file: file })
+}
+
+struct LockGuard {
+    _file: File,
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(path) = std::env::var_os("USERPROFILE") {
+            if !path.is_empty() {
+                return Some(PathBuf::from(path));
+            }
+        }
+    }
+    if let Some(path) = std::env::var_os("HOME") {
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn missing_settings_file_has_no_launch_setup_scope() {
+        let home = tempdir().unwrap();
+        assert_eq!(
+            load_launch_setup_scope_at(home.path(), Backend::Codex).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn saves_launch_setup_scope_per_backend() {
+        let home = tempdir().unwrap();
+
+        save_launch_setup_scope_at(home.path(), Backend::Codex, LaunchSetupScope::Global).unwrap();
+
+        assert_eq!(
+            load_launch_setup_scope_at(home.path(), Backend::Codex).unwrap(),
+            Some(LaunchSetupScope::Global)
+        );
+        assert_eq!(
+            load_launch_setup_scope_at(home.path(), Backend::Claude).unwrap(),
+            None
+        );
+        let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
+        assert!(
+            text.contains("[launch_setup.codex]"),
+            "settings TOML should use a backend-scoped table: {text}"
+        );
+        assert!(
+            text.contains("scope = \"global\""),
+            "settings TOML should persist the selected global scope: {text}"
+        );
+    }
+
+    #[test]
+    fn preserves_existing_settings_when_saving_scope() {
+        let home = tempdir().unwrap();
+        let path = settings_path_at(home.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "[unrelated]\nvalue = \"kept\"\n\n[launch_setup.claude]\nscope = \"session-only\"\n",
+        )
+        .unwrap();
+
+        save_launch_setup_scope_at(home.path(), Backend::Codex, LaunchSetupScope::Global).unwrap();
+
+        let text = fs::read_to_string(path).unwrap();
+        assert!(text.contains("[unrelated]"), "{text}");
+        assert!(text.contains("value = \"kept\""), "{text}");
+        assert!(text.contains("[launch_setup.claude]"), "{text}");
+        assert!(text.contains("[launch_setup.codex]"), "{text}");
+    }
+}

--- a/crates/clud-bin/src/launch_setup.rs
+++ b/crates/clud-bin/src/launch_setup.rs
@@ -28,6 +28,14 @@ impl LaunchSetupScope {
             LaunchSetupScope::Global => "global",
         }
     }
+
+    pub fn from_settings_str(value: &str) -> Option<Self> {
+        match value {
+            "session-only" | "session_only" => Some(LaunchSetupScope::SessionOnly),
+            "global" => Some(LaunchSetupScope::Global),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -104,6 +112,19 @@ pub fn scope_for_non_prompting_launch(
     interactive_terminal: bool,
 ) -> Option<LaunchSetupScope> {
     (!should_prompt_for_scope(args, interactive_terminal)).then_some(LaunchSetupScope::SessionOnly)
+}
+
+pub fn scope_for_configured_launch(
+    args: &Args,
+    interactive_terminal: bool,
+    configured_scope: Option<LaunchSetupScope>,
+) -> Option<LaunchSetupScope> {
+    if !args.dry_run {
+        if let Some(scope) = configured_scope {
+            return Some(scope);
+        }
+    }
+    scope_for_non_prompting_launch(args, interactive_terminal)
 }
 
 pub fn prompt_scope<W: Write>(out: &mut W) -> io::Result<LaunchSetupScope> {
@@ -434,6 +455,33 @@ mod tests {
         let args = parse(&["clud", "--codex", "--dry-run"]);
         assert_eq!(
             scope_for_non_prompting_launch(&args, true),
+            Some(LaunchSetupScope::SessionOnly)
+        );
+    }
+
+    #[test]
+    fn configured_global_scope_skips_prompt_for_bare_launches() {
+        let args = parse(&["clud", "--codex"]);
+        assert_eq!(
+            scope_for_configured_launch(&args, true, Some(LaunchSetupScope::Global)),
+            Some(LaunchSetupScope::Global)
+        );
+    }
+
+    #[test]
+    fn configured_global_scope_applies_to_one_shot_launches() {
+        let args = parse(&["clud", "--codex", "-p", "hello"]);
+        assert_eq!(
+            scope_for_configured_launch(&args, true, Some(LaunchSetupScope::Global)),
+            Some(LaunchSetupScope::Global)
+        );
+    }
+
+    #[test]
+    fn dry_run_ignores_configured_global_scope() {
+        let args = parse(&["clud", "--codex", "--dry-run"]);
+        assert_eq!(
+            scope_for_configured_launch(&args, true, Some(LaunchSetupScope::Global)),
             Some(LaunchSetupScope::SessionOnly)
         );
     }

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -8,6 +8,7 @@ pub mod args;
 pub mod backend;
 pub mod backend_bootstrap;
 pub mod capture;
+pub mod clud_settings;
 pub mod codex_hook_normalize;
 pub mod command;
 pub mod console_input;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,7 +1,8 @@
 use clud::{
-    args, backend, backend_bootstrap, command, console_setup, console_title, ctrl_c_track, daemon,
-    gc, graphics, hook_health, large_file_guard, launch_setup, loop_artifacts, loop_spec, runner,
-    startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
+    args, backend, backend_bootstrap, clud_settings, command, console_setup, console_title,
+    ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard, launch_setup,
+    loop_artifacts, loop_spec, runner, startup, trampoline, trash, ui, verbose_log, wasm,
+    worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -243,20 +244,38 @@ fn main() {
         }
     };
 
-    // Issue #242: mutable harness setup is scoped per launch. Automation,
-    // dry-runs, piped prompts, and one-shot prompt launches default to
-    // session-only and do not write backend home files. Bare interactive TUI
-    // launches can opt into global setup through a reusable selector; global
-    // setup runs only the selected backend's actions.
+    // Issue #242: mutable harness setup is scoped per launch until the user
+    // opts into a backend-level global preference. Dry-runs always remain
+    // session-only; otherwise a stored `~/.clud/settings.toml` scope wins.
+    // Bare interactive TUI launches without a stored scope can opt into global
+    // setup through a reusable selector. Global setup runs only the selected
+    // backend's actions.
     let setup_interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
+    let configured_scope = if args.dry_run {
+        None
+    } else {
+        match clud_settings::load_launch_setup_scope(backend) {
+            Ok(scope) => scope,
+            Err(error) => {
+                if args.verbose {
+                    eprintln!("[clud] note: could not read clud settings: {error}");
+                }
+                None
+            }
+        }
+    };
+    let mut persist_global_scope = false;
     let setup_scope = if let Some(scope) =
-        launch_setup::scope_for_non_prompting_launch(&args, setup_interactive)
+        launch_setup::scope_for_configured_launch(&args, setup_interactive, configured_scope)
     {
         scope
     } else {
         let mut err = io::stderr().lock();
         match launch_setup::prompt_scope(&mut err) {
-            Ok(scope) => scope,
+            Ok(scope) => {
+                persist_global_scope = matches!(scope, launch_setup::LaunchSetupScope::Global);
+                scope
+            }
             Err(error) => {
                 eprintln!(
                     "[clud] note: could not read launch setup scope ({error}); using session-only"
@@ -265,6 +284,11 @@ fn main() {
             }
         }
     };
+    if persist_global_scope {
+        if let Err(error) = clud_settings::save_launch_setup_scope(backend, setup_scope) {
+            eprintln!("[clud] note: could not save global setup preference: {error}");
+        }
+    }
     if matches!(setup_scope, launch_setup::LaunchSetupScope::Global) {
         let mut err = io::stderr().lock();
         if let Err(error) = launch_setup::run_setup(setup_scope, backend, args.verbose, &mut err) {

--- a/docs/architecture/launch-setup.md
+++ b/docs/architecture/launch-setup.md
@@ -14,14 +14,27 @@ Launch setup scope (Up/Down, Enter):
 [ ] Globally
 ```
 
-The default is session-only. The selector drains any key events that were
-already pending when it appeared, so the Enter key used to submit the `clud`
-command is not reused as the selector confirmation. Enter accepts the
-highlighted option, Up selects session-only, and Down selects global. A bare
-`clud` invocation (no `--claude`
-or `--codex`), non-interactive launches, piped stdin, `--dry-run`, one-shot
-prompt launches (`-p` / `-m`), continuations, resumes, and maintenance commands
-do not prompt; they use session-only.
+The default is session-only unless `~/.clud/settings.toml` already stores a
+backend-level global preference, for example:
+
+```toml
+[launch_setup.codex]
+scope = "global"
+```
+
+The selector drains any key events that were already pending when it appeared,
+so the Enter key used to submit the `clud` command is not reused as the
+selector confirmation. Enter accepts the highlighted option, Up selects
+session-only, and Down selects global. Selecting global writes the backend's
+scope to `~/.clud/settings.toml`, so later launches for that backend run global
+setup without prompting. Selecting session-only stays scoped to that one launch.
+
+A bare `clud` invocation (no `--claude` or `--codex`), non-interactive backend
+launches, piped stdin, one-shot prompt launches (`-p` / `-m`), continuations,
+and resumes do not prompt. They use session-only unless a stored backend scope
+says `global`. `--dry-run` always uses session-only and does not read or write
+the persisted preference. Self-contained maintenance commands exit before
+launch setup.
 
 Session-only launches skip persistent setup. They must not create or modify
 agent home setup files under `~/.claude`, `~/.codex`, `~/.agents`, or
@@ -37,6 +50,7 @@ Global setup runs only the selected backend's registered actions:
 | Claude | Claude drift skills | `~/.claude/skills/` |
 | Codex | bundled skills | `~/.codex/skills/` gated by `~/.codex`; stale clud-managed `~/.agents/skills/` copies are purged |
 | Codex | hook timeout normalization | `~/.codex/hooks.json` and `~/.clud/settings.lock` / `settings.json` |
+| All | persisted global setup preference | `~/.clud/settings.lock` / `settings.toml` |
 
 All setup failures are non-fatal. `main.rs` logs a `[clud] note: ...` line and
 continues to build and run the backend `LaunchPlan`.

--- a/docs/architecture/skill-system.md
+++ b/docs/architecture/skill-system.md
@@ -42,9 +42,12 @@ continues.
 ## Global Setup Flow
 
 `main()` resolves the backend, asks `launch_setup.rs` for a setup scope, and
-then builds the final `LaunchPlan`. Automation, piped stdin, `--dry-run`, and
+then builds the final `LaunchPlan`. If `~/.clud/settings.toml` contains a
+backend-level global preference, future launches for that backend run global
+setup without prompting. Otherwise automation, piped stdin, `--dry-run`, and
 one-shot prompt launches default to session-only. Bare interactive launches can
-opt into global setup.
+opt into global setup; choosing global persists that preference, while choosing
+session-only remains per-launch.
 
 When global setup is selected:
 


### PR DESCRIPTION
## Summary
- Adds `clud_settings` module: reads/writes `~/.clud/settings.toml` under a `settings.lock` exclusive lock, with backend-scoped tables (`[launch_setup.codex]`, `[launch_setup.claude]`).
- Wires `main.rs` to consult the stored backend scope before prompting. If a backend has `scope = "global"` stored, the prompt is skipped and global setup runs automatically; if no preference is stored and the launch is bare/interactive, the user is prompted as before, and selecting "Globally" persists that choice.
- `--dry-run` continues to never read or write the file and always uses session-only.

## Test plan
- [x] `bash lint`
- [x] `soldr cargo test -p clud --lib clud_settings::` (3 new unit tests pass)
- [x] `soldr cargo test -p clud --lib launch_setup::` (3 new + existing tests pass)
- [ ] CI: 6-platform matrix green
- [ ] Manual: select "Globally" in a Codex launch, re-run `clud --codex`, confirm no prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)