### PR TITLE
feat: add daemon prost wire dispatcher

### DIFF
--- a/crates/clud-bin/src/daemon/README.md
+++ b/crates/clud-bin/src/daemon/README.md
@@ -25,7 +25,7 @@ Internal helper subcommands `__daemon` and `__worker` re-enter the same binary i
 - `sessions.rs` — snapshot discovery + filtering: `resolve_session_id` (exact/name/prefix), `most_recent_session[_any]`, `list_background_sessions`, `list_attachable_sessions`.
 - `keys.rs` — `crossterm` `KeyEvent` → terminal byte sequence translator used by interactive attach.
 - `io_helpers.rs` — JSON read/write over TCP + atomic file writes, session-id generator, terminal-size probe, `--backlog-size` / `CLUD_BACKLOG_BYTES` parsing.
-- `wire_prost.rs` - prost v1 foundation for the future daemon wire: generated `clud.v1` types, CLUD/CLJS payload protocol discriminators, encode/decode helpers, and JSON-compatibility tests. The runtime still uses the JSON helpers until mixed-client and cross-version coverage lands.
+- `wire_prost.rs` - prost v1 foundation for the daemon wire: generated `clud.v1` types, CLUD/CLJS payload protocol discriminators, encode/decode helpers, JSON-compatibility tests, and the opt-in `CLUD_DAEMON_WIRE=prost` daemon RPC dispatcher. JSON remains the default until mixed-client and cross-version coverage lands.
 - `process_utils.rs` — `pid_is_alive`, `signal_process_tree`, `descendant_pids` via `sysinfo`.
 
 ## Key items

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, OpenOptions};
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, Write};
 use std::net::{Shutdown, TcpStream};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -20,6 +20,10 @@ use super::process_utils::{pid_is_alive, signal_process_tree};
 use super::types::{
     CtrlCProfile, DaemonInfo, DaemonRequest, DaemonResponse, GcOp, GcReply, ListRow, RepoVisit,
     SessionSnapshot, WorkerClientMessage,
+};
+use super::wire_prost::{
+    daemon_wire_format_from_env, decode_daemon_response_line, encode_daemon_request_line,
+    DaemonWireFormat, WireError,
 };
 
 /// Idempotent best-effort daemon spawn (issue #135). Always called via
@@ -162,7 +166,11 @@ pub(super) fn send_daemon_request(
 ) -> io::Result<DaemonResponse> {
     let info = read_json_file::<DaemonInfo>(&daemon_info_path(state_dir))?;
     let mut stream = TcpStream::connect(("127.0.0.1", info.port))?;
-    write_json_line(&mut stream, request)?;
+    write_daemon_request(
+        &mut stream,
+        request,
+        daemon_wire_format_from_env().map_err(wire_error_to_io)?,
+    )?;
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
     let bytes = reader.read_line(&mut line)?;
@@ -172,7 +180,7 @@ pub(super) fn send_daemon_request(
             "daemon closed connection without replying",
         ));
     }
