### PR TITLE
fix(daemon): bump perf-budget sample counts to tighten median variance (#380)

### DIFF
--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -846,8 +846,14 @@ mod tests {
 
     const PROST_PERF_BUDGET_NUMERATOR: u128 = 120;
     const PROST_PERF_BUDGET_DENOMINATOR: u128 = 100;
-    const DAEMON_WIRE_PERF_WARMUP_SAMPLES: usize = 2;
-    const DAEMON_WIRE_PERF_MEASURED_SAMPLES: usize = 9;
+    // #380: macOS ARM runners exhibit bimodal latency (fast cluster ~50ms,
+    // slow cluster ~200ms). At N=9 the JSON and prost medians can land on
+    // opposite sides of the cluster gap purely by sample-count luck,
+    // flagging a false-positive budget violation. Bump warmup to settle the
+    // daemon process JIT / OS scheduler, and bump measured samples so the
+    // median's σ/√N variance drops below the 1.2× budget margin.
+    const DAEMON_WIRE_PERF_WARMUP_SAMPLES: usize = 8;
+    const DAEMON_WIRE_PERF_MEASURED_SAMPLES: usize = 25;
 
     fn read_daemon_events(state_dir: &Path) -> Vec<serde_json::Value> {
         let path = daemon_events_path(state_dir);


### PR DESCRIPTION
## Summary

\`prost_daemon_wire_list_rpc_stays_within_json_latency_budget\` flaked on macOS ARM with N=9 measured samples. The runner has bimodal latency (fast cluster ~50ms, slow cluster ~200ms), so the JSON and prost medians can land on opposite sides of the cluster gap purely by sample-count luck — flagging a false-positive budget violation when the underlying populations are within budget.

Example failure on \`main\` ([run 27796320885](https://github.com/zackees/clud/actions/runs/27796320885)):

\`\`\`
prost ListLiveCwds median latency 119.174834ms exceeded 20% JSON budget 95.0264ms;
JSON median 79.188667ms;
JSON samples [45.4, 56.8, 60.6, 65.3, 79.2, 159.5, 160.3, 200.4, 208.4] (ms)
prost samples [54.2, 70.4, 80.7, 80.9, 119.2, 127.9, 173.4, 197.0, 198.4] (ms)
\`\`\`

JSON has 5 samples in the fast cluster, prost has 4 — pure sample-count artifact.

## Fix

- \`DAEMON_WIRE_PERF_WARMUP_SAMPLES\`: 2 → 8 (more JIT / OS scheduler settling)
- \`DAEMON_WIRE_PERF_MEASURED_SAMPLES\`: 9 → 25 (median variance scales as σ/√N — drops well below the 1.2× budget margin)

Budget unchanged (\`PROST_PERF_BUDGET_NUMERATOR = 120\` / \`DENOMINATOR = 100\`). If prost still exceeds 1.2× at N=25, the signal is real and warrants investigation.

## Test plan

- [ ] CI green on all 24 jobs, especially macOS ARM unit-test.
- [x] Test passes locally on Windows x86 in ~4.3s (was ~1-2s at N=9).
- [x] \`fmt --check\` + \`clippy -D warnings\` clean.

Closes #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)