### PR TITLE
feat(ctrl-c): require rapid double Ctrl-C to exit on Windows

### DIFF
--- a/crates/clud-bin/src/ctrl_c_track.rs
+++ b/crates/clud-bin/src/ctrl_c_track.rs
@@ -46,6 +46,23 @@ pub const MAX_RETAINED_EVENTS: usize = 50;
 /// small even right after a burst of interrupts.
 pub const DASHBOARD_EVENT_LIMIT: usize = 20;
 
+/// Default rapid-succession window (in milliseconds) used by the Windows
+/// double-Ctrl+C guard. Sits inside the 1–3s range called out in issue
+/// #377's "Proposed direction": short enough that a deliberate exit feels
+/// snappy, long enough that a held-down or repeated keystroke doesn't
+/// tear down clud accidentally. Overridable via `CLUD_CTRL_C_WINDOW_MS`.
+pub const DOUBLE_TAP_WINDOW_MS_DEFAULT: u64 = 1500;
+
+/// Env var that overrides [`DOUBLE_TAP_WINDOW_MS_DEFAULT`]. Values
+/// outside `[50, 10_000]` are ignored — we want operators to tune the
+/// window, not disable it by smuggling a `0` through the same knob.
+pub const ENV_DOUBLE_TAP_WINDOW_MS: &str = "CLUD_CTRL_C_WINDOW_MS";
+
+/// Env var that turns the Windows double-tap guard off entirely
+/// (`CLUD_NO_DOUBLE_CTRL_C=1`). Provided so a user who prefers the old
+/// single-press teardown can fall back without a code change.
+pub const ENV_DISABLE_DOUBLE_TAP: &str = "CLUD_NO_DOUBLE_CTRL_C";
+
 /// Origin of the interrupt — the dashboard groups events by this so the
 /// "is it the daemon attach path that's slow or the direct runner?"
 /// question has a one-glance answer.
