### PR TITLE
[codex] add soldr optimize setup

### DIFF
--- a/.clud/settings.json
+++ b/.clud/settings.json
@@ -1,0 +1,9 @@
+{
+  "optimize": {
+    "rust": {
+      "install_soldr": true,
+      "soldr_version": "0.7.11",
+      "use_soldr_shims": true
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ coverage-*.xml
 .extern-repos/
 
 # clud loop state (GH issue cache, DONE/BLOCKED markers)
-.clud/
+.clud/*
 
 # Claude Code: ignore ephemeral session/cache state, keep project config
 # (settings + hooks + commands + agents + skills are checked in).
@@ -60,3 +60,7 @@ coverage-*.xml
 !.claude/agents/
 !.claude/skills/
 .claude/settings.local.json
+
+# clud project settings
+!.clud/
+!.clud/settings.json

--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -99,6 +99,8 @@ Process management and GC:
 - `worktrees.rs` - `--clean-worktrees` (issue #83): enumerates via
   `git worktree list --porcelain`, classifies clean / dirty / unpushed / gone,
   removes safe ones; `--dry-run` faithful.
+- `optimize.rs` - `clud optimize rust`: installs/persists soldr defaults and
+  writes repo-local `.clud/settings.json` directives.
 
 Platform glue:
 
@@ -149,6 +151,7 @@ Quick lookup, which file owns a given subcommand:
 - `clud gc list` / `purge` / `reconcile` -> `gc/cli.rs` (CLI handlers) talking to
   `daemon/gc_service.rs` (registry owner inside the always-on `__daemon`).
 - `clud --clean-worktrees` -> `worktrees.rs`.
+- `clud optimize rust` -> `optimize.rs`.
 - `clud --fix-hooks` -> `hook_health/`.
 
 ## Cross-Cutting Subsystems

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 use crate::graphics::GraphicsMode;
@@ -258,6 +258,41 @@ pub enum Command {
         #[arg(required = true, value_name = "PATH")]
         paths: Vec<PathBuf>,
     },
+    /// Install and persist fast local tooling defaults.
+    Optimize {
+        /// Toolchain family to optimize. Defaults to Rust.
+        #[arg(value_enum, default_value_t = OptimizeTarget::Rust)]
+        target: OptimizeTarget,
+        /// Persist the recommendation in ~/.clud/settings.toml.
+        #[arg(long = "global", conflicts_with = "repo")]
+        global: bool,
+        /// Write a repo-local .clud/settings.json directive.
+        #[arg(long = "repo", conflicts_with = "global")]
+        repo: bool,
+        /// Install soldr if it is missing from PATH.
+        #[arg(
+            long = "install-soldr",
+            default_value_t = true,
+            action = ArgAction::Set,
+            num_args = 0..=1,
+            default_missing_value = "true",
+            value_parser = clap::value_parser!(bool),
+        )]
+        install_soldr: bool,
+        /// Enable soldr shims for future clud-managed Rust setup.
+        #[arg(
+            long = "use-soldr-shims",
+            default_value_t = true,
+            action = ArgAction::Set,
+            num_args = 0..=1,
+            default_missing_value = "true",
+            value_parser = clap::value_parser!(bool),
+        )]
+        use_soldr_shims: bool,
+        /// soldr release version to install and persist.
+        #[arg(long = "soldr-version", default_value = "0.7.11")]
+        soldr_version: String,
+    },
     /// Control the always-on clud daemon.
     Daemon {
         #[command(subcommand)]
@@ -279,6 +314,12 @@ pub enum Command {
         #[arg(long = "spec-file")]
         spec_file: PathBuf,
     },
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptimizeTarget {
+    #[value(alias = "soldr")]
+    Rust,
 }
 
 /// Subcommands under `clud daemon`.
@@ -403,7 +444,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
         "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "ui",
-        "trash", "daemon", "__daemon", "__worker",
+        "trash", "optimize", "daemon", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/args_tests.rs
+++ b/crates/clud-bin/src/args_tests.rs
@@ -361,6 +361,72 @@ fn test_fix_subcommand() {
 }
 
 #[test]
+fn test_optimize_defaults_to_rust_global_soldr() {
+    let args = parse(&["clud", "optimize"]);
+    match args.command {
+        Some(Command::Optimize {
+            target,
+            global,
+            repo,
+            install_soldr,
+            use_soldr_shims,
+            ref soldr_version,
+        }) => {
+            assert_eq!(target, OptimizeTarget::Rust);
+            assert!(!global);
+            assert!(!repo);
+            assert!(install_soldr);
+            assert!(use_soldr_shims);
+            assert_eq!(soldr_version, "0.7.11");
+        }
+        other => panic!("expected Optimize subcommand, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_optimize_rust_repo_flags() {
+    let args = parse(&[
+        "clud",
+        "optimize",
+        "rust",
+        "--repo",
+        "--install-soldr=false",
+        "--use-soldr-shims=false",
+        "--soldr-version",
+        "1.2.3",
+    ]);
+    match args.command {
+        Some(Command::Optimize {
+            target,
+            global,
+            repo,
+            install_soldr,
+            use_soldr_shims,
+            ref soldr_version,
+        }) => {
+            assert_eq!(target, OptimizeTarget::Rust);
+            assert!(!global);
+            assert!(repo);
+            assert!(!install_soldr);
+            assert!(!use_soldr_shims);
+            assert_eq!(soldr_version, "1.2.3");
+        }
+        other => panic!("expected Optimize subcommand, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_optimize_soldr_alias_selects_rust() {
+    let args = parse(&["clud", "optimize", "soldr"]);
+    match args.command {
+        Some(Command::Optimize { target, .. }) => {
+            assert_eq!(target, OptimizeTarget::Rust);
+        }
+        other => panic!("expected Optimize subcommand, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_fix_with_url() {
     let args = parse(&[
         "clud",

--- a/crates/clud-bin/src/clud_settings.rs
+++ b/crates/clud-bin/src/clud_settings.rs
@@ -14,6 +14,23 @@ pub const CLUD_DIR_NAME: &str = ".clud";
 pub const SETTINGS_FILE_NAME: &str = "settings.toml";
 pub const LOCK_FILE_NAME: &str = "settings.lock";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RustOptimizeSettings {
+    pub use_soldr_shims: bool,
+    pub install_soldr: bool,
+    pub soldr_version: String,
+}
+
+impl Default for RustOptimizeSettings {
+    fn default() -> Self {
+        Self {
+            use_soldr_shims: true,
+            install_soldr: true,
+            soldr_version: "0.7.11".to_string(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum SettingsError {
     NoHomeDir,
@@ -197,6 +214,93 @@ pub fn save_launch_setup_scope_at(
     Ok(())
 }
 
+pub fn save_rust_optimize_settings(settings: &RustOptimizeSettings) -> Result<(), SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    save_rust_optimize_settings_at(&home, settings)
+}
+
+pub fn save_rust_optimize_settings_at(
+    home: &Path,
+    settings: &RustOptimizeSettings,
+) -> Result<(), SettingsError> {
+    let clud_dir = home.join(CLUD_DIR_NAME);
+    fs::create_dir_all(&clud_dir)?;
+    let lock_path = clud_dir.join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+
+    let path = settings_path_at(home);
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(SettingsError::Io(error)),
+    };
+    let mut document = if text.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        parse_settings(&path, &text)?
+    };
+
+    if document.get("optimize").and_then(Item::as_table).is_none() {
+        document["optimize"] = table();
+    }
+    if document["optimize"]
+        .get("rust")
+        .and_then(Item::as_table)
+        .is_none()
+    {
+        document["optimize"]["rust"] = table();
+    }
+    document["optimize"]["rust"]["use_soldr_shims"] = value(settings.use_soldr_shims);
+    document["optimize"]["rust"]["install_soldr"] = value(settings.install_soldr);
+    document["optimize"]["rust"]["soldr_version"] = value(settings.soldr_version.clone());
+
+    let mut body = document.to_string();
+    if !body.ends_with('\n') {
+        body.push('\n');
+    }
+    fs::write(path, body)?;
+    Ok(())
+}
+
+pub fn load_rust_optimize_settings_at(
+    home: &Path,
+) -> Result<Option<RustOptimizeSettings>, SettingsError> {
+    let path = settings_path_at(home);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let lock_path = home.join(CLUD_DIR_NAME).join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+    let text = fs::read_to_string(&path)?;
+    if text.trim().is_empty() {
+        return Ok(None);
+    }
+    let document = parse_settings(&path, &text)?;
+    let Some(table) = document
+        .get("optimize")
+        .and_then(|item| item.get("rust"))
+        .and_then(Item::as_table)
+    else {
+        return Ok(None);
+    };
+    let defaults = RustOptimizeSettings::default();
+    Ok(Some(RustOptimizeSettings {
+        use_soldr_shims: table
+            .get("use_soldr_shims")
+            .and_then(Item::as_bool)
+            .unwrap_or(defaults.use_soldr_shims),
+        install_soldr: table
+            .get("install_soldr")
+            .and_then(Item::as_bool)
+            .unwrap_or(defaults.install_soldr),
+        soldr_version: table
+            .get("soldr_version")
+            .and_then(Item::as_str)
+            .unwrap_or(&defaults.soldr_version)
+            .to_string(),
+    }))
+}
+
 fn parse_settings(path: &Path, text: &str) -> Result<DocumentMut, SettingsError> {
     text.parse::<DocumentMut>()
         .map_err(|error| SettingsError::Parse {
@@ -344,5 +448,42 @@ mod tests {
         assert!(text.contains("[launch_setup.codex]"), "{text}");
         assert!(text.contains("[hook_health]"), "{text}");
         assert!(text.contains("auto_fix_hooks = false"), "{text}");
+    }
+
+    #[test]
+    fn saves_rust_optimize_settings() {
+        let home = tempdir().unwrap();
+        let settings = RustOptimizeSettings {
+            use_soldr_shims: true,
+            install_soldr: false,
+            soldr_version: "1.2.3".to_string(),
+        };
+
+        save_rust_optimize_settings_at(home.path(), &settings).unwrap();
+
+        assert_eq!(
+            load_rust_optimize_settings_at(home.path()).unwrap(),
+            Some(settings)
+        );
+        let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
+        assert!(text.contains("[optimize.rust]"), "{text}");
+        assert!(text.contains("use_soldr_shims = true"), "{text}");
+        assert!(text.contains("install_soldr = false"), "{text}");
+        assert!(text.contains("soldr_version = \"1.2.3\""), "{text}");
+    }
+
+    #[test]
+    fn rust_optimize_settings_preserve_existing_settings() {
+        let home = tempdir().unwrap();
+        let path = settings_path_at(home.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "[unrelated]\nvalue = \"kept\"\n").unwrap();
+
+        save_rust_optimize_settings_at(home.path(), &RustOptimizeSettings::default()).unwrap();
+
+        let text = fs::read_to_string(path).unwrap();
+        assert!(text.contains("[unrelated]"), "{text}");
+        assert!(text.contains("value = \"kept\""), "{text}");
+        assert!(text.contains("[optimize.rust]"), "{text}");
     }
 }

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -138,6 +138,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         | Some(Command::Gc { .. })
         | Some(Command::Ui { .. })
         | Some(Command::Trash { .. })
+        | Some(Command::Optimize { .. })
         | Some(Command::Daemon { .. })
         | Some(Command::InternalDaemon { .. })
         | Some(Command::InternalWorker { .. }) => {}

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -25,6 +25,7 @@ pub mod launch_setup;
 pub mod loop_artifacts;
 pub mod loop_check;
 pub mod loop_spec;
+pub mod optimize;
 pub mod orphan_reaper;
 pub mod paste_image;
 pub mod process_tree;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,8 +1,8 @@
 use clud::{
     args, backend, backend_bootstrap, clud_settings, command, console_setup, console_title,
     ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard, launch_setup,
-    loop_artifacts, loop_spec, orphan_reaper, runner, runtime_cache, startup, trampoline, trash,
-    ui, verbose_log, wasm, worktrees,
+    loop_artifacts, loop_spec, optimize, orphan_reaper, runner, runtime_cache, startup, trampoline,
+    trash, ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -91,6 +91,27 @@ fn main() {
     }) = &args.command
     {
         std::process::exit(trash::run(&args, paths, *cross_volume));
+    }
+
+    // `clud optimize` is machine/repo setup and never launches a backend.
+    if let Some(args::Command::Optimize {
+        target,
+        global,
+        repo,
+        install_soldr,
+        use_soldr_shims,
+        soldr_version,
+    }) = &args.command
+    {
+        std::process::exit(optimize::run(
+            &args,
+            *target,
+            *global,
+            *repo,
+            *install_soldr,
+            *use_soldr_shims,
+            soldr_version,
+        ));
     }
 
     // Issue #83: `--clean-worktrees` is a self-contained maintenance path.

--- a/crates/clud-bin/src/optimize.rs
+++ b/crates/clud-bin/src/optimize.rs
@@ -1,0 +1,552 @@
+//! `clud optimize`: persistent, fast-machine setup recommendations.
+
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+
+use crate::args::{Args, OptimizeTarget};
+use crate::clud_settings::{self, RustOptimizeSettings};
+use crate::loop_spec;
+
+const REPO_DIRECTIVE_DIR: &str = ".clud";
+const REPO_DIRECTIVE_FILE: &str = "settings.json";
+
+pub fn run(
+    args: &Args,
+    target: OptimizeTarget,
+    global: bool,
+    repo: bool,
+    install_soldr: bool,
+    use_soldr_shims: bool,
+    soldr_version: &str,
+) -> i32 {
+    match target {
+        OptimizeTarget::Rust => run_rust(
+            args,
+            global,
+            repo,
+            install_soldr,
+            use_soldr_shims,
+            soldr_version,
+        ),
+    }
+}
+
+fn run_rust(
+    args: &Args,
+    global: bool,
+    repo: bool,
+    install_soldr: bool,
+    use_soldr_shims: bool,
+    soldr_version: &str,
+) -> i32 {
+    let settings = RustOptimizeSettings {
+        use_soldr_shims,
+        install_soldr,
+        soldr_version: soldr_version.to_string(),
+    };
+    let write_repo = repo || !global;
+
+    if args.dry_run {
+        println!("[clud] dry-run: optimize rust");
+        if global {
+            println!(
+                "[clud] dry-run: would write ~/.clud/settings.toml [optimize.rust] use_soldr_shims={} install_soldr={} soldr_version=\"{}\"",
+                settings.use_soldr_shims, settings.install_soldr, settings.soldr_version
+            );
+        }
+        if write_repo {
+            match repo_directive_path() {
+                Ok(path) => println!(
+                    "[clud] dry-run: would write repo directive {}",
+                    path.display()
+                ),
+                Err(error) => {
+                    eprintln!("[clud] error: {error}");
+                    return 1;
+                }
+            }
+        }
+        if install_soldr {
+            println!("[clud] dry-run: would install soldr if missing from PATH");
+        }
+        return 0;
+    }
+
+    if global {
+        if let Err(error) = clud_settings::save_rust_optimize_settings(&settings) {
+            eprintln!("[clud] error: failed to save optimize settings: {error}");
+            return 1;
+        }
+        println!("[clud] wrote global Rust optimizer defaults to ~/.clud/settings.toml");
+    }
+
+    if write_repo {
+        match write_repo_directive(&settings) {
+            Ok(path) => {
+                println!(
+                    "[clud] wrote repo Rust optimizer directive to {}",
+                    path.display()
+                );
+                if let Err(error) = stage_repo_directive(&path) {
+                    eprintln!("[clud] error: failed to stage repo directive: {error}");
+                    return 1;
+                }
+                println!("[clud] staged {}", display_repo_path(&path));
+            }
+            Err(error) => {
+                eprintln!("[clud] error: failed to write repo directive: {error}");
+                return 1;
+            }
+        }
+    }
+
+    if install_soldr {
+        match ensure_soldr_installed(soldr_version) {
+            Ok(outcome) => println!("[clud] {outcome}"),
+            Err(error) => {
+                eprintln!("[clud] error: failed to install soldr: {error}");
+                return 1;
+            }
+        }
+    } else {
+        println!("[clud] skipped soldr install");
+    }
+
+    if use_soldr_shims {
+        println!("[clud] enabled soldr shim preference for future clud-managed Rust setup");
+    } else {
+        println!("[clud] disabled soldr shim preference");
+    }
+    0
+}
+
+fn write_repo_directive(settings: &RustOptimizeSettings) -> io::Result<PathBuf> {
+    let path = repo_directive_path()?;
+    let repo_root = path
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| io::Error::other("could not resolve repo root"))?;
+    ensure_rust_project(repo_root)?;
+    write_repo_directive_at(&path, settings)?;
+    let gitignore_updated = ensure_gitignore_tracks_repo_settings(repo_root)?;
+    ensure_not_ignored(repo_root, &path)?;
+    if gitignore_updated {
+        stage_repo_path(repo_root, Path::new(".gitignore"))?;
+    }
+    Ok(path)
+}
+
+fn repo_directive_path() -> io::Result<PathBuf> {
+    let cwd = env::current_dir()?;
+    let root = loop_spec::git_root_from(&cwd);
+    Ok(root.join(REPO_DIRECTIVE_DIR).join(REPO_DIRECTIVE_FILE))
+}
+
+fn write_repo_directive_at(path: &Path, settings: &RustOptimizeSettings) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut root = match fs::read_to_string(path) {
+        Ok(text) if !text.trim().is_empty() => serde_json::from_str::<serde_json::Value>(&text)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
+        Ok(_) => serde_json::json!({}),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => serde_json::json!({}),
+        Err(error) => return Err(error),
+    };
+    if !root.is_object() {
+        root = serde_json::json!({});
+    }
+    root["optimize"]["rust"] = serde_json::json!({
+        "use_soldr_shims": settings.use_soldr_shims,
+        "install_soldr": settings.install_soldr,
+        "soldr_version": settings.soldr_version,
+    });
+    let mut body = serde_json::to_string_pretty(&root).map_err(io::Error::other)?;
+    body.push('\n');
+    fs::write(path, body)
+}
+
+fn ensure_rust_project(repo_root: &Path) -> io::Result<()> {
+    if repo_root.join("Cargo.toml").is_file() {
+        return Ok(());
+    }
+    Err(io::Error::other(format!(
+        "{} does not look like a Rust project: Cargo.toml was not found",
+        repo_root.display()
+    )))
+}
+
+fn ensure_gitignore_tracks_repo_settings(repo_root: &Path) -> io::Result<bool> {
+    let gitignore = repo_root.join(".gitignore");
+    let original = match fs::read_to_string(&gitignore) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error),
+    };
+    let updated = rewrite_gitignore_for_repo_settings(&original);
+    if updated != original {
+        fs::write(gitignore, updated)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn rewrite_gitignore_for_repo_settings(original: &str) -> String {
+    let mut lines: Vec<String> = original.lines().map(str::to_string).collect();
+    let had_trailing_newline = original.ends_with('\n');
+    let has_unignore_dir = lines
+        .iter()
+        .any(|line| matches!(line.trim(), "!.clud/" | "!/.clud/"));
+    let has_unignore_settings = lines.iter().any(|line| {
+        matches!(
+            line.trim(),
+            "!.clud/settings.json" | "!/.clud/settings.json"
+        )
+    });
+
+    for line in &mut lines {
+        if matches!(line.trim(), ".clud/" | "/.clud/" | ".clud" | "/.clud") {
+            *line = ".clud/*".to_string();
+        }
+    }
+
+    if !has_unignore_dir || !has_unignore_settings {
+        if !lines.is_empty() && lines.last().is_some_and(|line| !line.trim().is_empty()) {
+            lines.push(String::new());
+        }
+        lines.push("# clud project settings".to_string());
+        if !has_unignore_dir {
+            lines.push("!.clud/".to_string());
+        }
+        if !has_unignore_settings {
+            lines.push("!.clud/settings.json".to_string());
+        }
+    }
+
+    let mut out = lines.join("\n");
+    if had_trailing_newline || !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+fn ensure_not_ignored(repo_root: &Path, path: &Path) -> io::Result<()> {
+    let relative = path.strip_prefix(repo_root).unwrap_or(path);
+    let output = ProcessCommand::new("git")
+        .arg("check-ignore")
+        .arg("--quiet")
+        .arg(relative)
+        .current_dir(repo_root)
+        .output()?;
+    match output.status.code() {
+        Some(0) => Err(io::Error::other(format!(
+            "{} is still ignored by git",
+            relative.display()
+        ))),
+        Some(1) => Ok(()),
+        _ => Err(io::Error::other(format!(
+            "git check-ignore failed for {}",
+            relative.display()
+        ))),
+    }
+}
+
+fn stage_repo_directive(path: &Path) -> io::Result<()> {
+    let repo_root = path
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| io::Error::other("could not resolve repo root"))?;
+    let relative = path.strip_prefix(repo_root).unwrap_or(path);
+    stage_repo_path(repo_root, relative)
+}
+
+fn stage_repo_path(repo_root: &Path, relative: &Path) -> io::Result<()> {
+    let status = ProcessCommand::new("git")
+        .arg("add")
+        .arg(relative)
+        .current_dir(repo_root)
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!("git add failed with {status}")))
+    }
+}
+
+fn display_repo_path(path: &Path) -> String {
+    path.parent()
+        .and_then(|parent| parent.file_name())
+        .zip(path.file_name())
+        .map(|(dir, file)| format!("{}/{}", dir.to_string_lossy(), file.to_string_lossy()))
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn ensure_soldr_installed(version: &str) -> Result<String, String> {
+    if let Ok(path) = which::which("soldr") {
+        return Ok(format!("soldr already installed at {}", path.display()));
+    }
+    let home = home_dir().ok_or_else(|| "could not resolve user home directory".to_string())?;
+    let target_dir = global_bin_dir(&home);
+    fs::create_dir_all(&target_dir)
+        .map_err(|error| format!("create {}: {error}", target_dir.display()))?;
+
+    let asset = soldr_asset_for_current_platform(version)?;
+    let url = format!(
+        "https://github.com/zackees/soldr/releases/download/v{version}/{}",
+        asset.file_name
+    );
+    let temp_dir = env::temp_dir().join(format!("clud-soldr-{}", std::process::id()));
+    if temp_dir.exists() {
+        fs::remove_dir_all(&temp_dir)
+            .map_err(|error| format!("clear {}: {error}", temp_dir.display()))?;
+    }
+    fs::create_dir_all(&temp_dir).map_err(|error| format!("create temp dir: {error}"))?;
+    let cleanup_dir = temp_dir.clone();
+    let result = install_soldr_from_url(&url, &asset, &temp_dir, &target_dir);
+    let _ = fs::remove_dir_all(cleanup_dir);
+    result
+}
+
+fn install_soldr_from_url(
+    url: &str,
+    asset: &SoldrAsset,
+    temp_dir: &Path,
+    target_dir: &Path,
+) -> Result<String, String> {
+    let archive = temp_dir.join(&asset.file_name);
+    eprintln!("[clud] downloading {url}");
+    let response = ureq::get(url)
+        .call()
+        .map_err(|error| format!("download {url}: {error}"))?;
+    let mut reader = response.into_reader();
+    let mut file = fs::File::create(&archive)
+        .map_err(|error| format!("create {}: {error}", archive.display()))?;
+    io::copy(&mut reader, &mut file).map_err(|error| format!("write download: {error}"))?;
+
+    extract_archive(&archive, temp_dir, asset)?;
+    let src = find_file_named(temp_dir, asset.binary_name)
+        .ok_or_else(|| format!("{} not found in {}", asset.binary_name, asset.file_name))?;
+    let target = target_dir.join(asset.binary_name);
+    fs::copy(&src, &target)
+        .map_err(|error| format!("copy {} to {}: {error}", src.display(), target.display()))?;
+    make_executable(&target)?;
+    Ok(format!(
+        "installed soldr {version} to {path}",
+        version = asset.version,
+        path = target.display()
+    ))
+}
+
+fn extract_archive(archive: &Path, temp_dir: &Path, asset: &SoldrAsset) -> Result<(), String> {
+    let status = if asset.extension == "zip" {
+        expand_zip(archive, temp_dir)?
+    } else {
+        ProcessCommand::new("tar")
+            .arg("-xzf")
+            .arg(archive)
+            .arg("-C")
+            .arg(temp_dir)
+            .status()
+            .map_err(|error| format!("failed to start tar: {error}"))?
+    };
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "extract {} failed with {status}",
+            archive.display()
+        ))
+    }
+}
+
+fn expand_zip(archive: &Path, temp_dir: &Path) -> Result<std::process::ExitStatus, String> {
+    let mut command = ProcessCommand::new("powershell");
+    command
+        .arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-Command")
+        .arg("Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force")
+        .arg(archive)
+        .arg(temp_dir);
+    match command.status() {
+        Ok(status) => Ok(status),
+        Err(first_error) => ProcessCommand::new("pwsh")
+            .arg("-NoProfile")
+            .arg("-Command")
+            .arg("Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force")
+            .arg(archive)
+            .arg(temp_dir)
+            .status()
+            .map_err(|second_error| {
+                format!("failed to start powershell ({first_error}) or pwsh ({second_error})")
+            }),
+    }
+}
+
+fn find_file_named(root: &Path, name: &str) -> Option<PathBuf> {
+    let entries = fs::read_dir(root).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.file_name().and_then(|file| file.to_str()) == Some(name) {
+            return Some(path);
+        }
+        if path.is_dir() {
+            if let Some(found) = find_file_named(&path, name) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = fs::metadata(path)
+        .map_err(|error| format!("metadata {}: {error}", path.display()))?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)
+        .map_err(|error| format!("chmod {}: {error}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+fn global_bin_dir(home: &Path) -> PathBuf {
+    let cargo_home = env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".cargo"));
+    let cargo_bin = cargo_home.join("bin");
+    if cargo_bin.exists() {
+        cargo_bin
+    } else {
+        home.join(".local").join("bin")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SoldrAsset {
+    version: String,
+    file_name: String,
+    extension: &'static str,
+    binary_name: &'static str,
+}
+
+fn soldr_asset_for_current_platform(version: &str) -> Result<SoldrAsset, String> {
+    let arch = match env::consts::ARCH {
+        "x86_64" | "amd64" => "x86_64",
+        "aarch64" | "arm64" => "aarch64",
+        other => return Err(format!("unsupported architecture: {other}")),
+    };
+    let (os, extension, binary_name) = match env::consts::OS {
+        "linux" => ("unknown-linux-gnu", "tar.gz", "soldr"),
+        "macos" => ("apple-darwin", "tar.gz", "soldr"),
+        "windows" => ("pc-windows-msvc", "zip", "soldr.exe"),
+        other => return Err(format!("unsupported OS: {other}")),
+    };
+    Ok(SoldrAsset {
+        version: version.to_string(),
+        file_name: format!("soldr-v{version}-{arch}-{os}.{extension}"),
+        extension,
+        binary_name,
+    })
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(path) = env::var_os("USERPROFILE") {
+            if !path.is_empty() {
+                return Some(PathBuf::from(path));
+            }
+        }
+    }
+    if let Some(path) = env::var_os("HOME") {
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn writes_repo_directive() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".clud").join("settings.json");
+        let settings = RustOptimizeSettings {
+            use_soldr_shims: false,
+            install_soldr: true,
+            soldr_version: "9.9.9".to_string(),
+        };
+
+        write_repo_directive_at(&path, &settings).unwrap();
+
+        let text = fs::read_to_string(path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["optimize"]["rust"]["use_soldr_shims"], false);
+        assert_eq!(parsed["optimize"]["rust"]["install_soldr"], true);
+        assert_eq!(parsed["optimize"]["rust"]["soldr_version"], "9.9.9");
+    }
+
+    #[test]
+    fn repo_directive_preserves_existing_json() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".clud").join("settings.json");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "{\n  \"other\": true\n}\n").unwrap();
+
+        write_repo_directive_at(&path, &RustOptimizeSettings::default()).unwrap();
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(parsed["other"], true);
+        assert_eq!(parsed["optimize"]["rust"]["use_soldr_shims"], true);
+    }
+
+    #[test]
+    fn gitignore_rewrite_unignores_settings_only() {
+        let original = "target/\n.clud/\n";
+
+        let updated = rewrite_gitignore_for_repo_settings(original);
+
+        assert!(updated.contains(".clud/*"), "{updated}");
+        assert!(updated.contains("!.clud/"), "{updated}");
+        assert!(updated.contains("!.clud/settings.json"), "{updated}");
+    }
+
+    #[test]
+    fn soldr_asset_matches_current_platform() {
+        let asset = soldr_asset_for_current_platform("1.2.3").unwrap();
+        assert!(asset.file_name.starts_with("soldr-v1.2.3-"), "{asset:?}");
+        if cfg!(windows) {
+            assert!(asset.file_name.ends_with(".zip"), "{asset:?}");
+            assert_eq!(asset.binary_name, "soldr.exe");
+        } else {
+            assert!(asset.file_name.ends_with(".tar.gz"), "{asset:?}");
+            assert_eq!(asset.binary_name, "soldr");
+        }
+    }
+
+    #[test]
+    fn finds_nested_binary() {
+        let dir = tempdir().unwrap();
+        let nested = dir.path().join("pkg").join("bin");
+        fs::create_dir_all(&nested).unwrap();
+        let binary = nested.join("soldr");
+        fs::write(&binary, "x").unwrap();
+
+        assert_eq!(find_file_named(dir.path(), "soldr"), Some(binary));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `clud optimize` for Rust/soldr setup. The command detects Rust projects, writes repo-local `.clud/settings.json` defaults for soldr shims, keeps `.clud/settings.json` trackable while leaving other `.clud` state ignored, and stages the project settings file after writing it.

Also supports `clud optimize soldr` as an alias for the Rust optimizer target, plus optional global `~/.clud/settings.toml` persistence and soldr installation if it is missing.

## Validation

- `soldr cargo test -p clud --lib args::`
- `soldr cargo test -p clud --lib optimize::`
- `soldr cargo test -p clud --lib clud_settings::`
- `soldr cargo run -p clud -- optimize rust`
- `soldr cargo run -p clud -- --dry-run optimize soldr --install-soldr=false`