### PR TITLE
feat: make clud-fix own issue orchestration

### DIFF
--- a/crates/clud-bin/assets/skills/clud-fix/README.md
+++ b/crates/clud-bin/assets/skills/clud-fix/README.md
@@ -1,11 +1,12 @@
 # clud-fix/
 
-Bundled skill that drives a GitHub issue through the full fix lifecycle:
-implementation PR, merge to the default branch, issue closure, and validation
-that the reported reproduction no longer fails. It uses `clud-pr` for worktree,
-PR, CI/review, and merge-mode mechanics. Code changes follow RED -> GREEN:
-focused failing test or repro first, implementation second, passing focused
-signal before broad gates.
+Bundled skill that drives a single GitHub issue or a meta/parent/burn-down issue
+through the full fix lifecycle: implementation PRs, merge to the default branch,
+child issue closure, parent checklist updates, parent closure, and validation
+that reported reproductions no longer fail. It owns the outer issue-level
+`/goal` and uses `clud-pr` in delegated mode for worktree, PR, CI/review, and
+merge-mode mechanics. Code changes follow RED -> GREEN: focused failing test or
+repro first, implementation second, passing focused signal before broad gates.
 
 ## Files
 
@@ -19,4 +20,5 @@ The file is embedded into the `clud` binary at compile time via
 setup, `ensure_installed` writes `<skills_dir>/clud-fix/SKILL.md` for the
 selected backend only when the target file is missing: Claude Code under
 `~/.claude/skills`, and Codex under `~/.codex/skills` gated by `~/.codex`.
-Existing user edits are preserved. All install errors are non-fatal.
+The Claude drift installer also includes `clud-fix` so stale managed Claude
+copies are upgraded to the canonical workflow. All install errors are non-fatal.

--- a/crates/clud-bin/assets/skills/clud-fix/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-fix/SKILL.md
@@ -1,21 +1,28 @@
 ---
 name: clud-fix
-description: Drive a GitHub issue end-to-end until PRs are merged, the issue is closed, and the reported reproduction is validated fixed on main.
+description: Drive single GitHub issues or meta/parent burn-down issues until PRs are merged, issues are closed, and reported reproductions are validated fixed on main.
 triggers:
   - When the user says "/clud-fix <issue-url-or-num>"
+  - When the user says "$clud-fix <issue-url-or-num>" from Codex
   - When the user asks to fix a GitHub issue and expects merged-and-validated, not just a PR
-  - When a previous /clud-pr run closed but the issue is still open or unvalidated
-  - When the user points at a meta, tracking, or epic issue and asks for all sub-issues fixed
+  - When the user points at a meta, parent, tracking, epic, or burn-down issue and asks for all sub-issues fixed
+  - When the user invokes "/goal $clud-fix <issue-or-issue-url>"
 ---
 <!-- managed-by: clud -->
 
 # /clud-fix
 
-Drive a GitHub issue until all required closure evidence exists: the fixing PR
-is merged to the default branch, the issue is closed, and the issue's reported
-reproduction no longer reproduces on current main. This skill orchestrates
-existing clud workflows; it does not reimplement the worktree, CI, review, or
-merge logic owned by [[clud-pr]].
+Drive a GitHub issue until the real issue-level completion condition is true.
+For a single issue, that means PR(s) merged to the default branch, the issue
+closed, and the reported reproduction or acceptance check validated on current
+main. For a meta/parent/burn-down issue, that means every child issue is closed
+and validated, the parent checklist is updated where possible, and the parent
+issue itself is closed.
+
+This skill is the outer issue orchestrator for both Claude and Codex through
+clud. It delegates one-PR work and PR merge work to [[clud-pr]], but it owns the
+issue-level `/goal` lifecycle. Do not invoke or depend on a standalone merge
+skill.
 
 For code changes, preserve RED -> GREEN: identify or add the focused failing
 test or executable reproduction first, implement the scoped fix, then rerun that
@@ -27,79 +34,207 @@ focused signal until it passes before broad gates.
 - A bare `#<num>` only when the current checkout is the right repository. Resolve
   `<owner>/<repo>` with `gh repo view` before acting.
 
-The argument can be a single issue or a meta/tracking issue that lists
+The argument can be a single issue or a meta/parent/burn-down issue that lists
 sub-issues. Classify the mode before planning any implementation.
