### PR TITLE
feat: bundle clud-fix for Codex

### DIFF
--- a/crates/clud-bin/assets/skills/README.md
+++ b/crates/clud-bin/assets/skills/README.md
@@ -21,6 +21,9 @@ do not write persistent skill files. Stale clud-managed copies under
 - [clud-pr/](clud-pr/README.md) - Implement a GitHub issue, PR follow-up, or
   freeform task inside a `.claude/` worktree, or take an open PR through
   CI/review fixes to merge; code changes follow RED -> GREEN.
+- [clud-fix/](clud-fix/README.md) - Drive a GitHub issue through PR merge,
+  issue closure, and validation that the reported reproduction is fixed on
+  main; code changes follow RED -> GREEN.
 - [clud-tag-release/](clud-tag-release/README.md) - Tag a release after
   validating version match, clean `main`, and no duplicate tag, then push and
   surface the auto-release workflow URL.

--- a/crates/clud-bin/assets/skills/clud-fix/README.md
+++ b/crates/clud-bin/assets/skills/clud-fix/README.md
@@ -1,0 +1,22 @@
+# clud-fix/
+
+Bundled skill that drives a GitHub issue through the full fix lifecycle:
+implementation PR, merge to the default branch, issue closure, and validation
+that the reported reproduction no longer fails. It uses `clud-pr` for worktree,
+PR, CI/review, and merge-mode mechanics. Code changes follow RED -> GREEN:
+focused failing test or repro first, implementation second, passing focused
+signal before broad gates.
+
+## Files
+
+- `SKILL.md` - Frontmatter, triggers, and the full orchestration playbook.
+
+## How it ships
+
+The file is embedded into the `clud` binary at compile time via
+`include_str!("../assets/skills/clud-fix/SKILL.md")` from
+`crates/clud-bin/src/skills.rs` (entry in `BUNDLED_SKILLS`). During global
+setup, `ensure_installed` writes `<skills_dir>/clud-fix/SKILL.md` for the
+selected backend only when the target file is missing: Claude Code under
+`~/.claude/skills`, and Codex under `~/.codex/skills` gated by `~/.codex`.
+Existing user edits are preserved. All install errors are non-fatal.

