### PR TITLE
Default hook health repairs

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -99,6 +99,10 @@ pub struct Args {
     #[arg(long = "fix-hooks")]
     pub fix_hooks: bool,
 
+    /// Globally disable automatic deterministic hook-health repairs on launch.
+    #[arg(long = "no-fix-hooks", conflicts_with = "fix_hooks")]
+    pub no_fix_hooks: bool,
+
     /// Issue #83: minimum age before a clean worktree is treated as stale.
     /// Accepts `30s`, `5m`, `2h`, `1d`. Defaults to `1d`.
     #[arg(long = "stale-after", default_value = "1d")]
@@ -368,6 +372,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--no-drag-drop",
         "--clean-worktrees",
         "--fix-hooks",
+        "--no-fix-hooks",
         "--yes",
         "--force",
         "--no-daemon",

--- a/crates/clud-bin/src/args_tests.rs
+++ b/crates/clud-bin/src/args_tests.rs
@@ -628,6 +628,7 @@ fn test_default_no_flags() {
     assert!(!args.no_dnd);
     assert!(!args.clean_worktrees);
     assert!(!args.fix_hooks);
+    assert!(!args.no_fix_hooks);
     assert!(!args.yes);
     assert!(!args.force);
     assert_eq!(args.stale_after, "1d");
@@ -691,7 +692,15 @@ fn test_clean_worktrees_with_dry_run() {
 fn test_fix_hooks_flag() {
     let args = parse(&["clud", "--fix-hooks"]);
     assert!(args.fix_hooks);
+    assert!(!args.no_fix_hooks);
     assert!(!args.dry_run);
+}
+
+#[test]
+fn test_no_fix_hooks_flag() {
+    let args = parse(&["clud", "--no-fix-hooks"]);
+    assert!(args.no_fix_hooks);
+    assert!(!args.fix_hooks);
 }
 
 #[test]

--- a/crates/clud-bin/src/clud_settings.rs
+++ b/crates/clud-bin/src/clud_settings.rs
@@ -45,6 +45,70 @@ pub fn settings_path_at(home: &Path) -> PathBuf {
     home.join(CLUD_DIR_NAME).join(SETTINGS_FILE_NAME)
 }
 
+pub fn load_auto_fix_hooks_enabled() -> Result<bool, SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    load_auto_fix_hooks_enabled_at(&home)
+}
+
+pub fn load_auto_fix_hooks_enabled_at(home: &Path) -> Result<bool, SettingsError> {
+    let path = settings_path_at(home);
+    if !path.exists() {
+        return Ok(true);
+    }
+    let lock_path = home.join(CLUD_DIR_NAME).join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+    let text = fs::read_to_string(&path)?;
+    if text.trim().is_empty() {
+        return Ok(true);
+    }
+    let document = parse_settings(&path, &text)?;
+    Ok(document
+        .get("hook_health")
+        .and_then(|item| item.get("auto_fix_hooks"))
+        .and_then(Item::as_bool)
+        .unwrap_or(true))
+}
+
+pub fn save_auto_fix_hooks_enabled(enabled: bool) -> Result<(), SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    save_auto_fix_hooks_enabled_at(&home, enabled)
+}
+
+pub fn save_auto_fix_hooks_enabled_at(home: &Path, enabled: bool) -> Result<(), SettingsError> {
+    let clud_dir = home.join(CLUD_DIR_NAME);
+    fs::create_dir_all(&clud_dir)?;
+    let lock_path = clud_dir.join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+
+    let path = settings_path_at(home);
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(SettingsError::Io(error)),
+    };
+    let mut document = if text.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        parse_settings(&path, &text)?
+    };
+
+    if document
+        .get("hook_health")
+        .and_then(Item::as_table)
+        .is_none()
+    {
+        document["hook_health"] = table();
+    }
+    document["hook_health"]["auto_fix_hooks"] = value(enabled);
+
+    let mut body = document.to_string();
+    if !body.ends_with('\n') {
+        body.push('\n');
+    }
+    fs::write(path, body)?;
+    Ok(())
+}
+
 pub fn load_launch_setup_scope(
     backend: Backend,
 ) -> Result<Option<LaunchSetupScope>, SettingsError> {
@@ -196,6 +260,27 @@ mod tests {
     }
 
     #[test]
+    fn missing_settings_file_defaults_auto_fix_hooks_enabled() {
+        let home = tempdir().unwrap();
+        assert!(load_auto_fix_hooks_enabled_at(home.path()).unwrap());
+    }
+
+    #[test]
+    fn saves_auto_fix_hooks_sticky_opt_out_and_reset() {
+        let home = tempdir().unwrap();
+
+        save_auto_fix_hooks_enabled_at(home.path(), false).unwrap();
+        assert!(!load_auto_fix_hooks_enabled_at(home.path()).unwrap());
+
+        save_auto_fix_hooks_enabled_at(home.path(), true).unwrap();
+        assert!(load_auto_fix_hooks_enabled_at(home.path()).unwrap());
+
+        let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
+        assert!(text.contains("[hook_health]"), "{text}");
+        assert!(text.contains("auto_fix_hooks = true"), "{text}");
+    }
+
+    #[test]
     fn saves_launch_setup_scope_per_backend() {
         let home = tempdir().unwrap();
 
@@ -238,5 +323,26 @@ mod tests {
         assert!(text.contains("value = \"kept\""), "{text}");
         assert!(text.contains("[launch_setup.claude]"), "{text}");
         assert!(text.contains("[launch_setup.codex]"), "{text}");
+    }
+
+    #[test]
+    fn auto_fix_hooks_setting_preserves_existing_settings() {
+        let home = tempdir().unwrap();
+        let path = settings_path_at(home.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "[unrelated]\nvalue = \"kept\"\n\n[launch_setup.codex]\nscope = \"global\"\n",
+        )
+        .unwrap();
+
+        save_auto_fix_hooks_enabled_at(home.path(), false).unwrap();
+
+        let text = fs::read_to_string(path).unwrap();
+        assert!(text.contains("[unrelated]"), "{text}");
+        assert!(text.contains("value = \"kept\""), "{text}");
+        assert!(text.contains("[launch_setup.codex]"), "{text}");
+        assert!(text.contains("[hook_health]"), "{text}");
+        assert!(text.contains("auto_fix_hooks = false"), "{text}");
     }
 }

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -224,19 +224,19 @@ fn running_process_service_def_dir() -> PathBuf {
 
     #[cfg(windows)]
     {
-        return dirs::config_dir()
+        dirs::config_dir()
             .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
             .join("running-process")
-            .join("services");
+            .join("services")
     }
     #[cfg(target_os = "macos")]
     {
-        return dirs::home_dir()
+        dirs::home_dir()
             .unwrap_or_else(std::env::temp_dir)
             .join("Library")
             .join("Application Support")
             .join("running-process")
-            .join("services");
+            .join("services")
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
@@ -696,6 +696,7 @@ mod tests {
             no_dnd: false,
             clean_worktrees: false,
             fix_hooks: false,
+            no_fix_hooks: false,
             stale_after: "1d".into(),
             yes: false,
             force: false,

--- a/crates/clud-bin/src/hook_health.rs
+++ b/crates/clud-bin/src/hook_health.rs
@@ -22,6 +22,8 @@ const PRE_TOOL_USE: &str = "PreToolUse";
 const CODEX_PRE_TOOL_USE_STATE: &str = "pre_tool_use";
 const CATCH_ALL_MATCHER: &str = "*";
 const FIX_HINT: &str = "Run `clud --fix-hooks`.";
+const LEGACY_CODEX_HOOKS_FEATURE: &str = "codex_hooks";
+const CURRENT_CODEX_HOOKS_FEATURE: &str = "hooks";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum HookFrontend {
@@ -142,6 +144,7 @@ pub struct HookHealthReport {
     pub claude: FrontendHookSummary,
     pub codex: FrontendHookSummary,
     pub codex_project_trust: Option<CodexProjectTrust>,
+    pub codex_legacy_hook_feature_configs: Vec<PathBuf>,
     pub warnings: Vec<String>,
 }
 
@@ -150,6 +153,9 @@ pub enum RepairAction {
     AddCodexProjectTrust {
         config_path: PathBuf,
         project_key: String,
+    },
+    MigrateCodexHooksFeatureFlag {
+        config_path: PathBuf,
     },
     BackendPrompt {
         source: HookFrontend,
@@ -164,6 +170,20 @@ pub enum RepairAction {
         prompt: String,
     },
 }
+
+#[derive(Debug)]
+pub struct DeterministicRepairError {
+    path: PathBuf,
+    error: io::Error,
+}
+
+impl fmt::Display for DeterministicRepairError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", display_path(&self.path), self.error)
+    }
+}
+
+impl std::error::Error for DeterministicRepairError {}
 
 pub fn should_check_launch(args: &Args) -> bool {
     if args.fix_hooks || args.clean_worktrees {
@@ -188,6 +208,11 @@ pub fn emit_launch_warnings() {
     }
 }
 
+pub fn apply_default_repairs() -> Result<usize, DeterministicRepairError> {
+    let report = inspect_current();
+    apply_deterministic_repairs(deterministic_repair_actions(&report))
+}
+
 pub fn run_fix_hooks(args: &Args, selected_backend: Backend) -> i32 {
     let mut report = inspect_current();
     print_report_warnings(&report);
@@ -197,31 +222,9 @@ pub fn run_fix_hooks(args: &Args, selected_backend: Backend) -> i32 {
         return 0;
     }
 
-    let deterministic = plan_repairs(&report)
-        .into_iter()
-        .filter_map(|action| match action {
-            RepairAction::AddCodexProjectTrust {
-                config_path,
-                project_key,
-            } => Some((config_path, project_key)),
-            RepairAction::BackendPrompt { .. } | RepairAction::ValidationPrompt { .. } => None,
-        })
-        .collect::<Vec<_>>();
-
-    for (config_path, project_key) in deterministic {
-        match add_codex_project_trust(&config_path, &project_key) {
-            Ok(()) => eprintln!(
-                "[clud] added Codex project trust entry `{project_key}` to {}",
-                display_path(&config_path)
-            ),
-            Err(error) => {
-                eprintln!(
-                    "[clud] error: failed to update {}: {error}",
-                    display_path(&config_path)
-                );
-                return 1;
-            }
-        }
+    if let Err(error) = apply_deterministic_repairs(deterministic_repair_actions(&report)) {
+        eprintln!("[clud] error: failed to update {error}");
+        return 1;
     }
 
     report = inspect_current();
@@ -230,7 +233,8 @@ pub fn run_fix_hooks(args: &Args, selected_backend: Backend) -> i32 {
         .filter_map(|action| match action {
             RepairAction::BackendPrompt { prompt, .. } => Some(prompt),
             RepairAction::ValidationPrompt { prompt, .. } => Some(prompt),
-            RepairAction::AddCodexProjectTrust { .. } => None,
+            RepairAction::AddCodexProjectTrust { .. }
+            | RepairAction::MigrateCodexHooksFeatureFlag { .. } => None,
         })
         .collect::<Vec<_>>();
 
@@ -269,6 +273,60 @@ pub fn run_fix_hooks(args: &Args, selected_backend: Backend) -> i32 {
     0
 }
 
+fn deterministic_repair_actions(report: &HookHealthReport) -> Vec<RepairAction> {
+    plan_repairs(report)
+        .into_iter()
+        .filter(|action| {
+            matches!(
+                action,
+                RepairAction::AddCodexProjectTrust { .. }
+                    | RepairAction::MigrateCodexHooksFeatureFlag { .. }
+            )
+        })
+        .collect()
+}
+
+fn apply_deterministic_repairs(
+    actions: Vec<RepairAction>,
+) -> Result<usize, DeterministicRepairError> {
+    let mut applied = 0;
+    for action in actions {
+        match action {
+            RepairAction::AddCodexProjectTrust {
+                config_path,
+                project_key,
+            } => {
+                add_codex_project_trust(&config_path, &project_key).map_err(|error| {
+                    DeterministicRepairError {
+                        path: config_path.clone(),
+                        error,
+                    }
+                })?;
+                applied += 1;
+                eprintln!(
+                    "[clud] added Codex project trust entry `{project_key}` to {}",
+                    display_path(&config_path)
+                );
+            }
+            RepairAction::MigrateCodexHooksFeatureFlag { config_path } => {
+                migrate_codex_hooks_feature_flag(&config_path).map_err(|error| {
+                    DeterministicRepairError {
+                        path: config_path.clone(),
+                        error,
+                    }
+                })?;
+                applied += 1;
+                eprintln!(
+                    "[clud] migrated deprecated Codex `{LEGACY_CODEX_HOOKS_FEATURE}` feature flag to `{CURRENT_CODEX_HOOKS_FEATURE}` in {}",
+                    display_path(&config_path)
+                );
+            }
+            RepairAction::BackendPrompt { .. } | RepairAction::ValidationPrompt { .. } => {}
+        }
+    }
+    Ok(applied)
+}
+
 pub fn inspect_current() -> HookHealthReport {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let repo_root = loop_spec::git_root_from(&cwd);
@@ -285,13 +343,22 @@ fn hook_home_dir() -> Option<PathBuf> {
 pub fn inspect_paths(repo_root: &Path, home: Option<&Path>) -> HookHealthReport {
     let claude = collect_claude(repo_root, home);
     let (codex, codex_project_trust) = collect_codex(repo_root, home);
-    let warnings = build_warnings(&claude, &codex);
+    let codex_legacy_hook_feature_configs =
+        collect_codex_legacy_hook_feature_configs(repo_root, home);
+    let mut warnings = build_warnings(&claude, &codex);
+    for config_path in &codex_legacy_hook_feature_configs {
+        warnings.push(format!(
+            "Codex config {} uses deprecated `[features].{LEGACY_CODEX_HOOKS_FEATURE}`; migrate it to `[features].{CURRENT_CODEX_HOOKS_FEATURE}`. {FIX_HINT}",
+            display_path(config_path)
+        ));
+    }
     HookHealthReport {
         repo_root: repo_root.to_path_buf(),
         home: home.map(Path::to_path_buf),
         claude,
         codex,
         codex_project_trust,
+        codex_legacy_hook_feature_configs,
         warnings,
     }
 }
@@ -299,6 +366,13 @@ pub fn inspect_paths(repo_root: &Path, home: Option<&Path>) -> HookHealthReport 
 pub fn plan_repairs(report: &HookHealthReport) -> Vec<RepairAction> {
     let mut actions = Vec::new();
     actions.extend(validation_prompt_actions(report));
+    actions.extend(
+        report
+            .codex_legacy_hook_feature_configs
+            .iter()
+            .cloned()
+            .map(|config_path| RepairAction::MigrateCodexHooksFeatureFlag { config_path }),
+    );
 
     let project_hooks = report.repo_root.join(".codex").join("hooks.json");
     let has_project_codex_hooks = report
@@ -471,6 +545,41 @@ fn collect_codex(
     apply_codex_activity_state(&mut summary, &project_hooks, project_trust.as_ref(), home);
     warn_on_powershell_exit_code_risk(&mut summary);
     (summary, project_trust)
+}
+
+fn collect_codex_legacy_hook_feature_configs(
+    repo_root: &Path,
+    home: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = home {
+        paths.push(home.join(".codex").join("config.toml"));
+    }
+    paths.push(repo_root.join(".codex").join("config.toml"));
+
+    let mut configs: Vec<PathBuf> = Vec::new();
+    for path in paths {
+        if path.is_file()
+            && codex_config_has_legacy_hooks_feature(&path)
+            && !configs.iter().any(|existing| same_path(existing, &path))
+        {
+            configs.push(path);
+        }
+    }
+    configs
+}
+
+fn codex_config_has_legacy_hooks_feature(path: &Path) -> bool {
+    let Ok(text) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(document) = text.parse::<DocumentMut>() else {
+        return false;
+    };
+    document
+        .get("features")
+        .and_then(|item| item.get(LEGACY_CODEX_HOOKS_FEATURE))
+        .is_some()
 }
 
 fn apply_codex_activity_state(
@@ -921,6 +1030,7 @@ fn run_backend_prompt(
         no_dnd: true,
         clean_worktrees: false,
         fix_hooks: false,
+        no_fix_hooks: false,
         stale_after: "1d".to_string(),
         yes: false,
         force: false,
@@ -983,6 +1093,10 @@ fn print_dry_run_plan(report: &HookHealthReport) {
                 "- add Codex project trust key `{project_key}` to {}",
                 display_path(&config_path)
             ),
+            RepairAction::MigrateCodexHooksFeatureFlag { config_path } => println!(
+                "- migrate deprecated Codex `[features].{LEGACY_CODEX_HOOKS_FEATURE}` to `[features].{CURRENT_CODEX_HOOKS_FEATURE}` in {}",
+                display_path(&config_path)
+            ),
             RepairAction::BackendPrompt {
                 source,
                 target,
@@ -1024,6 +1138,33 @@ fn add_codex_project_trust(config_path: &Path, project_key: &str) -> io::Result<
     if let Some(parent) = config_path.parent() {
         fs::create_dir_all(parent)?;
     }
+    fs::write(config_path, document.to_string())
+}
+
+fn migrate_codex_hooks_feature_flag(config_path: &Path) -> io::Result<()> {
+    let text = fs::read_to_string(config_path)?;
+    let mut document = text
+        .parse::<DocumentMut>()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+
+    let Some(legacy_value) = document
+        .get("features")
+        .and_then(|item| item.get(LEGACY_CODEX_HOOKS_FEATURE))
+        .cloned()
+    else {
+        return Ok(());
+    };
+
+    if document["features"]
+        .get(CURRENT_CODEX_HOOKS_FEATURE)
+        .is_none()
+    {
+        document["features"][CURRENT_CODEX_HOOKS_FEATURE] = legacy_value;
+    }
+    if let Some(features) = document["features"].as_table_mut() {
+        features.remove(LEGACY_CODEX_HOOKS_FEATURE);
+    }
+
     fs::write(config_path, document.to_string())
 }
 

--- a/crates/clud-bin/src/hook_health_tests.rs
+++ b/crates/clud-bin/src/hook_health_tests.rs
@@ -187,6 +187,60 @@ fn deterministic_trust_repair_adds_canonical_key() {
 }
 
 #[test]
+fn legacy_codex_hooks_feature_warns_and_plans_deterministic_repair() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let config = repo.join(".codex").join("config.toml");
+    write(&config, "[features]\ncodex_hooks = true\n");
+
+    let report = inspect_paths(&repo, None);
+
+    assert_eq!(
+        report.codex_legacy_hook_feature_configs,
+        vec![config.clone()]
+    );
+    assert!(report
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("deprecated `[features].codex_hooks`")));
+    assert!(plan_repairs(&report).into_iter().any(|action| matches!(
+        action,
+        RepairAction::MigrateCodexHooksFeatureFlag { config_path } if config_path == config
+    )));
+}
+
+#[test]
+fn legacy_codex_hooks_feature_migration_moves_value_and_preserves_other_config() {
+    let temp = tempdir().unwrap();
+    let config = temp.path().join("home").join(".codex").join("config.toml");
+    write(
+        &config,
+        "[features]\ncodex_hooks = true\nmodel = \"gpt-5\"\n\n[projects.repo]\ntrust_level = \"trusted\"\n",
+    );
+
+    migrate_codex_hooks_feature_flag(&config).unwrap();
+
+    let text = fs::read_to_string(config).unwrap();
+    assert!(text.contains("hooks = true"), "{text}");
+    assert!(!text.contains("codex_hooks"), "{text}");
+    assert!(text.contains("model = \"gpt-5\""), "{text}");
+    assert!(text.contains("[projects.repo]"), "{text}");
+}
+
+#[test]
+fn legacy_codex_hooks_feature_migration_preserves_existing_hooks_value() {
+    let temp = tempdir().unwrap();
+    let config = temp.path().join("home").join(".codex").join("config.toml");
+    write(&config, "[features]\ncodex_hooks = false\nhooks = true\n");
+
+    migrate_codex_hooks_feature_flag(&config).unwrap();
+
+    let text = fs::read_to_string(config).unwrap();
+    assert!(text.contains("hooks = true"), "{text}");
+    assert!(!text.contains("codex_hooks"), "{text}");
+}
+
+#[test]
 fn catch_all_codex_hook_satisfies_specific_claude_matchers() {
     let temp = tempdir().unwrap();
     let repo = temp.path().join("repo");

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -108,11 +108,30 @@ fn main() {
         std::process::exit(worktrees::run(&opts));
     }
 
-    // Issue #112: explicit hook-parity remediation path. Normal launches only
-    // warn; this flag is the opt-in path that may edit deterministic Codex
-    // trust config and ask the selected backend to migrate hook definitions.
+    if args.no_fix_hooks {
+        if args.dry_run {
+            println!("[clud] dry-run: would disable automatic hook-health repairs globally");
+        } else if let Err(error) = clud_settings::save_auto_fix_hooks_enabled(false) {
+            eprintln!("[clud] error: failed to persist --no-fix-hooks: {error}");
+            std::process::exit(1);
+        } else {
+            eprintln!(
+                "[clud] disabled automatic hook-health repairs globally; run `clud --fix-hooks` to re-enable"
+            );
+        }
+    }
+
+    // Issue #112: explicit hook-parity remediation path. This flag resets the
+    // sticky opt-out, applies deterministic repairs, and asks the selected
+    // backend to migrate hook definitions when semantic translation is needed.
     if args.fix_hooks {
         let selected_backend = backend::resolve_backend(args.claude, args.codex);
+        if !args.dry_run {
+            if let Err(error) = clud_settings::save_auto_fix_hooks_enabled(true) {
+                eprintln!("[clud] error: failed to persist --fix-hooks: {error}");
+                std::process::exit(1);
+            }
+        }
         std::process::exit(hook_health::run_fix_hooks(&args, selected_backend));
     }
 
@@ -169,6 +188,24 @@ fn main() {
     }
 
     if hook_health::should_check_launch(&args) {
+        let auto_fix_hooks = if args.no_fix_hooks {
+            false
+        } else {
+            match clud_settings::load_auto_fix_hooks_enabled() {
+                Ok(enabled) => enabled,
+                Err(error) => {
+                    eprintln!(
+                        "[clud] warning: failed to load hook-health settings: {error}; using default"
+                    );
+                    true
+                }
+            }
+        };
+        if auto_fix_hooks && !args.dry_run {
+            if let Err(error) = hook_health::apply_default_repairs() {
+                eprintln!("[clud] warning: failed to auto-repair hook health: {error}");
+            }
+        }
         if args.verbose {
             verbose_log::log("[clud] hooks: checking launch parity");
         }


### PR DESCRIPTION
Summary:
- Default normal Codex launches to automatic deterministic hook-health repairs.
- Add a sticky global `--no-fix-hooks` opt-out in `~/.clud/settings.toml`; explicit `--fix-hooks` re-enables it.
- Migrate deprecated Codex `[features].codex_hooks` config entries to `[features].hooks`.

Tests:
- bash lint
- soldr cargo test -p clud --lib