+
+## Goal Ownership
+
+When the user invokes `/goal $clud-fix <issue-or-issue-url>`, this skill owns
+the outer goal until the issue-level completion condition is proven.
+
+For a single issue, use a goal equivalent to:
+
+```text
+/goal Fix issue #N: PR(s) merged to main, issue closed, and reported reproduction validated fixed on current main.
+```
+
+For a meta/parent/burn-down issue, use a goal equivalent to:
+
+```text
+/goal Complete meta issue #N: every child issue closed/validated, parent checklist updated, parent issue closed, and final evidence reported.
+```
+
+When delegating to [[clud-pr]], explicitly tell it that this is a delegated
+`clud-fix` call. Delegated `clud-pr` work must not invoke a nested `/goal`,
+replace the outer goal, or narrow success to "PR opened." It must return
+structured evidence for `clud-fix` to evaluate: issue URL, PR URL(s), PR merged
+state, tests run, validation notes, blocker reason if any, and issue closure
+state.
 
 ## Done When
 
-For a single issue, all three conditions are mandatory:
+### Single Issue
 
-1. Every PR opened for the issue is merged into the repository default branch.
+All three conditions are mandatory:
+
+1. Every fixing PR for the issue is merged into the repository default branch.
 2. The issue is closed on GitHub.
 3. The reported reproduction or acceptance check passes against current main.
 
-For a meta issue, process open sub-issues sequentially until the open sub-issue
-list is empty, the meta issue closes, the user stops the run, or an explicit
-blocker/cap is reached.
+Missing any one means the goal is not done.
 
-## Workflow
+### Meta / Parent / Burn-Down Issue
 
-1. **Intake gate.** Fetch the issue with
-   `gh issue view <num> --repo <owner>/<repo> --json number,state,title,body,labels,comments,url`.
-   If the issue is not open, stop and report the current state.
-2. **Classify single vs. meta.** Treat it as meta when labels, title, body, or
-   the user's invocation clearly identify a tracking/epic issue or a checklist
-   of child issue references.
-3. **For under-specified single issues, investigate first.** If there is no
-   concrete reproduction, falsifiable symptom, fixed criterion, or bounded
-   scope, post an investigation report to the issue instead of opening a PR.
+All conditions are mandatory:
+
+1. Every enumerated child issue is closed on GitHub.
+2. Every child has validation evidence from the child issue's reported
+   reproduction or acceptance criteria, or a documented skipped/blocker state
+   that was surfaced to the user.
+3. Parent checklist items are checked when the parent has a checklist entry for
+   the child.
+4. The parent issue is closed on GitHub.
+5. Final evidence is reported: child issue URLs, PR URLs, validation evidence,
+   skipped/blocker reasons, and parent closure state.
+
+## Single-Issue Workflow
+
+1. **Intake gate.** Fetch the issue with:
+
+   ```bash
+   gh issue view <num> --repo <owner>/<repo> --json number,state,title,body,labels,comments,url
+   ```
+
+   If the issue is not open, stop and report the current state. Do not silently
+   reopen or push.
+
+2. **Readiness check.** A fixable single issue needs:
+   - concrete reproduction: command, code snippet, or observable behavior
+   - falsifiable symptom: wrong output, error, stack trace, screenshot, or
+     specific misbehavior
+   - fixed criterion: expected behavior or acceptance checklist
+   - bounded scope: a bug fix or small feature, not open-ended design
+
+3. **Under-specified issues get investigation first.** If any readiness item is
+   missing, post an investigation report to the issue instead of opening a PR.
    Include root-cause evidence, reproduction status, planned fix, validation
