### PR TITLE
feat(runtime-cache): add opt-in reexec hop

### DIFF
--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,14 +1,18 @@
 use clud::{
     args, backend, backend_bootstrap, clud_settings, command, console_setup, console_title,
     ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard, launch_setup,
-    loop_artifacts, loop_spec, runner, startup, trampoline, trash, ui, verbose_log, wasm,
-    worktrees,
+    loop_artifacts, loop_spec, runner, runtime_cache, startup, trampoline, trash, ui, verbose_log,
+    wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
 
 fn main() {
     verbose_log::init_launch_clock();
+
+    if let Err(err) = runtime_cache::hop_to_runtime_cache_if_enabled() {
+        eprintln!("[clud] warning: runtime cache hop failed: {err}");
+    }
 
     // Windows: rename ourselves so pip can always overwrite clud.exe.
     trampoline::unlock_exe();

--- a/crates/clud-bin/src/runtime_cache.rs
+++ b/crates/clud-bin/src/runtime_cache.rs
@@ -1,13 +1,11 @@
 //! Canonical per-version runtime cache for `clud.exe` (issue #333).
 //!
-//! Pure-function skeleton — see issue #333 for the full design and
-//! tracking meta #334 for the burn-down context. This module ships
-//! the cache-path computation, the cross-platform "am I running from
-//! the cache?" predicate, and the double-checked file-locked
-//! [`prepare_cached_clud_in`] copy-once helper. The actual re-exec
-//! wiring into `main()` and the `unlock_exe()` short-circuit are
-//! Phase 2 and land in a separate PR; production behavior is
-//! unchanged until then.
+//! Feature-flagged cache hop for #333. This module owns the cache-path
+//! computation, the cross-platform "am I running from the cache?"
+//! predicate, the double-checked file-locked [`prepare_cached_clud_in`]
+//! copy-once helper, and the opt-in re-exec hop. The hop is gated
+//! behind `CLUD_USE_RUNTIME_CACHE=1` so production behavior stays
+//! unchanged until the default-on phase.
 //!
 //! Design summary (full version in issue #333):
 //! - Layout: `~/.clud/runtime/clud-<version>/<binary-name>`.
@@ -21,15 +19,25 @@
 //!   with the cache key changed from per-launch random to per-version
 //!   so subsequent invocations are zero-I/O cache hits.
 
+use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use fs4::fs_std::FileExt;
 
 /// Subdirectory under `~/.clud/` where per-version cached binaries
 /// live. Mirrors zccache's `runtime-binaries/` convention.
 const RUNTIME_SUBDIR: &str = "runtime";
+
+/// Opt-in gate for the runtime-cache hop. Default off until the
+/// re-exec path has soaked in real PTY / backend workflows.
+const CLUD_USE_RUNTIME_CACHE: &str = "CLUD_USE_RUNTIME_CACHE";
+
+/// Existing escape hatch. During the opt-in phase it disables both the legacy
+/// unlock trampoline and the new runtime-cache hop.
+const CLUD_NO_UNLOCK: &str = "CLUD_NO_UNLOCK";
 
 /// Compile-time version stamp consumed by [`runtime_cache_dir`].
 const CLUD_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -61,6 +69,74 @@ pub fn cached_clud_binary_name() -> &'static str {
 /// `<runtime_cache_dir>/<cached_clud_binary_name>`.
 pub fn cached_clud_path() -> Option<PathBuf> {
     Some(runtime_cache_dir()?.join(cached_clud_binary_name()))
+}
+
+/// Returns true when the runtime-cache hop should run.
+pub fn runtime_cache_hop_enabled() -> bool {
+    runtime_cache_hop_enabled_from_vars(
+        std::env::var_os(CLUD_USE_RUNTIME_CACHE).is_some(),
+        std::env::var_os(CLUD_NO_UNLOCK).is_some(),
+        cfg!(debug_assertions),
+    )
+}
+
+fn runtime_cache_hop_enabled_from_vars(
+    use_runtime_cache: bool,
+    no_unlock: bool,
+    debug_assertions: bool,
+) -> bool {
+    use_runtime_cache && !no_unlock && !debug_assertions
+}
+
+/// If `CLUD_USE_RUNTIME_CACHE=1` is set, ensure this clud binary is
+/// cached under `~/.clud/runtime/clud-<version>/` and re-exec from
+/// there before normal startup work begins.
+///
+/// Returns normally only when the hop is disabled, the current process
+/// is already running from the runtime cache, or preparing/spawning the
+/// cached binary fails. On a successful hop this function replaces the
+/// process on Unix, or waits for the child and exits with its status on
+/// Windows.
+pub fn hop_to_runtime_cache_if_enabled() -> io::Result<()> {
+    if !runtime_cache_hop_enabled() {
+        return Ok(());
+    }
+
+    let current_exe = std::env::current_exe()?;
+    if exe_is_under_clud_runtime(&current_exe) {
+        return Ok(());
+    }
+
+    let cached = prepare_cached_clud(&current_exe)?;
+    if paths_equivalent(&current_exe, &cached) {
+        return Ok(());
+    }
+
+    reexec_from_cached_binary(&cached)
+}
+
+fn paths_equivalent(a: &Path, b: &Path) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+fn reexec_from_cached_binary(cached: &Path) -> io::Result<()> {
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = Command::new(cached).args(&args).exec();
+        Err(err)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let status = Command::new(cached).args(&args).status()?;
+        std::process::exit(status.code().unwrap_or(1));
+    }
 }
 
 /// True if `exe` resolves into a path under `~/.clud/runtime/`.
@@ -198,6 +274,26 @@ mod tests {
         let path = cached_clud_path().expect("home dir resolvable");
         let dir = runtime_cache_dir().expect("home dir resolvable");
         assert_eq!(path, dir.join(cached_clud_binary_name()));
+    }
+
+    #[test]
+    fn runtime_cache_hop_enabled_requires_opt_in() {
+        assert!(!runtime_cache_hop_enabled_from_vars(false, false, false));
+    }
+
+    #[test]
+    fn runtime_cache_hop_enabled_respects_existing_unlock_escape_hatch() {
+        assert!(!runtime_cache_hop_enabled_from_vars(true, true, false));
+    }
+
+    #[test]
+    fn runtime_cache_hop_enabled_stays_off_for_debug_builds() {
+        assert!(!runtime_cache_hop_enabled_from_vars(true, false, true));
+    }
+
+    #[test]
+    fn runtime_cache_hop_enabled_when_opted_in_without_escape_hatch() {
+        assert!(runtime_cache_hop_enabled_from_vars(true, false, false));
     }
 
     #[test]

--- a/crates/clud-bin/src/runtime_cache.rs
+++ b/crates/clud-bin/src/runtime_cache.rs
@@ -23,7 +23,6 @@ use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use fs4::fs_std::FileExt;
 
@@ -127,15 +126,54 @@ fn reexec_from_cached_binary(cached: &Path) -> io::Result<()> {
 
     #[cfg(unix)]
     {
-        use std::os::unix::process::CommandExt;
-        let err = Command::new(cached).args(&args).exec();
-        Err(err)
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let mut argv = Vec::with_capacity(args.len() + 1);
+        argv.push(
+            CString::new(cached.as_os_str().as_bytes())
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?,
+        );
+        for arg in args {
+            argv.push(
+                CString::new(arg.as_os_str().as_bytes())
+                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?,
+            );
+        }
+        let mut argv_ptrs = argv.iter().map(|arg| arg.as_ptr()).collect::<Vec<_>>();
+        argv_ptrs.push(std::ptr::null());
+
+        unsafe {
+            libc::execv(argv[0].as_ptr(), argv_ptrs.as_ptr());
+        }
+        Err(io::Error::last_os_error())
     }
 
     #[cfg(not(unix))]
     {
-        let status = Command::new(cached).args(&args).status()?;
-        std::process::exit(status.code().unwrap_or(1));
+        use running_process::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+
+        let mut argv = Vec::with_capacity(args.len() + 1);
+        argv.push(cached.as_os_str().to_string_lossy().into_owned());
+        argv.extend(
+            args.into_iter()
+                .map(|arg| arg.to_string_lossy().into_owned()),
+        );
+
+        let process = NativeProcess::new(ProcessConfig {
+            command: CommandSpec::Argv(argv),
+            cwd: None,
+            env: None,
+            capture: false,
+            stderr_mode: StderrMode::Stdout,
+            creationflags: None,
+            create_process_group: false,
+            stdin_mode: StdinMode::Inherit,
+            nice: None,
+        });
+        process.start().map_err(io::Error::other)?;
+        let code = process.wait(None).map_err(io::Error::other)?;
+        std::process::exit(code);
     }
 }
 
@@ -179,8 +217,7 @@ pub fn exe_is_under_runtime_root(exe: &Path, runtime_root: &Path) -> bool {
 /// see "doesn't exist" or "fully written," never a partial file.
 ///
 /// Returns the cached path on success. Pure I/O — does not re-exec
-/// or otherwise modify the current process. The re-exec hop is
-/// Phase 2 and lives in a separate PR.
+/// or otherwise modify the current process.
 pub fn prepare_cached_clud(source: &Path) -> io::Result<PathBuf> {
     let cached = cached_clud_path().ok_or_else(|| {
         io::Error::new(

--- a/crates/clud-bin/src/trampoline.rs
+++ b/crates/clud-bin/src/trampoline.rs
@@ -18,6 +18,8 @@
 use std::fs;
 use std::path::Path;
 
+use crate::runtime_cache;
+
 /// Spawn the current executable as a detached background process.
 ///
 /// On Windows, takes care to prevent the detached child from inheriting our
@@ -156,6 +158,9 @@ pub fn unlock_exe() {
         Ok(p) => p,
         Err(_) => return,
     };
+    if runtime_cache::exe_is_under_clud_runtime(&my_exe) {
+        return;
+    }
 
     // Rename clud.exe → clud.exe.old.<rand>. We keep running from the renamed file.
     let rand_id: u32 = std::process::id()


### PR DESCRIPTION
## Summary

- Wire the canonical per-version runtime cache into startup behind `CLUD_USE_RUNTIME_CACHE=1`.
- Keep `CLUD_NO_UNLOCK=1` as the escape hatch for both the cache hop and legacy unlock path.
- Skip the cache hop for debug builds so dev binaries do not populate `~/.clud/runtime`.
- Short-circuit the Windows `unlock_exe()` trampoline once clud is already running from the runtime cache.

## Tracking

Refs #342
Refs #333

This does not close #342; the burndown meta stays open until all linked items are closed or explicitly superseded.

## Tests

- `soldr cargo fmt --check` passed.
- `soldr cargo build -p clud` blocked before Cargo started by zackees/soldr#741 (`private daemon cache dir mismatch: connected to ...\\v1.12.7, requested ...`).
- `soldr cargo test -p clud runtime_cache -- --test-threads=1` blocked by the same zackees/soldr#741 issue before Cargo started.