### PR TITLE
feat: tidy Codex settings and Ctrl+C diagnostics

### DIFF
--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -158,6 +158,10 @@ pub struct Args {
 
     #[arg(last = true, id = "BACKEND_ARGS")]
     pub passthrough: Vec<String>,
+
+    /// Runtime Codex `-c` config overrides loaded from ~/.clud/settings.json.
+    #[arg(skip)]
+    pub codex_config_overrides: Vec<String>,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -265,7 +269,7 @@ pub enum Command {
         /// Toolchain family to optimize. Defaults to Rust.
         #[arg(value_enum, default_value_t = OptimizeTarget::Rust)]
         target: OptimizeTarget,
-        /// Persist the recommendation in ~/.clud/settings.toml.
+        /// Persist the recommendation in ~/.clud/settings.json.
         #[arg(long = "global", conflicts_with = "repo")]
         global: bool,
         /// Write a repo-local .clud/settings.json directive.

--- a/crates/clud-bin/src/clud_settings.rs
+++ b/crates/clud-bin/src/clud_settings.rs
@@ -1,18 +1,24 @@
-//! User-level clud settings persisted under `~/.clud/settings.toml`.
+//! User-level clud settings persisted under `~/.clud/settings.json`.
 
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 
 use fs4::fs_std::FileExt;
-use toml_edit::{table, value, DocumentMut, Item};
+use serde_json::{json, Map, Value};
+use toml_edit::{DocumentMut, Item};
 
 use crate::backend::Backend;
 use crate::launch_setup::LaunchSetupScope;
 
 pub const CLUD_DIR_NAME: &str = ".clud";
-pub const SETTINGS_FILE_NAME: &str = "settings.toml";
+pub const SETTINGS_FILE_NAME: &str = "settings.json";
+pub const LEGACY_SETTINGS_FILE_NAME: &str = "settings.toml";
 pub const LOCK_FILE_NAME: &str = "settings.lock";
+pub const DEFAULT_CODEX_GITHUB_PLUGIN_CONFIG_OVERRIDE: &str =
+    "plugins.\"github@openai-curated\".enabled=false";
+const CODEX_CONFIG_OVERRIDES_NOTE: &str =
+    "clud passes these strings as repeated `codex -c` config overrides before the Codex subcommand. Edit config_overrides to change plugin/connector behavior.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RustOptimizeSettings {
@@ -44,7 +50,7 @@ impl std::fmt::Display for SettingsError {
             SettingsError::NoHomeDir => write!(f, "could not resolve user home directory"),
             SettingsError::Io(error) => write!(f, "{error}"),
             SettingsError::Parse { path, error } => {
-                write!(f, "malformed TOML in {}: {error}", path.display())
+                write!(f, "malformed settings in {}: {error}", path.display())
             }
         }
     }
@@ -62,27 +68,55 @@ pub fn settings_path_at(home: &Path) -> PathBuf {
     home.join(CLUD_DIR_NAME).join(SETTINGS_FILE_NAME)
 }
 
+pub fn legacy_settings_path_at(home: &Path) -> PathBuf {
+    home.join(CLUD_DIR_NAME).join(LEGACY_SETTINGS_FILE_NAME)
+}
+
+pub fn default_codex_config_overrides() -> Vec<String> {
+    vec![DEFAULT_CODEX_GITHUB_PLUGIN_CONFIG_OVERRIDE.to_string()]
+}
+
+pub fn load_or_init_codex_config_overrides(
+    write_default: bool,
+) -> Result<Vec<String>, SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    load_or_init_codex_config_overrides_at(&home, write_default)
+}
+
+pub fn load_or_init_codex_config_overrides_at(
+    home: &Path,
+    write_default: bool,
+) -> Result<Vec<String>, SettingsError> {
+    let clud_dir = home.join(CLUD_DIR_NAME);
+    let lock_path = clud_dir.join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+    let path = settings_path_at(home);
+    let mut document = read_settings_or_legacy(home)?;
+
+    match read_codex_config_overrides(&document, &path)? {
+        Some(overrides) => Ok(overrides),
+        None if write_default => {
+            seed_codex_config_override_defaults(&mut document);
+            write_settings(&path, &document)?;
+            Ok(default_codex_config_overrides())
+        }
+        None => Ok(default_codex_config_overrides()),
+    }
+}
+
 pub fn load_auto_fix_hooks_enabled() -> Result<bool, SettingsError> {
     let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
     load_auto_fix_hooks_enabled_at(&home)
 }
 
 pub fn load_auto_fix_hooks_enabled_at(home: &Path) -> Result<bool, SettingsError> {
-    let path = settings_path_at(home);
-    if !path.exists() {
-        return Ok(true);
-    }
     let lock_path = home.join(CLUD_DIR_NAME).join(LOCK_FILE_NAME);
     let _lock = acquire_lock(&lock_path)?;
-    let text = fs::read_to_string(&path)?;
-    if text.trim().is_empty() {
-        return Ok(true);
-    }
-    let document = parse_settings(&path, &text)?;
+    let document = read_settings_or_legacy(home)?;
     Ok(document
         .get("hook_health")
         .and_then(|item| item.get("auto_fix_hooks"))
-        .and_then(Item::as_bool)
+        .and_then(Value::as_bool)
         .unwrap_or(true))
 }
 
