### PR TITLE
feat: wire prost worker attach path

### DIFF
--- a/crates/clud-bin/src/daemon/attach.rs
+++ b/crates/clud-bin/src/daemon/attach.rs
@@ -11,9 +11,8 @@ use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 
 use super::client::{
     ensure_daemon, request_session_interrupt, send_daemon_request, send_worker_message,
-    shutdown_worker_connection,
+    shutdown_worker_connection, write_worker_message,
 };
-use super::io_helpers::write_json_line;
 use super::keys::translate_key_event;
 use super::process_utils::pid_is_alive;
 use super::sessions::resolve_session_id;
@@ -22,6 +21,7 @@ use super::types::{
     KeyAction, LocalAttachResult, LocalInterruptProfile, RawTerminalGuard, SessionKind,
     SessionSnapshot, WorkerClientMessage, WorkerServerMessage, BACKGROUND_PROMPT_TIMEOUT,
 };
+use super::wire_prost::{daemon_wire_format_from_env, decode_worker_server_line, DaemonWireFormat};
 use crate::session::{InteractiveHooks, PtyInputSink};
 use crate::voice::VoiceMode;
 
@@ -35,6 +35,7 @@ const INTERRUPT_EXIT_GRACE: Duration = Duration::from_millis(500);
 /// and is forwarded to the PTY master alongside real keystrokes.
 struct WorkerInputSink {
     writer: Arc<Mutex<TcpStream>>,
+    format: DaemonWireFormat,
 }
 
 impl PtyInputSink for WorkerInputSink {
@@ -43,7 +44,7 @@ impl PtyInputSink for WorkerInputSink {
             data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
             submit,
         };
-        send_worker_message(&self.writer, &msg)
+        send_worker_message(&self.writer, &msg, self.format)
     }
 }
 