-    serde_json::from_str(&line).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    decode_daemon_response_line(&line).map_err(wire_error_to_io)
 }
 
 pub(super) fn request_session_termination(
@@ -225,7 +233,10 @@ pub fn try_handoff_kill_to_daemon(state_dir: &Path, pids: &[u32], reason: Option
         pids: pids.to_vec(),
         reason: reason.map(|s| s.to_string()),
     };
-    if write_json_line(&mut stream, &request).is_err() {
+    let Ok(format) = daemon_wire_format_from_env() else {
+        return false;
+    };
+    if write_daemon_request(&mut stream, &request, format).is_err() {
         return false;
     }
     // We could parse the ack here, but the wire contract guarantees the
@@ -318,6 +329,20 @@ fn is_old_daemon_signature(err: &io::Error) -> bool {
             | io::ErrorKind::ConnectionReset
             | io::ErrorKind::ConnectionAborted
     )
+}
+
+fn write_daemon_request(
+    stream: &mut TcpStream,
+    request: &DaemonRequest,
+    format: DaemonWireFormat,
+) -> io::Result<()> {
+    let bytes = encode_daemon_request_line(request, format).map_err(wire_error_to_io)?;
+    stream.write_all(&bytes)?;
+    stream.flush()
+}
+
+fn wire_error_to_io(err: WireError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, err)
 }
 
 pub(super) fn send_worker_message(
@@ -541,6 +566,7 @@ mod tests {
     use super::*;
     use std::net::TcpListener;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
 
     /// Issue #192: a daemon whose `daemon.json` reports the same version
     /// as the spawning binary must NOT be restarted. This is the steady-
@@ -616,6 +642,31 @@ mod tests {
         (port, saw_request)
     }
 
+    fn spawn_shutdown_ack_peer() -> (u16, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (line_tx, line_rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut line = String::new();
+                let _ = reader.read_line(&mut line);
+                let _ = line_tx.send(line.clone());
+                let (_, format) =
+                    super::super::wire_prost::decode_daemon_request_line(&line).unwrap();
+                let response = DaemonResponse::ShutdownAck { pid: 4242 };
+                let bytes =
+                    super::super::wire_prost::encode_daemon_response_line(&response, format)
+                        .unwrap();
+                stream.write_all(&bytes).unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        (port, line_rx)
+    }
+
     #[test]
     fn send_daemon_request_translates_silent_peer_to_unexpected_eof() {
         let tmp = tempfile::tempdir().unwrap();
@@ -640,6 +691,38 @@ mod tests {
             saw_request.load(Ordering::SeqCst),
             "stub peer should have observed the request before closing"
         );
+    }
+
+    #[test]
+    fn send_daemon_request_defaults_to_legacy_json_wire() {
+        let _guard = EnvGuard::unset(super::super::wire_prost::ENV_DAEMON_WIRE);
+        let tmp = tempfile::tempdir().unwrap();
+        let (port, line_rx) = spawn_shutdown_ack_peer();
+        write_daemon_info(tmp.path(), std::process::id(), port);
+
+        let response = send_daemon_request(tmp.path(), &DaemonRequest::Shutdown).unwrap();
+        assert!(matches!(
+            response,
+            DaemonResponse::ShutdownAck { pid: 4242 }
+        ));
+        let line = line_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(line.starts_with(r#"{"op":"shutdown"}"#));
+    }
+
+    #[test]
+    fn send_daemon_request_uses_prost_wire_when_requested() {
+        let _guard = EnvGuard::set(super::super::wire_prost::ENV_DAEMON_WIRE, "prost");
+        let tmp = tempfile::tempdir().unwrap();
+        let (port, line_rx) = spawn_shutdown_ack_peer();
+        write_daemon_info(tmp.path(), std::process::id(), port);
+
+        let response = send_daemon_request(tmp.path(), &DaemonRequest::Shutdown).unwrap();
+        assert!(matches!(
+            response,
+            DaemonResponse::ShutdownAck { pid: 4242 }
+        ));
+        let line = line_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(line.starts_with("CLUD-FRAME/1 434c5544 "));
     }
 
     #[test]
@@ -678,5 +761,51 @@ mod tests {
             !daemon_info_path(tmp.path()).exists(),
             "stale daemon.json should be removed"
         );
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn lock() -> std::sync::MutexGuard<'static, ()> {
+            static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+            LOCK.get_or_init(|| std::sync::Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+        }
+
+        fn set(key: &'static str, value: &str) -> Self {
+            let lock = Self::lock();
+            let prior = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self {
+                key,
+                prior,
+                _lock: lock,
+            }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let lock = Self::lock();
+            let prior = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self {
+                key,
+                prior,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
     }
 }

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -18,13 +18,16 @@ use super::gc_service::{
     spawn_registry_worker_for_state, GcRequestMsg, RegistryMsg, WORKER_REPLY_TIMEOUT,
 };
 use super::http::{default_live_sessions_provider, spawn_dashboard};
-use super::io_helpers::{new_session_id, read_json_file, write_json_file, write_json_line};
+use super::io_helpers::{new_session_id, read_json_file, write_json_file};
 use super::paths::{daemon_info_path, session_snapshot_path, sessions_dir, spec_path, specs_dir};
 use super::process_utils::{pid_is_alive, signal_process_tree};
 use super::sessions::list_live_session_cwds;
 use super::types::{
     unix_millis_now, CtrlCProfile, DaemonInfo, DaemonRequest, DaemonResponse, GcReply,
     SessionSnapshot, WorkerLaunchSpec,
+};
+use super::wire_prost::{
+    decode_daemon_request_line, encode_daemon_response_line, DaemonWireFormat, WireError,
 };
 
 fn current_unix() -> i64 {
@@ -148,8 +151,7 @@ fn handle_daemon_connection(
     if reader.read_line(&mut line)? == 0 {
         return Ok(());
     }
-    let request: DaemonRequest = serde_json::from_str(&line)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
+    let (request, response_format) = decode_daemon_request_line(&line).map_err(wire_error_to_io)?;
     let response = match request {
         DaemonRequest::Create { spec } => match daemon_create_session(state_dir, workers, *spec) {
             Ok(session) => DaemonResponse::Created { session },
@@ -201,12 +203,26 @@ fn handle_daemon_connection(
         },
     };
     let is_shutdown = matches!(response, DaemonResponse::ShutdownAck { .. });
-    let result = write_json_line(&mut stream, &response);
+    let result = write_daemon_response(&mut stream, &response, response_format);
     if is_shutdown {
         let _ = stream.shutdown(std::net::Shutdown::Write);
         shutdown_requested.store(true, Ordering::SeqCst);
     }
     result
+}
+
+fn write_daemon_response(
+    stream: &mut TcpStream,
+    response: &DaemonResponse,
+    format: DaemonWireFormat,
+) -> io::Result<()> {
+    let bytes = encode_daemon_response_line(response, format).map_err(wire_error_to_io)?;
+    stream.write_all(&bytes)?;
+    stream.flush()
+}
+
+fn wire_error_to_io(err: WireError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, err)
 }
 
 /// Hand a GC op to the registry worker and await the reply. Returns a

--- a/crates/clud-bin/src/daemon/wire_prost.rs
+++ b/crates/clud-bin/src/daemon/wire_prost.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use prost::Message;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -22,6 +23,11 @@ pub(super) const CLUD_PROST_PAYLOAD_PROTOCOL: u32 = 0x434c_5544;
 /// ASCII "CLJS" in a u32. This names the legacy JSON payload path while the
 /// migration runs with both encoders available.
 pub(super) const CLUD_JSON_PAYLOAD_PROTOCOL: u32 = 0x434c_4a53;
+/// Selects the daemon RPC line format. Unset or `json` keeps the legacy JSON
+/// line protocol; `prost` opts into the v1 prost frame envelope.
+pub(super) const ENV_DAEMON_WIRE: &str = "CLUD_DAEMON_WIRE";
+
+const DAEMON_FRAME_LINE_PREFIX: &str = "CLUD-FRAME/1 ";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct WireFrame {
@@ -29,11 +35,37 @@ pub(super) struct WireFrame {
     pub(super) payload: Vec<u8>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DaemonWireFormat {
+    Json,
+    Prost,
+}
+
+impl DaemonWireFormat {
+    fn from_env_value(value: Option<&str>) -> Result<Self, WireError> {
+        let Some(raw) = value else {
+            return Ok(Self::Json);
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Ok(Self::Json);
+        }
+        match trimmed.to_ascii_lowercase().as_str() {
+            "json" | "legacy" | "legacy-json" => Ok(Self::Json),
+            "prost" => Ok(Self::Prost),
+            _ => Err(WireError::InvalidDaemonWire(raw.to_string())),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(super) enum WireError {
     MissingPayload(&'static str),
     UnknownPayloadProtocol(u32),
+    InvalidDaemonWire(String),
+    InvalidFrameLine(String),
     Json(serde_json::Error),
+    Base64(base64::DecodeError),
     Decode(prost::DecodeError),
     U16OutOfRange { field: &'static str, value: u32 },
 }
@@ -45,7 +77,17 @@ impl fmt::Display for WireError {
             Self::UnknownPayloadProtocol(protocol) => {
                 write!(f, "unsupported clud payload_protocol 0x{protocol:08x}")
             }
+            Self::InvalidDaemonWire(value) => {
+                write!(
+                    f,
+                    "unsupported {ENV_DAEMON_WIRE} value {value:?}; expected json or prost"
+                )
+            }
+            Self::InvalidFrameLine(line) => {
+                write!(f, "invalid clud daemon frame line: {line}")
+            }
             Self::Json(err) => write!(f, "json conversion failed: {err}"),
+            Self::Base64(err) => write!(f, "frame payload base64 decode failed: {err}"),
             Self::Decode(err) => write!(f, "prost decode failed: {err}"),
             Self::U16OutOfRange { field, value } => {
                 write!(f, "{field} value {value} exceeds u16::MAX")
@@ -62,10 +104,62 @@ impl From<serde_json::Error> for WireError {
     }
 }
 
+impl From<base64::DecodeError> for WireError {
+    fn from(value: base64::DecodeError) -> Self {
+        Self::Base64(value)
+    }
+}
+
 impl From<prost::DecodeError> for WireError {
     fn from(value: prost::DecodeError) -> Self {
         Self::Decode(value)
     }
+}
+
+pub(super) fn daemon_wire_format_from_env() -> Result<DaemonWireFormat, WireError> {
+    DaemonWireFormat::from_env_value(std::env::var(ENV_DAEMON_WIRE).ok().as_deref())
+}
+
+pub(super) fn encode_daemon_request_line(
+    request: &DaemonRequest,
+    format: DaemonWireFormat,
+) -> Result<Vec<u8>, WireError> {
+    match format {
+        DaemonWireFormat::Json => encode_json_line(request),
+        DaemonWireFormat::Prost => {
+            let frame = encode_daemon_request_prost(request, "daemon-request")?;
+            Ok(encode_wire_frame_line(&frame))
+        }
+    }
+}
+
+pub(super) fn decode_daemon_request_line(
+    line: &str,
+) -> Result<(DaemonRequest, DaemonWireFormat), WireError> {
+    if let Some(frame) = decode_wire_frame_line(line)? {
+        return Ok((decode_daemon_request(&frame)?, DaemonWireFormat::Prost));
+    }
+    Ok((serde_json::from_str(line)?, DaemonWireFormat::Json))
+}
+
+pub(super) fn encode_daemon_response_line(
+    response: &DaemonResponse,
+    format: DaemonWireFormat,
+) -> Result<Vec<u8>, WireError> {
+    match format {
+        DaemonWireFormat::Json => encode_json_line(response),
+        DaemonWireFormat::Prost => {
+            let frame = encode_daemon_response_prost(response, "daemon-response")?;
+            Ok(encode_wire_frame_line(&frame))
+        }
+    }
+}
+
+pub(super) fn decode_daemon_response_line(line: &str) -> Result<DaemonResponse, WireError> {
+    if let Some(frame) = decode_wire_frame_line(line)? {
+        return decode_daemon_response(&frame);
+    }
+    Ok(serde_json::from_str(line)?)
 }
 
 pub(super) fn encode_daemon_request_prost(
@@ -157,6 +251,46 @@ fn prost_frame(payload: Vec<u8>) -> WireFrame {
         payload_protocol: CLUD_PROST_PAYLOAD_PROTOCOL,
         payload,
     }
+}
+
+fn encode_json_line<T: Serialize>(value: &T) -> Result<Vec<u8>, WireError> {
+    let mut bytes = serde_json::to_vec(value)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn encode_wire_frame_line(frame: &WireFrame) -> Vec<u8> {
+    let payload = BASE64_STANDARD.encode(&frame.payload);
+    format!(
+        "{DAEMON_FRAME_LINE_PREFIX}{:08x} {payload}\n",
+        frame.payload_protocol
+    )
+    .into_bytes()
+}
+
+fn decode_wire_frame_line(line: &str) -> Result<Option<WireFrame>, WireError> {
+    let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
+    let Some(rest) = trimmed.strip_prefix(DAEMON_FRAME_LINE_PREFIX) else {
+        return Ok(None);
+    };
+    let Some((protocol_hex, payload_b64)) = rest.split_once(' ') else {
+        return Err(WireError::InvalidFrameLine(
+            "missing protocol or payload".to_string(),
+        ));
+    };
+    if protocol_hex.len() != 8 || payload_b64.is_empty() {
+        return Err(WireError::InvalidFrameLine(
+            "expected 8-digit protocol and non-empty payload".to_string(),
+        ));
+    }
+    let payload_protocol = u32::from_str_radix(protocol_hex, 16).map_err(|_| {
+        WireError::InvalidFrameLine(format!("invalid payload protocol {protocol_hex:?}"))
+    })?;
+    let payload = BASE64_STANDARD.decode(payload_b64)?;
+    Ok(Some(WireFrame {
+        payload_protocol,
+        payload,
+    }))
 }
 
 fn daemon_request_to_proto(
@@ -563,6 +697,62 @@ mod tests {
     fn payload_protocol_constants_are_ascii_discriminators() {
         assert_eq!(CLUD_PROST_PAYLOAD_PROTOCOL.to_be_bytes(), *b"CLUD");
         assert_eq!(CLUD_JSON_PAYLOAD_PROTOCOL.to_be_bytes(), *b"CLJS");
+    }
+
+    #[test]
+    fn daemon_wire_format_env_values_default_to_json() {
+        assert_eq!(
+            DaemonWireFormat::from_env_value(None).unwrap(),
+            DaemonWireFormat::Json
+        );
+        assert_eq!(
+            DaemonWireFormat::from_env_value(Some("")).unwrap(),
+            DaemonWireFormat::Json
+        );
+        assert_eq!(
+            DaemonWireFormat::from_env_value(Some("legacy-json")).unwrap(),
+            DaemonWireFormat::Json
+        );
+        assert_eq!(
+            DaemonWireFormat::from_env_value(Some("prost")).unwrap(),
+            DaemonWireFormat::Prost
+        );
+        assert!(matches!(
+            DaemonWireFormat::from_env_value(Some("bincode")),
+            Err(WireError::InvalidDaemonWire(_))
+        ));
+    }
+
+    #[test]
+    fn daemon_request_line_json_preserves_legacy_shape() {
+        let request = DaemonRequest::Shutdown;
+        let line = encode_daemon_request_line(&request, DaemonWireFormat::Json).unwrap();
+        assert!(line.starts_with(br#"{"op":"shutdown"}"#));
+
+        let line = String::from_utf8(line).unwrap();
+        let (decoded, format) = decode_daemon_request_line(&line).unwrap();
+        assert_eq!(format, DaemonWireFormat::Json);
+        assert_json_parity(&request, &decoded);
+    }
+
+    #[test]
+    fn daemon_request_line_prost_carries_frame_envelope() {
+        let request = DaemonRequest::Shutdown;
+        let line = encode_daemon_request_line(&request, DaemonWireFormat::Prost).unwrap();
+        let line = String::from_utf8(line).unwrap();
+        assert!(line.starts_with("CLUD-FRAME/1 434c5544 "));
+
+        let (decoded, format) = decode_daemon_request_line(&line).unwrap();
+        assert_eq!(format, DaemonWireFormat::Prost);
+        assert_json_parity(&request, &decoded);
+    }
+
+    #[test]
+    fn daemon_response_line_prost_roundtrips() {
+        let response = DaemonResponse::ShutdownAck { pid: 1234 };
+        let line = encode_daemon_response_line(&response, DaemonWireFormat::Prost).unwrap();
+        let decoded = decode_daemon_response_line(&String::from_utf8(line).unwrap()).unwrap();
+        assert_json_parity(&response, &decoded);
     }
 
     #[test]

--- a/docs/architecture/daemon-ipc.md
+++ b/docs/architecture/daemon-ipc.md
@@ -38,9 +38,9 @@ The hidden subcommands are declared in `crates/clud-bin/src/args.rs` and accept 
 
 ## Wire protocol
 
-Loopback TCP (`127.0.0.1:0`, OS-assigned ephemeral port), one request per connection for the daemon side, a persistent connection per attached client for the worker side. Every message is currently a single line of UTF-8 JSON terminated by `\n`; see `write_json_line` at `io_helpers.rs:25`. All enums are tagged with `"op"` (serde `tag = "op"`, snake_case variants).
+Loopback TCP (`127.0.0.1:0`, OS-assigned ephemeral port), one request per connection for the daemon side, a persistent connection per attached client for the worker side. JSON remains the default runtime format: every message is a single line of UTF-8 JSON terminated by `\n`; see `write_json_line` at `io_helpers.rs:25`. All enums are tagged with `"op"` (serde `tag = "op"`, snake_case variants).
 
-The prost migration foundation lives in `wire_prost.rs` and `proto/clud_v1.proto`. It defines `CLUD` (`0x434c5544`) for prost payloads and `CLJS` (`0x434c4a53`) for legacy JSON payloads so a future dispatcher can route by `Frame.payload_protocol` without changing the existing JSON shapes. This foundation does not switch the live TCP path; JSON remains the runtime default until mixed-client and cross-version tests are in place.
+The prost migration foundation lives in `wire_prost.rs` and `proto/clud_v1.proto`. It defines `CLUD` (`0x434c5544`) for prost payloads and `CLJS` (`0x434c4a53`) for legacy JSON payloads so the dispatcher can route by `Frame.payload_protocol` without changing the existing JSON shapes. `CLUD_DAEMON_WIRE=prost` opts daemon RPCs into a `CLUD-FRAME/1 <payload_protocol_hex> <base64_payload>` line envelope that carries the v1 prost payload; the daemon replies in the same format it received. The worker attach stream still uses JSON lines, and JSON remains the daemon default until mixed-client and previous-release compatibility tests are in place.
 
 **Client → daemon** (`DaemonRequest`, `types.rs:103`):
 


### PR DESCRIPTION
Coordinated with zackees/running-process#233
Refs zackees/running-process#242
Refs #308

## Summary
- add an opt-in daemon RPC wire selector via `CLUD_DAEMON_WIRE=prost`
- keep legacy JSON as the default line protocol and preserve JSON compatibility
- route daemon request/response lines through a `CLUD-FRAME/1 <payload_protocol_hex> <base64_payload>` prost envelope when requested
- have the daemon reply using the same daemon wire format it received
- document that worker attach streams and default daemon RPCs remain JSON for now

## Tests
- `soldr cargo fmt --all`
- `soldr cargo test -p clud daemon_wire -- --nocapture`
- `soldr cargo test -p clud send_daemon_request -- --nocapture`
- `soldr cargo test -p clud wire_prost -- --nocapture`
- `soldr cargo check -p clud`
- `soldr cargo fmt --all -- --check`
- `soldr cargo test -p clud`

## Remaining #233 acceptance gaps
- Prost is opt-in via `CLUD_DAEMON_WIRE=prost`; JSON remains the default daemon wire.
- Worker attach streams still use JSON lines.
- Complex launch/session payloads still rely on JSON mirrors inside the prost schema.
- running-process broker `Frame` integration remains blocked on the currently published clud dependency surface.
- Mixed JSON/prost and previous-release client compatibility tests still need to land before flipping defaults.