### PR TITLE
feat(ctrl-c): capture Windows forensic context

### DIFF
--- a/crates/clud-bin/src/ctrl_c_track.rs
+++ b/crates/clud-bin/src/ctrl_c_track.rs
@@ -169,6 +169,42 @@ pub struct CtrlCEvent {
     /// the same handler but mean very different things.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ctrl_event_kind: Option<CtrlEventKind>,
+    /// Best-effort forensic context captured after clud observed a
+    /// Windows console-control event. Win32 does not expose the sender
+    /// of `CTRL_C_EVENT`; this snapshot records the console/process
+    /// context that existed when clud began interrupt teardown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forensics: Option<CtrlCForensics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CtrlCForensics {
+    pub captured_at_ms: u64,
+    pub current_pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_parent_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_root_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub child_tree_pids: Vec<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ancestor_pids: Vec<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub console_process_pids: Vec<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreground_window_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub processes: Vec<CtrlCProcessSnapshot>,
+    pub source_limit: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CtrlCProcessSnapshot {
+    pub pid: u32,
+    pub parent_pid: u32,
+    pub exe: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<String>,
 }
 
 // Process-wide observation point. Re-stamped on every Ctrl+C the signal
@@ -207,6 +243,7 @@ pub struct HandoffOutcome {
 }
 
 static HANDOFF_OUTCOME: Mutex<Option<HandoffOutcome>> = Mutex::new(None);
+static FORENSICS: Mutex<Option<CtrlCForensics>> = Mutex::new(None);
 
 /// Mark the process as having observed Ctrl+C. Safe to call from a signal
 /// handler — no allocations, no locks, just an atomic store.
@@ -262,6 +299,19 @@ pub fn record_handoff(handed_off: bool, reason: Option<&str>) {
     }
 }
 
+/// Capture best-effort context for a Ctrl+C event. This is intentionally
+/// called from teardown code, not from the signal/control handler itself:
+/// Win32 does not report the sender PID for `CTRL_C_EVENT`, and anything
+/// richer than atomics would be the wrong work to do inside the handler.
+pub fn record_forensics(child_root_pid: Option<u32>) {
+    let Some(snapshot) = platform_forensics(child_root_pid) else {
+        return;
+    };
+    if let Ok(mut guard) = FORENSICS.lock() {
+        *guard = Some(snapshot);
+    }
+}
+
 /// If Ctrl+C was observed during this process's lifetime, write an event
 /// file under `<state_dir>/ctrl_c_events/`. Best-effort: every error path
 /// is silent. This must never block exit.
