### PR TITLE
feat(pty): intercept Ctrl+V image paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,9 +382,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "clud"
 version = "2.1.0"
 dependencies = [
+ "arboard",
  "base64",
  "clap",
  "cpal",
@@ -570,6 +600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +795,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -874,6 +922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +972,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1089,6 +1158,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -1575,6 +1645,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-audio-toolbox"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1705,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,7 +1729,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1644,6 +1741,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -1953,6 +2061,12 @@ dependencies = [
  "ref-cast",
  "wide",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2575,6 +2689,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "tiny_http"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,6 +3079,12 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
@@ -3551,6 +3685,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,6 +3722,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 description = "Fast CLI for running Claude Code and Codex in YOLO mode"
 
 [dependencies]
+arboard = "3"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"

--- a/crates/clud-bin/src/console_input.rs
+++ b/crates/clud-bin/src/console_input.rs
@@ -49,9 +49,15 @@
 /// link-time dependency on `windows-sys`.
 pub const VK_RETURN: u16 = 0x0D;
 
+/// Windows virtual-key code for V. Ctrl+V is the clipboard-paste chord.
+pub const VK_V: u16 = 0x56;
+
 /// `KEY_EVENT_RECORD::dwControlKeyState` bit for Left- or Right-Shift.
 /// Mirrors `wincon.h`'s `SHIFT_PRESSED`.
 pub const SHIFT_PRESSED: u32 = 0x0010;
+
+/// `KEY_EVENT_RECORD::dwControlKeyState` bits for Left- or Right-Ctrl.
+pub const CTRL_PRESSED: u32 = 0x0004 | 0x0008;
 
 /// Subset of `KEY_EVENT_RECORD` the translator needs. Tests construct
 /// these directly without going through Windows APIs.
@@ -83,6 +89,15 @@ pub enum InputEvent {
 /// written to the child PTY's stdin. See the module-level docstring
 /// for the translation rules.
 pub fn translate(events: &[InputEvent]) -> Vec<u8> {
+    translate_with_clipboard(events, || {
+        crate::paste_image::handle_clipboard().ok().flatten()
+    })
+}
+
+pub fn translate_with_clipboard<F>(events: &[InputEvent], mut handle_clipboard: F) -> Vec<u8>
+where
+    F: FnMut() -> Option<Vec<u8>>,
+{
     let mut out = Vec::new();
     for event in events {
         let key = match event {
@@ -94,6 +109,12 @@ pub fn translate(events: &[InputEvent]) -> Vec<u8> {
             let shift = (key.control_key_state & SHIFT_PRESSED) != 0;
             out.push(if shift { b'\n' } else { b'\r' });
             continue;
+        }
+        if key.virtual_key_code == VK_V && (key.control_key_state & CTRL_PRESSED) != 0 {
+            if let Some(bytes) = handle_clipboard() {
+                out.extend_from_slice(&bytes);
+                continue;
+            }
         }
         // Regular char key. `unicode_char` is one UTF-16 code unit; for
         // BMP keys that's the full character. Surrogate pairs from
@@ -450,6 +471,20 @@ mod tests {
             key_down(VK_RETURN, b'\r' as u16, 0),
         ];
         assert_eq!(translate(&events), b"hi\nm\r");
+    }
+
+    #[test]
+    fn ctrl_v_uses_clipboard_image_bytes_when_available() {
+        let events = [key_down(VK_V, 0x16, CTRL_PRESSED)];
+        let bytes = translate_with_clipboard(&events, || Some(b"C:\\tmp\\paste.png\n".to_vec()));
+        assert_eq!(bytes, b"C:\\tmp\\paste.png\n");
+    }
+
+    #[test]
+    fn ctrl_v_falls_through_to_control_byte_when_clipboard_unavailable() {
+        let events = [key_down(VK_V, 0x16, CTRL_PRESSED)];
+        let bytes = translate_with_clipboard(&events, || None);
+        assert_eq!(bytes, vec![0x16]);
     }
 
     // ---------- from_input_record tests ----------

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -26,6 +26,7 @@ pub mod loop_artifacts;
 pub mod loop_check;
 pub mod loop_spec;
 pub mod orphan_reaper;
+pub mod paste_image;
 pub mod process_tree;
 pub mod runner;
 pub mod runtime_cache;

--- a/crates/clud-bin/src/paste_image.rs
+++ b/crates/clud-bin/src/paste_image.rs
@@ -1,0 +1,106 @@
+//! Clipboard paste helpers for PTY-mode Ctrl+V interception (#328).
+
+use std::borrow::Cow;
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub fn handle_clipboard() -> io::Result<Option<Vec<u8>>> {
+    let mut clipboard = arboard::Clipboard::new()
+        .map_err(|err| io::Error::other(format!("open clipboard: {err}")))?;
+    let image = match clipboard.get_image() {
+        Ok(image) => image,
+        Err(_) => return Ok(None),
+    };
+    let path = write_clipboard_png(image.width, image.height, image.bytes.as_ref())?;
+    Ok(Some(path_to_pty_bytes(&path)))
+}
+
+pub fn expand_ctrl_v_bytes<F>(chunk: &[u8], mut handle_clipboard: F) -> Cow<'_, [u8]>
+where
+    F: FnMut() -> Option<Vec<u8>>,
+{
+    if !chunk.contains(&CTRL_V) {
+        return Cow::Borrowed(chunk);
+    }
+    let mut out = Vec::with_capacity(chunk.len());
+    for &byte in chunk {
+        if byte == CTRL_V {
+            if let Some(bytes) = handle_clipboard() {
+                out.extend_from_slice(&bytes);
+            } else {
+                out.push(CTRL_V);
+            }
+        } else {
+            out.push(byte);
+        }
+    }
+    Cow::Owned(out)
+}
+
+pub fn write_clipboard_png(width: usize, height: usize, rgba: &[u8]) -> io::Result<PathBuf> {
+    let width_u32 = u32::try_from(width)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "clipboard image too wide"))?;
+    let height_u32 = u32::try_from(height)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "clipboard image too tall"))?;
+    let image =
+        image::RgbaImage::from_raw(width_u32, height_u32, rgba.to_vec()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "clipboard image byte count does not match dimensions",
+            )
+        })?;
+    let dir = std::env::temp_dir().join("clud-clipboard");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(unique_png_name());
+    image
+        .save_with_format(&path, image::ImageFormat::Png)
+        .map_err(|err| io::Error::other(format!("write clipboard png: {err}")))?;
+    Ok(path)
+}
+
+fn path_to_pty_bytes(path: &Path) -> Vec<u8> {
+    let mut bytes = path.to_string_lossy().into_owned().into_bytes();
+    bytes.push(b'\n');
+    bytes
+}
+
+fn unique_png_name() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("paste-{}-{nanos}.png", std::process::id())
+}
+
+const CTRL_V: u8 = 0x16;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_ctrl_v_replaces_marker_when_clipboard_has_bytes() {
+        let expanded = expand_ctrl_v_bytes(b"a\x16b", || Some(b"image.png\n".to_vec()));
+        assert_eq!(expanded.as_ref(), b"aimage.png\nb");
+    }
+
+    #[test]
+    fn expand_ctrl_v_falls_through_when_clipboard_unavailable() {
+        let expanded = expand_ctrl_v_bytes(b"a\x16b", || None);
+        assert_eq!(expanded.as_ref(), b"a\x16b");
+    }
+
+    #[test]
+    fn expand_ctrl_v_borrows_chunks_without_marker() {
+        let expanded = expand_ctrl_v_bytes(b"abc", || Some(b"unused".to_vec()));
+        assert!(matches!(expanded, Cow::Borrowed(_)));
+        assert_eq!(expanded.as_ref(), b"abc");
+    }
+
+    #[test]
+    fn write_clipboard_png_rejects_bad_rgba_len() {
+        let err = write_clipboard_png(2, 2, &[0, 0, 0]).expect_err("bad len");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+}

