### PR TITLE
[codex] add slay command

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -206,6 +206,8 @@ pub enum Command {
         #[arg(long = "all")]
         all: bool,
     },
+    /// Kill all active background sessions.
+    Slay,
     List,
     /// pm2-style log viewer: dump or tail a session's captured output.
     ///
@@ -443,8 +445,8 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
-        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "list", "logs", "gc", "ui",
-        "trash", "optimize", "daemon", "__daemon", "__worker",
+        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "slay", "list", "logs", "gc",
+        "ui", "trash", "optimize", "daemon", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/args_tests.rs
+++ b/crates/clud-bin/src/args_tests.rs
@@ -535,6 +535,13 @@ fn test_kill_all() {
 }
 
 #[test]
+fn test_slay_subcommand() {
+    let args = parse(&["clud", "slay"]);
+    assert!(matches!(args.command, Some(Command::Slay)));
+    assert!(args.passthrough.is_empty());
+}
+
+#[test]
 fn test_name_flag() {
     let args = parse(&["clud", "--name", "my-session", "--detach", "-p", "hello"]);
     assert_eq!(args.session_name.as_deref(), Some("my-session"));

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -133,6 +133,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         }
         Some(Command::Attach { .. })
         | Some(Command::Kill { .. })
+        | Some(Command::Slay)
         | Some(Command::List)
         | Some(Command::Logs { .. })
         | Some(Command::Gc { .. })

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -289,6 +289,10 @@ pub fn handle_special_command(args: &Args, interrupted: &AtomicBool) -> Option<i
             let state_dir = state_dir(args);
             Some(run_kill(&state_dir, session_id.as_deref(), *all))
         }
+        Some(Command::Slay) => {
+            let state_dir = state_dir(args);
+            Some(run_kill(&state_dir, None, true))
+        }
         Some(Command::List) => {
             let state_dir = state_dir(args);
             Some(run_list(&state_dir))


### PR DESCRIPTION
## Summary

Adds `clud slay` as a first-class shorthand for killing all active background sessions.

## Root Cause

`slay` was not registered as a known clud subcommand, so the passthrough parser treated it as a backend argument and forwarded it into the launched terminal/backend instead of dispatching a clud maintenance command.

## Changes

- Adds a `Slay` CLI subcommand.
- Routes `clud slay` through the existing `kill --all` implementation.
- Ensures launch-plan construction does not start a backend for `slay`.
- Adds a parser regression test proving `slay` is not passthrough.

## Validation

- `soldr cargo test -p clud args::tests::test_slay_subcommand`
- `soldr cargo check -p clud`