### PR TITLE
fix(windows): teardown retry loop in clud-pr skill + CLUD_NO_UNLOCK=1 in test harness (closes #300, addresses #331 Fix B)

### DIFF
--- a/crates/clud-bin/assets/skills/clud-pr/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-pr/SKILL.md
@@ -29,7 +29,7 @@ Five hard rules:
    - If no, delete any `.claude/worktrees/` created during this run, then either ask to add `.claude/` to `.gitignore` or use a sibling path outside the repo (`../<repo>-wt-<branch>/`). Do not create an unignored worktree inside the repo.
 2. **Stale worktrees.** Before creating a new worktree, run `git worktree prune`, then scan `.claude/worktrees/*` for directories older than 24 hours. If any exist, list them and ask whether to delete them. Do not remove stale worktrees without permission.
 3. **Create the worktree.** `git fetch origin main && git worktree add -b feat/<short-name> .claude/worktrees/<branch> origin/main`. All edits, commits, lint, and tests happen inside that path.
-4. **Tear down.** After `gh pr create` succeeds, run `git worktree remove .claude/worktrees/<branch>`, then `git worktree prune`, and confirm the entry is gone from `git worktree list`.
+4. **Tear down.** After `gh pr create` succeeds, remove the worktree with **a retry loop** because Windows file-lock races against long-lived background daemons (zccache, rust-analyzer) routinely cause the first removal attempt to fail with `Permission denied` / `Device or resource busy` — the handles release within seconds. Pattern: try `git worktree remove .claude/worktrees/<branch> --force`; if it fails, sleep 1s and try `rm -rf .claude/worktrees/<branch>`; retry up to ~5 attempts total (5s wall). After success, run `git worktree prune` and confirm the entry is gone from `git worktree list`. See [`zackees/soldr#710`](https://github.com/zackees/soldr/issues/710) for the proper soldr-side fix (in design); this retry loop is the cheap defensive backstop. On POSIX the first attempt always succeeds (delete-on-close semantics), so the retry loop is a no-op there.
 
 ## Mode Selection
 
@@ -81,7 +81,7 @@ Use this when the user asks to merge, land, or ship an already-open PR.
 9. **Clean tree gate.** Run `git status` inside the worktree. Commit source changes that belong in the PR. Delete tmp, scratch, and build artifacts. The worktree must be clean before push.
 10. **Commit.** Use a conventional commit. Reference the issue when one exists (`Closes #<num>` in the commit body or PR body). For freeform tasks, summarize the task instead.
 11. **Push and open PR.** `git push -u origin <branch>`, then `gh pr create`. The body should include the issue link when present, a concise summary, and tests run.
-12. **Remove the worktree.** Run `git worktree remove .claude/worktrees/<branch>`, then `git worktree prune`, confirm it is gone, then verify the main checkout's `git status` is clean.
+12. **Remove the worktree.** Follow the **Tear down** retry pattern in the Worktree Workspace section — `git worktree remove --force` first, then `rm -rf` with up to 5 retries at 1s spacing for the Windows file-lock race, then `git worktree prune`, confirm it is gone, then verify the main checkout's `git status` is clean.
 13. **Final response.** Give the PR URL and any essential test note. Keep it short.
 
 ## Failure Modes To Avoid

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -95,7 +95,18 @@ PROJECT_VERSION = _project_version()
 
 def copied_clud_env(_source: Path) -> dict[str, str]:
     """Return an environment that can launch a copied clud binary."""
-    return os.environ.copy()
+    env = os.environ.copy()
+    # Suppress unlock_exe()'s in-place rename trampoline when the
+    # launched binary lives in a tmpdir (every _run() invocation).
+    # Without this, the trampoline renames `<tmpdir>/clud.exe` to
+    # `<tmpdir>/clud.exe.old.<rand>` and races against
+    # `TemporaryDirectory.__exit__`'s shutil.rmtree on Windows —
+    # SECTION release on process exit is async, so the tmpdir cleanup
+    # gets WinError 32 on the still-locked `.old.<rand>` file. The
+    # trampoline brings zero benefit here (the tmpdir binary is
+    # never `pip install`'d at this path). See issues #331, #333.
+    env["CLUD_NO_UNLOCK"] = "1"
+    return env
 
 
 def _run(*args: str, input_data: str | None = None) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary

Two tiny Windows file-lock micro-fixes batched in one PR. Both are 2026-06-15 deliverables from meta #334.

### Closes #300 — `clud-pr` teardown retry loop

`crates/clud-bin/assets/skills/clud-pr/SKILL.md`:
- Worktree Workspace `Tear down` step (line 32): replace single-attempt `git worktree remove` with the retry-loop wording. Tolerates the Windows \"Permission denied / Device or resource busy\" race against long-lived daemons (zccache-daemon, rust-analyzer) holding handles into the worktree's \`target/\` for seconds after \`cargo\` exits.
- Task To PR Workflow `Remove the worktree` step (line 84): reference the same retry pattern from the Worktree Workspace section.

POSIX hits the first-try success path so the retry is a no-op there. The retry-loop wording matches what \`~/.claude/skills/clud-pr/SKILL.md\` already shipped as a local proof-of-concept; this lifts it upstream so every clud-pr user benefits on Windows.

### Addresses #331 Fix B — `tests/test_hello.py::copied_clud_env` sets `CLUD_NO_UNLOCK=1`

The trampoline's in-place rename of \`<tmpdir>/clud.exe\` -> \`<tmpdir>/clud.exe.old.<rand>\` races against \`TemporaryDirectory.__exit__\`'s \`shutil.rmtree\` on Windows — the SECTION release on process exit is async, so tmpdir cleanup gets \`WinError 32\` on the still-locked \`.old.<rand>\` file. The env-var escape hatch already exists in \`crates/clud-bin/src/trampoline.rs:151\` for exactly this case ('CI / test harnesses that spawn many short-lived clud invocations').

This is the immediate unflake. The structural fix (canonical per-version runtime cache + double-checked locking, supersedes #331 Fix A) lives in #333 and is independent of this PR.

## Why batched

Both are 2-line changes from the same investigation. Separate PRs would be review overhead with no review benefit — reviewers can verify both at once and they hit related-but-distinct surfaces (skill markdown vs Python test harness).

## Test plan

- [x] \`uv run -m ruff check tests/test_hello.py\` — clean (exit 0)
- [x] \`git diff --stat\` — scoped to the two changed files (+14 / -3)
- [ ] CI: \`test_dry_run_safe_mode\` and siblings on \`windows-2025\` should no longer flake on the \`PermissionError [WinError 32]\` for \`clud.exe.old.<rand>\` — that was the original signal that surfaced #331.

## Refs

- Closes #300
- Addresses #331 (Fix B portion; Fix A is superseded by #333)
- Tracked under meta #334