-   command, and open questions.
-4. **Survey existing PRs.** Search for PRs that mention or close the issue. If a
-   merged PR already claims the issue, validate against current main and close
-   the issue if validation succeeds. If an open PR exists, use [[clud-pr]] PR
-   merge mode to drive it through CI/review fixes and merge.
-5. **Plan the fix.** Identify files to touch, tests to add, and the validation
-   command that proves the reported reproduction is fixed. For non-trivial
-   design scope, check in with the user before opening a PR.
-6. **Implement and ship via [[clud-pr]].** Hand off the issue URL or PR URL to
-   [[clud-pr]]. It owns the disposable worktree, focused RED -> GREEN cycle,
-   broad lint/test gates, commit, push, PR creation, CI/review fix loop, and
-   merge mode.
-7. **Validate on main.** After merge, run
-   `git fetch origin && git checkout main && git pull` in the main checkout, then
-   run the issue's original reproduction or acceptance command. CI green is not
-   enough; validation must exercise the reported behavior.
-8. **Close or confirm closed.** Verify with `gh issue view <num> --json state`.
+   command, and open questions. Then stop with the blocker surfaced; do not
+   manufacture a PR that cannot be validated.
+
+4. **Survey existing PRs.** Search for PRs that mention or close the issue:
+
+   ```bash
+   gh pr list --repo <owner>/<repo> --search "<num> in:body" --state all --json number,state,headRefName,mergedAt,url
+   ```
+
+   If a merged PR already claims the issue, validate against current main and
+   close the issue if validation succeeds. If an open PR exists, delegate to
+   [[clud-pr]] PR merge mode, in delegated mode, to drive it through CI/review
+   fixes and merge.
+
+5. **Plan validation before implementation.** Identify files to touch, focused
+   RED test/repro, and the post-merge validation command. For non-trivial design
+   scope, check in with the user before opening a PR.
+
+6. **Delegate PR work to [[clud-pr]].** Hand off the issue URL and state:
+   "delegated from `clud-fix`; do not set a nested `/goal`; return structured
+   evidence." [[clud-pr]] owns the disposable worktree, RED -> GREEN cycle,
+   lint/test gates, PR creation, CI/review fix loop, and merge mode.
+
+7. **Validate on main.** After merge, run:
+
+   ```bash
+   git fetch origin && git checkout main && git pull
+   ```
+
+   Then run the issue's original reproduction or acceptance command. CI green is
+   not enough; validation must exercise the reported behavior.
+
+8. **Close or confirm closed.** Verify with:
+
+   ```bash
+   gh issue view <num> --repo <owner>/<repo> --json state,closedAt
+   ```
+
    If the issue is still open after a validated merge, close it with a comment
    naming the merged PR and validation evidence.
-9. **Report.** Return the merged PR URL(s), the closed issue URL, and one
-   sentence of validation evidence.
 
-## Meta Workflow
+9. **Report.** Return the merged PR URL(s), the closed issue URL, and validation
+   evidence.
 
-1. Enumerate child issue references from the meta issue body and GitHub issue
-   metadata.
-2. Work one open child issue at a time, in listed order. Do not parallelize
-   sub-issues.
-3. For each child, run the single-issue workflow from intake through validation
-   and closure.
-4. Refresh the child list between iterations so newly closed or newly added
-   issues are handled correctly.
-5. When no open child issues remain, report the per-child outcomes and stop. Do
-   not manufacture new work.
+## Meta / Parent / Burn-Down Workflow
+
+1. **Fetch and classify the parent.** Treat an issue as meta/parent/burn-down
+   when labels, title, checklist body, linked issue references, GitHub sub-issue
+   metadata, or explicit user wording identify a tracker.
+
+2. **Enumerate child issues.** Collect child references from:
+   - markdown checklist lines like `- [ ] #123` or `- [x] #124`
+   - `owner/repo#123`
+   - full GitHub issue URLs
+   - GitHub sub-issue metadata when available
+
+   Verify each child's GitHub state before deciding it is already done.
+
+3. **Create/update the durable ledger.** Store progress in:
+
+   ```text
+   .clud/fix/<owner>__<repo>__issue-<num>.json
+   ```
+
+   Track parent issue URL/state, enumerated children, child status
+   (`pending`, `in_progress`, `closed`, `skipped`, `blocked`), PR URLs,
+   validation evidence, parent checklist update state, and final parent closure
+   evidence. Use the ledger to resume after context limits, process exits, or
+   manual interruptions.
+
+4. **Process children sequentially.** Work one open child at a time, in listed
+   order. Never parallelize child issues; parallel PRs make CI and status
+   reporting incoherent.
+
+5. **Run the single-issue workflow for each child.** Re-enter the single-issue
+   workflow from intake through validation and closure. Under-specified children
+   get an investigation report and are marked `skipped` or `blocked` in the
+   ledger; they are not retried indefinitely in the same run.
+
+6. **Update the parent after each child.** When a child is closed and validated,
+   tick the parent checklist item if present. Post a concise status line:
+   `[meta #N] child #X -> CLOSED (validated by <command/evidence>)` or
+   `[meta #N] child #X -> skipped (<reason>)`.
+
+7. **Refresh the parent between children.** Re-fetch the parent body and
+   metadata so newly added child issues are picked up and externally closed
+   children are skipped.
+
+8. **Close the parent only when complete.** When the refreshed child list has no
+   open children and no unresolved blockers, close the parent issue with a
+   summary of child outcomes and validation evidence.
+
+9. **Final report.** Report parent URL and CLOSED state, child issue URLs,
+   merged PR URLs, validation evidence, and any skipped/blocker details.
+
+## Loop Caps
+
+- Single issue: at most 10 PRs total, 3 merge/fix rounds per PR, 2 validation
+  retries.
+- Meta/parent issue: no outer child-count cap. Per-child caps still apply. If a
+  child exhausts a cap, mark it blocked/skipped in the ledger, surface it, and
+  continue to the next child unless the user asks to stop.
+
+## Claude And Codex Parity
+
+This skill must work the same through clud for Claude and Codex:
+
+- Codex reads the bundled skill from `~/.codex/skills/clud-fix/SKILL.md`.
+- Claude reads the managed skill from `~/.claude/skills/clud-fix/SKILL.md`.
+- The bundled source in `crates/clud-bin/assets/skills/clud-fix/SKILL.md` is the
+  canonical workflow for both backends.
+- Stale Claude-local managed copies must be updated by clud's Claude drift
+  installer; stale standalone merge skill installs must be purged safely.
 
 ## Failure Modes To Avoid
 