@@ -92,38 +126,10 @@ pub fn save_auto_fix_hooks_enabled(enabled: bool) -> Result<(), SettingsError> {
 }
 
 pub fn save_auto_fix_hooks_enabled_at(home: &Path, enabled: bool) -> Result<(), SettingsError> {
-    let clud_dir = home.join(CLUD_DIR_NAME);
-    fs::create_dir_all(&clud_dir)?;
-    let lock_path = clud_dir.join(LOCK_FILE_NAME);
-    let _lock = acquire_lock(&lock_path)?;
-
-    let path = settings_path_at(home);
-    let text = match fs::read_to_string(&path) {
-        Ok(text) => text,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(SettingsError::Io(error)),
-    };
-    let mut document = if text.trim().is_empty() {
-        DocumentMut::new()
-    } else {
-        parse_settings(&path, &text)?
-    };
-
-    if document
-        .get("hook_health")
-        .and_then(Item::as_table)
-        .is_none()
-    {
-        document["hook_health"] = table();
-    }
-    document["hook_health"]["auto_fix_hooks"] = value(enabled);
-
-    let mut body = document.to_string();
-    if !body.ends_with('\n') {
-        body.push('\n');
-    }
-    fs::write(path, body)?;
-    Ok(())
+    with_settings_document(home, |document| {
+        object_entry(document, "hook_health")
+            .insert("auto_fix_hooks".to_string(), Value::Bool(enabled));
+    })
 }
 
 pub fn load_launch_setup_scope(
@@ -137,22 +143,14 @@ pub fn load_launch_setup_scope_at(
     home: &Path,
     backend: Backend,
 ) -> Result<Option<LaunchSetupScope>, SettingsError> {
-    let path = settings_path_at(home);
-    if !path.exists() {
-        return Ok(None);
-    }
     let lock_path = home.join(CLUD_DIR_NAME).join(LOCK_FILE_NAME);
     let _lock = acquire_lock(&lock_path)?;
-    let text = fs::read_to_string(&path)?;
-    if text.trim().is_empty() {
-        return Ok(None);
-    }
-    let document = parse_settings(&path, &text)?;
+    let document = read_settings_or_legacy(home)?;
     let Some(scope) = document
         .get("launch_setup")
         .and_then(|item| item.get(backend_settings_key(backend)))
         .and_then(|item| item.get("scope"))
-        .and_then(Item::as_str)
+        .and_then(Value::as_str)
     else {
         return Ok(None);
     };
@@ -172,46 +170,19 @@ pub fn save_launch_setup_scope_at(
     backend: Backend,
     scope: LaunchSetupScope,
 ) -> Result<(), SettingsError> {
-    let clud_dir = home.join(CLUD_DIR_NAME);
-    fs::create_dir_all(&clud_dir)?;
-    let lock_path = clud_dir.join(LOCK_FILE_NAME);
-    let _lock = acquire_lock(&lock_path)?;
-
-    let path = settings_path_at(home);
-    let text = match fs::read_to_string(&path) {
-        Ok(text) => text,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(SettingsError::Io(error)),
-    };
-    let mut document = if text.trim().is_empty() {
-        DocumentMut::new()
-    } else {
-        parse_settings(&path, &text)?
-    };
-
-    if document
-        .get("launch_setup")
-        .and_then(Item::as_table)
-        .is_none()
-    {
-        document["launch_setup"] = table();
-    }
-    let backend_key = backend_settings_key(backend);
-    if document["launch_setup"]
-        .get(backend_key)
-        .and_then(Item::as_table)
-        .is_none()
-    {
-        document["launch_setup"][backend_key] = table();
-    }
-    document["launch_setup"][backend_key]["scope"] = value(scope.as_str());
-
-    let mut body = document.to_string();
-    if !body.ends_with('\n') {
-        body.push('\n');
-    }
-    fs::write(path, body)?;
-    Ok(())
+    with_settings_document(home, |document| {
+        let launch_setup = object_entry(document, "launch_setup");
+        let entry = launch_setup
+            .entry(backend_settings_key(backend).to_string())
+            .or_insert_with(|| json!({}));
+        if !entry.is_object() {
+            *entry = json!({});
+        }
+        entry.as_object_mut().unwrap().insert(
+            "scope".to_string(),
+            Value::String(scope.as_str().to_string()),
+        );
+    })
 }
 
 pub fn save_rust_optimize_settings(settings: &RustOptimizeSettings) -> Result<(), SettingsError> {
@@ -223,63 +194,143 @@ pub fn save_rust_optimize_settings_at(
     home: &Path,
     settings: &RustOptimizeSettings,
 ) -> Result<(), SettingsError> {
-    let clud_dir = home.join(CLUD_DIR_NAME);
-    fs::create_dir_all(&clud_dir)?;
-    let lock_path = clud_dir.join(LOCK_FILE_NAME);
-    let _lock = acquire_lock(&lock_path)?;
-
-    let path = settings_path_at(home);
-    let text = match fs::read_to_string(&path) {
-        Ok(text) => text,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
-        Err(error) => return Err(SettingsError::Io(error)),
-    };
-    let mut document = if text.trim().is_empty() {
-        DocumentMut::new()
-    } else {
-        parse_settings(&path, &text)?
-    };
-
-    if document.get("optimize").and_then(Item::as_table).is_none() {
-        document["optimize"] = table();
-    }
-    if document["optimize"]
-        .get("rust")
-        .and_then(Item::as_table)
-        .is_none()
-    {
-        document["optimize"]["rust"] = table();
-    }
-    document["optimize"]["rust"]["use_soldr_shims"] = value(settings.use_soldr_shims);
-    document["optimize"]["rust"]["install_soldr"] = value(settings.install_soldr);
-    document["optimize"]["rust"]["soldr_version"] = value(settings.soldr_version.clone());
-
-    let mut body = document.to_string();
-    if !body.ends_with('\n') {
-        body.push('\n');
-    }
-    fs::write(path, body)?;
-    Ok(())
+    with_settings_document(home, |document| {
+        let optimize = object_entry(document, "optimize");
+        optimize.insert(
+            "rust".to_string(),
+            json!({
+                "use_soldr_shims": settings.use_soldr_shims,
+                "install_soldr": settings.install_soldr,
+                "soldr_version": settings.soldr_version.clone(),
+            }),
+        );
+    })
 }
 
 pub fn load_rust_optimize_settings_at(
     home: &Path,
 ) -> Result<Option<RustOptimizeSettings>, SettingsError> {
-    let path = settings_path_at(home);
-    if !path.exists() {
-        return Ok(None);
-    }
     let lock_path = home.join(CLUD_DIR_NAME).join(LOCK_FILE_NAME);
     let _lock = acquire_lock(&lock_path)?;
-    let text = fs::read_to_string(&path)?;
-    if text.trim().is_empty() {
-        return Ok(None);
+    let document = read_settings_or_legacy(home)?;
+    rust_optimize_from_json(&document)
+}
+
+fn with_settings_document<F>(home: &Path, mutate: F) -> Result<(), SettingsError>
+where
+    F: FnOnce(&mut Value),
+{
+    let clud_dir = home.join(CLUD_DIR_NAME);
+    fs::create_dir_all(&clud_dir)?;
+    let lock_path = clud_dir.join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+    let path = settings_path_at(home);
+    let mut document = read_settings_or_legacy(home)?;
+    mutate(&mut document);
+    write_settings(&path, &document)
+}
+
+fn read_settings_or_legacy(home: &Path) -> Result<Value, SettingsError> {
+    let path = settings_path_at(home);
+    match fs::read_to_string(&path) {
+        Ok(text) if text.trim().is_empty() => return Ok(json!({})),
+        Ok(text) => return parse_json_settings(&path, &text),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(SettingsError::Io(error)),
     }
-    let document = parse_settings(&path, &text)?;
-    let Some(table) = document
+
+    let legacy_path = legacy_settings_path_at(home);
+    match fs::read_to_string(&legacy_path) {
+        Ok(text) if text.trim().is_empty() => Ok(json!({})),
+        Ok(text) => parse_legacy_toml_settings(&legacy_path, &text),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(json!({})),
+        Err(error) => Err(SettingsError::Io(error)),
+    }
+}
+
+fn parse_json_settings(path: &Path, text: &str) -> Result<Value, SettingsError> {
+    let value: Value = serde_json::from_str(text).map_err(|error| SettingsError::Parse {
+        path: path.to_path_buf(),
+        error: error.to_string(),
+    })?;
+    if value.is_object() {
+        Ok(value)
+    } else {
+        Err(SettingsError::Parse {
+            path: path.to_path_buf(),
+            error: "root must be a JSON object".to_string(),
+        })
+    }
+}
+
+fn parse_legacy_toml_settings(path: &Path, text: &str) -> Result<Value, SettingsError> {
+    let document = text
+        .parse::<DocumentMut>()
+        .map_err(|error| SettingsError::Parse {
+            path: path.to_path_buf(),
+            error: error.to_string(),
+        })?;
+    let mut root = json!({});
+
+    if let Some(enabled) = document
+        .get("hook_health")
+        .and_then(|item| item.get("auto_fix_hooks"))
+        .and_then(Item::as_bool)
+    {
+        object_entry(&mut root, "hook_health")
+            .insert("auto_fix_hooks".to_string(), Value::Bool(enabled));
+    }
+
+    if let Some(launch_setup) = document.get("launch_setup").and_then(Item::as_table) {
+        for (backend, item) in launch_setup.iter() {
+            if let Some(scope) = item
+                .get("scope")
+                .and_then(Item::as_str)
+                .and_then(LaunchSetupScope::from_settings_str)
+            {
+                object_entry(&mut root, "launch_setup").insert(
+                    backend.to_string(),
+                    json!({ "scope": scope.as_str().to_string() }),
+                );
+            }
+        }
+    }
+
+    if let Some(rust) = document
         .get("optimize")
         .and_then(|item| item.get("rust"))
         .and_then(Item::as_table)
+    {
+        let defaults = RustOptimizeSettings::default();
+        object_entry(&mut root, "optimize").insert(
+            "rust".to_string(),
+            json!({
+                "use_soldr_shims": rust
+                    .get("use_soldr_shims")
+                    .and_then(Item::as_bool)
+                    .unwrap_or(defaults.use_soldr_shims),
+                "install_soldr": rust
+                    .get("install_soldr")
+                    .and_then(Item::as_bool)
+                    .unwrap_or(defaults.install_soldr),
+                "soldr_version": rust
+                    .get("soldr_version")
+                    .and_then(Item::as_str)
+                    .unwrap_or(&defaults.soldr_version),
+            }),
+        );
+    }
+
+    Ok(root)
+}
+
+fn rust_optimize_from_json(
+    document: &Value,
+) -> Result<Option<RustOptimizeSettings>, SettingsError> {
+    let Some(table) = document
+        .get("optimize")
+        .and_then(|item| item.get("rust"))
+        .and_then(Value::as_object)
     else {
         return Ok(None);
     };
@@ -287,26 +338,92 @@ pub fn load_rust_optimize_settings_at(
     Ok(Some(RustOptimizeSettings {
         use_soldr_shims: table
             .get("use_soldr_shims")
-            .and_then(Item::as_bool)
+            .and_then(Value::as_bool)
             .unwrap_or(defaults.use_soldr_shims),
         install_soldr: table
             .get("install_soldr")
-            .and_then(Item::as_bool)
+            .and_then(Value::as_bool)
             .unwrap_or(defaults.install_soldr),
         soldr_version: table
             .get("soldr_version")
-            .and_then(Item::as_str)
+            .and_then(Value::as_str)
             .unwrap_or(&defaults.soldr_version)
             .to_string(),
     }))
 }
 
-fn parse_settings(path: &Path, text: &str) -> Result<DocumentMut, SettingsError> {
-    text.parse::<DocumentMut>()
-        .map_err(|error| SettingsError::Parse {
+fn write_settings(path: &Path, document: &Value) -> Result<(), SettingsError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut body =
+        serde_json::to_string_pretty(document).map_err(|error| SettingsError::Parse {
             path: path.to_path_buf(),
             error: error.to_string(),
-        })
+        })?;
+    body.push('\n');
+    fs::write(path, body)?;
+    Ok(())
+}
+
+fn read_codex_config_overrides(
+    document: &Value,
+    path: &Path,
+) -> Result<Option<Vec<String>>, SettingsError> {
+    let Some(value) = document
+        .get("codex")
+        .and_then(|item| item.get("config_overrides"))
+    else {
+        return Ok(None);
+    };
+    let Some(items) = value.as_array() else {
+        return Err(SettingsError::Parse {
+            path: path.to_path_buf(),
+            error: "codex.config_overrides must be an array of strings".to_string(),
+        });
+    };
+    let mut overrides = Vec::with_capacity(items.len());
+    for item in items {
+        let Some(text) = item.as_str() else {
+            return Err(SettingsError::Parse {
+                path: path.to_path_buf(),
+                error: "codex.config_overrides must be an array of strings".to_string(),
+            });
+        };
+        if !text.trim().is_empty() {
+            overrides.push(text.to_string());
+        }
+    }
+    Ok(Some(overrides))
+}
+
+fn seed_codex_config_override_defaults(document: &mut Value) {
+    let codex = object_entry(document, "codex");
+    codex
+        .entry("config_overrides_note".to_string())
+        .or_insert_with(|| Value::String(CODEX_CONFIG_OVERRIDES_NOTE.to_string()));
+    codex
+        .entry("config_overrides".to_string())
+        .or_insert_with(|| {
+            Value::Array(
+                default_codex_config_overrides()
+                    .into_iter()
+                    .map(Value::String)
+                    .collect(),
+            )
+        });
+}
+
+fn object_entry<'a>(document: &'a mut Value, key: &str) -> &'a mut Map<String, Value> {
+    if !document.is_object() {
+        *document = json!({});
+    }
+    let root = document.as_object_mut().unwrap();
+    let entry = root.entry(key.to_string()).or_insert_with(|| json!({}));
+    if !entry.is_object() {
+        *entry = json!({});
+    }
+    entry.as_object_mut().unwrap()
 }
 
 fn backend_settings_key(backend: Backend) -> &'static str {
@@ -370,6 +487,56 @@ mod tests {
     }
 
     #[test]
+    fn missing_codex_overrides_default_without_writing_on_dry_run() {
+        let home = tempdir().unwrap();
+
+        assert_eq!(
+            load_or_init_codex_config_overrides_at(home.path(), false).unwrap(),
+            default_codex_config_overrides()
+        );
+        assert!(!settings_path_at(home.path()).exists());
+    }
+
+    #[test]
+    fn first_run_codex_overrides_are_documented_in_settings_json() {
+        let home = tempdir().unwrap();
+
+        assert_eq!(
+            load_or_init_codex_config_overrides_at(home.path(), true).unwrap(),
+            default_codex_config_overrides()
+        );
+
+        let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            json["codex"]["config_overrides"][0],
+            DEFAULT_CODEX_GITHUB_PLUGIN_CONFIG_OVERRIDE
+        );
+        assert!(
+            json["codex"]["config_overrides_note"]
+                .as_str()
+                .unwrap()
+                .contains("codex -c"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn existing_codex_overrides_are_user_owned() {
+        let home = tempdir().unwrap();
+        let path = settings_path_at(home.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, r#"{"codex":{"config_overrides":[]}}"#).unwrap();
+
+        assert_eq!(
+            load_or_init_codex_config_overrides_at(home.path(), true).unwrap(),
+            Vec::<String>::new()
+        );
+        let text = fs::read_to_string(path).unwrap();
+        assert!(!text.contains(DEFAULT_CODEX_GITHUB_PLUGIN_CONFIG_OVERRIDE));
+    }
+
+    #[test]
     fn saves_auto_fix_hooks_sticky_opt_out_and_reset() {
         let home = tempdir().unwrap();
 
@@ -380,8 +547,8 @@ mod tests {
         assert!(load_auto_fix_hooks_enabled_at(home.path()).unwrap());
 
         let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
-        assert!(text.contains("[hook_health]"), "{text}");
-        assert!(text.contains("auto_fix_hooks = true"), "{text}");
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["hook_health"]["auto_fix_hooks"], true);
     }
 
     #[test]
@@ -399,14 +566,8 @@ mod tests {
             None
         );
         let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
-        assert!(
-            text.contains("[launch_setup.codex]"),
-            "settings TOML should use a backend-scoped table: {text}"
-        );
-        assert!(
-            text.contains("scope = \"global\""),
-            "settings TOML should persist the selected global scope: {text}"
-        );
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["launch_setup"]["codex"]["scope"], "global");
     }
 
     #[test]
@@ -416,17 +577,17 @@ mod tests {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(
             &path,
-            "[unrelated]\nvalue = \"kept\"\n\n[launch_setup.claude]\nscope = \"session-only\"\n",
+            r#"{"unrelated":{"value":"kept"},"launch_setup":{"claude":{"scope":"session-only"}}}"#,
         )
         .unwrap();
 
         save_launch_setup_scope_at(home.path(), Backend::Codex, LaunchSetupScope::Global).unwrap();
 
         let text = fs::read_to_string(path).unwrap();
-        assert!(text.contains("[unrelated]"), "{text}");
-        assert!(text.contains("value = \"kept\""), "{text}");
-        assert!(text.contains("[launch_setup.claude]"), "{text}");
-        assert!(text.contains("[launch_setup.codex]"), "{text}");
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["unrelated"]["value"], "kept");
+        assert_eq!(json["launch_setup"]["claude"]["scope"], "session-only");
+        assert_eq!(json["launch_setup"]["codex"]["scope"], "global");
     }
 
     #[test]
@@ -436,18 +597,17 @@ mod tests {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(
             &path,
-            "[unrelated]\nvalue = \"kept\"\n\n[launch_setup.codex]\nscope = \"global\"\n",
+            r#"{"unrelated":{"value":"kept"},"launch_setup":{"codex":{"scope":"global"}}}"#,
         )
         .unwrap();
 
         save_auto_fix_hooks_enabled_at(home.path(), false).unwrap();
 
         let text = fs::read_to_string(path).unwrap();
-        assert!(text.contains("[unrelated]"), "{text}");
-        assert!(text.contains("value = \"kept\""), "{text}");
-        assert!(text.contains("[launch_setup.codex]"), "{text}");
-        assert!(text.contains("[hook_health]"), "{text}");
-        assert!(text.contains("auto_fix_hooks = false"), "{text}");
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["unrelated"]["value"], "kept");
+        assert_eq!(json["launch_setup"]["codex"]["scope"], "global");
+        assert_eq!(json["hook_health"]["auto_fix_hooks"], false);
     }
 
     #[test]
@@ -466,10 +626,10 @@ mod tests {
             Some(settings)
         );
         let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
-        assert!(text.contains("[optimize.rust]"), "{text}");
-        assert!(text.contains("use_soldr_shims = true"), "{text}");
-        assert!(text.contains("install_soldr = false"), "{text}");
-        assert!(text.contains("soldr_version = \"1.2.3\""), "{text}");
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["optimize"]["rust"]["use_soldr_shims"], true);
+        assert_eq!(json["optimize"]["rust"]["install_soldr"], false);
+        assert_eq!(json["optimize"]["rust"]["soldr_version"], "1.2.3");
     }
 
     #[test]