--- a/crates/clud-bin/src/session.rs
+++ b/crates/clud-bin/src/session.rs
@@ -744,18 +744,26 @@ where
         if let Ok(chunk) = stdin_rx.try_recv() {
             let requested_interrupt =
                 interrupt_on_ctrl_c_byte && stdin_chunk_requests_interrupt(&chunk);
+            let chunk = if interactive_real_stdin {
+                crate::paste_image::expand_ctrl_v_bytes(&chunk, || {
+                    crate::paste_image::handle_clipboard().ok().flatten()
+                })
+            } else {
+                std::borrow::Cow::Borrowed(chunk.as_slice())
+            };
             // Run the bracketed-paste normalizer over the chunk BEFORE
             // forwarding to the PTY. Non-paste bytes pass through with
             // O(1) state cost (just a 6-byte prefix matcher); paste
             // bodies are buffered and rewritten in place.
-            let outgoing = paste.process(&chunk);
+            let outgoing = paste.process(chunk.as_ref());
             if let Err(err) = process.write_impl(&outgoing, false) {
                 eprintln!("[clud] warning: failed to forward stdin to pty: {}", err);
             } else if hooks.intercept_f3() {
-                // F3 detection still runs over the ORIGINAL chunk: a
-                // press inside a paste body is unusual but we want
-                // detection symmetry with raw byte forwarding.
-                let events = observer.observe(&chunk);
+                // F3 detection runs over the outgoing user input after
+                // Ctrl+V image expansion but before any backend write
+                // side effects. A press inside paste text is unusual but
+                // should keep detection symmetry with raw forwarding.
+                let events = observer.observe(chunk.as_ref());
                 let mut sink = NativePtyProcessSink::new(process);
                 for _ in 0..events.presses {
                     if let Err(err) = hooks.on_f3_press(&mut sink) {


### PR DESCRIPTION
## Summary

- Add a `paste_image` helper that reads clipboard image bytes with `arboard`, writes a temporary PNG under the system temp dir, and returns the path bytes for PTY injection.
- Extend Windows `console_input` translation so Ctrl+V (`VK_V` + Ctrl) injects the clipboard image path when an image is available and falls through to the normal `0x16` byte when clipboard access/text-only paste is unavailable.
- Expand `0x16` in the interactive PTY stdin byte stream, covering POSIX-style terminals while leaving piped/non-interactive stdin byte-for-byte unchanged.

## Tracking

Refs #328
Refs #342

This is a Ctrl+V interception slice for PTY mode. It does not close #328: the final Windows+Claude default flip still depends on the launch-mode audit from PR #345, and broader docs/default-path work remains.

## Tests

- `soldr cargo fmt --check`
- `python ci/banned_imports.py`
- `soldr cargo test -p clud paste_image -- --test-threads=1` was blocked before Cargo by the local soldr/zccache private cache-dir mismatch.
- `soldr cargo test -p clud console_input -- --test-threads=1` was blocked by the same local soldr/zccache issue.
- `soldr --no-cache cargo test -p clud paste_image -- --test-threads=1` passed: 4 tests.
- `soldr --no-cache cargo test -p clud console_input -- --test-threads=1` passed: 16 tests.
- `soldr --no-cache cargo clippy -p clud --all-targets -- -D warnings`