-- Treating PR merge as sufficient without issue closure and reproduction
-  validation.
+- Letting delegated [[clud-pr]] replace the outer `clud-fix` `/goal`.
+- Calling the goal done after PR merge alone.
+- Closing a parent issue while any child issue is still open or unvalidated.
+- Skipping validation because CI passed.
 - Opening a PR for an issue that lacks a concrete reproduction or fixed
   criterion.
-- Skipping validation because CI passed.
-- Expecting a standalone merge skill; use [[clud-pr]] PR merge mode.
-- Working meta sub-issues in parallel.
-- Pushing to an unfamiliar third-party repository without confirming access and
-  intent with the user.
+- Working meta child issues in parallel.
+- Depending on a standalone merge skill; use [[clud-pr]] PR merge mode.
+- Treating a checked checklist item as proof without verifying the child issue
+  state on GitHub.
+- Manufacturing new child issues after the open-child list is empty.
 
 ## When Not To Use This
 

--- a/crates/clud-bin/assets/skills/clud-pr/README.md
+++ b/crates/clud-bin/assets/skills/clud-pr/README.md
@@ -1,6 +1,6 @@
 # clud-pr/
 
-Bundled skill that implements a GitHub issue, PR follow-up, or freeform task inside a `.claude/worktrees/<branch>/` worktree and ships it as one clean PR. It also owns PR merge mode, formerly `/clud-pr-merge`, for taking an open PR through CI/review fixes to merge. Triggers on `/clud-pr`, merge/land requests, a PR URL/number (triage mode), an issue URL/number, or any phrasing like "ship", "do-pr", or a task sentence with intent to deliver. Code changes follow RED -> GREEN: failing focused test/repro first, implementation second, passing signal before broad gates.
+Bundled skill that implements a GitHub issue, PR follow-up, or freeform task inside a `.claude/worktrees/<branch>/` worktree and ships it as one clean PR. It also owns PR merge mode, formerly `/clud-pr-merge`, for taking an open PR through CI/review fixes to merge. When delegated from `clud-fix`, it skips nested `/goal` setup and returns structured PR/merge evidence to the issue-level orchestrator. Triggers on `/clud-pr`, merge/land requests, a PR URL/number (triage mode), an issue URL/number, or any phrasing like "ship", "do-pr", or a task sentence with intent to deliver. Code changes follow RED -> GREEN: failing focused test/repro first, implementation second, passing signal before broad gates.
 
 ## Files
 

