### PR TITLE
feat(daemon): install clud.servicedef at bringup; bump to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clud"
-version = "2.0.19"
+version = "2.1.0"
 dependencies = [
  "base64",
  "clap",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mock-agent"
-version = "2.0.19"
+version = "2.1.0"
 dependencies = [
  "libc",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.19"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.85"
 license-file = "LICENSE"

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -116,27 +116,20 @@ fn run_running_process_diagnostics(state_dir: &Path, json: bool) -> i32 {
     let current_exe = std::env::current_exe().ok();
     let broker_requested = env_flag_eq_one(RUNNING_PROCESS_BROKER_ENV);
     let broker_disabled = env_flag_eq_one(RUNNING_PROCESS_DISABLE_ENV);
+    let servicedef_installed = service_def_path.exists();
     let mode = if broker_disabled {
-        "direct-daemon-fallback-disabled"
-    } else if broker_requested {
-        "direct-daemon-fallback-broker-requested"
+        "disabled-direct-daemon"
     } else {
-        "direct-daemon-fallback"
+        "frame-lane-with-tcp-fallback"
     };
     let summary = if broker_disabled {
-        "RUNNING_PROCESS_DISABLE=1 forces the direct clud daemon path."
-    } else if broker_requested {
-        "Broker mode is requested, but clud still falls back to its direct daemon path in this stub."
+        "RUNNING_PROCESS_DISABLE=1 bypasses the running-process frame lane; clud uses its direct TCP daemon path only."
     } else {
-        "Clud is using its direct daemon path; running-process broker wiring is deferred."
+        "Clud serves a running-process broker v1 frame lane (payload protocol 0x7C4C) next to its TCP wire; clients try the lane first and fall back to TCP."
     };
     let deferred = [
-        "BackendHandle adoption",
-        "binary .servicedef packaging/install",
-        "broker-client connect_to_backend / Hello-skip wiring",
-        "clud JSON/prost wire migration completion",
-        "broker-mode/direct-mode integration tests",
-        "three-OS acceptance, lint, dylint, Phase 7 rollout, and Phase 8 escape-hatch removal",
+        "broker-spawned backend adoption (the clud daemon remains self-managed)",
+        "Phase 8 escape-hatch removal",
     ];
 
     if json {
@@ -148,8 +141,8 @@ fn run_running_process_diagnostics(state_dir: &Path, json: bool) -> i32 {
                 "path": path_string(&service_def_path),
                 "directory_env_override": RUNNING_PROCESS_SERVICE_DEF_DIR_ENV,
                 "isolation": "SHARED_BROKER",
-                "installed_by_clud": false,
-                "status": "stubbed_deferred",
+                "installed_by_clud": servicedef_installed,
+                "status": if servicedef_installed { "installed" } else { "pending_first_daemon_bringup" },
             },
             "daemon": {
                 "state_dir": path_string(state_dir),
@@ -164,8 +157,8 @@ fn run_running_process_diagnostics(state_dir: &Path, json: bool) -> i32 {
             "mode": {
                 "current": mode,
                 "summary": summary,
-                "uses_direct_daemon_fallback": true,
-                "broker_client_wired": false,
+                "uses_direct_daemon_fallback": broker_disabled,
+                "broker_client_wired": !broker_disabled,
             },
             "environment": {
                 "RUNNING_PROCESS_DISABLE": broker_disabled,
@@ -181,10 +174,11 @@ fn run_running_process_diagnostics(state_dir: &Path, json: bool) -> i32 {
             }
         }
     } else {
-        println!("running-process adoption preview for clud");
+        println!("running-process adoption status for clud");
         println!("service: {RUNNING_PROCESS_SERVICE_NAME}");
         println!("isolation: SHARED_BROKER");
         println!("servicedef: {}", service_def_path.display());
+        println!("servicedef installed: {servicedef_installed}");
         println!("daemon state: {}", state_dir.display());
         println!("daemon info: {}", daemon_info_path.display());
         println!("live daemon reachable: {}", live_daemon.is_some());
@@ -217,41 +211,12 @@ fn env_flag_eq_one(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Single source of truth: running-process's own resolver (honors the
+/// `RUNNING_PROCESS_SERVICE_DEF_DIR` override, then platform defaults).
+/// The daemon writes `clud.servicedef` into the same directory at
+/// bringup (`rp_broker::install_service_definition`).
 fn running_process_service_def_dir() -> PathBuf {
-    if let Some(path) = std::env::var_os(RUNNING_PROCESS_SERVICE_DEF_DIR_ENV) {
-        return PathBuf::from(path);
-    }
-
-    #[cfg(windows)]
-    {
-        dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
-            .join("running-process")
-            .join("services")
-    }
-    #[cfg(target_os = "macos")]
-    {
-        dirs::home_dir()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("Library")
-            .join("Application Support")
-            .join("running-process")
-            .join("services")
-    }
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME") {
-            PathBuf::from(config_home)
-                .join("running-process")
-                .join("services")
-        } else {
-            dirs::home_dir()
-                .unwrap_or_else(std::env::temp_dir)
-                .join(".config")
-                .join("running-process")
-                .join("services")
-        }
-    }
+    running_process::broker::server::service_definition_dir()
 }
 
 fn path_string(path: &Path) -> String {

--- a/crates/clud-bin/src/daemon/rp_broker.rs
+++ b/crates/clud-bin/src/daemon/rp_broker.rs
@@ -37,8 +37,12 @@ use running_process::broker::backend_sdk::{
 };
 use running_process::broker::client::{connect_to_backend, ConnectBackendRequest};
 use running_process::broker::doctor::default_broker_endpoint;
-use running_process::broker::protocol::{encode_framed, Endpoint, Frame};
-use running_process::broker::server::local_socket_name;
+use running_process::broker::protocol::{
+    encode_framed, BrokerIsolation, Endpoint, Frame, ServiceDefinition,
+};
+use running_process::broker::server::{
+    local_socket_name, service_definition_dir, write_service_definition,
+};
 use running_process::NativeProcess;
 use sha2::{Digest, Sha256};
 
@@ -159,6 +163,19 @@ pub(super) fn spawn_frame_lane(
     if running_process_disabled() {
         return None;
     }
+    // Packaged `.servicedef` (soldr#722 pattern, #385 item 4): refresh
+    // clud's service definition on every daemon bringup so the broker's
+    // registry always points at the binary that is actually serving.
+    // Best-effort and independent of the frame lane. Skipped under
+    // `cfg!(test)` — unit tests spawn `run_daemon` in-process and must
+    // not register the throwaway test executable in the user's real
+    // service-definition directory; `install_service_definition` itself
+    // is covered by a dedicated test against a temp dir.
+    if !cfg!(test) {
+        if let Err(err) = install_service_definition() {
+            eprintln!("[clud] note: running-process servicedef install skipped: {err}");
+        }
+    }
     match start_frame_lane(state_dir, workers, gc_tx, shutdown_requested) {
         Ok(lane) => Some(lane),
         Err(err) => {
@@ -166,6 +183,26 @@ pub(super) fn spawn_frame_lane(
             None
         }
     }
+}
+
+/// Install/refresh `clud.servicedef` in the running-process
+/// service-definition directory (`RUNNING_PROCESS_SERVICE_DEF_DIR`
+/// override honored by [`service_definition_dir`]). The definition uses
+/// SHARED_BROKER isolation and points at the current executable.
+pub(super) fn install_service_definition() -> io::Result<PathBuf> {
+    let exe = std::env::current_exe()?;
+    let definition = ServiceDefinition {
+        service_name: RUNNING_PROCESS_SERVICE_NAME.into(),
+        binary_path: exe.to_string_lossy().into_owned(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: String::new(),
+        min_version: String::new(),
+        version_allow_list: Vec::new(),
+        labels: Default::default(),
+    };
+    write_service_definition(&service_definition_dir(), &definition)
+        .map_err(|err| io::Error::other(err.to_string()))
 }
 
 fn start_frame_lane(
@@ -718,6 +755,39 @@ mod tests {
             assert!(matches!(response, DaemonResponse::ShutdownAck { .. }));
         }
         assert_eq!(daemon_thread.join().unwrap(), 0);
+    }
+
+    /// `.servicedef` packaging (#385 item 4): the install helper writes
+    /// a valid SHARED_BROKER definition for service "clud" pointing at
+    /// the current executable, into the (env-overridden) directory.
+    #[test]
+    fn install_service_definition_writes_valid_shared_broker_servicedef() {
+        use prost::Message as _;
+        use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
+        use running_process::broker::server::validate_service_definition_for_service;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(
+            "RUNNING_PROCESS_SERVICE_DEF_DIR",
+            tmp.path().to_str().unwrap(),
+        );
+        let path = install_service_definition().expect("install servicedef");
+        assert_eq!(path, tmp.path().join("clud.servicedef"));
+
+        let bytes = std::fs::read(&path).unwrap();
+        let definition = ServiceDefinition::decode(bytes.as_slice()).unwrap();
+        assert_eq!(definition.service_name, RUNNING_PROCESS_SERVICE_NAME);
+        assert_eq!(definition.isolation, BrokerIsolation::SharedBroker as i32);
+        assert_eq!(
+            std::path::PathBuf::from(&definition.binary_path),
+            std::env::current_exe().unwrap()
+        );
+        validate_service_definition_for_service(&definition, RUNNING_PROCESS_SERVICE_NAME)
+            .expect("definition must validate");
+
+        // Idempotent refresh: a second install overwrites in place.
+        let again = install_service_definition().expect("reinstall servicedef");
+        assert_eq!(again, path);
     }
 
     #[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.0.19"
+version = "2.1.0"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "clud"
-version = "2.0.19"
+version = "2.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Installs a packaged `clud.servicedef` into the running-process service-definition directory at daemon bringup (soldr#722 pattern), so the shared broker can discover and verify the clud daemon.
- Bumps version to 2.1.0 to cut a release carrying the full broker adoption stack (#321, #322, #323, #324).

Final PR for zackees/running-process#385.

## Test plan
- [x] Local lint/test green (staged pre-validated; clean rebase onto post-#324 main)
- [ ] CI green (or failures pre-existing on main)
- [ ] Release automation publishes 2.1.0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)