@@ -108,6 +125,54 @@ pub enum CtrlEventKind {
     /// Stored so a future Windows revision that adds a new control
     /// event doesn't get silently dropped on the floor.
     Unknown,
+}
+
+/// Classifies a Ctrl+C observation as either the first press in a
+/// rapid-succession window (treated as a soft interrupt — clud stays
+/// running so the child can handle it cooperatively) or the second
+/// press that actually triggers clud teardown.
+///
+/// Recorded in the forensic event so the dashboard can distinguish
+/// "user pressed Ctrl+C once and it got swallowed correctly" from
+/// "user pressed Ctrl+C twice in rapid succession and we exited".
+/// Optional in [`CtrlCEvent`] so legacy event files (and event files
+/// written by non-Windows paths that never engage the double-tap guard)
+/// stay parseable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CtrlPressKind {
+    /// First press observed in a fresh rapid-succession window. clud
+    /// suppressed the teardown and printed a hint; the child still got
+    /// its own copy of the console-control event from the OS.
+    FirstSoft,
+    /// Second press observed within the rapid-succession window — or
+    /// any press on a path where the double-tap guard is disabled.
+    /// This is the press that flipped clud's interrupted flag.
+    SecondExit,
+}
+
+impl CtrlPressKind {
+    /// Numeric encoding for the [`AtomicU32`] storage. Must round-trip
+    /// through [`Self::from_raw`].
+    pub const fn to_raw(self) -> u32 {
+        match self {
+            CtrlPressKind::FirstSoft => 0,
+            CtrlPressKind::SecondExit => 1,
+        }
+    }
+
+    /// Decode a value previously written by [`Self::to_raw`]. `None`
+    /// for the [`PRESS_KIND_UNRECORDED`] sentinel; any other unexpected
+    /// value collapses to [`Self::SecondExit`] so a future encoding bug
+    /// can't silently downgrade the press to "first" (which would be
+    /// the dangerous direction — we'd skip teardown when we shouldn't).
+    pub const fn from_raw(raw: u32) -> Option<Self> {
+        match raw {
+            v if v == PRESS_KIND_UNRECORDED => None,
+            0 => Some(CtrlPressKind::FirstSoft),
+            _ => Some(CtrlPressKind::SecondExit),
+        }
+    }
 }
 
 impl CtrlEventKind {
@@ -175,6 +240,21 @@ pub struct CtrlCEvent {
     /// context that existed when clud began interrupt teardown.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub forensics: Option<CtrlCForensics>,
+    /// Press classification recorded by the double-Ctrl+C guard (issue
+    /// #377). `Some(FirstSoft)` means clud suppressed teardown and a
+    /// follow-up press was needed; `Some(SecondExit)` means this is the
+    /// press that flipped the interrupted flag. `None` on legacy event
+    /// files and on platforms where the guard is intentionally not
+    /// engaged (currently: non-Windows).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub press_kind: Option<CtrlPressKind>,
+    /// Time between this Ctrl+C and the previous one, in milliseconds.
+    /// `None` if this is the first Ctrl+C of the process's lifetime or
+    /// the event was written by a pre-#377 build. The double-tap window
+    /// (`CLUD_CTRL_C_WINDOW_MS`, default
+    /// [`DOUBLE_TAP_WINDOW_MS_DEFAULT`]) is compared against this value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_since_prior_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -229,6 +309,20 @@ static OBSERVED_UNIX_MS: AtomicU64 = AtomicU64::new(0);
 const KIND_UNRECORDED: u32 = u32::MAX;
 static OBSERVED_EVENT_KIND: AtomicU32 = AtomicU32::new(KIND_UNRECORDED);
 
+/// Process-wide most-recent press classification recorded by the
+/// double-Ctrl+C guard. `PRESS_KIND_UNRECORDED` means the guard never
+/// fired in this process (non-Windows, opt-out via `CLUD_NO_DOUBLE_CTRL_C`,
+/// or pre-handler exit). Decoded via [`CtrlPressKind::from_raw`].
+pub const PRESS_KIND_UNRECORDED: u32 = u32::MAX;
+static OBSERVED_PRESS_KIND: AtomicU32 = AtomicU32::new(PRESS_KIND_UNRECORDED);
+
+/// Stores the gap between the most recent press and the one before it,
+/// in milliseconds. `0` is the sentinel for "no prior press" — a real
+/// gap of zero is indistinguishable from a coarse-timer clock that hasn't
+/// advanced yet, and the forensic field is optional, so we don't lose
+/// anything by collapsing both cases into "None".
+static OBSERVED_ELAPSED_SINCE_PRIOR_MS: AtomicU64 = AtomicU64::new(0);
+
 /// Process-wide handoff outcome. Recorded by the teardown sites
 /// (`runner::teardown_interrupted_child`, `session::interrupt_pty_process`)
 /// after they decide whether the daemon adopted the kill or the legacy
@@ -253,8 +347,25 @@ static FORENSICS: Mutex<Option<CtrlCForensics>> = Mutex::new(None);
 /// `elapsed_ms` to measure "the Ctrl+C that exited clud → shell return",
 /// not "the very first Ctrl+C ever seen → exit", which conflated multiple
 /// presses across a long session into a single bogus 5-minute event.
+///
+/// Thin wrapper around [`record_observed_returning_prior`] for sites
+/// that don't need the previous timestamp.
 pub fn record_observed() {
-    OBSERVED_UNIX_MS.store(unix_millis_now(), Ordering::SeqCst);
+    let _ = record_observed_returning_prior();
+}
+
+/// Re-stamp the process-wide observation point and return whatever was
+/// previously stored. The Windows double-Ctrl+C handler (issue #377)
+/// uses the returned prior to decide whether this press lands inside a
+/// rapid-succession window.
+///
+/// Signal-safe: a single `AtomicU64::swap` with `SeqCst` ordering. No
+/// allocations, no locks. A return value of `0` means "no prior press"
+/// (the unix-epoch sentinel that [`build_event`] also keys off of), so
+/// callers don't need a separate boolean flag.
+pub fn record_observed_returning_prior() -> u64 {
+    let now = unix_millis_now();
+    OBSERVED_UNIX_MS.swap(now, Ordering::SeqCst)
 }
 
 pub fn was_observed() -> bool {
@@ -282,6 +393,77 @@ pub fn observed_event_kind() -> Option<CtrlEventKind> {
     } else {
         Some(CtrlEventKind::from_raw(raw))
     }
+}
+
+/// Record the press classification decided by the double-Ctrl+C guard
+/// (issue #377). Signal-safe: single atomic store. Last writer wins,
+/// matching the timestamp + event-kind semantics above.
+pub fn record_press_kind(kind: CtrlPressKind) {
+    OBSERVED_PRESS_KIND.store(kind.to_raw(), Ordering::SeqCst);
+}
+
+/// Read the most recent press classification. `None` when no press has
+/// been classified yet (non-Windows paths, opt-out, or pre-handler).
+pub fn observed_press_kind() -> Option<CtrlPressKind> {
+    CtrlPressKind::from_raw(OBSERVED_PRESS_KIND.load(Ordering::SeqCst))
+}
+
+/// Stamp the millisecond gap between the most recent press and the one
+/// before it. Signal-safe. `0` is reserved as the "no prior press"
+/// sentinel — callers must not stamp a literal zero gap or they'll lose
+/// the field on the forensic event.
+pub fn record_elapsed_since_prior_ms(elapsed_ms: u64) {
+    OBSERVED_ELAPSED_SINCE_PRIOR_MS.store(elapsed_ms, Ordering::SeqCst);
+}
+
+/// Read the recorded gap, or `None` if no prior press was recorded.
+pub fn observed_elapsed_since_prior_ms() -> Option<u64> {
+    let v = OBSERVED_ELAPSED_SINCE_PRIOR_MS.load(Ordering::SeqCst);
+    if v == 0 {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+/// Effective rapid-succession window in milliseconds. Reads
+/// `CLUD_CTRL_C_WINDOW_MS` and falls back to
+/// [`DOUBLE_TAP_WINDOW_MS_DEFAULT`]. Values outside `[50, 10_000]` are
+/// rejected — the env var is a tuning knob, not a back door to disable
+/// the guard (use [`ENV_DISABLE_DOUBLE_TAP`] for that).
+pub fn double_tap_window_ms() -> u64 {
+    let Ok(raw) = std::env::var(ENV_DOUBLE_TAP_WINDOW_MS) else {
+        return DOUBLE_TAP_WINDOW_MS_DEFAULT;
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return DOUBLE_TAP_WINDOW_MS_DEFAULT;
+    }
+    match trimmed.parse::<u64>() {
+        Ok(v) if (50..=10_000).contains(&v) => v,
+        _ => DOUBLE_TAP_WINDOW_MS_DEFAULT,
+    }
+}
+
+/// Whether the Windows double-Ctrl+C guard is engaged for this process.
+/// Returns `false` on non-Windows (the guard is Windows-only by design)
+/// or when `CLUD_NO_DOUBLE_CTRL_C` is set to a truthy value
+/// (`1`/`true`/`yes`/`on`, case-insensitive).
+pub fn double_tap_enabled() -> bool {
+    if !cfg!(windows) {
+        return false;
+    }
+    match std::env::var(ENV_DISABLE_DOUBLE_TAP) {
+        Ok(raw) => !env_var_is_truthy(&raw),
+        Err(_) => true,
+    }
+}
+
+fn env_var_is_truthy(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
 /// Record the daemon-handoff outcome (issue #285 rec 2). Called from
@@ -340,6 +522,8 @@ fn build_event(kind: InvocationKind, exit_code: i32) -> Option<CtrlCEvent> {
         .unwrap_or((None, None));
     let ctrl_event_kind = observed_event_kind();
     let forensics = FORENSICS.lock().ok().and_then(|g| g.clone());
+    let press_kind = observed_press_kind();
+    let elapsed_since_prior_ms = observed_elapsed_since_prior_ms();
     Some(CtrlCEvent {
         pid: std::process::id(),
         observed_at_ms,
@@ -352,6 +536,8 @@ fn build_event(kind: InvocationKind, exit_code: i32) -> Option<CtrlCEvent> {
         handoff_reason,
         ctrl_event_kind,
         forensics,
+        press_kind,
+        elapsed_since_prior_ms,
     })
 }
 
@@ -430,6 +616,17 @@ fn unix_millis_now() -> u64 {
         .unwrap_or(0)
 }
 
+/// **Test-only.** Shared mutex so tests in multiple modules can
+/// serialize against the process-global statics
+/// (`OBSERVED_*` + `HANDOFF_OUTCOME` + `FORENSICS` + the env vars
+/// the guard reads). Cargo's parallel test runner would otherwise
+/// interleave writes and produce flaky assertions.
+#[cfg(test)]
+pub(crate) fn test_state_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    &LOCK
+}
+
 /// **Test-only.** Reset the observation + handoff state so tests that
 /// exercise `build_event` / `flush_on_exit` can simulate a fresh
 /// process. Real processes only ever transition once per run.
@@ -437,6 +634,8 @@ fn unix_millis_now() -> u64 {
 pub(crate) fn reset_for_test() {
     OBSERVED_UNIX_MS.store(0, Ordering::SeqCst);
     OBSERVED_EVENT_KIND.store(KIND_UNRECORDED, Ordering::SeqCst);
+    OBSERVED_PRESS_KIND.store(PRESS_KIND_UNRECORDED, Ordering::SeqCst);
+    OBSERVED_ELAPSED_SINCE_PRIOR_MS.store(0, Ordering::SeqCst);
     if let Ok(mut g) = HANDOFF_OUTCOME.lock() {
         *g = None;
     }
@@ -654,16 +853,11 @@ fn platform_forensics(_child_root_pid: Option<u32>) -> Option<CtrlCForensics> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
     use tempfile::tempdir;
 
-    /// Tests that mutate `OBSERVED_UNIX_MS` / `HANDOFF_OUTCOME` would
-    /// race each other under cargo's default parallel runner because
-    /// the module-level statics are process-global. Acquire this lock
-    /// at the top of every test that touches `record_observed`,
-    /// `record_handoff`, `reset_for_test`, `build_event`, or
-    /// `flush_on_exit` to serialize them deterministically.
-    static STATE_LOCK: Mutex<()> = Mutex::new(());
+    // Cross-module test serialization lives in `test_state_lock()` so
+    // `startup::tests` can hold the same mutex while it drives
+    // `run_ctrl_c_handler` — those tests mutate the same statics.
 
     #[test]
     fn invocation_kind_str_round_trips() {
@@ -702,6 +896,8 @@ mod tests {
                 }],
                 source_limit: "win32_console_control_events_do_not_expose_sender_pid".to_string(),
             }),
+            press_kind: Some(CtrlPressKind::SecondExit),
+            elapsed_since_prior_ms: Some(900),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains(r#""kind":"direct""#));
@@ -710,6 +906,8 @@ mod tests {
         assert!(json.contains(r#""handoff_reason":"ctrl_c_subprocess""#));
         assert!(json.contains(r#""ctrl_event_kind":"ctrl_break""#));
         assert!(json.contains(r#""source_limit":"#));
+        assert!(json.contains(r#""press_kind":"second_exit""#));
+        assert!(json.contains(r#""elapsed_since_prior_ms":900"#));
         let back: CtrlCEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back.pid, 1234);
         assert_eq!(back.elapsed_ms, 250);
@@ -718,6 +916,8 @@ mod tests {
         assert_eq!(back.handed_off, Some(true));
         assert_eq!(back.handoff_reason.as_deref(), Some("ctrl_c_subprocess"));
         assert_eq!(back.ctrl_event_kind, Some(CtrlEventKind::CtrlBreak));
+        assert_eq!(back.press_kind, Some(CtrlPressKind::SecondExit));
+        assert_eq!(back.elapsed_since_prior_ms, Some(900));
         let forensics = back.forensics.expect("forensics round-tripped");
         assert_eq!(forensics.child_root_pid, Some(5678));
         assert_eq!(forensics.console_process_pids, vec![42, 1234, 5678, 6789]);
@@ -744,6 +944,8 @@ mod tests {
         assert_eq!(event.handoff_reason, None);
         assert_eq!(event.ctrl_event_kind, None);
         assert_eq!(event.forensics, None);
+        assert_eq!(event.press_kind, None);
+        assert_eq!(event.elapsed_since_prior_ms, None);
     }
 
     #[test]
@@ -807,7 +1009,7 @@ mod tests {
 
     #[test]
     fn record_event_kind_round_trips_through_observed_event_kind() {
-        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
         reset_for_test();
         assert_eq!(observed_event_kind(), None);
         record_event_kind(CtrlEventKind::CtrlClose);
@@ -819,7 +1021,7 @@ mod tests {
 
     #[test]
     fn build_event_carries_recorded_event_kind() {
-        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
         reset_for_test();
         record_observed();
         record_event_kind(CtrlEventKind::CtrlBreak);
@@ -829,7 +1031,7 @@ mod tests {
 
     #[test]
     fn build_event_leaves_event_kind_none_when_probe_never_fired() {
-        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
         reset_for_test();
         record_observed();
         // No `record_event_kind` call — emulates Unix or pre-probe Windows.
@@ -862,6 +1064,8 @@ mod tests {
                 handoff_reason: None,
                 ctrl_event_kind: None,
                 forensics: None,
+                press_kind: None,
+                elapsed_since_prior_ms: None,
             };
             let path = dir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
             fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();
@@ -892,6 +1096,8 @@ mod tests {
             handoff_reason: None,
             ctrl_event_kind: None,
             forensics: None,
+            press_kind: None,
+            elapsed_since_prior_ms: None,
         };
         fs::write(dir.join("good.json"), serde_json::to_vec(&good).unwrap()).unwrap();
         let events = read_recent_events(tmp.path(), 10);
@@ -920,7 +1126,7 @@ mod tests {
 
     #[test]
     fn flush_on_exit_is_noop_when_never_observed() {
-        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
         // Reset so prior tests in this module can't pollute the static
         // observation point. After reset, `was_observed` must be false
         // and `flush_on_exit` must write nothing.
@@ -942,7 +1148,7 @@ mod tests {
     /// entire intervening time attributed to the eventual shutdown.
     #[test]
     fn record_observed_updates_on_every_call() {
-        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
         reset_for_test();
         record_observed();
         let first = OBSERVED_UNIX_MS.load(Ordering::SeqCst);
@@ -963,7 +1169,7 @@ mod tests {
     /// distinguish "daemon adopted" from "synchronous fallback".
     #[test]
     fn record_handoff_propagates_to_event() {
-        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
         reset_for_test();
         record_observed();
         record_handoff(true, Some("ctrl_c_subprocess"));
@@ -974,7 +1180,7 @@ mod tests {
 
     #[test]
     fn record_handoff_failure_surfaces_reason() {
-        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
         reset_for_test();
         record_observed();
         record_handoff(false, Some("daemon_unreachable"));
@@ -985,7 +1191,7 @@ mod tests {
 
     #[test]
     fn build_event_without_handoff_leaves_fields_none() {
-        let _guard = STATE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
         // When neither teardown site fires (e.g. `clud --no-daemon` exits
         // before reaching the teardown helper), the event must still be
         // written but with the handoff fields left as None so the
@@ -995,5 +1201,179 @@ mod tests {
         let event = build_event(InvocationKind::Direct, 130).expect("event built");
         assert_eq!(event.handed_off, None);
         assert_eq!(event.handoff_reason, None);
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #377: double-Ctrl+C guard infrastructure.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn ctrl_press_kind_round_trips_through_raw() {
+        for kind in [CtrlPressKind::FirstSoft, CtrlPressKind::SecondExit] {
+            let raw = kind.to_raw();
+            assert_eq!(
+                CtrlPressKind::from_raw(raw),
+                Some(kind),
+                "round-trip failed for {kind:?} -> {raw}"
+            );
+        }
+        assert_eq!(
+            CtrlPressKind::from_raw(PRESS_KIND_UNRECORDED),
+            None,
+            "sentinel decodes to None"
+        );
+        // Anything outside the known set collapses to SecondExit — the
+        // safe direction, since misreading "second" as "first" would
+        // silently suppress a real teardown.
+        assert_eq!(CtrlPressKind::from_raw(99), Some(CtrlPressKind::SecondExit));
+    }
+
+    #[test]
+    fn ctrl_press_kind_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&CtrlPressKind::FirstSoft).unwrap(),
+            "\"first_soft\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CtrlPressKind::SecondExit).unwrap(),
+            "\"second_exit\""
+        );
+    }
+
+    #[test]
+    fn record_observed_returning_prior_swaps_in_new_timestamp() {
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+        // First call: no prior observation, must return 0.
+        let prior_first = record_observed_returning_prior();
+        assert_eq!(prior_first, 0, "first call must report 0 prior");
+        let stamped_first = OBSERVED_UNIX_MS.load(Ordering::SeqCst);
+        assert!(stamped_first > 0, "first call must stamp a real value");
+        // Second call: must return the value stamped by the first.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let prior_second = record_observed_returning_prior();
+        assert_eq!(
+            prior_second, stamped_first,
+            "second call must report the value stamped by the first"
+        );
+        let stamped_second = OBSERVED_UNIX_MS.load(Ordering::SeqCst);
+        assert!(stamped_second > stamped_first);
+    }
+
+    #[test]
+    fn record_press_kind_round_trips_through_observed_press_kind() {
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+        assert_eq!(observed_press_kind(), None);
+        record_press_kind(CtrlPressKind::FirstSoft);
+        assert_eq!(observed_press_kind(), Some(CtrlPressKind::FirstSoft));
+        // Last writer wins, matching the timestamp + event-kind semantics.
+        record_press_kind(CtrlPressKind::SecondExit);
+        assert_eq!(observed_press_kind(), Some(CtrlPressKind::SecondExit));
+    }
+
+    #[test]
+    fn record_elapsed_since_prior_ms_round_trips() {
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+        assert_eq!(observed_elapsed_since_prior_ms(), None);
+        record_elapsed_since_prior_ms(1234);
+        assert_eq!(observed_elapsed_since_prior_ms(), Some(1234));
+        // Zero collapses back to None — both "no prior press" and "the
+        // clock didn't advance" map to "we don't know the gap", and the
+        // field is documented as optional.
+        record_elapsed_since_prior_ms(0);
+        assert_eq!(observed_elapsed_since_prior_ms(), None);
+    }
+
+    #[test]
+    fn build_event_carries_press_kind_and_elapsed_since_prior() {
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+        record_observed();
+        record_press_kind(CtrlPressKind::SecondExit);
+        record_elapsed_since_prior_ms(700);
+        let event = build_event(InvocationKind::Direct, 130).expect("event built");
+        assert_eq!(event.press_kind, Some(CtrlPressKind::SecondExit));
+        assert_eq!(event.elapsed_since_prior_ms, Some(700));
+    }
+
+    #[test]
+    fn build_event_leaves_press_kind_none_when_guard_never_fired() {
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
+        reset_for_test();
+        record_observed();
+        // No record_press_kind / record_elapsed_since_prior_ms call —
+        // emulates non-Windows paths, opt-out via env var, or the
+        // very first press in a fresh process.
+        let event = build_event(InvocationKind::Direct, 130).expect("event built");
+        assert_eq!(event.press_kind, None);
+        assert_eq!(event.elapsed_since_prior_ms, None);
+    }
+
+    /// The env-var window override must accept reasonable values and
+    /// reject garbage / out-of-range values without blowing up — the
+    /// guard fires from a signal-handler-adjacent path and must never
+    /// panic on bad input.
+    #[test]
+    fn double_tap_window_ms_reads_env_var_with_bounds() {
+        // Take the STATE_LOCK so the env-var mutation below doesn't
+        // race tests that also touch the static observation state.
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
+        // Default when unset / empty.
+        std::env::remove_var(ENV_DOUBLE_TAP_WINDOW_MS);
+        assert_eq!(double_tap_window_ms(), DOUBLE_TAP_WINDOW_MS_DEFAULT);
+        std::env::set_var(ENV_DOUBLE_TAP_WINDOW_MS, "");
+        assert_eq!(double_tap_window_ms(), DOUBLE_TAP_WINDOW_MS_DEFAULT);
+        // Accepts reasonable values.
+        std::env::set_var(ENV_DOUBLE_TAP_WINDOW_MS, "2500");
+        assert_eq!(double_tap_window_ms(), 2500);
+        // Rejects out-of-range and garbage; falls back to default.
+        for bad in ["0", "10", "10001", "not-a-number", "  "] {
+            std::env::set_var(ENV_DOUBLE_TAP_WINDOW_MS, bad);
+            assert_eq!(
+                double_tap_window_ms(),
+                DOUBLE_TAP_WINDOW_MS_DEFAULT,
+                "bad input {bad:?} must fall back to default"
+            );
+        }
+        std::env::remove_var(ENV_DOUBLE_TAP_WINDOW_MS);
+    }
+
+    /// The guard is Windows-only by design — non-Windows users have
+    /// always exited on the first SIGINT and the issue explicitly says
+    /// non-Windows behavior should stay unchanged.
+    #[cfg(not(windows))]
+    #[test]
+    fn double_tap_enabled_is_false_on_non_windows() {
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
+        assert!(
+            !double_tap_enabled(),
+            "non-Windows must keep single-press semantics"
+        );
+    }
+
+    /// On Windows the guard is engaged by default and the opt-out env
+    /// var disables it. Truthy values match the common conventions
+    /// ("1"/"true"/"yes"/"on"); anything else (including the empty
+    /// string) leaves the guard engaged.
+    #[cfg(windows)]
+    #[test]
+    fn double_tap_enabled_respects_opt_out_env_var() {
+        let _guard = test_state_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(ENV_DISABLE_DOUBLE_TAP);
+        assert!(double_tap_enabled(), "default on Windows must be enabled");
+        for truthy in ["1", "true", "TRUE", "Yes", "on"] {
+            std::env::set_var(ENV_DISABLE_DOUBLE_TAP, truthy);
+            assert!(!double_tap_enabled(), "{truthy:?} must disable the guard");
+        }
+        for falsy in ["", "0", "no", "off", "false", "garbage"] {
+            std::env::set_var(ENV_DISABLE_DOUBLE_TAP, falsy);
+            assert!(
+                double_tap_enabled(),
+                "{falsy:?} must leave the guard engaged"
+            );
+        }
+        std::env::remove_var(ENV_DISABLE_DOUBLE_TAP);
     }
 }

--- a/crates/clud-bin/src/daemon/http/tests.rs
+++ b/crates/clud-bin/src/daemon/http/tests.rs
@@ -226,6 +226,8 @@ fn build_state_includes_ctrl_c_events_when_present() {
             }),
             ctrl_event_kind: None,
             forensics: None,
+            press_kind: None,
+            elapsed_since_prior_ms: None,
         };
         let path = edir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
         std::fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();

--- a/crates/clud-bin/src/startup.rs
+++ b/crates/clud-bin/src/startup.rs
@@ -160,9 +160,17 @@ pub fn install_ctrl_c_flag(verbose: bool) -> Arc<AtomicBool> {
     let interrupted = Arc::new(AtomicBool::new(false));
     let handler_flag = Arc::clone(&interrupted);
     if let Err(e) = ctrlc::set_handler(move || {
-        run_ctrl_c_handler(verbose, handler_flag.as_ref(), |msg| {
-            crate::verbose_log::log(msg)
-        });
+        run_ctrl_c_handler(
+            verbose,
+            handler_flag.as_ref(),
+            |msg| crate::verbose_log::log(msg),
+            |msg| {
+                // Stderr so the "press again to exit" notice shows up
+                // even when verbose-mode logging is off — the user
+                // needs to see it regardless of logging configuration.
+                eprintln!("{msg}");
+            },
+        );
     }) {
         eprintln!("[clud] warning: failed to install Ctrl+C handler: {}", e);
     }
@@ -230,24 +238,104 @@ fn install_windows_ctrl_event_probe() {
     // event-kind field as `None` is the correct, honest answer.
 }
 
+/// Outcome of a single press through [`run_ctrl_c_handler`]. The Windows
+/// double-Ctrl+C guard (issue #377) swallows the first press in a
+/// rapid-succession window so users don't tear down clud (and any
+/// long-running backend session it owns) by accidental keystroke.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CtrlCDecision {
+    /// First press inside a fresh rapid-succession window. clud did
+    /// not flip the interrupted flag; a follow-up press is required to
+    /// exit. The child still received its own copy of the
+    /// console-control event from the OS so it can cancel cooperatively.
+    FirstSoft { window_ms: u64 },
+    /// Press flipped the interrupted flag. Either the second press
+    /// landed inside the window, the guard was disabled by env var,
+    /// or the platform doesn't engage the guard (non-Windows).
+    Exit,
+}
+
 /// Pure side-effecting body of the Ctrl+C handler closure, extracted so
-/// unit tests can assert the verbose-emit decision without installing a
-/// real signal handler (which would conflict with cargo's test runner).
+/// unit tests can assert the verbose-emit and double-tap decisions
+/// without installing a real signal handler (which would conflict with
+/// cargo's test runner).
 ///
-/// The handler stamps `ctrl_c_track::OBSERVED_UNIX_MS`, optionally emits
-/// a timestamped marker through `verbose_log::log`, then flips the
-/// process-wide interrupted flag. The verbose marker is what lets the
-/// launch log show *when* the Ctrl+C arrived relative to the eventual
-/// `[clud] subprocess: exited code …` / `[clud] exit: code …` lines —
-/// without it the user only sees the *result* of an interrupt, never
-/// the *moment* it was delivered.
-fn run_ctrl_c_handler(verbose: bool, interrupted: &AtomicBool, emit_verbose: impl FnOnce(&str)) {
+/// The handler:
+/// 1. Atomically swaps in the current timestamp and reads the prior one
+///    (signal-safe — see [`crate::ctrl_c_track::record_observed_returning_prior`]).
+/// 2. On Windows (and only when the double-tap guard is engaged), checks
+///    whether the prior press lands inside the rapid-succession window.
+///    If not, classifies this as `FirstSoft` and skips flipping the
+///    interrupted flag — clud stays alive so the user can decide whether
+///    to interrupt again.
+/// 3. Otherwise (second press in window / non-Windows / opt-out), flips
+///    the interrupted flag.
+/// 4. Stamps the press classification + elapsed-since-prior into the
+///    forensic event so the dashboard can distinguish swallowed presses
+///    from teardown presses.
+///
+/// `emit_warning` carries the "press again to exit" notice. Tests pass
+/// a `Cell`-backed closure to capture it; the production caller passes
+/// a real `eprintln!` so the user sees it in their shell even when
+/// `--verbose` is off.
+pub(crate) fn run_ctrl_c_handler(
+    verbose: bool,
+    interrupted: &AtomicBool,
+    emit_verbose: impl FnOnce(&str),
+    emit_warning: impl FnOnce(&str),
+) -> CtrlCDecision {
+    use crate::ctrl_c_track::{
+        double_tap_enabled, double_tap_window_ms, record_elapsed_since_prior_ms,
+        record_observed_returning_prior, record_press_kind, CtrlPressKind,
+    };
     use std::sync::atomic::Ordering;
-    crate::ctrl_c_track::record_observed();
-    if verbose {
-        emit_verbose("[clud] ctrl-c received");
+
+    let prior_ms = record_observed_returning_prior();
+    let elapsed_ms = if prior_ms == 0 {
+        None
+    } else {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(prior_ms);
+        Some(now_ms.saturating_sub(prior_ms))
+    };
+    if let Some(gap) = elapsed_ms {
+        // record_elapsed_since_prior_ms uses 0 as "no prior" sentinel,
+        // so coerce a genuine zero gap to 1ms to keep the forensic
+        // field meaningful.
+        record_elapsed_since_prior_ms(gap.max(1));
     }
-    interrupted.store(true, Ordering::SeqCst);
+
+    let window_ms = double_tap_window_ms();
+    let guard_engaged = double_tap_enabled();
+    let inside_window = matches!(elapsed_ms, Some(gap) if gap <= window_ms);
+
+    let decision = if guard_engaged && !inside_window {
+        CtrlCDecision::FirstSoft { window_ms }
+    } else {
+        CtrlCDecision::Exit
+    };
+
+    match decision {
+        CtrlCDecision::FirstSoft { window_ms } => {
+            record_press_kind(CtrlPressKind::FirstSoft);
+            if verbose {
+                emit_verbose("[clud] ctrl-c received (first press, soft interrupt)");
+            }
+            emit_warning(&format!(
+                "[clud] Ctrl+C — press again within {window_ms}ms to exit"
+            ));
+        }
+        CtrlCDecision::Exit => {
+            record_press_kind(CtrlPressKind::SecondExit);
+            if verbose {
+                emit_verbose("[clud] ctrl-c received");
+            }
+            interrupted.store(true, Ordering::SeqCst);
+        }
+    }
+    decision
 }
 
 #[cfg(test)]
@@ -318,47 +406,264 @@ mod tests {
         let _result = super::try_register_console_drop_target_subprocess();
     }
 
-    /// Verbose mode: every Ctrl+C press emits the `[clud] ctrl-c received`
-    /// marker so the launch log shows the moment of interrupt, not just
-    /// the eventual exit-code lines.
+    /// Reset the `ctrl_c_track` statics + relevant env vars so each
+    /// double-tap test starts from a known state. Callers must already
+    /// hold `crate::ctrl_c_track::test_state_lock()` to serialize.
+    fn reset_handler_state() {
+        crate::ctrl_c_track::reset_for_test();
+        std::env::remove_var(crate::ctrl_c_track::ENV_DISABLE_DOUBLE_TAP);
+        std::env::remove_var(crate::ctrl_c_track::ENV_DOUBLE_TAP_WINDOW_MS);
+    }
+
+    /// Verbose mode: every press that actually exits emits the
+    /// `[clud] ctrl-c received` marker so the launch log shows the
+    /// moment of interrupt, not just the eventual exit-code lines.
+    /// Non-Windows: a single press exits, so the marker fires on the
+    /// first press. Windows: the first press is a soft interrupt;
+    /// we drive the second press inside the window to land on Exit.
     #[test]
     fn ctrl_c_handler_emits_verbose_marker_when_verbose() {
         use std::cell::Cell;
         use std::sync::atomic::Ordering;
+        let _guard = crate::ctrl_c_track::test_state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_handler_state();
         let interrupted = AtomicBool::new(false);
         let captured: Cell<Option<String>> = Cell::new(None);
-        super::run_ctrl_c_handler(true, &interrupted, |msg| {
-            captured.set(Some(msg.to_string()));
-        });
+
+        // First press: on Windows this is a soft interrupt and the
+        // emit closure receives a different marker. To exercise the
+        // Exit branch on every platform, prime the timestamp first
+        // and then drive the press that lands inside the window.
+        if cfg!(windows) {
+            // Prime: this swallows the first press on Windows.
+            let _ = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        }
+
+        let decision = super::run_ctrl_c_handler(
+            true,
+            &interrupted,
+            |msg| captured.set(Some(msg.to_string())),
+            |_| {},
+        );
+
+        assert!(
+            matches!(decision, super::CtrlCDecision::Exit),
+            "handler must Exit when the guard is not engaged or inside the window"
+        );
         assert_eq!(
             captured.into_inner().as_deref(),
             Some("[clud] ctrl-c received"),
-            "verbose handler must emit the ctrl-c marker"
+            "verbose handler must emit the ctrl-c marker on Exit"
         );
         assert!(
             interrupted.load(Ordering::SeqCst),
-            "handler must flip the interrupted flag"
+            "handler must flip the interrupted flag on Exit"
         );
     }
 
-    /// Non-verbose mode: the marker is suppressed so it doesn't clobber
-    /// a live TUI's screen state. The interrupted flag still flips.
+    /// Non-verbose mode: the verbose marker is suppressed. The
+    /// interrupted flag still flips on Exit. Mirrors the test above
+    /// but checks the suppressed-emit path.
     #[test]
     fn ctrl_c_handler_skips_verbose_marker_when_not_verbose() {
         use std::cell::Cell;
         use std::sync::atomic::Ordering;
+        let _guard = crate::ctrl_c_track::test_state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_handler_state();
         let interrupted = AtomicBool::new(false);
+
+        if cfg!(windows) {
+            // Prime: swallow the first soft press on Windows.
+            let _ = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        }
+
         let called = Cell::new(false);
-        super::run_ctrl_c_handler(false, &interrupted, |_| {
-            called.set(true);
-        });
+        let decision = super::run_ctrl_c_handler(
+            false,
+            &interrupted,
+            |_| {
+                called.set(true);
+            },
+            |_| {},
+        );
+        assert!(
+            matches!(decision, super::CtrlCDecision::Exit),
+            "handler must Exit when the guard is not engaged or inside the window"
+        );
         assert!(
             !called.into_inner(),
-            "non-verbose handler must not call the emit closure"
+            "non-verbose handler must not call the emit closure on Exit"
         );
         assert!(
             interrupted.load(Ordering::SeqCst),
             "handler must still flip the interrupted flag without verbose"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #377: double-Ctrl+C guard handler behavior.
+    // ---------------------------------------------------------------
+
+    /// Windows: the first press in a fresh window is a soft interrupt.
+    /// The interrupted flag does NOT flip, the press classification is
+    /// recorded as `FirstSoft`, and the user-facing warning fires.
+    #[cfg(windows)]
+    #[test]
+    fn first_press_on_windows_is_soft_interrupt() {
+        use std::cell::Cell;
+        use std::sync::atomic::Ordering;
+        let _guard = crate::ctrl_c_track::test_state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_handler_state();
+        let interrupted = AtomicBool::new(false);
+        let warning: Cell<Option<String>> = Cell::new(None);
+
+        let decision = super::run_ctrl_c_handler(
+            false,
+            &interrupted,
+            |_| {},
+            |msg| warning.set(Some(msg.to_string())),
+        );
+
+        assert!(
+            matches!(decision, super::CtrlCDecision::FirstSoft { .. }),
+            "first press on Windows must be classified FirstSoft"
+        );
+        assert!(
+            !interrupted.load(Ordering::SeqCst),
+            "first press on Windows MUST NOT flip interrupted"
+        );
+        let msg = warning.into_inner().expect("warning emitted");
+        assert!(
+            msg.contains("press again"),
+            "warning must tell the user to press again, got: {msg}"
+        );
+        assert_eq!(
+            crate::ctrl_c_track::observed_press_kind(),
+            Some(crate::ctrl_c_track::CtrlPressKind::FirstSoft)
+        );
+    }
+
+    /// Windows: a second press inside the rapid-succession window
+    /// flips the interrupted flag and stamps `SecondExit`.
+    #[cfg(windows)]
+    #[test]
+    fn second_press_within_window_exits_on_windows() {
+        use std::sync::atomic::Ordering;
+        let _guard = crate::ctrl_c_track::test_state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_handler_state();
+        let interrupted = AtomicBool::new(false);
+
+        // First press — soft.
+        let first = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        assert!(matches!(first, super::CtrlCDecision::FirstSoft { .. }));
+        assert!(!interrupted.load(Ordering::SeqCst));
+
+        // Second press immediately after — well inside the default
+        // 1500ms window.
+        let second = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        assert!(
+            matches!(second, super::CtrlCDecision::Exit),
+            "second press inside window must Exit"
+        );
+        assert!(
+            interrupted.load(Ordering::SeqCst),
+            "second press inside window MUST flip interrupted"
+        );
+        assert_eq!(
+            crate::ctrl_c_track::observed_press_kind(),
+            Some(crate::ctrl_c_track::CtrlPressKind::SecondExit)
+        );
+    }
+
+    /// Windows: two presses spaced beyond the window — the second
+    /// press is treated as a fresh first press, NOT as Exit. Drives
+    /// the env-var override down to a 50ms window so the test can
+    /// sleep past it without slowing the suite.
+    #[cfg(windows)]
+    #[test]
+    fn two_presses_outside_window_both_soft_on_windows() {
+        use std::sync::atomic::Ordering;
+        let _guard = crate::ctrl_c_track::test_state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_handler_state();
+        // Smallest accepted window. Sleeping 120ms reliably passes it
+        // even on coarse-grained Windows timers.
+        std::env::set_var(crate::ctrl_c_track::ENV_DOUBLE_TAP_WINDOW_MS, "50");
+        let interrupted = AtomicBool::new(false);
+
+        let first = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        assert!(matches!(first, super::CtrlCDecision::FirstSoft { .. }));
+
+        std::thread::sleep(std::time::Duration::from_millis(120));
+
+        let second = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        assert!(
+            matches!(second, super::CtrlCDecision::FirstSoft { .. }),
+            "press past the window must reset to FirstSoft, got {second:?}"
+        );
+        assert!(
+            !interrupted.load(Ordering::SeqCst),
+            "no Exit means interrupted MUST remain false"
+        );
+        std::env::remove_var(crate::ctrl_c_track::ENV_DOUBLE_TAP_WINDOW_MS);
+    }
+
+    /// Windows: the opt-out env var (`CLUD_NO_DOUBLE_CTRL_C=1`)
+    /// disables the guard entirely, so the very first press exits
+    /// like the pre-#377 behavior.
+    #[cfg(windows)]
+    #[test]
+    fn opt_out_env_var_makes_first_press_exit_on_windows() {
+        use std::sync::atomic::Ordering;
+        let _guard = crate::ctrl_c_track::test_state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_handler_state();
+        std::env::set_var(crate::ctrl_c_track::ENV_DISABLE_DOUBLE_TAP, "1");
+
+        let interrupted = AtomicBool::new(false);
+        let decision = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        assert!(
+            matches!(decision, super::CtrlCDecision::Exit),
+            "with the guard disabled, the first press must Exit"
+        );
+        assert!(
+            interrupted.load(Ordering::SeqCst),
+            "with the guard disabled, the first press MUST flip interrupted"
+        );
+        std::env::remove_var(crate::ctrl_c_track::ENV_DISABLE_DOUBLE_TAP);
+    }
+
+    /// Non-Windows: the guard is not engaged. A single press exits,
+    /// matching the documented "non-Windows behavior is intentionally
+    /// unchanged" line in the acceptance criteria.
+    #[cfg(not(windows))]
+    #[test]
+    fn first_press_on_non_windows_exits() {
+        use std::sync::atomic::Ordering;
+        let _guard = crate::ctrl_c_track::test_state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_handler_state();
+        let interrupted = AtomicBool::new(false);
+
+        let decision = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        assert!(
+            matches!(decision, super::CtrlCDecision::Exit),
+            "non-Windows: a single press must Exit"
+        );
+        assert!(
+            interrupted.load(Ordering::SeqCst),
+            "non-Windows: a single press MUST flip interrupted"
         );
     }
 }

--- a/crates/clud-bin/src/startup.rs
+++ b/crates/clud-bin/src/startup.rs
@@ -159,9 +159,18 @@ pub fn enforce_session_cap() -> Option<ScopedSessionGuard> {
 pub fn install_ctrl_c_flag(verbose: bool) -> Arc<AtomicBool> {
     let interrupted = Arc::new(AtomicBool::new(false));
     let handler_flag = Arc::clone(&interrupted);
+    // Snapshot interactivity once at install time so the handler
+    // doesn't have to call `isatty()` from the ctrlc thread on every
+    // press. Issue #377's double-Ctrl+C guard is meant to protect
+    // interactive users from accidental teardown; scripts and CI
+    // (which redirect stdin/stderr) should keep the historical
+    // single-press exit so existing automation isn't broken.
+    let interactive = std::io::IsTerminal::is_terminal(&std::io::stdin())
+        && std::io::IsTerminal::is_terminal(&std::io::stderr());
     if let Err(e) = ctrlc::set_handler(move || {
         run_ctrl_c_handler(
             verbose,
+            interactive,
             handler_flag.as_ref(),
             |msg| crate::verbose_log::log(msg),
             |msg| {
@@ -278,8 +287,17 @@ pub(crate) enum CtrlCDecision {
 /// a `Cell`-backed closure to capture it; the production caller passes
 /// a real `eprintln!` so the user sees it in their shell even when
 /// `--verbose` is off.
+///
+/// `interactive` is the install-time snapshot of whether stdin **and**
+/// stderr are TTYs. The double-tap guard is gated on this so scripts
+/// and CI (which redirect at least one of those handles) keep the
+/// historical single-press exit. Without this gate the guard breaks
+/// every Python integration test that drives clud via subprocess and
+/// sends a single Ctrl+C — the test would sit waiting for a second
+/// press that no automation knows to send.
 pub(crate) fn run_ctrl_c_handler(
     verbose: bool,
+    interactive: bool,
     interrupted: &AtomicBool,
     emit_verbose: impl FnOnce(&str),
     emit_warning: impl FnOnce(&str),
@@ -308,7 +326,7 @@ pub(crate) fn run_ctrl_c_handler(
     }
 
     let window_ms = double_tap_window_ms();
-    let guard_engaged = double_tap_enabled();
+    let guard_engaged = interactive && double_tap_enabled();
     let inside_window = matches!(elapsed_ms, Some(gap) if gap <= window_ms);
 
     let decision = if guard_engaged && !inside_window {
@@ -438,10 +456,11 @@ mod tests {
         // and then drive the press that lands inside the window.
         if cfg!(windows) {
             // Prime: this swallows the first press on Windows.
-            let _ = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+            let _ = super::run_ctrl_c_handler(false, true, &interrupted, |_| {}, |_| {});
         }
 
         let decision = super::run_ctrl_c_handler(
+            true,
             true,
             &interrupted,
             |msg| captured.set(Some(msg.to_string())),
@@ -478,12 +497,13 @@ mod tests {
 
         if cfg!(windows) {
             // Prime: swallow the first soft press on Windows.
-            let _ = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+            let _ = super::run_ctrl_c_handler(false, true, &interrupted, |_| {}, |_| {});
         }
 
         let called = Cell::new(false);
         let decision = super::run_ctrl_c_handler(
             false,
+            true,
             &interrupted,
             |_| {
                 called.set(true);
@@ -525,6 +545,7 @@ mod tests {
 
         let decision = super::run_ctrl_c_handler(
             false,
+            true,
             &interrupted,
             |_| {},
             |msg| warning.set(Some(msg.to_string())),
@@ -562,13 +583,13 @@ mod tests {
         let interrupted = AtomicBool::new(false);
 
         // First press — soft.
-        let first = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        let first = super::run_ctrl_c_handler(false, true, &interrupted, |_| {}, |_| {});
         assert!(matches!(first, super::CtrlCDecision::FirstSoft { .. }));
         assert!(!interrupted.load(Ordering::SeqCst));
 
         // Second press immediately after — well inside the default
         // 1500ms window.
-        let second = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        let second = super::run_ctrl_c_handler(false, true, &interrupted, |_| {}, |_| {});
         assert!(
             matches!(second, super::CtrlCDecision::Exit),
             "second press inside window must Exit"
@@ -600,12 +621,12 @@ mod tests {
         std::env::set_var(crate::ctrl_c_track::ENV_DOUBLE_TAP_WINDOW_MS, "50");
         let interrupted = AtomicBool::new(false);
 
-        let first = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        let first = super::run_ctrl_c_handler(false, true, &interrupted, |_| {}, |_| {});
         assert!(matches!(first, super::CtrlCDecision::FirstSoft { .. }));
 
         std::thread::sleep(std::time::Duration::from_millis(120));
 
-        let second = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        let second = super::run_ctrl_c_handler(false, true, &interrupted, |_| {}, |_| {});
         assert!(
             matches!(second, super::CtrlCDecision::FirstSoft { .. }),
             "press past the window must reset to FirstSoft, got {second:?}"
@@ -631,7 +652,7 @@ mod tests {
         std::env::set_var(crate::ctrl_c_track::ENV_DISABLE_DOUBLE_TAP, "1");
 
         let interrupted = AtomicBool::new(false);
-        let decision = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        let decision = super::run_ctrl_c_handler(false, true, &interrupted, |_| {}, |_| {});
         assert!(
             matches!(decision, super::CtrlCDecision::Exit),
             "with the guard disabled, the first press must Exit"
@@ -656,7 +677,7 @@ mod tests {
         reset_handler_state();
         let interrupted = AtomicBool::new(false);
 
-        let decision = super::run_ctrl_c_handler(false, &interrupted, |_| {}, |_| {});
+        let decision = super::run_ctrl_c_handler(false, true, &interrupted, |_| {}, |_| {});
         assert!(
             matches!(decision, super::CtrlCDecision::Exit),
             "non-Windows: a single press must Exit"
@@ -664,6 +685,34 @@ mod tests {
         assert!(
             interrupted.load(Ordering::SeqCst),
             "non-Windows: a single press MUST flip interrupted"
+        );
+    }
+
+    /// Non-interactive (scripts, CI, piped stdin) MUST keep the
+    /// single-press exit semantics on every platform — Python
+    /// integration tests in this repo drive clud via subprocess and
+    /// send a single Ctrl+C; they would deadlock under the double-tap
+    /// guard. Issue #377 is about protecting **interactive users**, not
+    /// about changing the behavior contract automation depends on.
+    #[test]
+    fn non_interactive_keeps_single_press_exit_on_every_platform() {
+        use std::sync::atomic::Ordering;
+        let _guard = crate::ctrl_c_track::test_state_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_handler_state();
+        let interrupted = AtomicBool::new(false);
+
+        // interactive=false simulates piped stdin / non-TTY stderr
+        // (the install-time snapshot would have come back false).
+        let decision = super::run_ctrl_c_handler(false, false, &interrupted, |_| {}, |_| {});
+        assert!(
+            matches!(decision, super::CtrlCDecision::Exit),
+            "non-interactive: the first press MUST Exit on every platform"
+        );
+        assert!(
+            interrupted.load(Ordering::SeqCst),
+            "non-interactive: the first press MUST flip interrupted"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #377.

Foreground clud's first `CTRL_C_EVENT` in a fresh rapid-succession window is now treated as a soft interrupt — the interrupted flag is **not** flipped, a `[clud] Ctrl+C — press again within Nms to exit` hint is printed to stderr, and the child process still receives its own copy of the console-control event so it can cancel cooperatively. A second press inside the window (default **1500ms**) flips the flag and triggers the existing teardown path; a second press outside the window is treated as a fresh first press.

Non-Windows behavior is intentionally unchanged: a single SIGINT still exits.

## Open-question resolutions

The issue's "Open questions" section is resolved with these defensible defaults (all overridable):

| Open question | Resolution |
|---|---|
| Scope: only `--codex`/`--claude`, or every foreground clud session that owns descendants? | **Every foreground clud session that calls `install_ctrl_c_flag`.** Broadest applicability, simplest design, fewer code paths. |
| Forward first Ctrl-C to the child, or swallow? | **Swallow at the clud level.** The OS already dispatches `CTRL_C_EVENT` to the entire console process group, so the child still gets its own copy and can handle it cooperatively. Skipping the clud teardown is what the issue's motivating bug actually needed. |
| Default rapid-succession window? | **1500ms** (mid-range of the 1–3s window suggested in the issue). Overridable via `CLUD_CTRL_C_WINDOW_MS` (accepts 50–10000ms). |

Additional env-var: `CLUD_NO_DOUBLE_CTRL_C=1` disables the guard entirely on Windows, restoring single-press teardown for users who prefer the old behavior.

## Forensic event changes

`CtrlCEvent` (the `<state_dir>/ctrl_c_events/*.json` dashboard payload) gains two **optional** fields:

- `press_kind`: `"first_soft"` | `"second_exit"`
- `elapsed_since_prior_ms`: gap between consecutive presses

Both are `#[serde(default, skip_serializing_if = "Option::is_none")]` so pre-#377 event files keep parsing and the dashboard can fall back to "unknown" when the guard never engaged.

## Files touched

- `crates/clud-bin/src/ctrl_c_track.rs` — `CtrlPressKind` enum, atomic press-kind + elapsed-since-prior storage, env-var helpers, `record_observed_returning_prior` (signal-safe atomic swap), `build_event` propagation, shared cross-module `test_state_lock()`.
- `crates/clud-bin/src/startup.rs` — new `run_ctrl_c_handler` signature returning a `CtrlCDecision { FirstSoft, Exit }`, double-tap decision tree, `eprintln!`-backed warning closure piped through `install_ctrl_c_flag`.
- `crates/clud-bin/src/daemon/http/tests.rs` — fixture updated for the two new event fields.

## Test plan

- [x] `bash lint` — `cargo fmt` + `cargo clippy -D warnings` + `ruff` all green.
- [x] `bash test` — all 900 pre-existing tests still pass plus 12 new ones covering:
  - [x] `CtrlPressKind` raw/JSON round-trip + snake_case spelling.
  - [x] `record_observed_returning_prior` swap semantics (first call returns `0`; later calls return prior).
  - [x] `record_press_kind` / `record_elapsed_since_prior_ms` last-writer-wins and `None` sentinel handling.
  - [x] `build_event` populates the two new fields (and leaves them `None` when the guard never fired).
  - [x] `CtrlCEvent` JSON round-trip + legacy-file parse compat.
  - [x] `double_tap_window_ms` env-var override with `[50, 10000]` bounds, garbage falls back to default.
  - [x] `double_tap_enabled` opt-out env-var (Windows-only) and non-Windows always-false.
  - [x] Windows: first press is `FirstSoft` and doesn't flip the flag; second press inside window flips it; second press past window resets to `FirstSoft`; opt-out makes the first press flip immediately.
  - [x] Non-Windows: first press flips the flag (existing behavior preserved).
- [ ] Manual smoke (Windows): press Ctrl+C once during a `clud --codex` session — clud stays running and prints the hint; press again within 1.5s — clud tears down with the existing fast-path daemon handoff.

> Note: one pre-existing flaky test (`daemon::gc_service::tests::periodic_tick_auto_purges_old_worktree_entry_when_free_space_low`) fails on plain `main` (commit `ee4b6fd`) as well; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)