--- a/crates/clud-bin/assets/skills/clud-pr/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-pr/SKILL.md
@@ -14,13 +14,14 @@ triggers:
 
 Read the user's task, express the bug fix or feature requirement as a failing test first, implement the fix until that test turns green, push it as one PR with no files left behind, then give the user the PR URL. The task may be an issue URL, issue number, PR URL, PR number, or a plain sentence.
 
-Five hard rules:
+Six hard rules:
 
-1. **Lock the goal in.** Before any code or merge work, invoke the `/goal <one-line deliverable>` slash command so the harness Stop hook blocks until you ship. Use the deliverable phrasings under each mode below. Skip only for PR Triage Mode until triage decides to act.
+1. **Lock the goal in, unless delegated.** Before any code or merge work, invoke the `/goal <one-line deliverable>` slash command so the harness Stop hook blocks until you ship. Use the deliverable phrasings under each mode below. Skip only for PR Triage Mode until triage decides to act, or when the caller explicitly says this is delegated from [[clud-fix]] and an outer issue-level goal is already active.
 2. **Use a disposable worktree.** Do all PR work inside `.claude/worktrees/<branch>/`, never on the main checkout.
 3. **Push the PR.** Finish with `gh pr create`; a local branch or commit is not the deliverable.
 4. **Leave nothing behind.** After the PR exists, remove the worktree and verify the main checkout's `git status` is clean.
 5. **RED -> GREEN for code changes.** Before implementing a bug fix or feature, add or identify an automated test that fails because the requirement is unmet. Run the focused test and capture the RED failure. Then implement until that test is GREEN. If no automated test is practical, document the reason and use the closest executable repro/check before coding.
+6. **Delegated mode returns evidence.** When called by [[clud-fix]], do not set or replace `/goal`; return structured evidence for the outer orchestrator instead.
 
 ## Worktree Workspace
 
@@ -35,15 +36,34 @@ Five hard rules:
 
 Look at the input first:
 
+- **Explicitly delegated from [[clud-fix]]** -> run the matching task or merge mode in **Delegated Mode**. Do not set a nested `/goal`.
 - **PR URL / number** -> run **PR triage mode**. Do not branch or code until triage decides what to do.
 - **Merge / land / ship current PR** -> run **PR merge mode**.
 - **Issue URL / number / freeform task sentence** -> run **task to PR workflow**.
+
+## Delegated Mode
+
+Use this mode when [[clud-fix]] hands off one issue or one PR while it owns an
+outer issue-level `/goal`.
+
+1. **Do not invoke `/goal`.** The active goal belongs to [[clud-fix]] and covers
+   issue closure, validation, parent checklist updates, and parent closure.
+2. **Run the normal task or merge workflow.** All worktree, RED -> GREEN, CI,
+   CodeRabbit, lint/test, commit, push, merge, and teardown rules still apply.
+3. **Return structured evidence instead of a goal result.** Include:
+   - issue URL or PR URL received
+   - PR URL opened or merged
+   - PR state and merge commit when applicable
+   - focused RED/GREEN command and broad checks run
+   - remaining blockers, if any
+   - issue closure state if known
+4. **Do not close parent/meta issues.** Parent issue state is owned by [[clud-fix]].
 
 ## PR Merge Mode
 
 Use this when the user asks to merge, land, or ship an already-open PR.
 
-1. **Set the goal.** Invoke `/goal Merge PR #<num> to main and report the merged URL.` so the Stop hook blocks until the PR is merged or you explicitly clear the goal.
+1. **Set the goal unless delegated.** Invoke `/goal Merge PR #<num> to main and report the merged URL.` so the Stop hook blocks until the PR is merged or you explicitly clear the goal. If delegated from [[clud-fix]], skip this nested goal and return structured merge evidence to the caller.
 2. **Resolve the PR.** `gh pr view --json number,headRefName,baseRefName,state,mergeable,statusCheckRollup,url`. Refuse if state is not `OPEN` or mergeability is a clear blocker.
 3. **Poll with a cap and visible status.** Estimate recent CI duration from `gh run list --branch <default> --limit 10 --json conclusion,startedAt,updatedAt`; announce the cap before waiting. Poll every 30 seconds, and check `gh pr view <num> --json state` first every time so a manually merged/closed PR exits immediately.
 4. **Classify CI failures.** A check passing on default but failing on the PR is a regression. A check already failing on default is pre-existing and not merge-blocking. A PR-only check missing on default must be compared against recent PRs before calling it pre-existing.