@@ -477,13 +637,46 @@ mod tests {
         let home = tempdir().unwrap();
         let path = settings_path_at(home.path());
         fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(&path, "[unrelated]\nvalue = \"kept\"\n").unwrap();
+        fs::write(&path, r#"{"unrelated":{"value":"kept"}}"#).unwrap();
 
         save_rust_optimize_settings_at(home.path(), &RustOptimizeSettings::default()).unwrap();
 
         let text = fs::read_to_string(path).unwrap();
-        assert!(text.contains("[unrelated]"), "{text}");
-        assert!(text.contains("value = \"kept\""), "{text}");
-        assert!(text.contains("[optimize.rust]"), "{text}");
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["unrelated"]["value"], "kept");
+        assert!(json["optimize"]["rust"].is_object());
+    }
+
+    #[test]
+    fn legacy_toml_is_read_and_migrated_on_next_save() {
+        let home = tempdir().unwrap();
+        let legacy = legacy_settings_path_at(home.path());
+        fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        fs::write(
+            &legacy,
+            "[hook_health]\nauto_fix_hooks = false\n\n[launch_setup.codex]\nscope = \"global\"\n\n[optimize.rust]\nuse_soldr_shims = true\ninstall_soldr = false\nsoldr_version = \"9.9.9\"\n",
+        )
+        .unwrap();
+
+        assert!(!load_auto_fix_hooks_enabled_at(home.path()).unwrap());
+        assert_eq!(
+            load_launch_setup_scope_at(home.path(), Backend::Codex).unwrap(),
+            Some(LaunchSetupScope::Global)
+        );
+        assert_eq!(
+            load_rust_optimize_settings_at(home.path()).unwrap(),
+            Some(RustOptimizeSettings {
+                use_soldr_shims: true,
+                install_soldr: false,
+                soldr_version: "9.9.9".to_string(),
+            })
+        );
+
+        save_auto_fix_hooks_enabled_at(home.path(), true).unwrap();
+        let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["hook_health"]["auto_fix_hooks"], true);
+        assert_eq!(json["launch_setup"]["codex"]["scope"], "global");
+        assert_eq!(json["optimize"]["rust"]["soldr_version"], "9.9.9");
     }
 }

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -33,6 +33,13 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         && !codex_uses_exec
         && (args.continue_session || args.resume.is_some());
 
