### PR TITLE
fix(lint): invoke ci.lint via venv python; skip maturin wheel rebuild

### DIFF
--- a/lint
+++ b/lint
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-uv sync --frozen --group dev --no-install-project 2>/dev/null || uv sync --group dev --no-install-project
-exec uv run --no-editable -m ci.lint "$@"
+# Sync dev deps but never install the project itself.
+uv sync --frozen --group dev --no-install-project 2>/dev/null \
+    || uv sync --group dev --no-install-project
+
+# Run the lint orchestrator via the synced venv's interpreter rather
+# than `uv run --no-editable` — the latter triggers a maturin wheel
+# rebuild on every fresh worktree, which on Windows fails the moment
+# `whisper-rs-sys`'s CMake step looks for `cl.exe` without MSVC's env
+# activated (issue #370). Lint doesn't need a built wheel: cargo fmt
+# and clippy work from the source tree, and ruff is a pure-Python
+# tool. Skipping the wheel build keeps lint fast and platform-neutral.
+if [[ -x .venv/Scripts/python.exe ]]; then
+    VENV_PY=.venv/Scripts/python.exe
+elif [[ -x .venv/bin/python ]]; then
+    VENV_PY=.venv/bin/python
+else
+    echo "lint: could not find .venv/{Scripts,bin}/python after uv sync" >&2
+    exit 1
+fi
+
+exec "$VENV_PY" -m ci.lint "$@"


### PR DESCRIPTION
## Summary

Closes #370.

`bash lint` previously used `uv run --no-editable -m ci.lint`, which re-installs the project non-editably on every fresh worktree. That non-editable install triggers a maturin wheel build → CMake-based build of `whisper-rs-sys` → search for `cl.exe` → failure on a plain Windows shell where MSVC env vars haven't been activated. Lint then fails before any actual linter runs — even on markdown-only PRs.

Lint never actually needs a built wheel:
- `cargo fmt --all --check` works from source
- `cargo clippy --workspace --all-targets -- -D warnings` works from source
- `python -m ruff check src tests ci` is a pure-Python tool

The script now runs the orchestrator via `.venv/{Scripts,bin}/python` directly after `uv sync --no-install-project`, which leaves the project unbuilt and platform-neutral. Sync still happens so the dev-group deps (ruff, banned_imports tooling, etc.) are available.

## Scope vs. issue #370

This is the **symptom-level fix** for #370 — `bash lint` now succeeds on a fresh Windows worktree (without VsDevCmd), and any platform that doesn't have a system C compiler available.

The structural follow-ups proposed in #370 stay valuable for paths that genuinely need a built wheel:

- **Fix A (zigbuild wiring)** — would replace MSVC dependency for `bash build` / `bash test` too. `maturin[zig]` + `ziglang` dev deps are already present, so the wiring is small.
- **Fix B (soldr-routed cargo in ci/lint.py)** — orthogonal hygiene fix; routes raw cargo through soldr.

I'm closing #370 because the user-visible "`bash lint` fails on a fresh Windows worktree" pain is gone. If the structural follow-ups should track separately, please re-open or split into new issues.

## Test plan

Validated locally on a fresh Windows worktree branched off `origin/main`:

```
git worktree add -b fix/lint-no-wheel-rebuild-370 .claude/worktrees/fix-lint-370 origin/main
cd .claude/worktrees/fix-lint-370
bash lint    # PASS — no maturin/cmake invocation; cargo fmt + clippy + ruff all green
```

- [x] `bash lint` runs to completion (`All checks passed!`) — no `maturin pep517 build-wheel`, no CMake invocation, no `whisper-rs-sys` build
- [x] Falls through to `cargo fmt` + `cargo clippy` + `ruff` exactly as before
- [x] Both `.venv/Scripts/python.exe` (Windows) and `.venv/bin/python` (POSIX) paths handled
- [ ] CI matrix (24 jobs) — let the GitHub Actions runs validate Linux/macOS/Windows ARM+x86

🤖 Generated with [Claude Code](https://claude.com/claude-code)