@@ -102,6 +103,13 @@ pub(super) fn attach_to_session(
     session: &SessionSnapshot,
     interrupted: &AtomicBool,
 ) -> i32 {
+    let format = match daemon_wire_format_from_env() {
+        Ok(format) => format,
+        Err(err) => {
+            eprintln!("[clud] {err}");
+            return 1;
+        }
+    };
     let started = Instant::now();
     let attach_retry_window = Duration::from_secs(5);
     let (writer, mut reader) = loop {
@@ -125,13 +133,14 @@ pub(super) fn attach_to_session(
         let terminal =
             matches!(session.kind, SessionKind::Pty).then(crate::graphics::detect_current_terminal);
         let (rows, cols) = super::io_helpers::terminal_dimensions();
-        if let Err(err) = write_json_line(
+        if let Err(err) = write_worker_message(
             &mut stream,
             &WorkerClientMessage::Attach {
                 terminal,
                 rows: Some(rows),
                 cols: Some(cols),
             },
+            format,
         ) {
             eprintln!("[clud] failed to attach to session {}: {}", session.id, err);
             return 1;
@@ -175,7 +184,7 @@ pub(super) fn attach_to_session(
             }
         }
 
-        let message = match serde_json::from_str::<WorkerServerMessage>(&line) {
+        let message = match decode_worker_server_line(&line) {
             Ok(message) => message,
             Err(err) => {
                 eprintln!(
@@ -222,7 +231,7 @@ pub(super) fn attach_to_session(
         match reader.read_line(&mut line) {
             Ok(0) => break,
             Ok(_) => {
-                let Ok(message) = serde_json::from_str::<WorkerServerMessage>(&line) else {
+                let Ok(message) = decode_worker_server_line(&line) else {
                     continue;
                 };
                 match message {
@@ -254,7 +263,7 @@ pub(super) fn attach_to_session(
         && io::stdin().is_terminal()
         && io::stdout().is_terminal()
     {
-        run_remote_interactive(Arc::clone(&writer), interrupted, session.detachable)
+        run_remote_interactive(Arc::clone(&writer), format, interrupted, session.detachable)
     } else {
         wait_for_remote_or_interrupt(&exit_code, interrupted)
     };
@@ -272,12 +281,18 @@ pub(super) fn attach_to_session(
                     }
                     BackgroundPromptDecision::EndSession => {
                         eprintln!("[clud] ending session {}", session.id);
-                        send_interrupt_fast_path(state_dir, &session.id, &writer, interrupt);
+                        send_interrupt_fast_path(
+                            state_dir,
+                            &session.id,
+                            &writer,
+                            format,
+                            interrupt,
+                        );
                         (130, false)
                     }
                 }
             } else {
-                send_interrupt_fast_path(state_dir, &session.id, &writer, interrupt);
+                send_interrupt_fast_path(state_dir, &session.id, &writer, format, interrupt);
                 (130, false)
             }
         }
@@ -301,6 +316,7 @@ fn send_interrupt_fast_path(
     state_dir: &Path,
     session_id: &str,
     writer: &Arc<Mutex<TcpStream>>,
+    format: DaemonWireFormat,
     interrupt: LocalInterruptProfile,
 ) {
     let now = unix_millis_now();
@@ -320,6 +336,7 @@ fn send_interrupt_fast_path(
             &WorkerClientMessage::Interrupt {
                 profile: Some(profile),
             },
+            format,
         ) {
             eprintln!("[clud] warning: failed to hand Ctrl+C to daemon worker: {err}");
         }
@@ -329,6 +346,7 @@ fn send_interrupt_fast_path(
 
 fn run_remote_interactive(
     writer: Arc<Mutex<TcpStream>>,
+    format: DaemonWireFormat,
     interrupted: &AtomicBool,
     _detachable: bool,
 ) -> LocalAttachResult {
@@ -351,6 +369,7 @@ fn run_remote_interactive(
     let mut voice = VoiceMode::from_env();
     let mut sink = WorkerInputSink {
         writer: Arc::clone(&writer),
+        format,
     };
 
     // Issue #79: register the console IDropTarget so dropped paths reach
@@ -377,6 +396,7 @@ fn run_remote_interactive(
                                 data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
                                 submit,
                             },
+                            format,
                         );
                     }
                     KeyAction::Interrupt => {
@@ -406,11 +426,15 @@ fn run_remote_interactive(
                                 .encode(text.as_bytes()),
                             submit: false,
                         },
+                        format,
                     );
                 }
                 Ok(Event::Resize(cols, rows)) => {
-                    let _ =
-                        send_worker_message(&writer, &WorkerClientMessage::Resize { rows, cols });
+                    let _ = send_worker_message(
+                        &writer,
+                        &WorkerClientMessage::Resize { rows, cols },
+                        format,
+                    );
                 }
                 Ok(_) => {}
                 Err(_) => return LocalAttachResult::Completed(1),
@@ -439,6 +463,7 @@ fn run_remote_interactive(
                         data_b64: base64::engine::general_purpose::STANDARD.encode(&chunk),
                         submit: false,
                     },
+                    format,
                 );
             }
         }

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -12,7 +12,7 @@ use sysinfo::Signal;
 use crate::gc::InsertInput;
 use crate::trampoline;
 
-use super::io_helpers::{read_json_file, write_json_line};
+use super::io_helpers::read_json_file;
 use super::paths::{
     daemon_info_path, daemon_lock_path, session_snapshot_path, sessions_dir, spec_path, specs_dir,
 };
@@ -23,7 +23,7 @@ use super::types::{
 };
 use super::wire_prost::{
     daemon_wire_format_from_env, decode_daemon_response_line, encode_daemon_request_line,
-    DaemonWireFormat, WireError,
+    encode_worker_client_line, DaemonWireFormat, WireError,
 };
 
 /// Idempotent best-effort daemon spawn (issue #135). Always called via
@@ -348,9 +348,20 @@ fn wire_error_to_io(err: WireError) -> io::Error {
 pub(super) fn send_worker_message(
     writer: &Arc<Mutex<TcpStream>>,
     message: &WorkerClientMessage,
+    format: DaemonWireFormat,
 ) -> io::Result<()> {
     let mut guard = writer.lock().expect("writer mutex poisoned");
-    write_json_line(&mut guard, message)
+    write_worker_message(&mut guard, message, format)
+}
+
+pub(super) fn write_worker_message(
+    stream: &mut TcpStream,
+    message: &WorkerClientMessage,
+    format: DaemonWireFormat,
+) -> io::Result<()> {
+    let bytes = encode_worker_client_line(message, format).map_err(wire_error_to_io)?;
+    stream.write_all(&bytes)?;
+    stream.flush()
 }
 
 pub(super) fn shutdown_worker_connection(writer: &Arc<Mutex<TcpStream>>) -> io::Result<()> {

--- a/crates/clud-bin/src/daemon/io_helpers.rs
+++ b/crates/clud-bin/src/daemon/io_helpers.rs
@@ -1,6 +1,5 @@
 use std::fs;
-use std::io::{self, Write};
-use std::net::TcpStream;
+use std::io;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -20,14 +19,6 @@ pub(super) fn child_env() -> Vec<(String, String)> {
         format!("CLUD:{}", std::process::id()),
     ));
     env
-}
-
-pub(super) fn write_json_line<T: Serialize>(writer: &mut TcpStream, value: &T) -> io::Result<()> {
-    let bytes = serde_json::to_vec(value)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
-    writer.write_all(&bytes)?;
-    writer.write_all(b"\n")?;
-    writer.flush()
 }
 
 pub(super) fn write_json_file<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {

--- a/crates/clud-bin/src/daemon/wire_prost.rs
+++ b/crates/clud-bin/src/daemon/wire_prost.rs
@@ -162,6 +162,48 @@ pub(super) fn decode_daemon_response_line(line: &str) -> Result<DaemonResponse, 
     Ok(serde_json::from_str(line)?)
 }
 
+pub(super) fn encode_worker_client_line(
+    message: &WorkerClientMessage,
+    format: DaemonWireFormat,
+) -> Result<Vec<u8>, WireError> {
+    match format {
+        DaemonWireFormat::Json => encode_json_line(message),
+        DaemonWireFormat::Prost => {
+            let frame = encode_worker_client_prost(message)?;
+            Ok(encode_wire_frame_line(&frame))
+        }
+    }
+}
+
+pub(super) fn decode_worker_client_line(
+    line: &str,
+) -> Result<(WorkerClientMessage, DaemonWireFormat), WireError> {
+    if let Some(frame) = decode_wire_frame_line(line)? {
+        return Ok((decode_worker_client(&frame)?, DaemonWireFormat::Prost));
+    }
+    Ok((serde_json::from_str(line)?, DaemonWireFormat::Json))
+}
+
+pub(super) fn encode_worker_server_line(
+    message: &WorkerServerMessage,
+    format: DaemonWireFormat,
+) -> Result<Vec<u8>, WireError> {
+    match format {
+        DaemonWireFormat::Json => encode_json_line(message),
+        DaemonWireFormat::Prost => {
+            let frame = encode_worker_server_prost(message)?;
+            Ok(encode_wire_frame_line(&frame))
+        }
+    }
+}
+
+pub(super) fn decode_worker_server_line(line: &str) -> Result<WorkerServerMessage, WireError> {
+    if let Some(frame) = decode_wire_frame_line(line)? {
+        return decode_worker_server(&frame);
+    }
+    Ok(serde_json::from_str(line)?)
+}
+
 pub(super) fn encode_daemon_request_prost(
     request: &DaemonRequest,
     request_id: impl Into<String>,
@@ -872,6 +914,30 @@ mod tests {
             let decoded = decode_worker_server(&frame).unwrap();
             assert_json_parity(&message, &decoded);
         }
+    }
+
+    #[test]
+    fn worker_line_dispatch_preserves_json_and_prost_formats() {
+        let attach = WorkerClientMessage::Attach {
+            terminal: None,
+            rows: Some(24),
+            cols: Some(80),
+        };
+        let json_line = encode_worker_client_line(&attach, DaemonWireFormat::Json).unwrap();
+        assert!(json_line.starts_with(br#"{"op":"attach""#));
+        let (decoded_attach, format) =
+            decode_worker_client_line(&String::from_utf8(json_line).unwrap()).unwrap();
+        assert_eq!(format, DaemonWireFormat::Json);
+        assert_json_parity(&attach, &decoded_attach);
+
+        let attached = WorkerServerMessage::Attached {
+            session: Box::new(sample_snapshot()),
+        };
+        let prost_line = encode_worker_server_line(&attached, DaemonWireFormat::Prost).unwrap();
+        assert!(prost_line.starts_with(b"CLUD-FRAME/1 434c5544 "));
+        let decoded_attached =
+            decode_worker_server_line(&String::from_utf8(prost_line).unwrap()).unwrap();
+        assert_json_parity(&attached, &decoded_attached);
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/worker.rs
+++ b/crates/clud-bin/src/daemon/worker.rs
@@ -749,6 +749,11 @@ fn persist_snapshot(
     shared.persist_current_snapshot()
 }
 
+// Silence import warnings for items consumed only by the `Write` trait or
+// other macros above (none here currently).
+#[allow(unused_imports)]
+use Write as _;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -932,8 +937,3 @@ mod tests {
         assert!(handle.join().unwrap().is_ok());
     }
 }
-
-// Silence import warnings for items consumed only by the `Write` trait or
-// other macros above (none here currently).
-#[allow(unused_imports)]
-use Write as _;

--- a/crates/clud-bin/src/daemon/worker.rs
+++ b/crates/clud-bin/src/daemon/worker.rs
@@ -15,12 +15,15 @@ use crate::graphics::GraphicsConfig;
 use crate::subprocess;
 use crate::win_creation_flags::invisible_helper_creationflags;
 
-use super::io_helpers::{child_env, read_json_file, write_json_line};
+use super::io_helpers::{child_env, read_json_file};
 use super::paths::spec_path;
 use super::process_utils::pid_is_alive;
 use super::types::{
     CtrlCProfile, SessionKind, SessionRuntime, SessionSnapshot, WorkerClientMessage,
     WorkerLaunchSpec, WorkerServerMessage, DEFAULT_BACKLOG_LIMIT_BYTES,
+};
+use super::wire_prost::{
+    decode_worker_client_line, encode_worker_server_line, DaemonWireFormat, WireError,
 };
 use super::worker_shared::WorkerShared;
 
@@ -488,8 +491,7 @@ fn handle_worker_client(
     if read_worker_line(&mut reader, &mut line, None)? == 0 {
         return Ok(());
     }
-    let message: WorkerClientMessage = serde_json::from_str(&line)
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
+    let (message, format) = decode_worker_client_line(&line).map_err(worker_wire_error_to_io)?;
     let (terminal, attach_rows, attach_cols) = match message {
         WorkerClientMessage::Attach {
             terminal,
@@ -503,11 +505,12 @@ fn handle_worker_client(
         WorkerClientMessage::Input { .. }
         | WorkerClientMessage::Resize { .. }
         | WorkerClientMessage::Interrupt { .. } => {
-            return write_json_line(
+            return write_worker_server_line(
                 &mut stream,
                 &WorkerServerMessage::Error {
                     message: "expected attach handshake".to_string(),
                 },
+                format,
             );
         }
     };
@@ -517,15 +520,20 @@ fn handle_worker_client(
     let (client_id, rx, snapshot, backlog) = match shared.attach_client(shutdown_handle) {
         Ok(values) => values,
         Err(message) => {
-            return write_json_line(&mut stream, &WorkerServerMessage::Error { message });
+            return write_worker_server_line(
+                &mut stream,
+                &WorkerServerMessage::Error { message },
+                format,
+            );
         }
     };
     let mut writer = stream.try_clone()?;
-    write_json_line(
+    write_worker_server_line(
         &mut writer,
         &WorkerServerMessage::Attached {
             session: Box::new(snapshot.clone()),
         },
+        format,
     )?;
     let mut header_restore = None;
     if is_pty {
@@ -535,12 +543,13 @@ fn handle_worker_client(
                 Ok(Some(header)) => {
                     runtime.resize(header.text_rows, attach_cols);
                     shared.resize_capture(header.text_rows, attach_cols);
-                    write_json_line(
+                    write_worker_server_line(
                         &mut writer,
                         &WorkerServerMessage::Output {
                             data_b64: base64::engine::general_purpose::STANDARD
                                 .encode(&header.bytes),
                         },
+                        format,
                     )?;
                     header_restore = Some(header.restore_bytes);
                 }
@@ -552,23 +561,29 @@ fn handle_worker_client(
         }
     }
     for chunk in backlog {
-        write_json_line(
+        write_worker_server_line(
             &mut writer,
             &WorkerServerMessage::Output {
                 data_b64: base64::engine::general_purpose::STANDARD.encode(chunk),
             },
+            format,
         )?;
     }
     if let Some(exit_code) = snapshot.exit_code {
         if let Some(bytes) = header_restore.as_deref() {
-            write_json_line(
+            write_worker_server_line(
                 &mut writer,
                 &WorkerServerMessage::Output {
                     data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
                 },
+                format,
             )?;
         }
-        write_json_line(&mut writer, &WorkerServerMessage::Exited { exit_code })?;
+        write_worker_server_line(
+            &mut writer,
+            &WorkerServerMessage::Exited { exit_code },
+            format,
+        )?;
         shared.detach_client(client_id);
         return Ok(());
     }
@@ -579,11 +594,12 @@ fn handle_worker_client(
         while let Ok(message) = rx.recv() {
             if let WorkerServerMessage::Exited { .. } = &message {
                 if let Some(bytes) = header_restore.take() {
-                    if write_json_line(
+                    if write_worker_server_line(
                         &mut writer,
                         &WorkerServerMessage::Output {
                             data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
                         },
+                        format,
                     )
                     .is_err()
                     {
@@ -591,7 +607,7 @@ fn handle_worker_client(
                     }
                 }
             }
-            if write_json_line(&mut writer, &message).is_err() {
+            if write_worker_server_line(&mut writer, &message, format).is_err() {
                 break;
             }
         }
@@ -606,7 +622,7 @@ fn handle_worker_client(
                 if !shared.owns_client(client_id) {
                     break;
                 }
-                let Ok(message) = serde_json::from_str::<WorkerClientMessage>(&line) else {
+                let Ok((message, _message_format)) = decode_worker_client_line(&line) else {
                     continue;
                 };
                 match message {
@@ -670,6 +686,20 @@ fn handle_worker_client(
     Ok(())
 }
 
+fn write_worker_server_line(
+    writer: &mut TcpStream,
+    message: &WorkerServerMessage,
+    format: DaemonWireFormat,
+) -> io::Result<()> {
+    let bytes = encode_worker_server_line(message, format).map_err(worker_wire_error_to_io)?;
+    writer.write_all(&bytes)?;
+    writer.flush()
+}
+
+fn worker_wire_error_to_io(err: WireError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, err)
+}
+
 fn start_interrupt_fast_path(
     shared: &Arc<WorkerShared>,
     runtime: &SessionRuntime,
@@ -717,6 +747,190 @@ fn persist_snapshot(
     shared: &Arc<WorkerShared>,
 ) -> io::Result<()> {
     shared.persist_current_snapshot()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::wire_prost::{
+        decode_worker_server_line, encode_worker_client_line, DaemonWireFormat,
+    };
+    use std::io::BufRead;
+    use std::sync::Arc;
+    use std::time::Instant;
+    use tempfile::TempDir;
+
+    fn test_shared(tmp: &TempDir) -> Arc<WorkerShared> {
+        let snapshot = SessionSnapshot {
+            id: "worker-wire-test".to_string(),
+            kind: SessionKind::Subprocess,
+            cwd: None,
+            name: Some("worker wire test".to_string()),
+            created_at: Some(1),
+            detachable: true,
+            background: true,
+            attachable: true,
+            repeat_interval_secs: None,
+            repeat_next_run_at: None,
+            repeat_running: false,
+            daemon_pid: std::process::id(),
+            worker_pid: std::process::id(),
+            worker_port: 0,
+            root_pid: None,
+            exit_code: None,
+            ctrl_c: None,
+        };
+        Arc::new(WorkerShared::new(
+            tmp.path().to_path_buf(),
+            "worker-wire-test".to_string(),
+            snapshot,
+        ))
+    }
+
+    fn test_runtime() -> SessionRuntime {
+        SessionRuntime::Subprocess(Arc::new(NativeProcess::new(ProcessConfig {
+            command: subprocess::command_spec_for_subprocess(vec![
+                "__clud_unstarted_test_process__".to_string(),
+            ]),
+            cwd: None,
+            env: None,
+            capture: false,
+            stderr_mode: StderrMode::Stdout,
+            creationflags: None,
+            create_process_group: false,
+            stdin_mode: StdinMode::Null,
+            nice: None,
+        })))
+    }
+
+    fn attach_message() -> WorkerClientMessage {
+        WorkerClientMessage::Attach {
+            terminal: None,
+            rows: Some(24),
+            cols: Some(80),
+        }
+    }
+
+    fn write_client_message(
+        stream: &mut TcpStream,
+        message: &WorkerClientMessage,
+        format: DaemonWireFormat,
+    ) {
+        let bytes = encode_worker_client_line(message, format).unwrap();
+        stream.write_all(&bytes).unwrap();
+        stream.flush().unwrap();
+    }
+
+    fn spawn_worker_handler(
+        shared: Arc<WorkerShared>,
+    ) -> (TcpStream, thread::JoinHandle<io::Result<()>>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            handle_worker_client(
+                stream,
+                &shared,
+                &test_runtime(),
+                &GraphicsConfig::default(),
+                SessionKind::Subprocess,
+                24,
+                80,
+            )
+        });
+        let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        (stream, handle)
+    }
+
+    fn read_server_message(reader: &mut BufReader<TcpStream>) -> (String, WorkerServerMessage) {
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        let message = decode_worker_server_line(&line).unwrap();
+        (line, message)
+    }
+
+    #[test]
+    fn worker_attach_live_path_preserves_json_wire() {
+        let tmp = TempDir::new().unwrap();
+        let shared = test_shared(&tmp);
+        let (mut stream, handle) = spawn_worker_handler(shared);
+
+        write_client_message(&mut stream, &attach_message(), DaemonWireFormat::Json);
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let (line, message) = read_server_message(&mut reader);
+
+        assert!(line.starts_with(r#"{"op":"attached""#), "{line:?}");
+        assert!(matches!(message, WorkerServerMessage::Attached { .. }));
+        drop(reader);
+        drop(stream);
+        assert!(handle.join().unwrap().is_ok());
+    }
+
+    #[test]
+    fn worker_attach_live_path_accepts_prost_messages() {
+        let tmp = TempDir::new().unwrap();
+        let shared = test_shared(&tmp);
+        let (mut stream, handle) = spawn_worker_handler(Arc::clone(&shared));
+
+        write_client_message(&mut stream, &attach_message(), DaemonWireFormat::Prost);
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let (line, message) = read_server_message(&mut reader);
+
+        assert!(line.starts_with("CLUD-FRAME/1 434c5544 "), "{line:?}");
+        assert!(matches!(message, WorkerServerMessage::Attached { .. }));
+
+        write_client_message(
+            &mut stream,
+            &WorkerClientMessage::Input {
+                data_b64: base64::engine::general_purpose::STANDARD.encode(b"abc"),
+                submit: false,
+            },
+            DaemonWireFormat::Prost,
+        );
+        write_client_message(
+            &mut stream,
+            &WorkerClientMessage::Resize {
+                rows: 30,
+                cols: 100,
+            },
+            DaemonWireFormat::Prost,
+        );
+        write_client_message(
+            &mut stream,
+            &WorkerClientMessage::Interrupt {
+                profile: Some(CtrlCProfile {
+                    cli_pid: Some(77),
+                    fast_path: true,
+                    ..CtrlCProfile::default()
+                }),
+            },
+            DaemonWireFormat::Prost,
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let snapshot = shared.snapshot();
+            if snapshot
+                .ctrl_c
+                .as_ref()
+                .is_some_and(|profile| profile.cli_pid == Some(77) && profile.fast_path)
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "prost interrupt frame was not decoded by the worker attach loop"
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+
+        drop(reader);
+        drop(stream);
+        assert!(handle.join().unwrap().is_ok());
+    }
 }
 
 // Silence import warnings for items consumed only by the `Write` trait or


### PR DESCRIPTION
## Summary
- Add worker client/server line helpers that encode legacy JSON or framed prost using the existing worker prost payload helpers.
- Preserve per-connection worker response format: JSON attach stays JSON, prost attach receives prost worker responses.
- Route attach client input/resize/interrupt sends through the selected worker wire format and add live worker-handler coverage for JSON and prost connections.

## Tests
- `$env:CARGO_TARGET_DIR='C:\Users\niteris\dev\running-process\.extern-repos\clud\target'; soldr cargo test -p clud worker_attach_live_path -- --nocapture`
- `$env:CARGO_TARGET_DIR='C:\Users\niteris\dev\running-process\.extern-repos\clud\target'; soldr cargo test -p clud wire_prost -- --nocapture`
- `soldr cargo fmt --all -- --check`
- `git diff --check`

Refs zackees/running-process#233
Refs zackees/running-process#242