@@ -67,7 +87,7 @@ Use this when the user asks to merge, land, or ship an already-open PR.
 ## Task To PR Workflow
 
 1. **Read the task.** If the input includes an issue URL/number, fetch it with `gh issue view <num>` or the URL and extract acceptance criteria. If it is a plain sentence, treat that sentence as the acceptance criteria and infer the repo from the current checkout.
-2. **Set the goal.** After reading the task and before any worktree or code work, invoke `/goal Ship PR for <issue-or-task-summary>: report URL and confirm main checkout is clean.` so the Stop hook blocks until the PR URL is reported and the worktree is torn down. If issue-only checks resolve the work without a new PR, clear the goal before stopping.
+2. **Set the goal unless delegated.** After reading the task and before any worktree or code work, invoke `/goal Ship PR for <issue-or-task-summary>: report URL and confirm main checkout is clean.` so the Stop hook blocks until the PR URL is reported and the worktree is torn down. If delegated from [[clud-fix]], skip this nested goal and return structured PR evidence to the caller. If issue-only checks resolve the work without a new PR, clear the goal before stopping.
 3. **Issue-only checks.** For issue inputs only:
    - Verify the issue is open.
    - Search for PRs that already resolve it.
@@ -92,6 +112,7 @@ Use this when the user asks to merge, land, or ship an already-open PR.
 - Calling an issue resolved when its PR merged only into a stack branch.
 - Creating multiple PRs for one requested task.
 - Implementing before proving RED, or claiming coverage from a test that never failed for the bug/requirement.
+- Replacing an outer [[clud-fix]] `/goal` with a narrower PR-level goal while in delegated mode.
 - Pushing with a dirty worktree or leaving `.claude/worktrees/<branch>/` behind.
 - Skipping lint, tests, or failing hooks.
 - Auto-deleting stale worktrees without asking.

--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -37,6 +37,10 @@ const BUNDLED_SKILLS: &[Skill] = &[
         content: include_str!("../../../skills/clud-pr/SKILL.md"),
     },
     Skill {
+        name: "clud-fix",
+        content: include_str!("../assets/skills/clud-fix/SKILL.md"),
+    },
+    Skill {
         name: "clud-issue",
         content: include_str!("../../../skills/clud-issue/SKILL.md"),
     },
