### PR TITLE
feat: slay reaps orphans + optimize rust scope prompt

### DIFF
--- a/crates/clud-bin/src/daemon/attach.rs
+++ b/crates/clud-bin/src/daemon/attach.rs
@@ -94,7 +94,8 @@ pub(super) fn run_attach(session_id: &str, state_dir: &Path, interrupted: &Atomi
         | DaemonResponse::AdoptKillAck { .. }
         | DaemonResponse::Gc { .. }
         | DaemonResponse::LiveCwds { .. }
-        | DaemonResponse::ShutdownAck { .. } => 1,
+        | DaemonResponse::ShutdownAck { .. }
+        | DaemonResponse::ReapOrphansAck { .. } => 1,
     }
 }
 

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -254,6 +254,40 @@ pub fn try_handoff_kill_to_daemon(state_dir: &Path, pids: &[u32], reason: Option
     matches!(reader.read_line(&mut line), Ok(n) if n > 0)
 }
 
+/// Fire-and-forget: ask the daemon to sweep dead-originator CLUD orphans.
+/// Called from the foreground clud's exit hook. Tight 150ms read/write
+/// timeouts (mirrors `try_handoff_kill_to_daemon`) so a wedged daemon
+/// can't drag out CLI shutdown. Returns `true` when the ack arrives.
+///
+/// Failure modes (daemon down, version skew, network hiccup) all degrade
+/// silently — the daemon will still catch any dead-originator orphans on
+/// its next periodic sweep (`gc_service`-adjacent path), and the next
+/// `clud slay` invocation does the synchronous version.
+pub fn try_request_orphan_reap(state_dir: &Path) -> bool {
+    let info = match read_json_file::<DaemonInfo>(&daemon_info_path(state_dir)) {
+        Ok(info) => info,
+        Err(_) => return false,
+    };
+    let mut stream = match TcpStream::connect_timeout(
+        &std::net::SocketAddr::from(([127, 0, 0, 1], info.port)),
+        Duration::from_millis(150),
+    ) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(150)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(150)));
+    let Ok(format) = daemon_wire_format_from_env() else {
+        return false;
+    };
+    if write_daemon_request(&mut stream, &DaemonRequest::ReapOrphans, format).is_err() {
+        return false;
+    }
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    matches!(reader.read_line(&mut line), Ok(n) if n > 0)
+}
+
 pub(super) fn request_session_interrupt(
     state_dir: &Path,
     session_id: &str,

--- a/crates/clud-bin/src/daemon/commands.rs
+++ b/crates/clud-bin/src/daemon/commands.rs
@@ -10,6 +10,7 @@ use super::io_helpers::read_json_file;
 use super::paths::{logs_dir, session_log_path, session_snapshot_path};
 use super::sessions::{list_background_sessions, resolve_session_id};
 use super::types::SessionSnapshot;
+use crate::orphan_reaper::{reap_orphans, ReapOpts};
 
 pub(super) fn run_kill(state_dir: &Path, session_id: Option<&str>, all: bool) -> i32 {
     if let Err(err) = ensure_daemon(state_dir) {
@@ -19,10 +20,6 @@ pub(super) fn run_kill(state_dir: &Path, session_id: Option<&str>, all: bool) ->
 
     if all {
         let sessions = list_background_sessions(state_dir);
-        if sessions.is_empty() {
-            println!("No active sessions to kill.");
-            return 0;
-        }
         let mut failed = 0;
         for session in &sessions {
             match request_session_termination(state_dir, &session.id) {
@@ -32,6 +29,17 @@ pub(super) fn run_kill(state_dir: &Path, session_id: Option<&str>, all: bool) ->
                     failed += 1;
                 }
             }
+        }
+
+        // Also reap CLUD-tagged orphans whose originator clud is gone. The
+        // session registry only covers `--detach` / `--detachable` work; a
+        // foreground clud that died via SIGKILL leaves its env-tagged
+        // descendants behind, and they would otherwise live forever.
+        let outcome = reap_orphans(&ReapOpts::default());
+
+        if sessions.is_empty() && outcome.found == 0 {
+            println!("No active sessions or orphans to kill.");
+            return 0;
         }
         if failed > 0 {
             return 1;

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -502,7 +502,8 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         | DaemonResponse::AdoptKillAck { .. }
         | DaemonResponse::Gc { .. }
         | DaemonResponse::LiveCwds { .. }
-        | DaemonResponse::ShutdownAck { .. } => 1,
+        | DaemonResponse::ShutdownAck { .. }
+        | DaemonResponse::ReapOrphansAck { .. } => 1,
     }
 }
 

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -18,7 +18,8 @@ mod worker_shared;
 
 pub use client::{
     ensure_daemon, gc_client_insert, gc_client_list, gc_client_list_repo_visits, gc_client_purge,
-    gc_client_reconcile, gc_client_record_repo_visit, try_handoff_kill_to_daemon, GcPurgeOutcome,
+    gc_client_reconcile, gc_client_record_repo_visit, try_handoff_kill_to_daemon,
+    try_request_orphan_reap, GcPurgeOutcome,
 };
 pub use entry::{experimental_enabled, handle_special_command, run_centralized_session};
 pub use http::{

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -114,6 +114,13 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
         Arc::clone(&shutdown_requested),
     );
 
+    // Periodic orphan sweep. Catches CLUD-tagged descendants whose
+    // originator clud was SIGKILL'd and never ran its own exit hook (so
+    // the on-exit `ReapOrphans` IPC never fired). Pure background work —
+    // never blocks the accept loop. Sleeps in 1s slices so shutdown is
+    // promptly observed.
+    spawn_orphan_sweeper(Arc::clone(&shutdown_requested));
+
     loop {
         match listener.accept() {
             Ok((stream, _addr)) => {
@@ -229,6 +236,26 @@ pub(super) fn dispatch_daemon_request(
             spawn_adopt_kill_worker(pids.clone(), reason);
             DaemonResponse::AdoptKillAck {
                 accepted: pids.len(),
+            }
+        }
+        DaemonRequest::ReapOrphans => {
+            // Fire-and-forget: spawn the sweep on a background thread so the
+            // CLI's exit path never blocks on `kill_tree`. Ack with zeros —
+            // the foreground caller doesn't wait for the actual count.
+            thread::spawn(|| {
+                let _ = crate::orphan_reaper::reap_orphans(&crate::orphan_reaper::ReapOpts {
+                    keep: false,
+                    // Quiet on the daemon path: the daemon's stderr is a
+                    // log file no one is tailing during normal use, so
+                    // the per-row report would just be noise. The
+                    // synchronous `clud slay` path still prints.
+                    quiet: true,
+                    explain: false,
+                });
+            });
+            DaemonResponse::ReapOrphansAck {
+                found: 0,
+                reaped: 0,
             }
         }
         DaemonRequest::Gc { payload } => {
@@ -409,6 +436,40 @@ fn reap_worker_when_done(
 /// nobody is on the other end to receive a reply. The kill walk uses
 /// `process_tree::kill_tree` for parity with the synchronous path it
 /// replaces (see `runner::teardown_interrupted_child`).
+/// Period between dead-originator orphan sweeps in the daemon. 30s is a
+/// compromise: long enough that the scan (sysinfo + env-var read for every
+/// process on the host) isn't a noticeable background load, short enough
+/// that SIGKILL'd-clud orphans don't linger for minutes.
+const ORPHAN_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+fn spawn_orphan_sweeper(shutdown_requested: Arc<AtomicBool>) {
+    let _ = thread::Builder::new()
+        .name("clud-orphan-sweep".to_string())
+        .spawn(move || loop {
+            // Sleep in 1-second slices so shutdown is observed within ~1s.
+            let mut remaining = ORPHAN_SWEEP_INTERVAL;
+            while remaining > Duration::ZERO {
+                if shutdown_requested.load(Ordering::SeqCst) {
+                    return;
+                }
+                let slice = remaining.min(Duration::from_secs(1));
+                thread::sleep(slice);
+                remaining = remaining.saturating_sub(slice);
+            }
+            if shutdown_requested.load(Ordering::SeqCst) {
+                return;
+            }
+            let _ = crate::orphan_reaper::reap_orphans(&crate::orphan_reaper::ReapOpts {
+                keep: false,
+                // Quiet: the daemon log shouldn't fill with per-tick
+                // empty-sweep noise; per-process kill failures still
+                // surface via `kill_tree`'s own diagnostics if any.
+                quiet: true,
+                explain: false,
+            });
+        });
+}
+
 fn spawn_adopt_kill_worker(pids: Vec<u32>, reason: Option<String>) {
     let _ = thread::Builder::new()
         .name("clud-adopt-kill".to_string())

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -198,6 +198,14 @@ pub(super) enum DaemonRequest {
     },
     /// Ask the daemon to exit after replying. Used by `clud daemon restart`.
     Shutdown,
+    /// Fire-and-forget: ask the daemon to sweep every CLUD-tagged process
+    /// whose originator is no longer alive and `kill_tree` each. Sent from
+    /// the foreground clud's exit hook so the daemon catches descendants
+    /// the foreground couldn't reap on its own (e.g., reparented away from
+    /// `self_pid`, or left behind by a SIGKILL'd sibling clud). The daemon
+    /// replies `ReapOrphansAck` immediately and does the sweep on a
+    /// background thread.
+    ReapOrphans,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -229,6 +237,14 @@ pub(super) enum DaemonResponse {
     /// Acknowledgement for `DaemonRequest::Shutdown`.
     ShutdownAck {
         pid: u32,
+    },
+    /// Ack for [`DaemonRequest::ReapOrphans`]. Returned before the daemon
+    /// performs the kill (the sweep runs on a background thread), so the
+    /// CLI's exit path is never blocked. `found` and `reaped` are 0 in the
+    /// fast-path ack; populated only by the synchronous test path.
+    ReapOrphansAck {
+        found: u32,
+        reaped: u32,
     },
     Error {
         message: String,

--- a/crates/clud-bin/src/daemon/wire_prost/daemon_msgs.rs
+++ b/crates/clud-bin/src/daemon/wire_prost/daemon_msgs.rs
@@ -84,6 +84,7 @@ fn daemon_request_to_proto(
             payload_json: to_json_vec(payload)?,
         }),
         DaemonRequest::Shutdown => Request::Shutdown(proto::ShutdownRequest {}),
+        DaemonRequest::ReapOrphans => Request::ReapOrphans(proto::ReapOrphansRequest {}),
     };
     Ok(proto::ClientToDaemon {
         request: Some(request),
@@ -123,6 +124,7 @@ fn daemon_request_from_proto(proto: proto::ClientToDaemon) -> Result<DaemonReque
             payload: from_json_slice::<GcOp>(&gc.payload_json)?,
         }),
         Request::Shutdown(_) => Ok(DaemonRequest::Shutdown),
+        Request::ReapOrphans(_) => Ok(DaemonRequest::ReapOrphans),
     }
 }
 
@@ -174,6 +176,12 @@ fn daemon_response_to_proto(
         DaemonResponse::ShutdownAck { pid } => {
             Response::ShutdownAck(proto::ShutdownAckResponse { pid: *pid })
         }
+        DaemonResponse::ReapOrphansAck { found, reaped } => {
+            Response::ReapOrphansAck(proto::ReapOrphansAckResponse {
+                found: *found,
+                reaped: *reaped,
+            })
+        }
         DaemonResponse::Error { message } => Response::Error(proto::ErrorResponse {
             message: message.clone(),
         }),
@@ -212,6 +220,10 @@ fn daemon_response_from_proto(proto: proto::DaemonToClient) -> Result<DaemonResp
             reply: from_json_slice::<GcReply>(&gc.reply_json)?,
         }),
         Response::ShutdownAck(ack) => Ok(DaemonResponse::ShutdownAck { pid: ack.pid }),
+        Response::ReapOrphansAck(ack) => Ok(DaemonResponse::ReapOrphansAck {
+            found: ack.found,
+            reaped: ack.reaped,
+        }),
         Response::Error(error) => Ok(DaemonResponse::Error {
             message: error.message,
         }),

--- a/crates/clud-bin/src/daemon/wire_prost/tests.rs
+++ b/crates/clud-bin/src/daemon/wire_prost/tests.rs
@@ -170,6 +170,7 @@ fn daemon_request_prost_roundtrips_json_shapes() {
             },
         },
         DaemonRequest::Shutdown,
+        DaemonRequest::ReapOrphans,
     ];
 
     for request in cases {
@@ -202,6 +203,10 @@ fn daemon_response_prost_roundtrips_json_shapes() {
             reply: GcReply::ListOk { rows: Vec::new() },
         },
         DaemonResponse::ShutdownAck { pid: 1234 },
+        DaemonResponse::ReapOrphansAck {
+            found: 3,
+            reaped: 3,
+        },
         DaemonResponse::Error {
             message: "failed".to_string(),
         },

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -549,6 +549,19 @@ fn main() {
                 outcome.found, outcome.reaped
             ));
         }
+
+        // Have the daemon do a broader sweep on our behalf: any CLUD-tagged
+        // process whose originator is gone (e.g., a sibling clud was
+        // SIGKILL'd and never ran its own exit hook) gets reaped on the
+        // daemon's background thread. Fire-and-forget with a tight
+        // timeout; failure is silently absorbed — the daemon's periodic
+        // heartbeat sweep will catch anything we miss, and the next
+        // `clud slay` does the synchronous version.
+        if !args.keep_orphans {
+            if let Ok(state_dir) = daemon::default_state_dir() {
+                let _ = daemon::try_request_orphan_reap(&state_dir);
+            }
+        }
     }
     if args.verbose {
         verbose_log::log(format_args!("[clud] exit: code {exit_code}"));

--- a/crates/clud-bin/src/optimize.rs
+++ b/crates/clud-bin/src/optimize.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 use std::fs;
-use std::io;
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -12,6 +12,15 @@ use crate::loop_spec;
 use running_process::{
     CommandSpec, NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode,
 };
+
+/// Resolved write scope for `clud optimize rust`. Decoupled from the raw
+/// `--global` / `--repo` booleans so the interactive prompt can produce the
+/// same shape as the flag-driven path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WriteScope {
+    Repo,
+    Global,
+}
 
 const REPO_DIRECTIVE_DIR: &str = ".clud";
 const REPO_DIRECTIVE_FILE: &str = "settings.json";
@@ -50,18 +59,38 @@ fn run_rust(
         install_soldr,
         soldr_version: soldr_version.to_string(),
     };
-    let write_repo = repo || !global;
+
+    // Resolve scope. Explicit flags win. Otherwise: if we have a TTY and
+    // aren't in --dry-run, prompt — keeps automated callers stable (CI,
+    // tests, scripted pipelines) while giving interactive users a choice.
+    let scope = if global {
+        WriteScope::Global
+    } else if repo {
+        WriteScope::Repo
+    } else if !args.dry_run && io::stdin().is_terminal() && io::stderr().is_terminal() {
+        match prompt_scope_from_stdin() {
+            Ok(scope) => scope,
+            Err(error) => {
+                eprintln!("[clud] error: scope prompt failed: {error}");
+                return 1;
+            }
+        }
+    } else {
+        // Preserves the pre-prompt default for non-TTY / dry-run callers:
+        // bare `clud optimize rust` writes the repo directive.
+        WriteScope::Repo
+    };
 
     if args.dry_run {
         println!("[clud] dry-run: optimize rust");
-        if global {
-            println!(
-                "[clud] dry-run: would write ~/.clud/settings.toml [optimize.rust] use_soldr_shims={} install_soldr={} soldr_version=\"{}\"",
-                settings.use_soldr_shims, settings.install_soldr, settings.soldr_version
-            );
-        }
-        if write_repo {
-            match repo_directive_path() {
+        match scope {
+            WriteScope::Global => {
+                println!(
+                    "[clud] dry-run: would write ~/.clud/settings.toml [optimize.rust] use_soldr_shims={} install_soldr={} soldr_version=\"{}\"",
+                    settings.use_soldr_shims, settings.install_soldr, settings.soldr_version
+                );
+            }
+            WriteScope::Repo => match repo_directive_path() {
                 Ok(path) => println!(
                     "[clud] dry-run: would write repo directive {}",
                     path.display()
@@ -70,24 +99,35 @@ fn run_rust(
                     eprintln!("[clud] error: {error}");
                     return 1;
                 }
-            }
+            },
         }
         if install_soldr {
-            println!("[clud] dry-run: would install soldr if missing from PATH");
+            // Surface the dry-run install destination so the user can audit
+            // it the same way the live path now does.
+            match planned_soldr_install_target() {
+                Ok(target) => println!(
+                    "[clud] dry-run: would install soldr {} to {} (only if missing from PATH)",
+                    soldr_version,
+                    target.display()
+                ),
+                Err(error) => {
+                    eprintln!("[clud] error: {error}");
+                    return 1;
+                }
+            }
         }
         return 0;
     }
 
-    if global {
-        if let Err(error) = clud_settings::save_rust_optimize_settings(&settings) {
-            eprintln!("[clud] error: failed to save optimize settings: {error}");
-            return 1;
+    match scope {
+        WriteScope::Global => {
+            if let Err(error) = clud_settings::save_rust_optimize_settings(&settings) {
+                eprintln!("[clud] error: failed to save optimize settings: {error}");
+                return 1;
+            }
+            println!("[clud] wrote global Rust optimizer defaults to ~/.clud/settings.toml");
         }
-        println!("[clud] wrote global Rust optimizer defaults to ~/.clud/settings.toml");
-    }
-
-    if write_repo {
-        match write_repo_directive(&settings) {
+        WriteScope::Repo => match write_repo_directive(&settings) {
             Ok(path) => {
                 println!(
                     "[clud] wrote repo Rust optimizer directive to {}",
@@ -103,7 +143,7 @@ fn run_rust(
                 eprintln!("[clud] error: failed to write repo directive: {error}");
                 return 1;
             }
-        }
+        },
     }
 
     if install_soldr {
@@ -124,6 +164,56 @@ fn run_rust(
         println!("[clud] disabled soldr shim preference");
     }
     0
+}
+
+/// Interactive scope prompt for `clud optimize rust`. Writes to stderr so
+/// stdout stays clean for piped consumers. Enter (empty line) accepts the
+/// `[L]ocal` default to preserve the pre-prompt behavior. EOF (closed
+/// stdin) likewise falls back to Local.
+pub(crate) fn prompt_scope_from_stdin() -> io::Result<WriteScope> {
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    prompt_scope(&mut reader, &mut io::stderr())
+}
+
+pub(crate) fn prompt_scope<R: BufRead, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+) -> io::Result<WriteScope> {
+    write!(
+        writer,
+        "[clud] install scope — [L]ocal repo (.clud/settings.json) or [G]lobal (~/.clud/settings.toml)? [L]: "
+    )?;
+    writer.flush()?;
+    let mut line = String::new();
+    if reader.read_line(&mut line)? == 0 {
+        // EOF: treat as default selection rather than erroring.
+        return Ok(WriteScope::Repo);
+    }
+    Ok(parse_scope_answer(&line))
+}
+
+/// Pure mapping from a typed answer to a [`WriteScope`]. Unknown input
+/// falls back to the default (Local/Repo) rather than reprompting — the
+/// prompt is one-shot so automation that pipes "yes\n" still gets a sane
+/// outcome.
+pub(crate) fn parse_scope_answer(answer: &str) -> WriteScope {
+    let trimmed = answer.trim();
+    if trimmed.eq_ignore_ascii_case("g") || trimmed.eq_ignore_ascii_case("global") {
+        WriteScope::Global
+    } else {
+        WriteScope::Repo
+    }
+}
+
+/// Compute where `ensure_soldr_installed` would put the binary if it had
+/// to install today. Used by the pre-install announcement and the dry-run
+/// preview so the user knows the destination before any network I/O.
+fn planned_soldr_install_target() -> Result<PathBuf, String> {
+    let home = home_dir().ok_or_else(|| "could not resolve user home directory".to_string())?;
+    let target_dir = global_bin_dir(&home);
+    let asset = soldr_asset_for_current_platform("0.0.0")?; // version unused for binary_name
+    Ok(target_dir.join(asset.binary_name))
 }
 
 fn write_repo_directive(settings: &RustOptimizeSettings) -> io::Result<PathBuf> {
@@ -304,6 +394,15 @@ fn ensure_soldr_installed(version: &str) -> Result<String, String> {
         .map_err(|error| format!("create {}: {error}", target_dir.display()))?;
 
     let asset = soldr_asset_for_current_platform(version)?;
+    // Pre-announce *before* network I/O. Users running into a slow GitHub
+    // CDN otherwise stare at a silent terminal for tens of seconds; the
+    // single line up front makes both the action and the destination
+    // obvious before the spinner.
+    eprintln!(
+        "[clud] installing soldr {} to {}",
+        version,
+        target_dir.join(asset.binary_name).display()
+    );
     let url = format!(
         "https://github.com/zackees/soldr/releases/download/v{version}/{}",
         asset.file_name
@@ -600,5 +699,78 @@ mod tests {
         fs::write(&binary, "x").unwrap();
 
         assert_eq!(find_file_named(dir.path(), "soldr"), Some(binary));
+    }
+
+    #[test]
+    fn parse_scope_answer_defaults_to_repo_on_empty_or_garbage() {
+        assert_eq!(parse_scope_answer(""), WriteScope::Repo);
+        assert_eq!(parse_scope_answer("\n"), WriteScope::Repo);
+        assert_eq!(parse_scope_answer("   "), WriteScope::Repo);
+        // Unrecognized input keeps the safe default rather than reprompting.
+        assert_eq!(parse_scope_answer("yes"), WriteScope::Repo);
+        assert_eq!(parse_scope_answer("local"), WriteScope::Repo);
+        assert_eq!(parse_scope_answer("l"), WriteScope::Repo);
+        assert_eq!(parse_scope_answer("L"), WriteScope::Repo);
+    }
+
+    #[test]
+    fn parse_scope_answer_picks_global_on_g_variants() {
+        assert_eq!(parse_scope_answer("g"), WriteScope::Global);
+        assert_eq!(parse_scope_answer("G"), WriteScope::Global);
+        assert_eq!(parse_scope_answer("global"), WriteScope::Global);
+        assert_eq!(parse_scope_answer("Global"), WriteScope::Global);
+        assert_eq!(parse_scope_answer("  global  "), WriteScope::Global);
+        assert_eq!(parse_scope_answer("g\n"), WriteScope::Global);
+    }
+
+    #[test]
+    fn prompt_scope_treats_eof_as_default_repo() {
+        // Closed stdin (EOF on first read) must not error out — that would
+        // make the bare `clud optimize rust` invocation flaky for users in
+        // shells that lose their controlling TTY mid-command.
+        let mut reader = io::Cursor::new(Vec::<u8>::new());
+        let mut writer = Vec::<u8>::new();
+        let scope = prompt_scope(&mut reader, &mut writer).unwrap();
+        assert_eq!(scope, WriteScope::Repo);
+        let rendered = String::from_utf8(writer).unwrap();
+        assert!(
+            rendered.contains("install scope"),
+            "prompt was not rendered: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn prompt_scope_reads_user_response() {
+        let mut reader = io::Cursor::new(b"g\n".to_vec());
+        let mut writer = Vec::<u8>::new();
+        assert_eq!(
+            prompt_scope(&mut reader, &mut writer).unwrap(),
+            WriteScope::Global
+        );
+
+        let mut reader = io::Cursor::new(b"\n".to_vec());
+        let mut writer = Vec::<u8>::new();
+        assert_eq!(
+            prompt_scope(&mut reader, &mut writer).unwrap(),
+            WriteScope::Repo
+        );
+    }
+
+    #[test]
+    fn planned_soldr_install_target_resolves() {
+        // We only assert structural properties: a real home dir on the
+        // test host exists, and the returned path ends in the platform
+        // binary name. The exact directory varies (CARGO_HOME may or may
+        // not be set), so we don't pin it.
+        let target = planned_soldr_install_target().expect("home dir must resolve in test");
+        let last = target
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if cfg!(windows) {
+            assert_eq!(last, "soldr.exe");
+        } else {
+            assert_eq!(last, "soldr");
+        }
     }
 }

--- a/crates/clud-bin/src/orphan_reaper.rs
+++ b/crates/clud-bin/src/orphan_reaper.rs
@@ -195,7 +195,38 @@ pub fn scan_and_report(self_pid: u32, opts: &ReapOpts) -> ReapOutcome {
         })
         .collect();
 
-    let found = mine.len();
+    let header = format!("[clud] orphan scan on exit (originator=CLUD:{self_pid}):");
+    report_and_reap(mine, &header, opts)
+}
+
+/// Scan for *abandoned* CLUD-tagged descendants whose originator process is
+/// no longer alive (dead PID, or PID reused by a later-started process —
+/// `running_process` already guards both with a start-time check).
+///
+/// This is the broader sweep called by `clud slay`, by the daemon's
+/// periodic heartbeat, and on `DaemonRequest::ReapOrphans`. Unlike
+/// [`scan_and_report`], it does NOT restrict to descendants of the current
+/// process — anything CLUD-tagged with a dead originator is fair game.
+pub fn reap_orphans(opts: &ReapOpts) -> ReapOutcome {
+    let all = running_process::originator::find_processes_by_originator("CLUD");
+    let orphans: Vec<Descendant> = all
+        .into_iter()
+        .filter(|p| !p.parent_alive)
+        .map(|p| Descendant {
+            pid: p.pid,
+            name: p.name,
+            command: p.command,
+        })
+        .collect();
+
+    let header = "[clud] orphan sweep (dead originator):".to_string();
+    report_and_reap(orphans, &header, opts)
+}
+
+/// Shared classify / report / kill body for both entry points. Returns a
+/// default outcome when `descendants` is empty so callers can skip noise.
+fn report_and_reap(descendants: Vec<Descendant>, header: &str, opts: &ReapOpts) -> ReapOutcome {
+    let found = descendants.len();
     if found == 0 {
         return ReapOutcome::default();
     }
@@ -203,7 +234,7 @@ pub fn scan_and_report(self_pid: u32, opts: &ReapOpts) -> ReapOutcome {
     // Group by shape label so the report collapses N identical leaks into
     // a single row with a list of PIDs/ports.
     let mut by_label: BTreeMap<String, Vec<&Descendant>> = BTreeMap::new();
-    let classified: Vec<(Shape, &Descendant)> = mine
+    let classified: Vec<(Shape, &Descendant)> = descendants
         .iter()
         .map(|d| (classify(&d.name, &d.command), d))
         .collect();
@@ -217,10 +248,7 @@ pub fn scan_and_report(self_pid: u32, opts: &ReapOpts) -> ReapOutcome {
         } else {
             "(reaping)"
         };
-        eprintln!(
-            "[clud] orphan scan on exit (originator=CLUD:{self_pid}): \
-             {found} env-tagged descendant(s) {action_word}"
-        );
+        eprintln!("{header} {found} env-tagged descendant(s) {action_word}");
         for (label, ds) in &by_label {
             let pids: Vec<String> = ds.iter().map(|d| d.pid.to_string()).collect();
             eprintln!(
@@ -247,7 +275,7 @@ pub fn scan_and_report(self_pid: u32, opts: &ReapOpts) -> ReapOutcome {
     }
 
     let mut reaped = 0usize;
-    for d in &mine {
+    for d in &descendants {
         process_tree::kill_tree(d.pid);
         reaped += 1;
     }
@@ -404,5 +432,21 @@ mod tests {
         );
         assert_eq!(outcome.found, 0);
         assert_eq!(outcome.reaped, 0);
+    }
+
+    #[test]
+    fn reap_orphans_in_keep_mode_does_not_kill() {
+        // `keep: true` means: list candidates but never invoke kill_tree. The
+        // test host may or may not have CLUD-tagged descendants with a dead
+        // originator, so we only assert that `reaped == 0` (never kill) and
+        // that `found >= reaped`. This guards against regressions where the
+        // shared report_and_reap path stops honoring `keep`.
+        let outcome = reap_orphans(&ReapOpts {
+            keep: true,
+            quiet: true,
+            explain: false,
+        });
+        assert_eq!(outcome.reaped, 0);
+        assert!(outcome.found >= outcome.reaped);
     }
 }

--- a/crates/clud-bin/tests/orphan_reap.rs
+++ b/crates/clud-bin/tests/orphan_reap.rs
@@ -1,0 +1,96 @@
+//! Integration test: `orphan_reaper::reap_orphans` actually kills a
+//! CLUD-tagged process whose originator PID is no longer alive.
+//!
+//! Strategy: spawn `mock-agent --mock-sleep-ms 30000` with an env var of
+//! `RUNNING_PROCESS_ORIGINATOR=CLUD:99999999`. PID 99999999 is overwhelmingly
+//! unlikely to be a live process on the test host (and even if it is, the
+//! start-time guard inside `running-process` keeps it out of the alive set).
+//! That makes the spawned mock-agent an "orphan" by definition. We then
+//! invoke `reap_orphans` and assert the spawned PID is gone.
+
+use std::time::Duration;
+
+use running_process::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+
+use clud::orphan_reaper::{reap_orphans, ReapOpts};
+
+mod common;
+use common::{mock_agent_path, wait_until};
+
+/// Anyone-but-a-real-clud PID. Picked high enough to dodge live processes on
+/// the host yet inside the legal u32 range that
+/// `running-process::parse_originator_value` accepts.
+const DEAD_ORIGINATOR_PID: u32 = 99_999_999;
+
+#[test]
+fn reap_orphans_kills_a_dead_originator_child() {
+    let mock = mock_agent_path();
+
+    // Inherit our env so PATH / system DLLs resolve, then override the
+    // originator var to point at a PID that is not a live `clud` process.
+    let mut env: Vec<(String, String)> = std::env::vars().collect();
+    env.retain(|(k, _)| k != "RUNNING_PROCESS_ORIGINATOR");
+    env.push((
+        "RUNNING_PROCESS_ORIGINATOR".to_string(),
+        format!("CLUD:{DEAD_ORIGINATOR_PID}"),
+    ));
+
+    let config = ProcessConfig {
+        command: CommandSpec::Argv(vec![
+            mock.to_string_lossy().into_owned(),
+            "--mock-sleep-ms".to_string(),
+            "30000".to_string(),
+        ]),
+        cwd: None,
+        env: Some(env),
+        capture: false,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Null,
+        nice: None,
+    };
+    let process = NativeProcess::new(config);
+    process.start().expect("spawn mock-agent");
+
+    let target_pid = process.pid().expect("mock-agent has a pid");
+
+    // Wait until `find_processes_by_originator` actually observes the
+    // spawned child — sysinfo's environ readback is async on some hosts.
+    let observed = wait_until(Duration::from_secs(5), || {
+        running_process::originator::find_processes_by_originator("CLUD")
+            .iter()
+            .any(|p| p.pid == target_pid)
+    });
+    if !observed {
+        let _ = process.kill();
+        let _ = process.wait(Some(Duration::from_secs(2)));
+        panic!("spawned mock-agent (pid={target_pid}) was never observed as CLUD-tagged");
+    }
+
+    let outcome = reap_orphans(&ReapOpts {
+        keep: false,
+        quiet: true,
+        explain: false,
+    });
+    assert!(
+        outcome.found >= 1,
+        "reap_orphans must have found at least our spawned child (found={})",
+        outcome.found
+    );
+    assert!(
+        outcome.reaped >= 1,
+        "reap_orphans must have reaped at least our spawned child (reaped={})",
+        outcome.reaped
+    );
+
+    // Confirm the child actually died. Poll its returncode rather than
+    // re-scanning sysinfo: if `reap_orphans` killed the right tree, the
+    // mock-agent exits within a few hundred ms.
+    let died = wait_until(Duration::from_secs(5), || process.returncode().is_some());
+    if !died {
+        let _ = process.kill();
+        let _ = process.wait(Some(Duration::from_secs(2)));
+        panic!("mock-agent (pid={target_pid}) survived reap_orphans");
+    }
+}

--- a/proto/clud_v1.proto
+++ b/proto/clud_v1.proto
@@ -17,6 +17,7 @@ message ClientToDaemon {
     AdoptKillRequest adopt_kill = 6;
     GcRequest gc = 7;
     ShutdownRequest shutdown = 8;
+    ReapOrphansRequest reap_orphans = 9;
   }
   string request_id = 100;
 }
@@ -32,6 +33,7 @@ message DaemonToClient {
     GcResponse gc = 7;
     ShutdownAckResponse shutdown_ack = 8;
     ErrorResponse error = 9;
+    ReapOrphansAckResponse reap_orphans_ack = 10;
   }
   string request_id = 100;
 }
@@ -88,6 +90,21 @@ message GcRequest {
 }
 
 message ShutdownRequest {}
+
+// Issue: have-the-daemon-do-the-orphan-sweep. Fire-and-forget from the
+// foreground CLI's exit hook: the daemon walks every CLUD-tagged process
+// whose originator is no longer alive and reaps its tree. The ack is sent
+// before the kill begins so the CLI does not block on shutdown.
+message ReapOrphansRequest {}
+
+message ReapOrphansAckResponse {
+  // Number of CLUD-tagged processes whose originator was already dead at
+  // scan time. Always 0 in the fast-path ack; populated only by the
+  // synchronous test path.
+  uint32 found = 1;
+  // Number actually reaped. Same caveat as `found`.
+  uint32 reaped = 2;
+}
 
 // `session_json` (field 1) is a RETIRED JSON mirror of the typed
 // snapshot: encoders stopped emitting it in clud 2.1.0 (running-process


### PR DESCRIPTION
## Summary

Two related but independent CLI improvements, one commit each:

- **`clud slay` now reaps dead-originator orphans.** A foreground clud SIGKILL'd before its exit hook would leave every CLUD-tagged descendant alive forever — `slay` only walked the daemon's session registry. New `orphan_reaper::reap_orphans` uses `running_process`'s start-time-guarded `parent_alive` to find them, and `slay` invokes it after the session loop. New `DaemonRequest::ReapOrphans` fires the same sweep from every foreground exit (fire-and-forget, 150ms tight timeout) and on a daemon-side 30s heartbeat — so SIGKILL'd-clud orphans get cleaned up even with no user intervention.
- **`clud optimize rust` prompts for scope and pre-announces the soldr install path.** Bare `clud optimize rust` now asks `[L]ocal repo / [G]lobal?` on a TTY, defaulting to Local on Enter / EOF. Non-TTY / `--dry-run` / scripted callers keep the prior default so CI stays stable. Before the GitHub download starts, `[clud] installing soldr X.Y.Z to <path>` prints so the user knows the destination during the spinner.

## Test plan

- [x] `bash lint` clean (cargo fmt + clippy -D warnings + ruff).
- [x] `bash test`: 850 Rust unit tests, 19 Rust integration tests, 80 Python unit tests all pass.
- [x] New unit tests: `reap_orphans_in_keep_mode_does_not_kill`, `parse_scope_answer_*`, `prompt_scope_*`, `planned_soldr_install_target_resolves`.
- [x] New wire-parity cases added for `DaemonRequest::ReapOrphans` / `DaemonResponse::ReapOrphansAck` (JSON + prost).
- [x] New integration test `tests/orphan_reap.rs`: spawns `mock-agent` with `RUNNING_PROCESS_ORIGINATOR=CLUD:99999999`, calls `reap_orphans`, asserts the mock dies. Passes on Windows x86_64.
- [ ] Manual smoke: run `clud slay` after closing a terminal that hosted active claude/codex sessions and confirm leftover tagged trees are reaped.
- [ ] Manual smoke: run `clud optimize rust` in a TTY and confirm the prompt + pre-announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)