### PR TITLE
feat(symbols): `clud symbols install` opportunistic verifier (PR 3/3 for #374)

### DIFF
--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -145,11 +145,22 @@ Diagnostics and misc:
   Windows) reports share one writer producing JSON records with backtrace
   under `~/.clud/state/crashes/<unix_ms>-<role>-<pid>.json`, prunes to
   the 50 most recent, and surfaces a one-line stderr notice on the next
-  launch when a new report appears. `install_native()` is idempotent —
-  the hook is installed once per process; re-calling only updates the
-  role tag. Native install **does not attach a SIGINT/CTRL_C_EVENT
-  handler**, leaving the existing `startup::install_ctrl_c_flag` /
-  `ctrl_c_track` (#372) path authoritative for Ctrl-C.
+  launch when a new report appears (plus a follow-up "backtrace appears
+  unsymbolicated; run `clud symbols verify`" line when the new report
+  has zero `at FILE:LINE` frames — #374 PR 3). `install_native()` is
+  idempotent — the hook is installed once per process; re-calling only
+  updates the role tag. Native install **does not attach a
+  SIGINT/CTRL_C_EVENT handler**, leaving the existing
+  `startup::install_ctrl_c_flag` / `ctrl_c_track` (#372) path
+  authoritative for Ctrl-C.
+- `symbols.rs` - `clud symbols` / `clud symbols install` / `clud symbols
+  verify [--all]` subcommand handler. With `debug = "line-tables-only"`
+  embedded in every build (#374 PR 1), no sidecar files need to be
+  fetched; the verifier confirms the running binary can resolve recent
+  crash reports' `at FILE:LINE` frames and exits 0/1 accordingly. The
+  bare `clud symbols` form prints a five-line summary. Self-contained
+  maintenance command; dispatched from `main.rs` before any backend
+  resolution. See `docs/architecture/crash-reports.md`.
 - `wasm.rs` - `wasmi`-based runner that loads a WASM module, registers a
   minimal `host.log` import, invokes a named export, and propagates the integer
   exit code.

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -304,6 +304,19 @@ pub enum Command {
         #[command(subcommand)]
         subcommand: DaemonSubcommand,
     },
+    /// Inspect or verify crash-report symbolication (#374 PR 3/3).
+    ///
+    /// clud builds with `debug = "line-tables-only"` embed every line
+    /// table in the binary itself, so there are no sidecar files to
+    /// install. This subcommand is an opportunistic verifier that
+    /// confirms the running binary can symbolicate recent crash reports
+    /// in `~/.clud/state/crashes/`. `clud symbols` (bare) prints a
+    /// summary; `clud symbols install` and `clud symbols verify` exit 1
+    /// when any inspected report is unsymbolicated.
+    Symbols {
+        #[command(subcommand)]
+        subcommand: Option<SymbolsSubcommand>,
+    },
     #[command(name = "__daemon", hide = true)]
     InternalDaemon {
         #[arg(long = "state-dir")]
@@ -328,7 +341,25 @@ pub enum OptimizeTarget {
     Rust,
 }
 
-/// Subcommands under `clud daemon`.
+/// Subcommands under `clud symbols`. See `crates/clud-bin/src/symbols.rs`.
+#[derive(Subcommand, Debug, Clone)]
+pub enum SymbolsSubcommand {
+    /// Verify that the running binary's embedded line tables resolve
+    /// recent crash report backtraces. With the embed-everywhere
+    /// strategy, this is a no-op when symbols are already present and
+    /// a diagnostic when they're not. Exits 1 if any inspected report
+    /// is unsymbolicated.
+    Install,
+    /// Same as `install` but with an explicit `--all` toggle.
+    Verify {
+        /// Verify every report under `~/.clud/state/crashes/` rather
+        /// than just the most-recent one.
+        #[arg(long = "all")]
+        all: bool,
+    },
+}
+
+/// Subcommands under `clud daemon`. See `crates/clud-bin/src/daemon/`.
 #[derive(Subcommand, Debug, Clone)]
 pub enum DaemonSubcommand {
     /// Restart the daemon process so the next CLI call uses the current binary.
@@ -450,7 +481,7 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
         "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "slay", "list", "logs", "gc",
-        "ui", "trash", "optimize", "daemon", "__daemon", "__worker",
+        "ui", "trash", "optimize", "daemon", "symbols", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/args_tests.rs
+++ b/crates/clud-bin/src/args_tests.rs
@@ -989,3 +989,48 @@ fn test_daemon_servicedef_alias_subcommand_parses() {
         other => panic!("expected Daemon::RunningProcess alias, got {other:?}"),
     }
 }
+
+#[test]
+fn test_symbols_bare_subcommand_yields_none() {
+    let args = parse(&["clud", "symbols"]);
+    match args.command {
+        Some(Command::Symbols { ref subcommand }) => assert!(subcommand.is_none()),
+        other => panic!("expected Symbols, got {other:?}"),
+    }
+    assert!(args.passthrough.is_empty());
+}
+
+#[test]
+fn test_symbols_install_subcommand_parses() {
+    let args = parse(&["clud", "symbols", "install"]);
+    match args.command {
+        Some(Command::Symbols {
+            subcommand: Some(SymbolsSubcommand::Install),
+        }) => {}
+        other => panic!("expected Symbols::Install, got {other:?}"),
+    }
+    assert!(args.passthrough.is_empty());
+}
+
+#[test]
+fn test_symbols_verify_all_subcommand_parses() {
+    let args = parse(&["clud", "symbols", "verify", "--all"]);
+    match args.command {
+        Some(Command::Symbols {
+            subcommand: Some(SymbolsSubcommand::Verify { all }),
+        }) => assert!(all),
+        other => panic!("expected Symbols::Verify --all, got {other:?}"),
+    }
+    assert!(args.passthrough.is_empty());
+}
+
+#[test]
+fn test_symbols_verify_default_all_false() {
+    let args = parse(&["clud", "symbols", "verify"]);
+    match args.command {
+        Some(Command::Symbols {
+            subcommand: Some(SymbolsSubcommand::Verify { all }),
+        }) => assert!(!all),
+        other => panic!("expected Symbols::Verify (no --all), got {other:?}"),
+    }
+}

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -147,6 +147,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         | Some(Command::Ui { .. })
         | Some(Command::Trash { .. })
         | Some(Command::Optimize { .. })
+        | Some(Command::Symbols { .. })
         | Some(Command::Daemon { .. })
         | Some(Command::InternalDaemon { .. })
         | Some(Command::InternalWorker { .. }) => {}

--- a/crates/clud-bin/src/crash_report.rs
+++ b/crates/clud-bin/src/crash_report.rs
@@ -91,6 +91,21 @@ pub fn install(role: &str) {
         if let Ok(dir) = crashes_dir() {
             if let Some((_, path)) = surface_previous_report(&dir) {
                 eprintln!("clud: previous crash report at {}", path.display());
+                // Opportunistic symbol-status hint: if the report's
+                // backtrace has no `at FILE:LINE` frames, point the user
+                // at `clud symbols verify` (#374 PR 3). Best-effort; if
+                // we can't read or parse the report we stay quiet.
+                if let Ok(raw) = fs::read_to_string(&path) {
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) {
+                        if let Some(bt) = value.get("backtrace").and_then(|v| v.as_str()) {
+                            if crate::symbols::is_unsymbolicated(bt) {
+                                eprintln!(
+                                    "clud: backtrace appears unsymbolicated; run `clud symbols verify` for diagnostic details"
+                                );
+                            }
+                        }
+                    }
+                }
             }
         }
         let prev_hook = std::panic::take_hook();
@@ -109,7 +124,11 @@ fn current_role() -> String {
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-fn crashes_dir() -> std::io::Result<PathBuf> {
+/// Returns `~/.clud/state/crashes/`, creating the directory if missing.
+///
+/// Exposed `pub(crate)` so the `symbols` subcommand reuses the same
+/// resolution logic (`CLUD_DAEMON_STATE_DIR` env override → home dir).
+pub(crate) fn crashes_dir() -> std::io::Result<PathBuf> {
     let state_dir = crate::daemon::default_state_dir()?;
     let dir = state_dir.join("crashes");
     fs::create_dir_all(&dir)?;

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -40,6 +40,7 @@ pub mod skills;
 pub mod startup;
 pub mod stream_json;
 pub mod subprocess;
+pub mod symbols;
 pub mod trampoline;
 pub mod trash;
 pub mod ui;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -2,7 +2,7 @@ use clud::{
     args, backend, backend_bootstrap, clud_settings, command, console_setup, console_title,
     crash_report, ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard, launch_log,
     launch_setup, loop_artifacts, loop_spec, optimize, orphan_reaper, runner, runtime_cache,
-    startup, trampoline, trash, ui, verbose_log, wasm, worktrees,
+    startup, symbols, trampoline, trash, ui, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -104,6 +104,13 @@ fn main() {
     }) = &args.command
     {
         std::process::exit(trash::run(&args, paths, *cross_volume));
+    }
+
+    // #374 (PR 3): `clud symbols` inspects / verifies crash-report
+    // symbolication against the running binary. Self-contained; never
+    // launches a backend.
+    if let Some(args::Command::Symbols { subcommand }) = &args.command {
+        std::process::exit(symbols::run(&args, subcommand.clone()));
     }
 
     // `clud optimize` is machine/repo setup and never launches a backend.

--- a/crates/clud-bin/src/symbols.rs
+++ b/crates/clud-bin/src/symbols.rs
@@ -1,0 +1,297 @@
+//! `clud symbols` — inspect or verify crash-report symbolication.
+//!
+//! Background: clud builds with `debug = "line-tables-only"` embed every
+//! line table in the binary itself (#374 PR 1, see
+//! [`crate::crash_report`]). There are no sidecar `.pdb` / `.dSYM` /
+//! `.dwp` files to fetch and the proposed "fetch sidecars on first
+//! unsymbolicated report" path from the original issue becomes a no-op
+//! in practice. The subcommand is kept as an opportunistic verifier:
+//!
+//! - `clud symbols` (bare) prints a five-line summary of the crash-
+//!   reports directory.
+//! - `clud symbols install` verifies that the running binary resolves
+//!   the most-recent crash report's backtrace. Exits 1 if it can't.
+//! - `clud symbols verify [--all]` is the same but explicit. `--all`
+//!   widens the scope from the most recent to every report.
+//!
+//! The opportunistic startup notice (see [`crate::crash_report::install`])
+//! prints a one-line hint pointing at `clud symbols verify` when a fresh
+//! report's backtrace is unsymbolicated, so users discover the command
+//! without needing to remember it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::args::{Args, SymbolsSubcommand};
+
+/// Heuristic for whether a single backtrace line is an `at FILE:LINE`
+/// frame produced by `std::backtrace::Backtrace`.
+///
+/// Pattern: leading whitespace, the literal `at `, then any path, then
+/// `:` and at least one digit. Optional `:column`. We match by character
+/// scan rather than regex to avoid pulling in `regex` for one helper.
+fn is_resolved_frame_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let Some(rest) = trimmed.strip_prefix("at ") else {
+        return false;
+    };
+    // Find the last `:` followed by digits. Backtrace lines on Windows
+    // can contain drive-letter colons (`C:\...`), so we scan from the
+    // right.
+    let last_colon = match rest.rfind(':') {
+        Some(i) => i,
+        None => return false,
+    };
+    let after_colon = &rest[last_colon + 1..];
+    // Trim trailing whitespace + an optional `:column` suffix —
+    // rustc-format lines look like `at file.rs:42:5`.
+    let after_colon = after_colon.trim_end();
+    // If there's a `:column`, split it off first.
+    let head = after_colon.split(':').next().unwrap_or("");
+    !head.is_empty() && head.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Count `at FILE:LINE` frame lines in a backtrace string.
+pub(crate) fn count_resolved_frames(backtrace: &str) -> usize {
+    backtrace
+        .lines()
+        .filter(|l| is_resolved_frame_line(l))
+        .count()
+}
+
+/// True when the backtrace contains zero `at FILE:LINE` lines. Empty
+/// backtraces are treated as unsymbolicated.
+pub(crate) fn is_unsymbolicated(backtrace: &str) -> bool {
+    count_resolved_frames(backtrace) == 0
+}
+
+/// Sort `dir` entries by filename's leading unix-ms prefix, newest
+/// first. Returns paths only.
+fn list_reports_newest_first(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut entries: Vec<(u128, PathBuf)> = fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy().into_owned();
+            if !name.ends_with(".json") {
+                return None;
+            }
+            let ms = name.split('-').next()?.parse::<u128>().ok()?;
+            Some((ms, e.path()))
+        })
+        .collect();
+    entries.sort_by(|a, b| b.0.cmp(&a.0));
+    Ok(entries.into_iter().map(|(_, p)| p).collect())
+}
+
+fn read_report_backtrace(path: &Path) -> Option<(String, String, u128)> {
+    let raw = fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let backtrace = value.get("backtrace")?.as_str()?.to_string();
+    let role = value
+        .get("role")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let ts = value
+        .get("timestamp_unix_ms")
+        .and_then(|v| v.as_u64())
+        .map(|t| t as u128)
+        .unwrap_or(0);
+    Some((backtrace, role, ts))
+}
+
+/// Dispatch entry called from `main.rs`. Returns a process exit code.
+pub fn run(_args: &Args, subcommand: Option<SymbolsSubcommand>) -> i32 {
+    let dir = match crate::crash_report::crashes_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("clud symbols: cannot resolve crash-report dir: {e}");
+            return 1;
+        }
+    };
+    let reports = match list_reports_newest_first(&dir) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("clud symbols: cannot read {}: {e}", dir.display());
+            return 1;
+        }
+    };
+    match subcommand {
+        None => print_summary(&dir, &reports),
+        Some(SymbolsSubcommand::Install) => {
+            verify(&reports, /*all=*/ false)
+        }
+        Some(SymbolsSubcommand::Verify { all }) => verify(&reports, all),
+    }
+}
+
+fn print_summary(dir: &Path, reports: &[PathBuf]) -> i32 {
+    println!("clud symbols: crashes dir: {}", dir.display());
+    println!("total reports: {}", reports.len());
+    if reports.is_empty() {
+        println!("no reports to inspect");
+        return 0;
+    }
+    let mut resolved = 0usize;
+    let mut unresolved = 0usize;
+    for path in reports {
+        if let Some((bt, _, _)) = read_report_backtrace(path) {
+            if is_unsymbolicated(&bt) {
+                unresolved += 1;
+            } else {
+                resolved += 1;
+            }
+        }
+    }
+    println!("reports with file:line frames: {resolved}");
+    println!("reports without file:line frames: {unresolved}");
+    if let Some(newest) = reports.first() {
+        if let Some((_, role, ts)) = read_report_backtrace(newest) {
+            println!(
+                "most recent: {} (role={}, unix_ms={})",
+                newest.display(),
+                role,
+                ts
+            );
+        } else {
+            println!("most recent: {}", newest.display());
+        }
+    }
+    0
+}
+
+fn verify(reports: &[PathBuf], all: bool) -> i32 {
+    if reports.is_empty() {
+        println!("clud symbols: no crash reports to verify");
+        return 0;
+    }
+    let targets: &[PathBuf] = if all { reports } else { &reports[..1] };
+    let mut all_resolved = true;
+    for path in targets {
+        match read_report_backtrace(path) {
+            Some((bt, role, _)) => {
+                let resolved = count_resolved_frames(&bt);
+                if resolved == 0 {
+                    println!(
+                        "FAIL {} (role={}): backtrace contains 0 file:line frames",
+                        path.display(),
+                        role
+                    );
+                    all_resolved = false;
+                } else {
+                    println!(
+                        "OK   {} (role={}): {} file:line frames",
+                        path.display(),
+                        role,
+                        resolved
+                    );
+                }
+            }
+            None => {
+                println!(
+                    "FAIL {}: unreadable JSON or missing backtrace",
+                    path.display()
+                );
+                all_resolved = false;
+            }
+        }
+    }
+    if all_resolved {
+        println!(
+            "clud symbols: OK — embedded line tables resolved {} report(s)",
+            targets.len()
+        );
+        0
+    } else {
+        println!(
+            "clud symbols: FAIL — embedded line tables did not resolve one or more reports.\n\
+             Build with `debug = \"line-tables-only\"` (already the project default) and ensure\n\
+             the binary running `clud symbols verify` is the same build that produced the report."
+        );
+        1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_resolved_lines_in_typical_backtrace() {
+        let bt = "   0: clud::main::h1234abcd\n             at /home/user/clud/src/main.rs:42:5\n   1: core::ops::function::FnOnce::call_once\n             at /rustc/abcdef/library/core/src/ops/function.rs:250:5\n";
+        assert_eq!(count_resolved_frames(bt), 2);
+        assert!(!is_unsymbolicated(bt));
+    }
+
+    #[test]
+    fn detects_unsymbolicated_backtrace() {
+        let bt = "   0: 0x7fffabcd1234\n   1: 0x7fffabcd5678\n   2: 0x7fffabcd9abc\n";
+        assert_eq!(count_resolved_frames(bt), 0);
+        assert!(is_unsymbolicated(bt));
+    }
+
+    #[test]
+    fn empty_backtrace_is_unsymbolicated() {
+        assert_eq!(count_resolved_frames(""), 0);
+        assert!(is_unsymbolicated(""));
+    }
+
+    #[test]
+    fn windows_drive_letter_does_not_trip_resolution() {
+        let bt =
+            "   0: clud::main::h1234abcd\n             at C:\\Users\\me\\clud\\src\\main.rs:42:5\n";
+        assert_eq!(count_resolved_frames(bt), 1);
+    }
+
+    #[test]
+    fn frame_without_at_prefix_is_not_resolved() {
+        let bt = "             /home/user/clud/src/main.rs:42:5\n";
+        assert_eq!(count_resolved_frames(bt), 0);
+    }
+
+    #[test]
+    fn frame_without_line_number_is_not_resolved() {
+        let bt = "             at /home/user/clud/src/main.rs\n";
+        assert_eq!(count_resolved_frames(bt), 0);
+    }
+
+    #[test]
+    fn list_reports_orders_by_unix_ms_prefix_desc() -> std::io::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        fs::write(tmp.path().join("100-foreground-1.json"), "{}")?;
+        fs::write(tmp.path().join("300-foreground-3.json"), "{}")?;
+        fs::write(tmp.path().join("200-foreground-2.json"), "{}")?;
+        let ordered = list_reports_newest_first(tmp.path())?;
+        assert_eq!(ordered.len(), 3);
+        assert!(ordered[0].ends_with("300-foreground-3.json"));
+        assert!(ordered[1].ends_with("200-foreground-2.json"));
+        assert!(ordered[2].ends_with("100-foreground-1.json"));
+        Ok(())
+    }
+
+    #[test]
+    fn read_report_backtrace_extracts_role_and_ts() -> std::io::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let path = tmp.path().join("500-daemon-9999.json");
+        fs::write(
+            &path,
+            r#"{
+                "version": "0.0.0",
+                "role": "daemon",
+                "kind": "panic",
+                "pid": 9999,
+                "args": [],
+                "timestamp_unix_ms": 500,
+                "panic_message": "boom",
+                "backtrace": "   0: clud::main::h\n             at /x/main.rs:1:1\n"
+            }"#,
+        )?;
+        let (bt, role, ts) = read_report_backtrace(&path).expect("parsed");
+        assert_eq!(role, "daemon");
+        assert_eq!(ts, 500);
+        assert!(bt.contains("/x/main.rs:1:1"));
+        assert_eq!(count_resolved_frames(&bt), 1);
+        Ok(())
+    }
+}

