### PR TITLE
feat(orphan-reaper): detect-and-slay env-tagged descendants on clud exit (#340)

### DIFF
--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -42,7 +42,7 @@ redb = "2"
 # the redb-open window to a few milliseconds at startup/shutdown so
 # concurrent launches serialize cleanly.
 fs4 = "0.13"
-running-process = { version = "4.3.0", default-features = false, features = ["telemetry", "client"] }
+running-process = { version = "4.3.0", default-features = false, features = ["telemetry", "client", "originator-scan"] }
 # running-process consumer adoption (upstream #385): the daemon's broker
 # v1 frame lane binds a local-socket endpoint (named pipe on Windows,
 # unix socket elsewhere) alongside the legacy TCP listener. Pinned to
@@ -82,7 +82,7 @@ tempfile = "3"
 # Cargo unifies this dev-dep feature into the test harness but NOT into
 # `cargo build --bin clud`, so the production binary stays seam-free per
 # the upstream rule ("never compiled into production consumers").
-running-process = { version = "4.3.0", default-features = false, features = ["telemetry", "client", "test-seams"] }
+running-process = { version = "4.3.0", default-features = false, features = ["telemetry", "client", "originator-scan", "test-seams"] }
 
 [build-dependencies]
 prost-build = "0.14"

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -138,6 +138,21 @@ pub struct Args {
     #[arg(long = "no-daemon")]
     pub no_daemon: bool,
 
+    /// Issue #340: keep env-tagged orphaned descendants alive on exit
+    /// (skip the auto-reap; still prints the report unless --quiet-orphans).
+    #[arg(long = "keep-orphans")]
+    pub keep_orphans: bool,
+
+    /// Issue #340: suppress the orphan-reaper surprise report on exit.
+    /// Reaping still happens unless --keep-orphans is also set.
+    #[arg(long = "quiet-orphans")]
+    pub quiet_orphans: bool,
+
+    /// Issue #340: dump the relevant env vars for each detected orphan
+    /// alongside the report, to help author allowlist rules.
+    #[arg(long = "explain-orphans")]
+    pub explain_orphans: bool,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 
@@ -376,6 +391,9 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--yes",
         "--force",
         "--no-daemon",
+        "--keep-orphans",
+        "--quiet-orphans",
+        "--explain-orphans",
         "--json",
         "--no-open",
         "--demo-gfx-sixel",

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -678,6 +678,9 @@ mod tests {
             daemon_state_dir: None,
             daemon_mode: None,
             no_daemon: false,
+            keep_orphans: false,
+            quiet_orphans: false,
+            explain_orphans: false,
             command: None,
             passthrough: Vec::new(),
         };

--- a/crates/clud-bin/src/hook_health/prompts.rs
+++ b/crates/clud-bin/src/hook_health/prompts.rs
@@ -198,6 +198,9 @@ pub(in crate::hook_health) fn run_backend_prompt(
         daemon_state_dir: None,
         daemon_mode: None,
         no_daemon: true,
+        keep_orphans: false,
+        quiet_orphans: false,
+        explain_orphans: false,
         command: None,
         passthrough: args.passthrough.clone(),
     };

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -25,6 +25,7 @@ pub mod launch_setup;
 pub mod loop_artifacts;
 pub mod loop_check;
 pub mod loop_spec;
+pub mod orphan_reaper;
 pub mod process_tree;
 pub mod runner;
 pub mod runtime_cache;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,8 +1,8 @@
 use clud::{
     args, backend, backend_bootstrap, clud_settings, command, console_setup, console_title,
     ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard, launch_setup,
-    loop_artifacts, loop_spec, runner, runtime_cache, startup, trampoline, trash, ui, verbose_log,
-    wasm, worktrees,
+    loop_artifacts, loop_spec, orphan_reaper, runner, runtime_cache, startup, trampoline, trash,
+    ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -511,6 +511,24 @@ fn main() {
     drop(_scanner_guard);
     drop(_session_guard);
     drop(_dnd_subprocess_guard);
+    // Issue #340: detect env-tagged orphans we are about to leave behind and
+    // (unless --keep-orphans) reap them. Skip for detached / detachable
+    // sessions — those descendants are intentionally outliving us and are
+    // owned by the daemon now.
+    if !args.detach && !args.detachable {
+        let opts = orphan_reaper::ReapOpts {
+            keep: args.keep_orphans,
+            quiet: args.quiet_orphans,
+            explain: args.explain_orphans,
+        };
+        let outcome = orphan_reaper::scan_and_report(std::process::id(), &opts);
+        if args.verbose && outcome.found > 0 {
+            verbose_log::log(format_args!(
+                "[clud] orphan reaper: found={} reaped={}",
+                outcome.found, outcome.reaped
+            ));
+        }
+    }
     if args.verbose {
         verbose_log::log(format_args!("[clud] exit: code {exit_code}"));
     }

--- a/crates/clud-bin/src/orphan_reaper.rs
+++ b/crates/clud-bin/src/orphan_reaper.rs
@@ -1,0 +1,408 @@
+//! Issue #340: detect and reap env-tagged orphaned descendants on clud exit.
+//!
+//! The `running-process` crate stamps every spawned descendant with
+//! `RUNNING_PROCESS_ORIGINATOR=CLUD:<pid>` so we can find them later via
+//! [`running_process::originator::find_processes_by_originator`]. This module
+//! consumes that tag at the *end* of a foreground `clud` invocation: it walks
+//! the descendant set whose `parent_pid` is *this* process, classifies each by
+//! cmdline shape (so the report reads "vite preview port=5173" instead of a
+//! 180-char path), prints a one-shot "surprise orphan" listing, then
+//! terminates them via [`crate::process_tree::kill_tree`].
+//!
+//! Default-on. Suppress per-knob:
+//!
+//! - `--keep-orphans`: list, but do not kill
+//! - `--quiet-orphans`: kill, but do not list
+//! - `--explain-orphans`: include each descendant's relevant env vars
+//!
+//! Detached / handover paths (`--detach`, `--detachable`) skip the reaper
+//! entirely — those descendants are intentionally outliving the foreground
+//! `clud` per (6) in the issue. The caller is responsible for that gate.
+
+use std::collections::BTreeMap;
+
+use crate::process_tree;
+
+/// Caller-controlled knobs for the reaper. Filled in from the parsed CLI args
+/// at the exit-hook site in `main.rs`.
+#[derive(Debug, Clone, Default)]
+pub struct ReapOpts {
+    /// `--keep-orphans`: list them, do not kill.
+    pub keep: bool,
+    /// `--quiet-orphans`: kill silently.
+    pub quiet: bool,
+    /// `--explain-orphans`: dump each descendant's classification-relevant
+    /// env vars beneath its row.
+    pub explain: bool,
+}
+
+/// Result returned by [`scan_and_report`]. Useful for tests and for the
+/// summary log line in `main.rs`.
+#[derive(Debug, Clone, Default)]
+pub struct ReapOutcome {
+    /// Number of descendants found whose `parent_pid` is `self_pid`.
+    pub found: usize,
+    /// Number we actually terminated.
+    pub reaped: usize,
+}
+
+/// One descendant's view, pre-classification.
+struct Descendant {
+    pid: u32,
+    name: String,
+    command: String,
+}
+
+/// Coarse cmdline-shape label. The classifier table is the heart of the
+/// "what is it likely?" answer; expand cases as we observe new leak shapes
+/// in the wild.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Shape {
+    VitePreview {
+        port: Option<String>,
+    },
+    ViteDev {
+        port: Option<String>,
+    },
+    OpenAiCodex,
+    ClaudeCode,
+    PyrightLangserver,
+    Pm2,
+    NpmRunPreview,
+    NpmRunDev,
+    NodejsWheelShim,
+    /// Catch-all: `name + first-arg-basename`.
+    Generic {
+        label: String,
+    },
+}
+
+impl Shape {
+    fn label(&self) -> String {
+        match self {
+            Shape::VitePreview { port } => match port {
+                Some(p) => format!("vite preview port={p}"),
+                None => "vite preview".to_string(),
+            },
+            Shape::ViteDev { port } => match port {
+                Some(p) => format!("vite dev port={p}"),
+                None => "vite dev".to_string(),
+            },
+            Shape::OpenAiCodex => "openai codex".to_string(),
+            Shape::ClaudeCode => "claude-code".to_string(),
+            Shape::PyrightLangserver => "pyright-langserver".to_string(),
+            Shape::Pm2 => "pm2".to_string(),
+            Shape::NpmRunPreview => "npm run preview".to_string(),
+            Shape::NpmRunDev => "npm run dev".to_string(),
+            Shape::NodejsWheelShim => "node (nodejs_wheel shim)".to_string(),
+            Shape::Generic { label } => label.clone(),
+        }
+    }
+}
+
+fn classify(name: &str, command: &str) -> Shape {
+    let cmd_lc = command.to_ascii_lowercase();
+    let name_lc = name.to_ascii_lowercase();
+
+    let port = extract_port(command);
+
+    if cmd_lc.contains("vite.js") && cmd_lc.contains("preview") {
+        return Shape::VitePreview { port };
+    }
+    if cmd_lc.contains("vite.js") || cmd_lc.contains("\\vite\\bin") || cmd_lc.contains("/vite/bin")
+    {
+        return Shape::ViteDev { port };
+    }
+    if cmd_lc.contains("codex.js") {
+        return Shape::OpenAiCodex;
+    }
+    if cmd_lc.contains("claude-code") || cmd_lc.contains("@anthropic-ai/claude-code") {
+        return Shape::ClaudeCode;
+    }
+    if cmd_lc.contains("pyright-langserver") || cmd_lc.contains("pyright/dist/langserver") {
+        return Shape::PyrightLangserver;
+    }
+    if cmd_lc.contains("pm2") {
+        return Shape::Pm2;
+    }
+    if name_lc == "npm.exe" || name_lc == "npm" {
+        if cmd_lc.contains(" preview") || cmd_lc.contains("\tpreview") {
+            return Shape::NpmRunPreview;
+        }
+        if cmd_lc.contains(" dev") || cmd_lc.contains("\tdev") {
+            return Shape::NpmRunDev;
+        }
+    }
+    if cmd_lc.contains("nodejs_wheel") {
+        return Shape::NodejsWheelShim;
+    }
+
+    // Fallback: name + first non-flag arg basename, so users still get a
+    // readable row instead of a raw path dump.
+    let first_arg = command
+        .split_whitespace()
+        .skip(1)
+        .find(|a| !a.starts_with('-'))
+        .unwrap_or("");
+    let basename = first_arg.rsplit(['/', '\\']).next().unwrap_or("");
+    let label = if basename.is_empty() {
+        name.to_string()
+    } else {
+        format!("{name}  {basename}")
+    };
+    Shape::Generic { label }
+}
+
+/// Extract a `--port N` (or `--port=N`) value from a command line. Returns
+/// `None` if not present or not numeric.
+fn extract_port(command: &str) -> Option<String> {
+    let mut tokens = command.split_whitespace();
+    while let Some(tok) = tokens.next() {
+        if let Some(eq_value) = tok.strip_prefix("--port=") {
+            if !eq_value.is_empty() && eq_value.chars().all(|c| c.is_ascii_digit()) {
+                return Some(eq_value.to_string());
+            }
+        }
+        if tok == "--port" {
+            if let Some(next) = tokens.next() {
+                if !next.is_empty() && next.chars().all(|c| c.is_ascii_digit()) {
+                    return Some(next.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Scan, classify, report, and (unless `opts.keep`) reap orphans whose
+/// originator-PID is `self_pid`.
+///
+/// This is the public entry point called from `main.rs` right before the
+/// foreground process exits. Returns counts for the caller's summary log.
+pub fn scan_and_report(self_pid: u32, opts: &ReapOpts) -> ReapOutcome {
+    let all = running_process::originator::find_processes_by_originator("CLUD");
+
+    // Only act on descendants whose originator points at *us*. Anything
+    // pointing at a different CLUD:<pid> belongs to a concurrent clud
+    // invocation and is not ours to touch.
+    let mine: Vec<Descendant> = all
+        .into_iter()
+        .filter(|p| p.parent_pid == self_pid)
+        .map(|p| Descendant {
+            pid: p.pid,
+            name: p.name,
+            command: p.command,
+        })
+        .collect();
+
+    let found = mine.len();
+    if found == 0 {
+        return ReapOutcome::default();
+    }
+
+    // Group by shape label so the report collapses N identical leaks into
+    // a single row with a list of PIDs/ports.
+    let mut by_label: BTreeMap<String, Vec<&Descendant>> = BTreeMap::new();
+    let classified: Vec<(Shape, &Descendant)> = mine
+        .iter()
+        .map(|d| (classify(&d.name, &d.command), d))
+        .collect();
+    for (shape, d) in &classified {
+        by_label.entry(shape.label()).or_default().push(*d);
+    }
+
+    if !opts.quiet {
+        let action_word = if opts.keep {
+            "(--keep-orphans set, leaving alive)"
+        } else {
+            "(reaping)"
+        };
+        eprintln!(
+            "[clud] orphan scan on exit (originator=CLUD:{self_pid}): \
+             {found} env-tagged descendant(s) {action_word}"
+        );
+        for (label, ds) in &by_label {
+            let pids: Vec<String> = ds.iter().map(|d| d.pid.to_string()).collect();
+            eprintln!(
+                "         {count}x  {label:<30}  pids=[{joined}]",
+                count = ds.len(),
+                label = label,
+                joined = pids.join(", "),
+            );
+            if opts.explain {
+                for d in ds {
+                    let cmd_display = if d.command.len() > 140 {
+                        format!("{}...", &d.command[..137])
+                    } else {
+                        d.command.clone()
+                    };
+                    eprintln!("            pid={:<7} {}", d.pid, cmd_display);
+                }
+            }
+        }
+    }
+
+    if opts.keep {
+        return ReapOutcome { found, reaped: 0 };
+    }
+
+    let mut reaped = 0usize;
+    for d in &mine {
+        process_tree::kill_tree(d.pid);
+        reaped += 1;
+    }
+
+    if !opts.quiet {
+        eprintln!("[clud] reaped {reaped} of {found} env-tagged descendant(s)");
+    }
+
+    ReapOutcome { found, reaped }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_vite_preview_with_port() {
+        let cmd =
+            "node C:\\Users\\x\\node_modules\\.bin\\..\\vite\\bin\\vite.js preview --port 8081";
+        assert_eq!(
+            classify("node.exe", cmd),
+            Shape::VitePreview {
+                port: Some("8081".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn classify_vite_preview_without_port() {
+        let cmd = "node vite.js preview";
+        assert_eq!(classify("node.exe", cmd), Shape::VitePreview { port: None });
+    }
+
+    #[test]
+    fn classify_vite_dev() {
+        let cmd = "node /usr/local/lib/node_modules/.bin/../vite/bin/vite.js --port=5173";
+        assert_eq!(
+            classify("node", cmd),
+            Shape::ViteDev {
+                port: Some("5173".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn classify_codex() {
+        let cmd = "node /home/user/.npm/lib/codex.js --bypass";
+        assert_eq!(classify("node", cmd), Shape::OpenAiCodex);
+    }
+
+    #[test]
+    fn classify_claude_code_cli() {
+        let cmd =
+            "C:\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe --dangerously-skip-permissions";
+        assert_eq!(classify("claude.exe", cmd), Shape::ClaudeCode);
+    }
+
+    #[test]
+    fn classify_pyright_langserver_python_shim() {
+        let cmd = "python.exe Scripts\\pyright-langserver.exe --stdio";
+        assert_eq!(classify("python.exe", cmd), Shape::PyrightLangserver);
+    }
+
+    #[test]
+    fn classify_pyright_langserver_node_side() {
+        let cmd = "node pyright/dist/langserver.index.js -- --stdio";
+        assert_eq!(classify("node", cmd), Shape::PyrightLangserver);
+    }
+
+    #[test]
+    fn classify_pm2() {
+        let cmd = "node pm2-beta/lib/Daemon.js";
+        assert_eq!(classify("node", cmd), Shape::Pm2);
+    }
+
+    #[test]
+    fn classify_npm_run_preview() {
+        let cmd = "C:\\Scripts\\npm.exe run preview -- --port 9090";
+        assert_eq!(classify("npm.exe", cmd), Shape::NpmRunPreview);
+    }
+
+    #[test]
+    fn classify_npm_run_dev() {
+        let cmd = "C:\\Scripts\\npm.exe run dev";
+        assert_eq!(classify("npm.exe", cmd), Shape::NpmRunDev);
+    }
+
+    #[test]
+    fn classify_nodejs_wheel_shim() {
+        let cmd = "C:\\tools\\python13\\Lib\\site-packages\\nodejs_wheel\\node.exe some-script.js";
+        assert_eq!(classify("node.exe", cmd), Shape::NodejsWheelShim);
+    }
+
+    #[test]
+    fn classify_generic_falls_back_to_name_and_basename() {
+        let cmd = "/usr/bin/some-thing /home/u/work/script.sh --arg1";
+        match classify("some-thing", cmd) {
+            Shape::Generic { label } => assert!(
+                label.contains("some-thing") && label.contains("script.sh"),
+                "got {label:?}"
+            ),
+            other => panic!("expected Generic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_port_space_form() {
+        assert_eq!(
+            extract_port("vite preview --port 8081 --host"),
+            Some("8081".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_port_equals_form() {
+        assert_eq!(extract_port("vite --port=5173"), Some("5173".to_string()));
+    }
+
+    #[test]
+    fn extract_port_none() {
+        assert_eq!(extract_port("vite preview"), None);
+    }
+
+    #[test]
+    fn extract_port_non_numeric_ignored() {
+        assert_eq!(extract_port("vite --port=abc"), None);
+    }
+
+    #[test]
+    fn shape_label_includes_port_when_present() {
+        assert_eq!(
+            Shape::VitePreview {
+                port: Some("8082".into())
+            }
+            .label(),
+            "vite preview port=8082"
+        );
+        assert_eq!(Shape::VitePreview { port: None }.label(), "vite preview");
+    }
+
+    #[test]
+    fn scan_finds_nothing_when_no_descendants_match_self_pid() {
+        // Pick a PID that is overwhelmingly unlikely to be a real CLUD originator
+        // on the test host. Even if a real clud session were running, its
+        // originator is its own PID, which is not u32::MAX. The scan returns
+        // a default outcome (0/0) without touching anything.
+        let outcome = scan_and_report(
+            u32::MAX,
+            &ReapOpts {
+                keep: true,
+                quiet: true,
+                explain: false,
+            },
+        );
+        assert_eq!(outcome.found, 0);
+        assert_eq!(outcome.reaped, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the MVP for the orphan-detect-and-slay feature requested in #340. On clud exit, walks descendants whose `RUNNING_PROCESS_ORIGINATOR=CLUD:<pid>` points at this clud, classifies each by cmdline shape (so the report reads "vite preview port=8081" instead of a 180-char path), prints a grouped surprise report, and terminates them via `process_tree::kill_tree`.

Default-on per the user's direction: we'd rather show one extra line on exit than ship another 107-orphan workstation discovery week.

## What's in this PR

- **New module** `crates/clud-bin/src/orphan_reaper.rs` — scan, classify, report, reap. 18 unit tests covering every cmdline-shape rule and the port extractor.
- **New flags** in `args.rs`:
  - `--keep-orphans` — list but do not kill
  - `--quiet-orphans` — kill but do not list
  - `--explain-orphans` — include each descendant's full cmdline beneath its row
- **Exit hook** in `main.rs` right before `std::process::exit`, after all guards drop. Skipped when `--detach` or `--detachable` is set (those descendants are intentionally outliving us and owned by the daemon, per (6) in #340).
- **Feature flag** `originator-scan` enabled on the running-process dep (both production and test-seams variants).
- Construction-site updates in `daemon/entry.rs` and `hook_health/prompts.rs` for the three new bool fields.

## Out of scope (deferred to follow-ups for #340)

- `clud ui` process-tree pane — requirement (1)
- Periodic daemon reaper for `RUNNING_PROCESS_ORIGINATOR=CLUD:<dead-pid>` — requirement (5)
- `~/.clud/expected-shapes.toml` user allowlist — refinement comment on #340
- Investigation of `JOB_OBJECT_LIMIT_BREAKAWAY_OK` in `running-process/spawn_imp_windows.rs:691` — requirement (3) lives in the other repo
- `--orphan-report=json`

## Sample output

```
[clud] orphan scan on exit (originator=CLUD:71584): 7 env-tagged descendant(s) (reaping)
         1x  claude-code                     pids=[59504]
         1x  npm run dev                     pids=[15004]
         1x  npm run preview                 pids=[47224]
         2x  pyright-langserver              pids=[86640, 70012]
         2x  vite preview port=8081          pids=[68548, 52744]
[clud] reaped 7 of 7 env-tagged descendant(s)
```

## Tests

- 18 new unit tests covering the classifier and port extractor
- `scan_finds_nothing_when_no_descendants_match_self_pid` smoke-tests the public entry against `u32::MAX` (no PID match) to confirm the safety filter

```
$ soldr cargo test -p clud --lib orphan_reaper
test result: ok. 18 passed; 0 failed; 0 ignored
```

## Safety notes

- The scan filters strictly by `parent_pid == std::process::id()` — a concurrent clud session's descendants are never touched.
- `--detach` / `--detachable` skip the reaper entirely. Detach is NOT a reap signal.
- `find_processes_by_originator` already does PID-reuse detection via `parent_alive` (start-time check). We use `parent_pid` as the filter rather than `parent_alive` because we are the parent — comparing the tagged value to our own PID is the authoritative check.
- `process_tree::kill_tree` is the same helper used for Ctrl+C teardown in `runner.rs`; it walks descendants leaves-first and is best-effort cross-platform.

Closes part of #340 (MVP for requirements 2 and 4 + cmdline classification from the refinement comment).