@@ -289,6 +339,7 @@ fn build_event(kind: InvocationKind, exit_code: i32) -> Option<CtrlCEvent> {
         .map(|o| (Some(o.handed_off), o.reason))
         .unwrap_or((None, None));
     let ctrl_event_kind = observed_event_kind();
+    let forensics = FORENSICS.lock().ok().and_then(|g| g.clone());
     Some(CtrlCEvent {
         pid: std::process::id(),
         observed_at_ms,
@@ -300,6 +351,7 @@ fn build_event(kind: InvocationKind, exit_code: i32) -> Option<CtrlCEvent> {
         handed_off,
         handoff_reason,
         ctrl_event_kind,
+        forensics,
     })
 }
 
@@ -388,6 +440,215 @@ pub(crate) fn reset_for_test() {
     if let Ok(mut g) = HANDOFF_OUTCOME.lock() {
         *g = None;
     }
+    if let Ok(mut g) = FORENSICS.lock() {
+        *g = None;
+    }
+}
+
+#[cfg(windows)]
+fn platform_forensics(child_root_pid: Option<u32>) -> Option<CtrlCForensics> {
+    use std::collections::{HashMap, HashSet};
+
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::Console::GetConsoleProcessList;
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    use windows::Win32::System::Threading::GetCurrentProcessId;
+    use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId};
+
+    #[derive(Clone)]
+    struct Entry {
+        pid: u32,
+        parent_pid: u32,
+        exe: String,
+    }
+
+    fn process_entries() -> Vec<Entry> {
+        let Ok(snapshot) = (unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) }) else {
+            return Vec::new();
+        };
+        let mut entries = Vec::new();
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+        if unsafe { Process32FirstW(snapshot, &mut entry) }.is_ok() {
+            loop {
+                entries.push(Entry {
+                    pid: entry.th32ProcessID,
+                    parent_pid: entry.th32ParentProcessID,
+                    exe: nul_terminated_wide_to_string(&entry.szExeFile),
+                });
+                if unsafe { Process32NextW(snapshot, &mut entry) }.is_err() {
+                    break;
+                }
+            }
+        }
+        let _ = unsafe { CloseHandle(snapshot) };
+        entries
+    }
+
+    fn nul_terminated_wide_to_string(buf: &[u16]) -> String {
+        let len = buf.iter().position(|&unit| unit == 0).unwrap_or(buf.len());
+        String::from_utf16_lossy(&buf[..len])
+    }
+
+    fn console_process_pids() -> Vec<u32> {
+        let mut buf = vec![0u32; 128];
+        let count = unsafe { GetConsoleProcessList(&mut buf) };
+        if count == 0 {
+            return Vec::new();
+        }
+        if count as usize > buf.len() {
+            buf.resize(count as usize, 0);
+            let count = unsafe { GetConsoleProcessList(&mut buf) };
+            buf.truncate(count as usize);
+        } else {
+            buf.truncate(count as usize);
+        }
+        buf.sort_unstable();
+        buf.dedup();
+        buf
+    }
+
+    fn foreground_window_pid() -> Option<u32> {
+        let hwnd = unsafe { GetForegroundWindow() };
+        if hwnd.is_invalid() {
+            return None;
+        }
+        let mut pid = 0u32;
+        unsafe {
+            GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        }
+        (pid != 0).then_some(pid)
+    }
+
+    fn descendant_pids(entries: &[Entry], root: u32) -> Vec<u32> {
+        let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+        for entry in entries {
+            children
+                .entry(entry.parent_pid)
+                .or_default()
+                .push(entry.pid);
+        }
+        let mut stack = vec![root];
+        let mut out = Vec::new();
+        while let Some(pid) = stack.pop() {
+            if let Some(next) = children.get(&pid) {
+                for child in next {
+                    out.push(*child);
+                    stack.push(*child);
+                }
+            }
+        }
+        out
+    }
+
+    fn ancestor_pids(entries_by_pid: &HashMap<u32, Entry>, current_pid: u32) -> Vec<u32> {
+        let mut out = Vec::new();
+        let mut seen = HashSet::new();
+        let mut pid = current_pid;
+        for _ in 0..64 {
+            let Some(entry) = entries_by_pid.get(&pid) else {
+                break;
+            };
+            let parent = entry.parent_pid;
+            if parent == 0 || parent == pid || !seen.insert(parent) {
+                break;
+            }
+            out.push(parent);
+            pid = parent;
+        }
+        out
+    }
+
+    let entries = process_entries();
+    let by_pid: HashMap<u32, Entry> = entries.iter().map(|e| (e.pid, e.clone())).collect();
+    let current_pid = unsafe { GetCurrentProcessId() };
+    let current_parent_pid = by_pid.get(&current_pid).map(|e| e.parent_pid);
+    let child_tree_pids = child_root_pid
+        .map(|pid| descendant_pids(&entries, pid))
+        .unwrap_or_default();
+    let ancestor_pids = ancestor_pids(&by_pid, current_pid);
+    let console_process_pids = console_process_pids();
+    let foreground_window_pid = foreground_window_pid();
+
+    let mut wanted = HashSet::new();
+    wanted.insert(current_pid);
+    if let Some(pid) = current_parent_pid {
+        wanted.insert(pid);
+    }
+    if let Some(pid) = child_root_pid {
+        wanted.insert(pid);
+    }
+    for pid in &child_tree_pids {
+        wanted.insert(*pid);
+    }
+    for pid in &ancestor_pids {
+        wanted.insert(*pid);
+    }
+    for pid in &console_process_pids {
+        wanted.insert(*pid);
+    }
+    if let Some(pid) = foreground_window_pid {
+        wanted.insert(pid);
+    }
+
+    let mut processes: Vec<CtrlCProcessSnapshot> = wanted
+        .into_iter()
+        .filter_map(|pid| {
+            let entry = by_pid.get(&pid)?;
+            let mut roles = Vec::new();
+            if pid == current_pid {
+                roles.push("clud".to_string());
+            }
+            if Some(pid) == current_parent_pid {
+                roles.push("clud_parent".to_string());
+            }
+            if Some(pid) == child_root_pid {
+                roles.push("child_root".to_string());
+            }
+            if child_tree_pids.contains(&pid) {
+                roles.push("child_descendant".to_string());
+            }
+            if ancestor_pids.contains(&pid) {
+                roles.push("clud_ancestor".to_string());
+            }
+            if console_process_pids.contains(&pid) {
+                roles.push("same_console".to_string());
+            }
+            if Some(pid) == foreground_window_pid {
+                roles.push("foreground_window_owner".to_string());
+            }
+            Some(CtrlCProcessSnapshot {
+                pid,
+                parent_pid: entry.parent_pid,
+                exe: entry.exe.clone(),
+                roles,
+            })
+        })
+        .collect();
+    processes.sort_by_key(|p| p.pid);
+
+    Some(CtrlCForensics {
+        captured_at_ms: unix_millis_now(),
+        current_pid,
+        current_parent_pid,
+        child_root_pid,
+        child_tree_pids,
+        ancestor_pids,
+        console_process_pids,
+        foreground_window_pid,
+        processes,
+        source_limit: "win32_console_control_events_do_not_expose_sender_pid".to_string(),
+    })
+}
+
+#[cfg(not(windows))]
+fn platform_forensics(_child_root_pid: Option<u32>) -> Option<CtrlCForensics> {
+    None
 }
 
 #[cfg(test)]