--- a/crates/clud-bin/tests/symbols.rs
+++ b/crates/clud-bin/tests/symbols.rs
@@ -1,0 +1,189 @@
+//! Integration test for `clud symbols`.
+//!
+//! Drops two canned crash-report JSON files into a tempdir, points
+//! `CLUD_DAEMON_STATE_DIR` at it, then exercises the subcommands as a
+//! subprocess of the installed `clud` binary so the full clap routing
+//! is covered.
+
+use std::fs;
+use std::time::Duration;
+
+use running_process::{
+    CommandSpec, NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode,
+};
+use tempfile::TempDir;
+
+fn write_report(dir: &std::path::Path, name: &str, backtrace: &str) {
+    let path = dir.join(name);
+    let body = serde_json::json!({
+        "version": "0.0.0",
+        "role": "test",
+        "kind": "panic",
+        "pid": 12345,
+        "cwd": null,
+        "args": [],
+        "timestamp_unix_ms": 100u64,
+        "panic_message": "synthetic",
+        "backtrace": backtrace,
+    });
+    fs::write(&path, body.to_string()).expect("write report");
+}
+
+/// Spawn `clud <args>` via running_process::NativeProcess, drain its
+/// merged stdout+stderr into a `String`, and return `(exit_code, output)`.
+fn run_clud(args: &[&str], state_dir: &std::path::Path) -> (i32, String) {
+    let mut argv = vec![env!("CARGO_BIN_EXE_clud").to_string()];
+    argv.extend(args.iter().map(|s| s.to_string()));
+
+    let mut env: Vec<(String, String)> = std::env::vars().collect();
+    env.retain(|(k, _)| k != "CLUD_DAEMON_STATE_DIR" && k != "CLUD_NO_DAEMON");
+    env.push((
+        "CLUD_DAEMON_STATE_DIR".to_string(),
+        state_dir.to_string_lossy().into_owned(),
+    ));
+    env.push(("CLUD_NO_DAEMON".to_string(), "1".to_string()));
+
+    let process = NativeProcess::new(ProcessConfig {
+        command: CommandSpec::Argv(argv),
+        cwd: None,
+        env: Some(env),
+        capture: true,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Null,
+        nice: None,
+    });
+    process.start().expect("spawn clud");
+
+    let mut buf = Vec::<u8>::new();
+    loop {
+        match process.read_combined(Some(Duration::from_millis(100))) {
+            ReadStatus::Line(event) => {
+                buf.extend_from_slice(&event.line);
+                buf.push(b'\n');
+            }
+            ReadStatus::Timeout => {
+                if process.returncode().is_some() {
+                    break;
+                }
+            }
+            ReadStatus::Eof => break,
+        }
+    }
+    let exit = process
+        .wait(Some(Duration::from_secs(15)))
+        .expect("wait clud");
+    (exit, String::from_utf8_lossy(&buf).into_owned())
+}
+
+#[test]
+fn symbols_verify_all_passes_when_every_report_has_file_line_frames() {
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state");
+    let crashes_dir = state_dir.join("crashes");
+    fs::create_dir_all(&crashes_dir).unwrap();
+    write_report(
+        &crashes_dir,
+        "100-test-1.json",
+        "   0: clud::main::h1234\n             at /home/u/clud/src/main.rs:42:5\n",
+    );
+    write_report(
+        &crashes_dir,
+        "200-test-2.json",
+        "   0: clud::main::h5678\n             at /home/u/clud/src/lib.rs:99:1\n",
+    );
+
+    let (exit, output) = run_clud(&["symbols", "verify", "--all"], &state_dir);
+    assert_eq!(exit, 0, "expected exit 0; output: {output}");
+    assert!(
+        output.contains("clud symbols: OK"),
+        "expected OK footer; got: {output}"
+    );
+}
+
+#[test]
+fn symbols_verify_all_fails_when_any_report_is_unsymbolicated() {
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state");
+    let crashes_dir = state_dir.join("crashes");
+    fs::create_dir_all(&crashes_dir).unwrap();
+    write_report(
+        &crashes_dir,
+        "100-test-1.json",
+        "   0: clud::main::h1234\n             at /home/u/clud/src/main.rs:42:5\n",
+    );
+    write_report(
+        &crashes_dir,
+        "200-test-2.json",
+        "   0: 0x7fffabcd1234\n   1: 0x7fffabcd5678\n",
+    );
+
+    let (exit, output) = run_clud(&["symbols", "verify", "--all"], &state_dir);
+    assert_ne!(exit, 0, "expected non-zero exit; output: {output}");
+    assert!(
+        output.contains("clud symbols: FAIL"),
+        "expected FAIL footer; got: {output}"
+    );
+}
+
+#[test]
+fn symbols_install_inspects_only_most_recent_report() {
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state");
+    let crashes_dir = state_dir.join("crashes");
+    fs::create_dir_all(&crashes_dir).unwrap();
+    // Older report is unsymbolicated; newest is symbolicated. `install`
+    // should only look at the newest and return OK.
+    write_report(
+        &crashes_dir,
+        "100-test-old.json",
+        "   0: 0x7fffabcd1234\n   1: 0x7fffabcd5678\n",
+    );
+    write_report(
+        &crashes_dir,
+        "999-test-new.json",
+        "   0: clud::main::h1234\n             at /home/u/clud/src/main.rs:42:5\n",
+    );
+
+    let (exit, output) = run_clud(&["symbols", "install"], &state_dir);
+    assert_eq!(exit, 0, "expected exit 0; output: {output}");
+    assert!(
+        output.contains("999-test-new.json"),
+        "should mention newest report; got: {output}"
+    );
+    assert!(
+        !output.contains("100-test-old.json"),
+        "should NOT mention older report; got: {output}"
+    );
+}
+
+#[test]
+fn symbols_bare_prints_summary() {
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path().join("state");
+    let crashes_dir = state_dir.join("crashes");
+    fs::create_dir_all(&crashes_dir).unwrap();
+    write_report(
+        &crashes_dir,
+        "100-test-1.json",
+        "   0: clud::main::h1234\n             at /home/u/clud/src/main.rs:42:5\n",
+    );
+    write_report(
+        &crashes_dir,
+        "200-test-2.json",
+        "   0: 0x7fffabcd1234\n   1: 0x7fffabcd5678\n",
+    );
+
+    let (exit, output) = run_clud(&["symbols"], &state_dir);
+    assert_eq!(exit, 0, "bare summary should exit 0");
+    assert!(output.contains("total reports: 2"), "got: {output}");
+    assert!(
+        output.contains("reports with file:line frames: 1"),
+        "got: {output}"
+    );
+    assert!(
+        output.contains("reports without file:line frames: 1"),
+        "got: {output}"
+    );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,7 @@ re-explaining.
 | [architecture/gc-and-registry.md](architecture/gc-and-registry.md) | ~250 | always-on `clud __daemon` single-owner redb model, session cap registry, worktree scanner, GC subcommands |
 | [architecture/windows-quirks.md](architecture/windows-quirks.md) | ~300 | Windows-only platform code: trampoline, BatBadBat `.cmd` rewrite, console modes, Shift+Enter key translation, `IDropTarget`, `CREATE_NO_WINDOW`, ARM whisper carveout |
 | [architecture/launch-plan.md](architecture/launch-plan.md) | ~180 | `LaunchPlan` as the single source of truth: construction, consumers, `--dry-run` JSON |
+| [architecture/crash-reports.md](architecture/crash-reports.md) | ~110 | Panic-hook + native crash handler + `clud symbols` verifier: JSON schema, embed-line-tables-everywhere choice, opportunistic-verify model (#374) |
 
 ## Quick Reference
 
@@ -27,6 +28,7 @@ re-explaining.
 - **"Why is `~/.clud/data.redb` behind a daemon?"** -> [gc-and-registry.md](architecture/gc-and-registry.md)
 - **"Why does Windows do X differently?"** -> [windows-quirks.md](architecture/windows-quirks.md)
 - **"Where does the argv that clud runs come from?"** -> [launch-plan.md](architecture/launch-plan.md)
+- **"What happens when clud crashes, and how do I read the report?"** -> [crash-reports.md](architecture/crash-reports.md)
 
 See also: [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md) for rationale behind the
 choices these subsystems embody.

--- a/docs/architecture/crash-reports.md
+++ b/docs/architecture/crash-reports.md
@@ -1,0 +1,120 @@
+# Crash reports
+
+JSON crash reports landed in three PRs against #374:
+
+- **PR #376** flipped both cargo profiles to `debug = "line-tables-only"`
+  so every clud build embeds `file:line` debug info, and added a
+  process-wide Rust panic hook (`crash_report::install`) that writes a
+  JSON record to `~/.clud/state/crashes/<unix_ms>-<role>-<pid>.json`
+  with bounded rotation (50 most recent).
+- **PR #385** added a native crash handler (`crash_report::install_native`,
+  built on the [`crash-handler`](https://docs.rs/crash-handler) crate)
+  for SIGSEGV / SIGBUS / SIGILL / SIGFPE / SIGABRT on Unix and
+  structured exceptions on Windows. Both panic-driven and
+  native-driven crashes share one writer; the JSON gains a `kind`
+  discriminator (`"panic"` vs `"native"`) plus native-only fields
+  (`signal_or_exception`, `signal_number`, `exception_code`,
+  `faulting_address`).
+- **PR #386** added the `clud symbols` / `clud symbols install` /
+  `clud symbols verify [--all]` subcommand that opportunistically
+  verifies the running binary can symbolicate recent crash reports.
+
+This doc explains the two non-obvious design choices.
+
+## DD-N: embed line tables everywhere, no sidecars
+
+The original #374 proposal sketched a `clud symbols install` command
+that would fetch matching `.pdb` / `.dSYM` / `.dwp` sidecars from a
+release artifact bucket, and a release-CI step that staged those
+sidecars alongside binaries.
+
+The agreed choice was to **embed `line-tables-only` debug info in every
+profile** instead:
+
+```toml
+# Cargo.toml (workspace root)
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.release]
+debug = "line-tables-only"
+```
+
+Tradeoffs accepted:
+
+- **+** No sidecar staging in release CI; no per-platform path tree to
+  maintain (`x86_64-unknown-linux-gnu/clud.dwp`,
+  `aarch64-apple-darwin/clud.dSYM/...`, ...).
+- **+** No "wrong build identity" symbol-resolution failures — the
+  binary that produced the crash IS the binary that resolves it.
+- **+** No network on the user's machine to symbolicate.
+- **−** Slightly larger binaries. `line-tables-only` is the cheapest
+  debug level (no variable / type info); growth measured in single-digit
+  MB rather than the 30-40% expansion of `debug = true`.
+- **−** Full source-level debugging (variable inspection, type-aware
+  tooling) still requires explicitly toggling `debug = true` locally.
+
+The `clud symbols install` subcommand is preserved as documented in the
+#374 acceptance criteria, but reinterpreted as an **opportunistic
+verifier** rather than a fetcher (next section).
+
+## DD-N: opportunistic verifier, not opportunistic fetcher
+
+The #374 open question was whether `clud symbols install` should be
+explicit (user runs it after seeing an unsymbolicated crash report) or
+opportunistic (auto-fetch sidecars on the next startup whenever an
+unsymbolicated report is present).
+
+With line tables embedded everywhere there is nothing to fetch, so
+"opportunistic fetch" collapses into "opportunistic verify":
+
+1. On every clud startup, `crash_report::install` scans
+   `~/.clud/state/crashes/` for a report newer than the recorded
+   `last_seen` watermark.
+2. If a fresh report is found, the existing one-line stderr notice
+   fires: `clud: previous crash report at <path>`.
+3. **New in PR 3:** if that fresh report's `backtrace` field contains
+   zero `at FILE:LINE` frames, a second line fires:
+   `clud: backtrace appears unsymbolicated; run `clud symbols verify`
+   for diagnostic details`.
+4. The `last_seen` watermark advances regardless, so subsequent
+   launches stay quiet about the same report.
+
+This gives users a discoverable on-ramp to the verifier without making
+network calls behind their back or running the verifier eagerly on
+every launch (the JSON parse + scan only happens when a fresh report
+exists, which should be vanishingly rare in normal operation).
+
+The verifier itself supports three forms:
+
+- `clud symbols` — five-line summary (total reports, count with /
+  without `file:line` frames, most-recent path).
+- `clud symbols install` — verify only the most-recent report;
+  exit 1 if it's unsymbolicated.
+- `clud symbols verify [--all]` — same; `--all` widens the scope from
+  the most-recent report to every report under
+  `~/.clud/state/crashes/`.
+
+A report is considered "unsymbolicated" when `count_resolved_frames` in
+`crates/clud-bin/src/symbols.rs:55` returns 0. The frame heuristic
+matches `at FILE:LINE` lines produced by `std::backtrace::Backtrace`
+(handling Windows drive-letter colons via right-anchored search).
+
+## Test coverage
+
+- `crash_report::tests::*` — panic-hook + rotation + sanitize + native
+  signal/exception name lookup (10 unit tests).
+- `tests/crash_report.rs` — end-to-end panic catch in-process (2
+  integration tests).
+- `symbols::tests::*` — `is_resolved_frame_line`, `count_resolved_frames`,
+  `is_unsymbolicated`, `list_reports_newest_first` (8 unit tests).
+- `tests/symbols.rs` — `clud symbols verify --all` / `clud symbols
+  install` / bare `clud symbols` exit codes + output (4 integration
+  tests spawning the real `clud` binary with `CLUD_DAEMON_STATE_DIR`
+  redirected).
+
+No deliberate-native-crash CI test: attaching a real signal/SEH handler
+in a test process would intercept SIGABRT in unrelated tests. The
+underlying `crash-handler` crate has upstream tests; manual reproduction
+steps are documented inline in
+`crates/clud-bin/src/crash_report.rs` next to the unit tests.


### PR DESCRIPTION
## Summary

Completes the 3-PR slice for #374:

- **PR 1 (#376)**: `debug = \"line-tables-only\"` profiles + Rust panic hook (`crash_report::install`).
- **PR 2 (#385)**: native crash handler (`crash-handler` crate; SIGSEGV / SIGBUS / SIGILL / SIGFPE / SIGABRT on Unix; structured exceptions on Windows).
- **PR 3 (this PR)**: `clud symbols install` opportunistic verifier + docs explaining the embed-line-tables-everywhere choice.

## Subcommand shape

- `clud symbols` (bare) — five-line summary of the crashes dir (total reports, count with / without `at FILE:LINE` frames, most-recent path).
- `clud symbols install` — verify the most-recent crash report resolves to file:line frames; exit 1 if it doesn't.
- `clud symbols verify [--all]` — same; `--all` widens to every report under `~/.clud/state/crashes/`.

## Why \"opportunistic verifier\" instead of \"opportunistic fetcher\"

The #374 open question was whether `clud symbols install` should be explicit (user runs it) or opportunistic (auto-fetch sidecars on the next startup if an unsymbolicated report exists). With line-tables embedded in every build, there's no sidecar to fetch — \"opportunistic fetch\" collapses into \"opportunistic verify\":

> The startup surface message gains a follow-up line — `clud: backtrace appears unsymbolicated; run \`clud symbols verify\` for diagnostic details` — only when a fresh report's backtrace has zero `at FILE:LINE` frames.

This gives users a discoverable on-ramp to the verifier without making network calls or running the verifier eagerly on every launch.

## Tests (16 new, all passing locally)

- **8 unit tests** in `symbols::tests::*` covering the frame heuristic, Windows drive-letter handling, empty backtraces, JSON parsing, and unix-ms ordering.
- **4 arg-parser tests** in `args::tests::test_symbols_*` covering bare / install / verify --all / verify default forms.
- **4 integration tests** in `tests/symbols.rs` spawning the real `clud` binary via `running_process::NativeProcess` with `CLUD_DAEMON_STATE_DIR` redirected to a tempdir.

## Docs

- `docs/architecture/crash-reports.md` — new topic doc covering the embed-line-tables-everywhere choice and the opportunistic-verify model.
- `docs/ARCHITECTURE.md` — index entry + quick-reference line.
- `crates/clud-bin/src/README.md` — new `symbols.rs` module entry + extended `crash_report.rs` entry calling out the unsymbolicated-notice follow-up line.

## Test plan

- [ ] CI green on all 24 jobs.
- [x] Local: 16/16 new tests pass; full lib test suite unaffected; `fmt --check` + `clippy -D warnings` clean.
- [ ] Manual: `clud symbols install` against a real crash report exits 0 with the OK footer.
- [ ] Manual: after deliberate panic + restart, the new unsymbolicated-notice line fires only when the backtrace has no `at FILE:LINE` frames.

For #374. Does NOT close #374 (already closed via PR #376's keyword-parser quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)