--- a/crates/clud-bin/assets/skills/clud-fix/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-fix/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: clud-fix
+description: Drive a GitHub issue end-to-end until PRs are merged, the issue is closed, and the reported reproduction is validated fixed on main.
+triggers:
+  - When the user says "/clud-fix <issue-url-or-num>"
+  - When the user asks to fix a GitHub issue and expects merged-and-validated, not just a PR
+  - When a previous /clud-pr run closed but the issue is still open or unvalidated
+  - When the user points at a meta, tracking, or epic issue and asks for all sub-issues fixed
+---
+<!-- managed-by: clud -->
+
+# /clud-fix
+
+Drive a GitHub issue until all required closure evidence exists: the fixing PR
+is merged to the default branch, the issue is closed, and the issue's reported
+reproduction no longer reproduces on current main. This skill orchestrates
+existing clud workflows; it does not reimplement the worktree, CI, review, or
+merge logic owned by [[clud-pr]].
+
+For code changes, preserve RED -> GREEN: identify or add the focused failing
+test or executable reproduction first, implement the scoped fix, then rerun that
+focused signal until it passes before broad gates.
+
+## Input
+
+- A GitHub issue URL such as `https://github.com/<owner>/<repo>/issues/<num>`.
+- A bare `#<num>` only when the current checkout is the right repository. Resolve
+  `<owner>/<repo>` with `gh repo view` before acting.
+
+The argument can be a single issue or a meta/tracking issue that lists
+sub-issues. Classify the mode before planning any implementation.
+
+## Done When
+
+For a single issue, all three conditions are mandatory:
+
+1. Every PR opened for the issue is merged into the repository default branch.
+2. The issue is closed on GitHub.
+3. The reported reproduction or acceptance check passes against current main.
+
+For a meta issue, process open sub-issues sequentially until the open sub-issue
+list is empty, the meta issue closes, the user stops the run, or an explicit
+blocker/cap is reached.
+
+## Workflow
+
+1. **Intake gate.** Fetch the issue with
+   `gh issue view <num> --repo <owner>/<repo> --json number,state,title,body,labels,comments,url`.
+   If the issue is not open, stop and report the current state.
+2. **Classify single vs. meta.** Treat it as meta when labels, title, body, or
+   the user's invocation clearly identify a tracking/epic issue or a checklist
+   of child issue references.
+3. **For under-specified single issues, investigate first.** If there is no
+   concrete reproduction, falsifiable symptom, fixed criterion, or bounded
+   scope, post an investigation report to the issue instead of opening a PR.
+   Include root-cause evidence, reproduction status, planned fix, validation
+   command, and open questions.
+4. **Survey existing PRs.** Search for PRs that mention or close the issue. If a
+   merged PR already claims the issue, validate against current main and close
+   the issue if validation succeeds. If an open PR exists, use [[clud-pr]] PR
+   merge mode to drive it through CI/review fixes and merge.
+5. **Plan the fix.** Identify files to touch, tests to add, and the validation
+   command that proves the reported reproduction is fixed. For non-trivial
+   design scope, check in with the user before opening a PR.
+6. **Implement and ship via [[clud-pr]].** Hand off the issue URL or PR URL to
+   [[clud-pr]]. It owns the disposable worktree, focused RED -> GREEN cycle,
+   broad lint/test gates, commit, push, PR creation, CI/review fix loop, and
+   merge mode.
+7. **Validate on main.** After merge, run
+   `git fetch origin && git checkout main && git pull` in the main checkout, then
+   run the issue's original reproduction or acceptance command. CI green is not
+   enough; validation must exercise the reported behavior.
+8. **Close or confirm closed.** Verify with `gh issue view <num> --json state`.
+   If the issue is still open after a validated merge, close it with a comment
+   naming the merged PR and validation evidence.
+9. **Report.** Return the merged PR URL(s), the closed issue URL, and one
+   sentence of validation evidence.
+
+## Meta Workflow
+
+1. Enumerate child issue references from the meta issue body and GitHub issue
+   metadata.
+2. Work one open child issue at a time, in listed order. Do not parallelize
+   sub-issues.
+3. For each child, run the single-issue workflow from intake through validation
+   and closure.
+4. Refresh the child list between iterations so newly closed or newly added
+   issues are handled correctly.
+5. When no open child issues remain, report the per-child outcomes and stop. Do
+   not manufacture new work.
+
+## Failure Modes To Avoid
+
+- Treating PR merge as sufficient without issue closure and reproduction
+  validation.
+- Opening a PR for an issue that lacks a concrete reproduction or fixed
+  criterion.
+- Skipping validation because CI passed.
+- Expecting a standalone merge skill; use [[clud-pr]] PR merge mode.
+- Working meta sub-issues in parallel.
+- Pushing to an unfamiliar third-party repository without confirming access and
+  intent with the user.
+
+## When Not To Use This
+
+- The user only wants a PR opened and does not require merge, closure, and
+  validation; use [[clud-pr]].
+- The task is design discussion rather than a bounded issue fix.
+- The requested issue has no falsifiable reproduction and no acceptance
+  criteria; post an investigation report first.

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -55,6 +55,10 @@ pub const BUNDLED_SKILLS: &[BundledSkill] = &[
         skill_md: include_str!("../assets/skills/clud-pr/SKILL.md"),
     },
     BundledSkill {
+        name: "clud-fix",
+        skill_md: include_str!("../assets/skills/clud-fix/SKILL.md"),
+    },
+    BundledSkill {
         name: "clud-tag-release",
         skill_md: include_str!("../assets/skills/clud-tag-release/SKILL.md"),
     },