@@ -416,6 +420,10 @@ mod tests {
         // just guards against accidental removal of any of them.
         let names: Vec<&str> = BUNDLED_SKILLS.iter().map(|s| s.name).collect();
         assert!(names.contains(&"clud-pr"), "clud-pr missing from bundle");
+        assert!(
+            names.contains(&"clud-fix"),
+            "clud-fix missing from Claude drift bundle"
+        );
         assert!(
             !names.contains(&"clud-pr-merge"),
             "clud-pr-merge should be retired into PURGED_SKILLS"

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -509,6 +509,57 @@ mod tests {
     }
 
     #[test]
+    fn clud_fix_skill_owns_issue_goal_and_meta_burndown() {
+        let skill = BUNDLED_SKILLS
+            .iter()
+            .find(|skill| skill.name == "clud-fix")
+            .expect("clud-fix must be bundled")
+            .skill_md;
+
+        for required in [
+            "/goal $clud-fix <issue-or-issue-url>",
+            "Complete meta issue #N",
+            "every child issue closed/validated",
+            "parent checklist updated",
+            "parent issue closed",
+            ".clud/fix/<owner>__<repo>__issue-<num>.json",
+            "Delegated `clud-pr` work must not invoke a nested `/goal`",
+            "Claude And Codex Parity",
+        ] {
+            assert!(
+                skill.contains(required),
+                "clud-fix skill missing required orchestration guidance: {required}"
+            );
+        }
+
+        assert!(
+            !skill.contains("clud-pr-merge"),
+            "clud-fix must not depend on the retired merge skill"
+        );
+    }
+
+    #[test]
+    fn clud_pr_skill_supports_delegated_mode_without_nested_goal() {
+        let skill = BUNDLED_SKILLS
+            .iter()
+            .find(|skill| skill.name == "clud-pr")
+            .expect("clud-pr must be bundled")
+            .skill_md;
+
+        for required in [
+            "Delegated Mode",
+            "Do not invoke `/goal`",
+            "When called by [[clud-fix]], do not set or replace `/goal`",
+            "Return structured evidence",
+        ] {
+            assert!(
+                skill.contains(required),
+                "clud-pr skill missing delegated-mode guidance: {required}"
+            );
+        }
+    }
+
+    #[test]
     fn skill_backends_include_claude_and_codex() {
         let backends: Vec<(Backend, &str, &str, Option<&str>)> = SKILL_BACKENDS
             .iter()

--- a/docs/architecture/skill-system.md
+++ b/docs/architecture/skill-system.md
@@ -33,7 +33,7 @@ multi-backend expander landed.
 | Backends targeted | Selected backend during global setup; Claude plus Codex today | Claude global setup only |
 | Source tree | `crates/clud-bin/assets/skills/` | Top-level `skills/` |
 | Existing file behavior | Skip, preserving user edits | Compare modulo whitespace; overwrite semantic divergence |
-| Bundled skills | `clud-loop`, `clud-issue`, `clud-issue-triage`, `clud-pr`, `clud-fix`, `clud-tag-release`, `clud-docker-rust-app-dev`, `clud-windows-trash`, `clud-extern-repos`, `clud-improve` | `clud-pr`, `clud-issue`, `clud-windows-trash`, `clud-extern-repos` |
+| Bundled skills | `clud-loop`, `clud-issue`, `clud-issue-triage`, `clud-pr`, `clud-fix`, `clud-tag-release`, `clud-docker-rust-app-dev`, `clud-windows-trash`, `clud-extern-repos`, `clud-improve` | `clud-pr`, `clud-fix`, `clud-issue`, `clud-windows-trash`, `clud-extern-repos` |
 | Retired purge list | Stale clud-managed copies under `~/.agents/skills/` | `clud-pr-merge` |
 
 Both flows are non-fatal. A failure logs a `[clud] note: ...` line and launch
@@ -65,7 +65,7 @@ When global setup is selected:
 | `clud-loop` | yes | no |
 | `clud-issue` | yes | yes |
 | `clud-pr` | yes | yes |
-| `clud-fix` | yes | no |
+| `clud-fix` | yes | yes |
 | `clud-issue-triage` | yes | no |
 | `clud-tag-release` | yes | no |
 | `clud-docker-rust-app-dev` | yes | no |

--- a/tests/integration/test_codex_skills.py
+++ b/tests/integration/test_codex_skills.py
@@ -51,6 +51,11 @@ def test_bundled_clud_fix_skill_carries_codex_install_metadata() -> None:
     assert "<!-- managed-by: clud -->" in body
     assert "RED -> GREEN" in body
     assert "clud-pr-merge" not in body
+    assert "/goal $clud-fix <issue-or-issue-url>" in body
+    assert "Complete meta issue #N" in body
+    assert "every child issue closed/validated" in body
+    assert "parent issue closed" in body
+    assert ".clud/fix/<owner>__<repo>__issue-<num>.json" in body
 
 
 def test_clud_codex_dry_run_does_not_crash(


### PR DESCRIPTION
﻿## Summary
- make `clud-fix` the outer issue-level orchestrator for single and meta/parent/burndown issues
- add delegated `clud-pr` mode so `/goal $clud-fix <issue>` keeps the outer goal while PR work returns evidence
- install/update `clud-fix` for both Codex and Claude managed skill paths and document the parity model

## Tests
- `cargo fmt --check`
- `python -c "import subprocess; from ci.env import activate, clean_env, cargo_argv; activate(); env=clean_env(); cmd=cargo_argv(['test','-p','clud','skills::tests'], env=env); print(' '.join(cmd)); raise SystemExit(subprocess.run(cmd, env=env).returncode)"`
- `$env:CLUD_INTEGRATION_TESTS='1'; python -m pytest tests/integration/test_codex_skills.py::test_bundled_clud_fix_skill_carries_codex_install_metadata -q`

## Notes
- `bash lint` is blocked locally before linting by the existing Windows `uv` wheel build path: `whisper-rs-sys`/MSVC/CMake fails with `FTK1011` while creating a file tracking log.

Closes #355