+    if matches!(backend, Backend::Codex) {
+        for override_value in &args.codex_config_overrides {
+            cmd.push("-c".to_string());
+            cmd.push(override_value.clone());
+        }
+    }
+
     if codex_uses_exec {
         cmd.push("exec".to_string());
     } else if codex_uses_resume {

--- a/crates/clud-bin/src/command/tests.rs
+++ b/crates/clud-bin/src/command/tests.rs
@@ -5,6 +5,7 @@ use super::prompts::{build_fix_prompt, build_up_prompt, is_github_url, FIX_PROMP
 use super::types::LaunchPlan;
 use crate::args::Args;
 use crate::backend::{Backend, LaunchMode};
+use crate::clud_settings::DEFAULT_CODEX_GITHUB_PLUGIN_CONFIG_OVERRIDE;
 
 fn parse(raw: &[&str]) -> Args {
     let raw: Vec<String> = raw.iter().map(|s| s.to_string()).collect();
@@ -12,8 +13,11 @@ fn parse(raw: &[&str]) -> Args {
 }
 
 fn plan(raw: &[&str]) -> LaunchPlan {
-    let args = parse(raw);
+    let mut args = parse(raw);
     let backend = crate::backend::resolve_backend(args.claude, args.codex);
+    if matches!(backend, Backend::Codex) {
+        args.codex_config_overrides = vec![DEFAULT_CODEX_GITHUB_PLUGIN_CONFIG_OVERRIDE.to_string()];
+    }
     build_launch_plan(&args, backend, backend.executable_name())
 }
 
@@ -26,6 +30,18 @@ fn prompt_from_plan(p: &LaunchPlan) -> &str {
 /// For codex we emit the prompt positionally, so this picks it up.
 fn last_arg(p: &LaunchPlan) -> &str {
     p.command.last().map(String::as_str).unwrap_or("")
+}
+
+fn codex_prefix() -> Vec<String> {
+    vec![
+        "codex".to_string(),
+        "-c".to_string(),
+        DEFAULT_CODEX_GITHUB_PLUGIN_CONFIG_OVERRIDE.to_string(),
+    ]
+}
+
+fn codex_exec_index(p: &LaunchPlan) -> usize {
+    p.command.iter().position(|arg| arg == "exec").unwrap()
 }
 
 #[test]
@@ -52,12 +68,15 @@ fn test_codex_prompt_goes_through_exec_subcommand() {
     let p = plan(&["clud", "--codex", "-p", "hello"]);
     assert_eq!(
         p.command,
-        vec![
-            "codex",
-            "exec",
-            "--dangerously-bypass-approvals-and-sandbox",
-            "hello",
+        [
+            codex_prefix(),
+            vec![
+                "exec".to_string(),
+                "--dangerously-bypass-approvals-and-sandbox".to_string(),
+                "hello".to_string(),
+            ],
         ]
+        .concat()
     );
     // `codex exec` is non-interactive; subprocess mode is fine.
     assert_eq!(p.launch_mode, LaunchMode::Subprocess);
@@ -73,7 +92,11 @@ fn test_codex_interactive_defaults_to_pty_without_tty() {
     let p = plan(&["clud", "--codex"]);
     assert_eq!(
         p.command,
-        vec!["codex", "--dangerously-bypass-approvals-and-sandbox"]
+        [
+            codex_prefix(),
+            vec!["--dangerously-bypass-approvals-and-sandbox".to_string()],
+        ]
+        .concat()
     );
     assert_eq!(p.launch_mode, LaunchMode::Pty);
 }
@@ -84,12 +107,15 @@ fn test_codex_continue_uses_resume_last() {
     let p = plan(&["clud", "--codex", "-c"]);
     assert_eq!(
         p.command,
-        vec![
-            "codex",
-            "resume",
-            "--dangerously-bypass-approvals-and-sandbox",
-            "--last",
+        [
+            codex_prefix(),
+            vec![
+                "resume".to_string(),
+                "--dangerously-bypass-approvals-and-sandbox".to_string(),
+                "--last".to_string(),
+            ],
         ]
+        .concat()
     );
     assert_eq!(p.launch_mode, LaunchMode::Pty);
 }
@@ -99,12 +125,15 @@ fn test_codex_resume_with_session_id() {
     let p = plan(&["clud", "--codex", "-r", "sess-123"]);
     assert_eq!(
         p.command,
-        vec![
-            "codex",
-            "resume",
-            "--dangerously-bypass-approvals-and-sandbox",
-            "sess-123",
+        [
+            codex_prefix(),
+            vec![
+                "resume".to_string(),
+                "--dangerously-bypass-approvals-and-sandbox".to_string(),
+                "sess-123".to_string(),
+            ],
         ]
+        .concat()
     );
 }
 
@@ -114,12 +143,15 @@ fn test_codex_model_uses_short_m() {
     let p = plan(&["clud", "--codex", "--model", "gpt-5"]);
     assert_eq!(
         p.command,
-        vec![
-            "codex",
-            "--dangerously-bypass-approvals-and-sandbox",
-            "-m",
-            "gpt-5"
+        [
+            codex_prefix(),
+            vec![
+                "--dangerously-bypass-approvals-and-sandbox".to_string(),
+                "-m".to_string(),
+                "gpt-5".to_string(),
+            ],
         ]
+        .concat()
     );
 }
 
@@ -127,7 +159,7 @@ fn test_codex_model_uses_short_m() {
 fn test_codex_up_routes_through_exec() {
     let p = plan(&["clud", "--codex", "up"]);
     assert_eq!(p.command[0], "codex");
-    assert_eq!(p.command[1], "exec");
+    assert!(codex_exec_index(&p) > 0);
     // Prompt is positional (last arg), not behind `-p`.
     assert!(p.command.iter().all(|a| a != "-p"));
     assert!(last_arg(&p).contains("codeup"));
@@ -306,7 +338,7 @@ fn test_loop_repeat_with_done_override_restores_contract() {
 fn test_codex_loop_routes_through_exec() {
     let p = plan(&["clud", "--codex", "loop", "--loop-count", "5", "do stuff"]);
     assert_eq!(p.command[0], "codex");
-    assert_eq!(p.command[1], "exec");
+    assert!(codex_exec_index(&p) > 0);
     assert!(p
         .command
         .contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
@@ -376,7 +408,7 @@ fn test_codex_loop_safe_mode_omits_bypass_flag() {
         .command
         .contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
     assert_eq!(p.command[0], "codex");
-    assert_eq!(p.command[1], "exec");
+    assert!(codex_exec_index(&p) > 0);
 }
 
 #[test]

--- a/crates/clud-bin/src/ctrl_c_track.rs
+++ b/crates/clud-bin/src/ctrl_c_track.rs
@@ -30,7 +30,7 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -67,6 +67,78 @@ impl InvocationKind {
     }
 }
 
+/// Specific console-control event that fired clud's interrupt handler.
+///
+/// `ctrlc::set_handler` folds five distinct Windows events
+/// (`CTRL_C_EVENT`, `CTRL_BREAK_EVENT`, `CTRL_CLOSE_EVENT`,
+/// `CTRL_LOGOFF_EVENT`, `CTRL_SHUTDOWN_EVENT`) into one callback, so by
+/// default we can't tell a real keyboard Ctrl+C from a
+/// `GenerateConsoleCtrlEvent` call somewhere in the descendant tree.
+/// The Windows probe in [`crate::startup`] inspects `dwCtrlType` before
+/// the ctrlc handler runs and stores the result here so the dashboard
+/// can show *which* event actually fired.
+///
+/// `None` in [`CtrlCEvent::ctrl_event_kind`] means the probe never ran
+/// (Unix builds, or pre-upgrade event files).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CtrlEventKind {
+    /// `CTRL_C_EVENT` on Windows, `SIGINT` on Unix. The classic
+    /// keyboard Ctrl+C — or a `GenerateConsoleCtrlEvent` broadcast
+    /// from a sibling/descendant.
+    CtrlC,
+    /// `CTRL_BREAK_EVENT` on Windows, `SIGBREAK` on Unix. Almost
+    /// never a keyboard press in modern terminals; usually a
+    /// `GenerateConsoleCtrlEvent` from a process trying to terminate
+    /// a console group.
+    CtrlBreak,
+    /// `CTRL_CLOSE_EVENT`. The console window's close button was
+    /// clicked, the host window is being destroyed, or `EndTask` was
+    /// invoked. The OS gives the handler ~5 seconds before killing
+    /// the process.
+    CtrlClose,
+    /// `CTRL_LOGOFF_EVENT`. Only delivered to service processes —
+    /// extremely unlikely in a foreground CLI but recorded for
+    /// completeness.
+    CtrlLogoff,
+    /// `CTRL_SHUTDOWN_EVENT`. System shutdown. Same service-process
+    /// caveat as `CtrlLogoff`.
+    CtrlShutdown,
+    /// The probe saw a `dwCtrlType` value the Win32 docs don't define.
+    /// Stored so a future Windows revision that adds a new control
+    /// event doesn't get silently dropped on the floor.
+    Unknown,
+}
+
+impl CtrlEventKind {
+    /// Numeric encoding used by the atomic storage. Must round-trip
+    /// through [`Self::from_raw`].
+    pub const fn to_raw(self) -> u32 {
+        match self {
+            CtrlEventKind::CtrlC => 0,
+            CtrlEventKind::CtrlBreak => 1,
+            CtrlEventKind::CtrlClose => 2,
+            CtrlEventKind::CtrlLogoff => 5,
+            CtrlEventKind::CtrlShutdown => 6,
+            CtrlEventKind::Unknown => u32::MAX - 1,
+        }
+    }
+
+    /// Decode a value previously written by [`Self::to_raw`]. Returns
+    /// [`CtrlEventKind::Unknown`] for any unexpected input so callers
+    /// never have to handle "impossible" cases.
+    pub const fn from_raw(raw: u32) -> Self {
+        match raw {
+            0 => CtrlEventKind::CtrlC,
+            1 => CtrlEventKind::CtrlBreak,
+            2 => CtrlEventKind::CtrlClose,
+            5 => CtrlEventKind::CtrlLogoff,
+            6 => CtrlEventKind::CtrlShutdown,
+            _ => CtrlEventKind::Unknown,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CtrlCEvent {
     pub pid: u32,
@@ -90,6 +162,13 @@ pub struct CtrlCEvent {
     /// so old event files stay parseable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub handoff_reason: Option<String>,
+    /// Specific Windows console-control event that fired the handler.
+    /// `None` on Unix and on pre-upgrade event files. Critical for
+    /// telling "user pressed Ctrl+C" from "some descendant called
+    /// `GenerateConsoleCtrlEvent`" — they exit identically through
+    /// the same handler but mean very different things.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ctrl_event_kind: Option<CtrlEventKind>,
 }
 
 // Process-wide observation point. Re-stamped on every Ctrl+C the signal
@@ -101,6 +180,18 @@ pub struct CtrlCEvent {
 // A zero value means "never observed" — the unix epoch is the natural
 // sentinel and saves us a separate boolean flag.
 static OBSERVED_UNIX_MS: AtomicU64 = AtomicU64::new(0);
+
+/// Process-wide last-observed control event kind, populated by the
+/// Windows probe installed in [`crate::startup::install_ctrl_c_flag`].
+/// `u32::MAX` is the "never observed" sentinel; real values come from
+/// [`CtrlEventKind::to_raw`].
+///
+/// Lives in its own atomic (separate from `OBSERVED_UNIX_MS`) so the
+/// timestamp updates from the existing `ctrlc` handler don't have to
+/// race with the kind-recording probe — the two writers touch
+/// independent locations.
+const KIND_UNRECORDED: u32 = u32::MAX;
+static OBSERVED_EVENT_KIND: AtomicU32 = AtomicU32::new(KIND_UNRECORDED);
 
 /// Process-wide handoff outcome. Recorded by the teardown sites
 /// (`runner::teardown_interrupted_child`, `session::interrupt_pty_process`)
@@ -131,6 +222,29 @@ pub fn record_observed() {
 
 pub fn was_observed() -> bool {
     OBSERVED_UNIX_MS.load(Ordering::SeqCst) != 0
+}
+
+/// Record which specific console-control event the Windows probe saw.
+/// Called from the `SetConsoleCtrlHandler` callback installed by
+/// [`crate::startup::install_ctrl_c_flag`] before the `ctrlc` handler
+/// fires. Signal-safe: a single atomic store, no allocation, no lock.
+///
+/// The last write wins, matching the [`record_observed`] semantics
+/// above: a burst of events maps to "the kind of the most recent one".
+pub fn record_event_kind(kind: CtrlEventKind) {
+    OBSERVED_EVENT_KIND.store(kind.to_raw(), Ordering::SeqCst);
+}
+
+/// Read the kind recorded by [`record_event_kind`]. Returns `None`
+/// when the probe never fired — Unix builds, or pre-probe code paths
+/// where Ctrl+C was observed but no kind was attributed.
+pub fn observed_event_kind() -> Option<CtrlEventKind> {
+    let raw = OBSERVED_EVENT_KIND.load(Ordering::SeqCst);
+    if raw == KIND_UNRECORDED {
+        None
+    } else {
+        Some(CtrlEventKind::from_raw(raw))
+    }
 }
 
 /// Record the daemon-handoff outcome (issue #285 rec 2). Called from
@@ -174,6 +288,7 @@ fn build_event(kind: InvocationKind, exit_code: i32) -> Option<CtrlCEvent> {
         .and_then(|g| g.clone())
         .map(|o| (Some(o.handed_off), o.reason))
         .unwrap_or((None, None));
+    let ctrl_event_kind = observed_event_kind();
     Some(CtrlCEvent {
         pid: std::process::id(),
         observed_at_ms,
@@ -184,6 +299,7 @@ fn build_event(kind: InvocationKind, exit_code: i32) -> Option<CtrlCEvent> {
         cwd,
         handed_off,
         handoff_reason,
+        ctrl_event_kind,
     })
 }
 
@@ -268,6 +384,7 @@ fn unix_millis_now() -> u64 {
 #[cfg(test)]
 pub(crate) fn reset_for_test() {
     OBSERVED_UNIX_MS.store(0, Ordering::SeqCst);
+    OBSERVED_EVENT_KIND.store(KIND_UNRECORDED, Ordering::SeqCst);
     if let Ok(mut g) = HANDOFF_OUTCOME.lock() {
         *g = None;
     }
@@ -306,12 +423,14 @@ mod tests {
             cwd: Some("/tmp/x".to_string()),
             handed_off: Some(true),
             handoff_reason: Some("ctrl_c_subprocess".to_string()),
+            ctrl_event_kind: Some(CtrlEventKind::CtrlBreak),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""kind":"direct""#));
         assert!(json.contains(r#""elapsed_ms":250"#));
         assert!(json.contains(r#""handed_off":true"#));
         assert!(json.contains(r#""handoff_reason":"ctrl_c_subprocess""#));
+        assert!(json.contains(r#""ctrl_event_kind":"ctrl_break""#));
         let back: CtrlCEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back.pid, 1234);
         assert_eq!(back.elapsed_ms, 250);
@@ -319,6 +438,7 @@ mod tests {
         assert_eq!(back.cwd.as_deref(), Some("/tmp/x"));
         assert_eq!(back.handed_off, Some(true));
         assert_eq!(back.handoff_reason.as_deref(), Some("ctrl_c_subprocess"));
+        assert_eq!(back.ctrl_event_kind, Some(CtrlEventKind::CtrlBreak));
     }
 
     #[test]
@@ -339,6 +459,98 @@ mod tests {
         assert_eq!(event.pid, 1234);
         assert_eq!(event.handed_off, None);
         assert_eq!(event.handoff_reason, None);
+        assert_eq!(event.ctrl_event_kind, None);
+    }
+
+    #[test]
+    fn ctrl_event_kind_round_trips_through_raw() {
+        for kind in [
+            CtrlEventKind::CtrlC,
+            CtrlEventKind::CtrlBreak,
+            CtrlEventKind::CtrlClose,
+            CtrlEventKind::CtrlLogoff,
+            CtrlEventKind::CtrlShutdown,
+            CtrlEventKind::Unknown,
+        ] {
+            let raw = kind.to_raw();
+            assert_eq!(
+                CtrlEventKind::from_raw(raw),
+                kind,
+                "round-trip failed for {kind:?} -> {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn ctrl_event_kind_from_raw_maps_undefined_to_unknown() {
+        // Windows reserves 3, 4, and 7+ as undocumented / future-use values.
+        // Anything outside the known set must funnel into Unknown so a
+        // future Windows revision can't crash forensics.
+        for raw in [3u32, 4, 7, 99, u32::MAX, u32::MAX - 1] {
+            assert_eq!(CtrlEventKind::from_raw(raw), CtrlEventKind::Unknown);
+        }
+    }
+
+    #[test]
+    fn ctrl_event_kind_serializes_as_snake_case() {
+        // Lock in the on-disk JSON spelling. Dashboard consumers and
+        // downstream telemetry depend on these literal strings.
+        assert_eq!(
+            serde_json::to_string(&CtrlEventKind::CtrlC).unwrap(),
+            "\"ctrl_c\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CtrlEventKind::CtrlBreak).unwrap(),
+            "\"ctrl_break\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CtrlEventKind::CtrlClose).unwrap(),
+            "\"ctrl_close\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CtrlEventKind::CtrlLogoff).unwrap(),
+            "\"ctrl_logoff\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CtrlEventKind::CtrlShutdown).unwrap(),
+            "\"ctrl_shutdown\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CtrlEventKind::Unknown).unwrap(),
+            "\"unknown\""
+        );
+    }
+
+    #[test]
+    fn record_event_kind_round_trips_through_observed_event_kind() {
+        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+        assert_eq!(observed_event_kind(), None);
+        record_event_kind(CtrlEventKind::CtrlClose);
+        assert_eq!(observed_event_kind(), Some(CtrlEventKind::CtrlClose));
+        // Last writer wins, matching the timestamp semantics.
+        record_event_kind(CtrlEventKind::CtrlBreak);
+        assert_eq!(observed_event_kind(), Some(CtrlEventKind::CtrlBreak));
+    }
+
+    #[test]
+    fn build_event_carries_recorded_event_kind() {
+        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+        record_observed();
+        record_event_kind(CtrlEventKind::CtrlBreak);
+        let event = build_event(InvocationKind::Direct, 130).expect("event built");
+        assert_eq!(event.ctrl_event_kind, Some(CtrlEventKind::CtrlBreak));
+    }
+
+    #[test]
+    fn build_event_leaves_event_kind_none_when_probe_never_fired() {
+        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+        record_observed();
+        // No `record_event_kind` call — emulates Unix or pre-probe Windows.
+        let event = build_event(InvocationKind::Direct, 130).expect("event built");
+        assert_eq!(event.ctrl_event_kind, None);
     }
 
     #[test]
@@ -364,6 +576,7 @@ mod tests {
                 cwd: None,
                 handed_off: None,
                 handoff_reason: None,
+                ctrl_event_kind: None,
             };
             let path = dir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
             fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();
@@ -392,6 +605,7 @@ mod tests {
             cwd: None,
             handed_off: Some(true),
             handoff_reason: None,
+            ctrl_event_kind: None,
         };
         fs::write(dir.join("good.json"), serde_json::to_vec(&good).unwrap()).unwrap();
         let events = read_recent_events(tmp.path(), 10);

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -688,6 +688,7 @@ mod tests {
             explain_orphans: false,
             command: None,
             passthrough: Vec::new(),
+            codex_config_overrides: Vec::new(),
         };
         assert!(experimental_enabled(&args));
     }

--- a/crates/clud-bin/src/daemon/http/tests.rs
+++ b/crates/clud-bin/src/daemon/http/tests.rs
@@ -224,6 +224,7 @@ fn build_state_includes_ctrl_c_events_when_present() {
             } else {
                 "daemon_unreachable".to_string()
             }),
+            ctrl_event_kind: None,
         };
         let path = edir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
         std::fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();

--- a/crates/clud-bin/src/hook_health/mod.rs
+++ b/crates/clud-bin/src/hook_health/mod.rs
@@ -93,7 +93,8 @@ pub fn run_fix_hooks(args: &Args, selected_backend: Backend) -> i32 {
             RepairAction::BackendPrompt { prompt, .. } => Some(prompt),
             RepairAction::ValidationPrompt { prompt, .. } => Some(prompt),
             RepairAction::AddCodexProjectTrust { .. }
-            | RepairAction::MigrateCodexHooksFeatureFlag { .. } => None,
+            | RepairAction::MigrateCodexHooksFeatureFlag { .. }
+            | RepairAction::NormalizeCodexBatchHookExitCode { .. } => None,
         })
         .collect::<Vec<_>>();
 

--- a/crates/clud-bin/src/hook_health/prompts.rs
+++ b/crates/clud-bin/src/hook_health/prompts.rs
@@ -203,6 +203,7 @@ pub(in crate::hook_health) fn run_backend_prompt(
         explain_orphans: false,
         command: None,
         passthrough: args.passthrough.clone(),
+        codex_config_overrides: args.codex_config_overrides.clone(),
     };
     let plan = command::build_launch_plan(&launch_args, selected_backend, &backend_path);
     let config = ProcessConfig {

--- a/crates/clud-bin/src/hook_health/repairs.rs
+++ b/crates/clud-bin/src/hook_health/repairs.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
 
 use super::codex_trust::{add_codex_project_trust, migrate_codex_hooks_feature_flag};
 use super::prompts::{catch_all_migration_prompt, migration_prompt, validation_prompt_actions};
@@ -33,6 +34,18 @@ pub fn plan_repairs(report: &HookHealthReport) -> Vec<RepairAction> {
             });
         }
     }
+
+    let mut risky_codex_hook_paths = BTreeSet::new();
+    for hook in &report.codex.hooks {
+        if hook_command_needs_last_exit_code(hook.command.as_deref()) {
+            risky_codex_hook_paths.insert(hook.source_path.clone());
+        }
+    }
+    actions.extend(
+        risky_codex_hook_paths
+            .into_iter()
+            .map(|hooks_path| RepairAction::NormalizeCodexBatchHookExitCode { hooks_path }),
+    );
 
     let claude_by_matcher = report.claude.hook_by_matcher();
     let codex_by_matcher = report.codex.hook_by_matcher();
@@ -155,6 +168,7 @@ pub(in crate::hook_health) fn deterministic_repair_actions(
                 action,
                 RepairAction::AddCodexProjectTrust { .. }
                     | RepairAction::MigrateCodexHooksFeatureFlag { .. }
+                    | RepairAction::NormalizeCodexBatchHookExitCode { .. }
             )
         })
         .collect()
@@ -195,8 +209,79 @@ pub(in crate::hook_health) fn apply_deterministic_repairs(
                     display_path(&config_path)
                 );
             }
+            RepairAction::NormalizeCodexBatchHookExitCode { hooks_path } => {
+                normalize_codex_batch_hook_exit_codes(&hooks_path).map_err(|error| {
+                    DeterministicRepairError {
+                        path: hooks_path.clone(),
+                        error,
+                    }
+                })?;
+                applied += 1;
+                eprintln!(
+                    "[clud] updated Codex hook batch wrapper exit-code propagation in {}",
+                    display_path(&hooks_path)
+                );
+            }
             RepairAction::BackendPrompt { .. } | RepairAction::ValidationPrompt { .. } => {}
         }
     }
     Ok(applied)
+}
+
+pub(in crate::hook_health) fn hook_command_needs_last_exit_code(command: Option<&str>) -> bool {
+    if !cfg!(target_os = "windows") {
+        return false;
+    }
+    let Some(command) = command else {
+        return false;
+    };
+    let lower = command.to_ascii_lowercase();
+    (lower.contains(".cmd") || lower.contains(".bat")) && !lower.contains("$lastexitcode")
+}
+
+fn normalize_codex_batch_hook_exit_codes(path: &std::path::Path) -> std::io::Result<()> {
+    let text = fs::read_to_string(path)?;
+    let mut json: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    let mut changed = 0usize;
+    normalize_value(&mut json, &mut changed);
+    if changed == 0 {
+        return Ok(());
+    }
+    let mut body = serde_json::to_string_pretty(&json).map_err(std::io::Error::other)?;
+    body.push('\n');
+    fs::write(path, body)
+}
+
+fn normalize_value(value: &mut serde_json::Value, changed: &mut usize) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(command) = map
+                .get("command")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+            {
+                if hook_command_needs_last_exit_code(Some(command.as_str())) {
+                    map.insert(
+                        "command".to_string(),
+                        serde_json::Value::String(format!(
+                            "{}; exit $LASTEXITCODE",
+                            command.trim_end()
+                        )),
+                    );
+                    *changed += 1;
+                    return;
+                }
+            }
+            for value in map.values_mut() {
+                normalize_value(value, changed);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                normalize_value(value, changed);
+            }
+        }
+        _ => {}
+    }
 }

--- a/crates/clud-bin/src/hook_health/types.rs
+++ b/crates/clud-bin/src/hook_health/types.rs
@@ -137,6 +137,9 @@ pub enum RepairAction {
     MigrateCodexHooksFeatureFlag {
         config_path: PathBuf,
     },
+    NormalizeCodexBatchHookExitCode {
+        hooks_path: PathBuf,
+    },
     BackendPrompt {
         source: HookFrontend,
         target: HookFrontend,

--- a/crates/clud-bin/src/hook_health/warnings.rs
+++ b/crates/clud-bin/src/hook_health/warnings.rs
@@ -83,6 +83,10 @@ pub(in crate::hook_health) fn print_dry_run_plan(report: &HookHealthReport) {
                 "- migrate deprecated Codex `[features].{LEGACY_CODEX_HOOKS_FEATURE}` to `[features].{CURRENT_CODEX_HOOKS_FEATURE}` in {}",
                 display_path(&config_path)
             ),
+            RepairAction::NormalizeCodexBatchHookExitCode { hooks_path } => println!(
+                "- add explicit `$LASTEXITCODE` propagation to Codex batch hook commands in {}",
+                display_path(&hooks_path)
+            ),
             RepairAction::BackendPrompt {
                 source,
                 target,

--- a/crates/clud-bin/src/hook_health_tests.rs
+++ b/crates/clud-bin/src/hook_health_tests.rs
@@ -240,6 +240,69 @@ fn legacy_codex_hooks_feature_migration_preserves_existing_hooks_value() {
     assert!(!text.contains("codex_hooks"), "{text}");
 }
 
+#[cfg(target_os = "windows")]
+#[test]
+fn codex_batch_hook_exit_code_risk_warns_and_plans_repair() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let home = temp.path().join("home");
+    let codex = repo.join(".codex").join("hooks.json");
+    write(
+        &codex,
+        r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"C:\\tools\\guard.cmd --check"}]}]}}"#,
+    );
+    write(
+        &home.join(".codex").join("config.toml"),
+        &format!(
+            "[projects.'{}']\ntrust_level = \"trusted\"\n{}",
+            codex_project_key(&repo),
+            trusted_state_for(&codex, 0, 0)
+        ),
+    );
+
+    let report = inspect_paths(&repo, Some(&home));
+
+    assert!(report
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("may fail open")));
+    assert!(plan_repairs(&report).into_iter().any(|action| matches!(
+        action,
+        RepairAction::NormalizeCodexBatchHookExitCode { hooks_path } if hooks_path == codex
+    )));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn codex_batch_hook_exit_code_repair_appends_lastexitcode() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let home = temp.path().join("home");
+    let codex = repo.join(".codex").join("hooks.json");
+    write(
+        &codex,
+        r#"{"hooks":{"PreToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"C:\\tools\\guard.cmd --check"},{"type":"command","command":"C:\\tools\\safe.cmd; exit $LASTEXITCODE"}]}]}}"#,
+    );
+    write(
+        &home.join(".codex").join("config.toml"),
+        &format!(
+            "[projects.'{}']\ntrust_level = \"trusted\"\n{}",
+            codex_project_key(&repo),
+            trusted_state_for(&codex, 0, 0)
+        ),
+    );
+
+    let report = inspect_paths(&repo, Some(&home));
+    apply_deterministic_repairs(deterministic_repair_actions(&report)).unwrap();
+
+    let text = fs::read_to_string(codex).unwrap();
+    assert!(
+        text.contains(r#"C:\\tools\\guard.cmd --check; exit $LASTEXITCODE"#),
+        "{text}"
+    );
+    assert_eq!(text.matches("safe.cmd; exit $LASTEXITCODE").count(), 1);
+}
+
 #[test]
 fn catch_all_codex_hook_satisfies_specific_claude_matchers() {
     let temp = tempdir().unwrap();

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -308,7 +308,7 @@ fn main() {
 
     // Issue #242: mutable harness setup is scoped per launch until the user
     // opts into a backend-level global preference. Dry-runs always remain
-    // session-only; otherwise a stored `~/.clud/settings.toml` scope wins.
+    // session-only; otherwise a stored `~/.clud/settings.json` scope wins.
     // Bare interactive TUI launches without a stored scope can opt into global
     // setup through a reusable selector. Global setup runs only the selected
     // backend's actions.
@@ -359,6 +359,20 @@ fn main() {
     }
     if args.verbose {
         verbose_log::log(format_args!("[clud] setup scope: {}", setup_scope.as_str()));
+    }
+
+    if matches!(backend, backend::Backend::Codex) {
+        match clud_settings::load_or_init_codex_config_overrides(!args.dry_run) {
+            Ok(overrides) => {
+                args.codex_config_overrides = overrides;
+            }
+            Err(error) => {
+                eprintln!(
+                    "[clud] warning: failed to load Codex settings: {error}; using default Codex config overrides"
+                );
+                args.codex_config_overrides = clud_settings::default_codex_config_overrides();
+            }
+        }
     }
 
     let plan = command::build_launch_plan(&args, backend, &backend_path);

--- a/crates/clud-bin/src/optimize.rs
+++ b/crates/clud-bin/src/optimize.rs
@@ -86,7 +86,7 @@ fn run_rust(
         match scope {
             WriteScope::Global => {
                 println!(
-                    "[clud] dry-run: would write ~/.clud/settings.toml [optimize.rust] use_soldr_shims={} install_soldr={} soldr_version=\"{}\"",
+                    "[clud] dry-run: would write ~/.clud/settings.json optimize.rust use_soldr_shims={} install_soldr={} soldr_version=\"{}\"",
                     settings.use_soldr_shims, settings.install_soldr, settings.soldr_version
                 );
             }
@@ -125,7 +125,7 @@ fn run_rust(
                 eprintln!("[clud] error: failed to save optimize settings: {error}");
                 return 1;
             }
-            println!("[clud] wrote global Rust optimizer defaults to ~/.clud/settings.toml");
+            println!("[clud] wrote global Rust optimizer defaults to ~/.clud/settings.json");
         }
         WriteScope::Repo => match write_repo_directive(&settings) {
             Ok(path) => {
@@ -182,7 +182,7 @@ pub(crate) fn prompt_scope<R: BufRead, W: Write>(
 ) -> io::Result<WriteScope> {
     write!(
         writer,
-        "[clud] install scope — [L]ocal repo (.clud/settings.json) or [G]lobal (~/.clud/settings.toml)? [L]: "
+        "[clud] install scope — [L]ocal repo (.clud/settings.json) or [G]lobal (~/.clud/settings.json)? [L]: "
     )?;
     writer.flush()?;
     let mut line = String::new();

--- a/crates/clud-bin/src/startup.rs
+++ b/crates/clud-bin/src/startup.rs
@@ -166,7 +166,68 @@ pub fn install_ctrl_c_flag(verbose: bool) -> Arc<AtomicBool> {
     }) {
         eprintln!("[clud] warning: failed to install Ctrl+C handler: {}", e);
     }
+    install_windows_ctrl_event_probe();
     interrupted
+}
+
+/// Install a `SetConsoleCtrlHandler` probe whose only job is to record
+/// **which** console-control event the OS delivered — `CTRL_C_EVENT`
+/// vs `CTRL_BREAK_EVENT` vs `CTRL_CLOSE_EVENT` etc. — so the dashboard
+/// can tell a real Ctrl+C keypress apart from a
+/// `GenerateConsoleCtrlEvent` broadcast made by some descendant in the
+/// process tree.
+///
+/// The probe is installed **after** the `ctrlc` crate's handler. Windows
+/// dispatches console-control handlers in **reverse order of
+/// registration** (most recently installed first), so our probe fires
+/// first, stamps the kind into [`crate::ctrl_c_track::record_event_kind`],
+/// and returns `FALSE` to fall through to the `ctrlc` handler, which
+/// preserves existing behavior (stamp the observation timestamp + flip
+/// the interrupted flag).
+///
+/// No-op on non-Windows builds — the kind isn't ambiguous there, and
+/// the `signal-hook` integration in the `ctrlc` crate already knows
+/// which signal it caught.
+#[cfg(windows)]
+fn install_windows_ctrl_event_probe() {
+    use windows::Win32::System::Console::SetConsoleCtrlHandler;
+    use windows_core::BOOL;
+
+    // The probe MUST be `unsafe extern "system" fn` and MUST be stateless
+    // (no closure captures), because the Win32 ABI calls it on an OS-
+    // managed thread with no Rust context. All communication with the
+    // rest of the process goes through the atomics in `ctrl_c_track`.
+    //
+    // We always return `FALSE` so the next handler in the chain (the
+    // `ctrlc` crate's handler, registered earlier) gets a chance to
+    // run. Returning `TRUE` here would short-circuit the chain and
+    // prevent `ctrlc`'s `record_observed` + interrupted-flag work.
+    unsafe extern "system" fn probe(ctrl_type: u32) -> BOOL {
+        crate::ctrl_c_track::record_event_kind(crate::ctrl_c_track::CtrlEventKind::from_raw(
+            ctrl_type,
+        ));
+        // `BOOL(0)` == FALSE — keep walking the handler chain.
+        BOOL(0)
+    }
+
+    // SAFETY: `SetConsoleCtrlHandler` is documented as safe to call from
+    // any thread at any time. `probe` is a `'static` function pointer
+    // with the correct ABI, and we pass `TRUE` to add (not remove).
+    let res = unsafe { SetConsoleCtrlHandler(Some(probe), true) };
+    if let Err(e) = res {
+        eprintln!(
+            "[clud] warning: failed to install Windows ctrl-event probe: {}",
+            e
+        );
+    }
+}
+
+#[cfg(not(windows))]
+fn install_windows_ctrl_event_probe() {
+    // The probe needs `SetConsoleCtrlHandler`, which only exists on
+    // Windows. On Unix the `ctrlc` crate's `signal-hook` backend
+    // already disambiguates SIGINT from SIGTERM, so leaving the
+    // event-kind field as `None` is the correct, honest answer.
 }
 
 /// Pure side-effecting body of the Ctrl+C handler closure, extracted so

--- a/docs/architecture/launch-setup.md
+++ b/docs/architecture/launch-setup.md
@@ -14,19 +14,24 @@ Launch setup scope (Up/Down, Enter):
 [ ] Globally
 ```
 
-The default is session-only unless `~/.clud/settings.toml` already stores a
+The default is session-only unless `~/.clud/settings.json` already stores a
 backend-level global preference, for example:
 
-```toml
-[launch_setup.codex]
-scope = "global"
+```json
+{
+  "launch_setup": {
+    "codex": {
+      "scope": "global"
+    }
+  }
+}
 ```
 
 The selector drains any key events that were already pending when it appeared,
 so the Enter key used to submit the `clud` command is not reused as the
 selector confirmation. Enter accepts the highlighted option, Up selects
 session-only, and Down selects global. Selecting global writes the backend's
-scope to `~/.clud/settings.toml`, so later launches for that backend run global
+scope to `~/.clud/settings.json`, so later launches for that backend run global
 setup without prompting. Selecting session-only stays scoped to that one launch.
 
 A bare `clud` invocation (no `--claude` or `--codex`), non-interactive backend
@@ -50,7 +55,7 @@ Global setup runs only the selected backend's registered actions:
 | Claude | Claude drift skills | `~/.claude/skills/` |
 | Codex | bundled skills | `~/.codex/skills/` gated by `~/.codex`; stale clud-managed `~/.agents/skills/` copies are purged |
 | Codex | hook timeout normalization | `~/.codex/hooks.json` and `~/.clud/settings.lock` / `settings.json` |
-| All | persisted global setup preference | `~/.clud/settings.lock` / `settings.toml` |
+| All | persisted global setup preference | `~/.clud/settings.lock` / `settings.json` |
 
 All setup failures are non-fatal. `main.rs` logs a `[clud] note: ...` line and
 continues to build and run the backend `LaunchPlan`.

--- a/docs/architecture/skill-system.md
+++ b/docs/architecture/skill-system.md
@@ -42,7 +42,7 @@ continues.
 ## Global Setup Flow
 
 `main()` resolves the backend, asks `launch_setup.rs` for a setup scope, and
-then builds the final `LaunchPlan`. If `~/.clud/settings.toml` contains a
+then builds the final `LaunchPlan`. If `~/.clud/settings.json` contains a
 backend-level global preference, future launches for that backend run global
 setup without prompting. Otherwise automation, piped stdin, `--dry-run`, and
 one-shot prompt launches default to session-only. Bare interactive launches can

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -475,7 +475,10 @@ class TestLoopMode:
         assert report["loop_markers"]["done_path"].replace("\\", "/").endswith(".clud/loop/DONE")
         assert report["iterations"] == 50
         cmd = report["command"]
-        assert cmd[1] == "exec"
+        assert cmd[0] == "codex"
+        assert "-c" in cmd
+        assert 'plugins."github@openai-curated".enabled=false' in cmd
+        assert cmd.index("exec") > 0
         assert "--dangerously-bypass-approvals-and-sandbox" in cmd
         assert "-p" not in cmd
 

--- a/tests/integration/test_mock_agents.py
+++ b/tests/integration/test_mock_agents.py
@@ -475,7 +475,7 @@ class TestLoopMode:
         assert report["loop_markers"]["done_path"].replace("\\", "/").endswith(".clud/loop/DONE")
         assert report["iterations"] == 50
         cmd = report["command"]
-        assert cmd[0] == "codex"
+        assert Path(cmd[0]).stem == "codex"
         assert "-c" in cmd
         assert 'plugins."github@openai-curated".enabled=false' in cmd
         assert cmd.index("exec") > 0


### PR DESCRIPTION
## Summary
- move clud user settings to `~/.clud/settings.json`, preserving legacy TOML reads and migrating on next save
- add documented Codex `-c` config overrides, defaulting the GitHub connector plugin off through clud settings
- add deterministic hook repair for Windows Codex batch hooks missing `$LASTEXITCODE` propagation
- record the specific Windows console-control event kind in Ctrl+C exit diagnostics

Fixes #358.

## Tests
- `soldr cargo fmt --check`
- `soldr cargo test -p clud`
- `$env:CLUD_INTEGRATION_TESTS='1'; python -m pytest tests/integration/test_mock_agents.py::TestLoopMode::test_codex_loop_dry_run -q`