### PR TITLE
chore(release): bump to 2.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 rust-version = "1.85"
 license-file = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "clud"
-version = "2.1.0"
+version = "2.2.0"
 description = "Fast Rust CLI for running Claude Code and Codex in YOLO mode"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clud/__init__.py
+++ b/src/clud/__init__.py
@@ -1,3 +1,3 @@
 """clud — Fast Rust CLI for running Claude Code and Codex in YOLO mode."""
 
-__version__ = "2.0.19"
+__version__ = "2.2.0"


### PR DESCRIPTION
## Summary

- Bump workspace + project version 2.1.0 → 2.2.0 to ship the seven `feat()` PRs that landed since 2.1.0 (runtime-cache, orphan-reaper, PTY image-paste interception, PTY default-audit flag, soldr optimize setup, slay command, slay-reaps-orphans + optimize scope prompt) plus four `refactor()` and one `fix(windows)`.
- Brings `src/clud/__init__.py` up to date — had been stuck at 2.0.19. The release workflow only validates Cargo.toml === pyproject.toml, but it's worth keeping the Python shim accurate.

## Test plan

- [x] `Cargo.toml [workspace.package].version` and `pyproject.toml [project].version` match (gate enforced by `.github/workflows/auto-release.yml`).
- [ ] Merge, then push tag `2.2.0` on main to trigger Auto Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)