@@ -424,6 +685,23 @@ mod tests {
             handed_off: Some(true),
             handoff_reason: Some("ctrl_c_subprocess".to_string()),
             ctrl_event_kind: Some(CtrlEventKind::CtrlBreak),
+            forensics: Some(CtrlCForensics {
+                captured_at_ms: 1_700_000_000_125,
+                current_pid: 1234,
+                current_parent_pid: Some(42),
+                child_root_pid: Some(5678),
+                child_tree_pids: vec![6789],
+                ancestor_pids: vec![42],
+                console_process_pids: vec![42, 1234, 5678, 6789],
+                foreground_window_pid: Some(42),
+                processes: vec![CtrlCProcessSnapshot {
+                    pid: 5678,
+                    parent_pid: 1234,
+                    exe: "cmd.exe".to_string(),
+                    roles: vec!["child_root".to_string(), "same_console".to_string()],
+                }],
+                source_limit: "win32_console_control_events_do_not_expose_sender_pid".to_string(),
+            }),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""kind":"direct""#));
@@ -431,6 +709,7 @@ mod tests {
         assert!(json.contains(r#""handed_off":true"#));
         assert!(json.contains(r#""handoff_reason":"ctrl_c_subprocess""#));
         assert!(json.contains(r#""ctrl_event_kind":"ctrl_break""#));
+        assert!(json.contains(r#""source_limit":"#));
         let back: CtrlCEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back.pid, 1234);
         assert_eq!(back.elapsed_ms, 250);
@@ -439,6 +718,10 @@ mod tests {
         assert_eq!(back.handed_off, Some(true));
         assert_eq!(back.handoff_reason.as_deref(), Some("ctrl_c_subprocess"));
         assert_eq!(back.ctrl_event_kind, Some(CtrlEventKind::CtrlBreak));
+        let forensics = back.forensics.expect("forensics round-tripped");
+        assert_eq!(forensics.child_root_pid, Some(5678));
+        assert_eq!(forensics.console_process_pids, vec![42, 1234, 5678, 6789]);
+        assert_eq!(forensics.processes[0].exe, "cmd.exe");
     }
 
     #[test]
@@ -460,6 +743,7 @@ mod tests {
         assert_eq!(event.handed_off, None);
         assert_eq!(event.handoff_reason, None);
         assert_eq!(event.ctrl_event_kind, None);
+        assert_eq!(event.forensics, None);
     }
 
     #[test]
@@ -577,6 +861,7 @@ mod tests {
                 handed_off: None,
                 handoff_reason: None,
                 ctrl_event_kind: None,
+                forensics: None,
             };
             let path = dir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
             fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();
@@ -606,6 +891,7 @@ mod tests {
             handed_off: Some(true),
             handoff_reason: None,
             ctrl_event_kind: None,
+            forensics: None,
         };
         fs::write(dir.join("good.json"), serde_json::to_vec(&good).unwrap()).unwrap();
         let events = read_recent_events(tmp.path(), 10);

--- a/crates/clud-bin/src/daemon/http/tests.rs
+++ b/crates/clud-bin/src/daemon/http/tests.rs
@@ -225,6 +225,7 @@ fn build_state_includes_ctrl_c_events_when_present() {
                 "daemon_unreachable".to_string()
             }),
             ctrl_event_kind: None,
+            forensics: None,
         };
         let path = edir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
         std::fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -346,6 +346,7 @@ enum ProcessOutcome {
 /// `kill_tree` + bounded wait) so `--no-daemon` users still get cleanup.
 fn teardown_interrupted_child(process: &running_process::NativeProcess, batch_wrapped: bool) {
     if let Some(pid) = process.pid() {
+        crate::ctrl_c_track::record_forensics(Some(pid));
         match crate::daemon::default_state_dir() {
             Ok(state_dir) => {
                 if crate::daemon::try_handoff_kill_to_daemon(
@@ -374,6 +375,7 @@ fn teardown_interrupted_child(process: &running_process::NativeProcess, batch_wr
         process_tree::kill_tree(pid);
     } else {
         crate::ctrl_c_track::record_handoff(false, Some("no_child_pid"));
+        crate::ctrl_c_track::record_forensics(None);
     }
     let _ = process.kill();
     // Daemon-less fallback only: bounded wait so the legacy path doesn't

--- a/crates/clud-bin/src/session/interrupt.rs
+++ b/crates/clud-bin/src/session/interrupt.rs
@@ -19,6 +19,7 @@ pub(super) fn reap_pty_exit(process: &NativePtyProcess) -> i32 {
 /// real kill_tree from out of the user's hot path.
 pub(super) fn interrupt_pty_process(process: &NativePtyProcess, verbose: bool) -> i32 {
     let pid = process.pid().ok().flatten();
+    crate::ctrl_c_track::record_forensics(pid);
     let handed_off = match pid {
         Some(pid) => match crate::daemon::default_state_dir() {
             Ok(state_dir) => {


### PR DESCRIPTION
## Summary

- persist best-effort Windows Ctrl-C forensic context in `ctrl_c_events/*.json`
- capture current/parent/ancestor pids, child root/tree pids, same-console pids, foreground-window pid, and process role snapshots
- record forensics from subprocess and PTY interrupt teardown before kill/handoff cleanup

## Tests

- `soldr cargo fmt --package clud`
- `$env:CARGO_TARGET_DIR='C:\tmp\clud-target-ctrlc-pr'; soldr cargo test -p clud ctrl_c_track --lib`
- `$env:CARGO_TARGET_DIR='C:\tmp\clud-target-ctrlc-pr'; soldr cargo test -p clud build_state_includes_ctrl_c_events_when_present --lib`
- `$env:CARGO_TARGET_DIR='C:\tmp\clud-target-ctrlc-pr'; soldr cargo check -p clud --bins --tests`

Note: the shorter `CARGO_TARGET_DIR` avoids a local Windows/MSBuild file-tracker path failure in the long disposable worktree path.