@@ -462,6 +466,7 @@ mod tests {
         assert!(names.contains(&"clud-issue"));
         assert!(names.contains(&"clud-issue-triage"));
         assert!(names.contains(&"clud-pr"));
+        assert!(names.contains(&"clud-fix"));
         assert!(names.contains(&"clud-tag-release"));
         assert!(names.contains(&"clud-docker-rust-app-dev"));
         assert!(names.contains(&"clud-windows-trash"));
@@ -586,7 +591,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_install_writes_bundled_skill_body_byte_for_byte() {
+    fn codex_install_writes_bundled_skill_bodies_byte_for_byte() {
         let home = tempdir().unwrap();
         std::fs::create_dir_all(home.path().join(".codex")).unwrap();
 
@@ -594,14 +599,21 @@ mod tests {
             .unwrap()
             .expect("codex backend should be active");
 
-        let expected = BUNDLED_SKILLS
-            .iter()
-            .find(|s| s.name == "clud-pr")
-            .expect("clud-pr must be bundled")
-            .skill_md;
-        let written =
-            std::fs::read_to_string(home.path().join(".codex/skills/clud-pr/SKILL.md")).unwrap();
-        assert_eq!(written, expected);
+        for skill_name in ["clud-pr", "clud-fix"] {
+            let expected = BUNDLED_SKILLS
+                .iter()
+                .find(|s| s.name == skill_name)
+                .unwrap_or_else(|| panic!("{skill_name} must be bundled"))
+                .skill_md;
+            let written = std::fs::read_to_string(
+                home.path()
+                    .join(".codex/skills")
+                    .join(skill_name)
+                    .join("SKILL.md"),
+            )
+            .unwrap();
+            assert_eq!(written, expected);
+        }
     }
 
     #[test]

--- a/docs/architecture/skill-system.md
+++ b/docs/architecture/skill-system.md
@@ -33,7 +33,7 @@ multi-backend expander landed.
 | Backends targeted | Selected backend during global setup; Claude plus Codex today | Claude global setup only |
 | Source tree | `crates/clud-bin/assets/skills/` | Top-level `skills/` |
 | Existing file behavior | Skip, preserving user edits | Compare modulo whitespace; overwrite semantic divergence |
-| Bundled skills | `clud-loop`, `clud-issue`, `clud-issue-triage`, `clud-pr`, `clud-tag-release`, `clud-docker-rust-app-dev`, `clud-windows-trash`, `clud-extern-repos` | `clud-pr`, `clud-issue`, `clud-windows-trash`, `clud-extern-repos` |
+| Bundled skills | `clud-loop`, `clud-issue`, `clud-issue-triage`, `clud-pr`, `clud-fix`, `clud-tag-release`, `clud-docker-rust-app-dev`, `clud-windows-trash`, `clud-extern-repos`, `clud-improve` | `clud-pr`, `clud-issue`, `clud-windows-trash`, `clud-extern-repos` |
 | Retired purge list | Stale clud-managed copies under `~/.agents/skills/` | `clud-pr-merge` |
 
 Both flows are non-fatal. A failure logs a `[clud] note: ...` line and launch
@@ -65,6 +65,7 @@ When global setup is selected:
 | `clud-loop` | yes | no |
 | `clud-issue` | yes | yes |
 | `clud-pr` | yes | yes |
+| `clud-fix` | yes | no |
 | `clud-issue-triage` | yes | no |
 | `clud-tag-release` | yes | no |
 | `clud-docker-rust-app-dev` | yes | no |

--- a/tests/integration/test_codex_skills.py
+++ b/tests/integration/test_codex_skills.py
@@ -22,8 +22,11 @@ import pytest
 pytestmark = pytest.mark.integration
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-BUNDLED_SKILL_PATH = (
+BUNDLED_CLUD_PR_SKILL_PATH = (
     REPO_ROOT / "crates" / "clud-bin" / "assets" / "skills" / "clud-pr" / "SKILL.md"
+)
+BUNDLED_CLUD_FIX_SKILL_PATH = (
+    REPO_ROOT / "crates" / "clud-bin" / "assets" / "skills" / "clud-fix" / "SKILL.md"
 )
 
 
@@ -31,12 +34,23 @@ def test_bundled_clud_pr_skill_carries_managed_marker_and_frontmatter() -> None:
     """The source-of-truth SKILL.md must carry the marker the installer keys
     its purge on. If this drifts, every install/purge guarantee in
     ``skills.rs`` silently weakens."""
-    body = BUNDLED_SKILL_PATH.read_text(encoding="utf-8")
+    body = BUNDLED_CLUD_PR_SKILL_PATH.read_text(encoding="utf-8")
     assert body.startswith("---"), "SKILL.md must begin with YAML frontmatter"
     assert "<!-- managed-by: clud -->" in body, (
         "managed-by marker is required for purge_stale_agents_skills "
         "to recognize clud-managed copies"
     )
+
+
+def test_bundled_clud_fix_skill_carries_codex_install_metadata() -> None:
+    """Issue #353: clud-fix must be a multi-backend bundled skill so Codex
+    installs it under ~/.codex/skills just like the other clud skills."""
+    body = BUNDLED_CLUD_FIX_SKILL_PATH.read_text(encoding="utf-8")
+    assert body.startswith("---"), "SKILL.md must begin with YAML frontmatter"
+    assert "name: clud-fix" in body
+    assert "<!-- managed-by: clud -->" in body
+    assert "RED -> GREEN" in body
+    assert "clud-pr-merge" not in body
 
 
 def test_clud_codex_dry_run_does_not_crash(


### PR DESCRIPTION
﻿## Summary

- add `clud-fix` to the multi-backend bundled skill assets
- register it in `skills.rs` so Codex global setup installs `~/.codex/skills/clud-fix/SKILL.md`
- update skill docs/tests and avoid retired `clud-pr-merge` terminology

Closes #353

## Tests

- `bash lint`
- focused Rust skill tests through `ci.env` cargo argv: 23 passed
- `CLUD_INTEGRATION_TESTS=1 uv run --no-editable pytest tests/integration/test_codex_skills.py::test_bundled_clud_fix_skill_carries_codex_install_metadata -q`

Note: `bash test` passed the Rust suite including `skills::tests`, then failed one unrelated Windows console-title Python assertion (`expected 'clud <tmpdir>', got '? clud'`).
