### PR TITLE
feat(skills): add PR Drive Mode to /clud-pr + PR URL input to /clud-fix (#395)

### DIFF
--- a/crates/clud-bin/assets/skills/clud-fix/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-fix/SKILL.md
@@ -31,11 +31,29 @@ focused signal until it passes before broad gates.
 ## Input
 
 - A GitHub issue URL such as `https://github.com/<owner>/<repo>/issues/<num>`.
-- A bare `#<num>` only when the current checkout is the right repository. Resolve
-  `<owner>/<repo>` with `gh repo view` before acting.
+- A GitHub PR URL such as `https://github.com/<owner>/<repo>/pull/<num>`.
+- A bare `#<num>` (issue) or `!<num>` (PR) only when the current checkout is the
+  right repository. Resolve `<owner>/<repo>` with `gh repo view` before acting.
 
-The argument can be a single issue or a meta/parent/burn-down issue that lists
-sub-issues. Classify the mode before planning any implementation.
+The argument can be a single issue, a meta/parent/burn-down issue that lists
+sub-issues, or a PR. Classify the mode before planning any implementation.
+
+### PR URL input
+
+A PR URL input bypasses the single-issue / meta classifier entirely and
+delegates to [[clud-pr]] PR Drive Mode: actively check CI builders + code-review
+comments (CodeRabbit, GitHub Copilot review, human reviewers) + files needing
+resolve, apply scoped fixes, push the new commits without force-push, and merge
+when the PR is clean. Once [[clud-pr]] returns with the PR merged, this skill
+validates against the underlying issue (if linked via `Closes #<N>`) and closes
+it if validation passes.
+
+Recognition rules for distinguishing PR URLs vs issue URLs vs bare numbers are
+documented under "Input Recognition" in [[clud-pr]] — same disambiguation logic
+applies here. See #395 for the spec.
+
+This makes `/clud-fix` symmetric: issue URL → "fix this issue end-to-end";
+PR URL → "drive this PR end-to-end through merge + validation."
 
 ## Goal Ownership
 

--- a/crates/clud-bin/assets/skills/clud-pr/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-pr/SKILL.md
@@ -32,14 +32,33 @@ Six hard rules:
 3. **Create the worktree.** `git fetch origin main && git worktree add -b feat/<short-name> .claude/worktrees/<branch> origin/main`. All edits, commits, lint, and tests happen inside that path.
 4. **Tear down.** After `gh pr create` succeeds, audit live processes before removing the worktree. Search for processes whose executable path or command line references `.claude/worktrees/<branch>` (on Windows, `Get-CimInstance Win32_Process | Where-Object { $_.ExecutablePath -like '*<branch>*' -or $_.CommandLine -like '*<worktree-path>*' }`). If a matching process is useful verification that is still making progress, wait and report status. If it is an abandoned or timed-out child from this run, stop only that exact process tree before cleanup and record what was stopped. Never kill guessed or unrelated processes. Only after the audit is clear, run `git worktree remove .claude/worktrees/<branch>`, then `git worktree prune`, and confirm the entry is gone from `git worktree list`. If removal still fails with a lock, re-audit exact holders or use `clud trash` for a quarantine fallback; do not use a blind `rm -rf` retry loop.
 
+## Input Recognition
+
+Before mode selection, classify the input to distinguish PR URLs, issue URLs, and bare numbers. GitHub shares the integer namespace between issues and PRs in a single repo — a number is one or the other but never both — so the bare-number probe is unambiguous once both APIs are checked.
+
+| Input shape | Detection rule | Resolves to |
+|---|---|---|
+| `https://github.com/<o>/<r>/pull/<N>` (singular `pull`) | URL path contains `/pull/` | PR |
+| `https://github.com/<o>/<r>/pulls/<N>` (plural) | `gh` normalizes this | PR |
+| `https://github.com/<o>/<r>/issues/<N>` | URL path contains `/issues/` | issue |
+| Bare `#<N>` or `<N>` | try `gh pr view <N> --repo <o>/<r> --json number,state` first — on success treat as PR; else `gh issue view <N>` and treat as issue | PR or issue |
+| `pr:<N>` or `issue:<N>` prefix in the invocation | explicit override; skip probing | per prefix |
+| Freeform task sentence | not a reference; no probing | freeform task |
+
+If the input is a bare number and both `gh pr view` and `gh issue view` succeed, that's a contradiction of GitHub's namespace rule — refuse with `unknown-reference` and stop. If neither succeeds, refuse with `unknown-reference` and stop.
+
+Multi-forge support (GitLab MRs, Bitbucket PRs, Gitea/Forgejo pulls, self-hosted variants) is tracked separately and not in scope for this section; all examples and probes here assume GitHub.
+
 ## Mode Selection
 
-Look at the input first:
+After Input Recognition, route by the resolved input shape and PR state:
 
 - **Explicitly delegated from [[clud-fix]]** -> run the matching task or merge mode in **Delegated Mode**. Do not set a nested `/goal`.
-- **PR URL / number** -> run **PR triage mode**. Do not branch or code until triage decides what to do.
-- **Merge / land / ship current PR** -> run **PR merge mode**.
-- **Issue URL / number / freeform task sentence** -> run **task to PR workflow**.
+- **PR URL / number, OPEN** -> run **PR Drive Mode**. Actively drive the PR to a clean mergeable state without asking the user step by step.
+- **PR URL / number, CLOSED-not-merged** -> run **PR Triage Mode**. (The user typed a closed PR; triage is the right asking-first scaffold.)
+- **PR URL / number, MERGED** -> report and stop; follow-up work belongs in a new PR or issue.
+- **Merge / land / ship current PR** -> run **PR Merge Mode**.
+- **Issue URL / number / freeform task sentence** -> run **Task To PR Workflow**.
 
 ## Delegated Mode
 
@@ -84,6 +103,45 @@ Use this when the user asks to merge, land, or ship an already-open PR.
 5. **Check for an existing follow-up PR.** Search PRs and the closed PR timeline for later work that appears to address the comments or CI.
 6. **Ask before acting.** For each real finding, ask whether to address it in a new PR. If the user says yes, continue through the task to PR workflow and reference the closed PR in the new PR body.
 
+## PR Drive Mode
+
+Invoked when Mode Selection resolves to **PR URL / number, OPEN**. The intent is "this PR is open, drive it to a clean mergeable state — check CI, address review comments, resolve conflicts, push the fixes." No step-by-step "ask the user" prompts like PR Triage Mode; act on each finding, with the hard rules below preventing the agent from doing anything unsafe.
+
+### Workflow
+
+1. **Check CI builders.** Run `gh pr checks <pr> --json bucket,name,workflow,link,state`. For each failing or in-progress check:
+   - Pull the failure logs (`gh run view <run-id> --log-failed`).
+   - Classify the failure: real test failure / lint failure / build failure / known-flake / infrastructure / config error.
+   - For local-fixable failures (test, lint, build, config), apply scoped fixes inside a worktree of the PR's head ref.
+   - For non-local failures (infra outage, secret/permission missing, external service down), refuse with a structured "needs human" message and stop — do not loop trying random things.
+
+2. **Check code-review comments (AI + human).**
+   - `gh pr view <pr> --json reviews,comments`
+   - `gh api repos/<owner>/<repo>/pulls/<pr>/comments` (review-thread comments)
+   - Filter substantively: include CodeRabbit (`coderabbitai*`), GitHub Copilot review (`github-actions[bot]` for Copilot review identity, `copilot-*`), and any human reviewer with non-nit content. Skip praise, nits, "consider", and threads marked resolved/outdated.
+   - Address each actionable comment as a separate commit (or tightly-related batch).
+
+3. **Check files needing resolve.** Run `gh pr view <pr> --json mergeable,mergeStateStatus`:
+   - If `mergeable: CONFLICTING` or `mergeStateStatus: DIRTY`, fetch the head ref into a worktree, run `git merge origin/<base>`, resolve the conflicts using the parent skill's existing language-aware conventions where possible (and the per-bucket review rules from `/clud-review` discovery if available).
+   - If the conflict is non-trivial (logic-level, not insert-line adjacency like skill-registry inserts), refuse with a structured "needs human merge decision" message and stop.
+
+4. **Apply fixes.** Same worktree-based pattern as `Task To PR Workflow`: small commits per fix, conventional commit messages, no force-push to main, no `--no-verify`, no skipped hooks. When `/clud-review` is wired in as a pre-push step in a future iteration, invoke it on the new commits before push.
+
+5. **Push the new commits.** `git push origin <head-ref>` — regular push, NOT force. The existing commits stay; new commits stack on top. CI auto-re-triggers.
+
+6. **Loop until green or capped.** Reuse the existing PR merge-mode loop caps: at most 3 round-trips through CI / review / conflict surfaces per PR. If still not green after that, surface the blocking finding and stop.
+
+7. **Merge when clean.** Once all three remediation surfaces are clean AND CI is green AND `mergeable: MERGEABLE`, squash-merge and delete the branch. Validate against the underlying issue when one is referenced via `Closes #<N>` (re-run any focused issue-test if `/clud-review`'s issue-test discovery found one).
+
+### Hard rules
+
+1. **No force-push.** Every fix is a new commit on the existing branch. The PR's commit history grows; it never gets rewritten.
+2. **No `--no-verify`, no skipped hooks.** Fix the hook failure instead.
+3. **One scoped fix per commit.** Multiple unrelated comments → multiple commits. Cosmetic batching is fine (e.g., one commit for "rename `x` → `y` across 4 files") but don't squash a CI fix and a CodeRabbit fix together.
+4. **Refuse on uncovered failure shapes.** If the agent can't fix the failure (infrastructure, permissions, logic-level merge conflicts that need a design call), emit a structured "needs-human" terminal and stop. Do NOT enter a retry loop on things the agent doesn't know how to fix.
+5. **Cap on the existing PR merge-mode loop caps.** No new outer cap; reuse 3 merge retries / 2 validation retries / 10 PRs total.
+6. **Never approve the PR.** The agent applies fixes and pushes; the final merge action is allowed but the agent never `gh pr review --approve` on its own work.
+
 ## Task To PR Workflow
 
 1. **Read the task.** If the input includes an issue URL/number, fetch it with `gh issue view <num>` or the URL and extract acceptance criteria. If it is a plain sentence, treat that sentence as the acceptance criteria and infer the repo from the current checkout.
@@ -116,6 +174,11 @@ Use this when the user asks to merge, land, or ship an already-open PR.
 - Pushing with a dirty worktree or leaving `.claude/worktrees/<branch>/` behind.
 - Skipping lint, tests, or failing hooks.
 - Auto-deleting stale worktrees without asking.
+- **PR Drive Mode: force-pushing the PR branch.** Every fix is a new commit on the existing branch. The PR's commit history grows; it never gets rewritten.
+- **PR Drive Mode: `--no-verify` or skipped hooks to get past a failing pre-commit.** Fix the hook failure instead.
+- **PR Drive Mode: squashing CI fixes with CodeRabbit-comment fixes into one commit.** One scoped fix per commit so reviewers can read the history.
+- **PR Drive Mode: retry-loop on non-fixable failures.** Refuse-and-stop terminals for infra outages, secret/permission missing, logic-level merge conflicts that need a design call. No infinite retries on things the agent doesn't know how to fix.
+- **PR Drive Mode: agent self-approval.** The agent applies fixes and pushes; the final merge action is allowed, but the agent never `gh pr review --approve` on its own work.
 
 ## When Not To Use This
 


### PR DESCRIPTION
## Summary

Implements the PR Drive Mode spec from #395 verbatim. Pure SKILL.md edits to `crates/clud-bin/assets/skills/clud-pr/SKILL.md` and `crates/clud-bin/assets/skills/clud-fix/SKILL.md` — no Rust/Python code changes, just the agent-prompt layer.

### /clud-pr changes

- **New Input Recognition section** before Mode Selection. Documents the GitHub URL detection table: `/pull/N` and `/pulls/N` → PR, `/issues/N` → issue, bare `<N>` probes `gh pr view` first then falls back to `gh issue view`, `pr:<N>` / `issue:<N>` explicit prefix override. Notes that GitHub shares the integer namespace between issues and PRs so the bare-number probe is unambiguous.
- **Mode Selection** updated: OPEN PR URL routes to PR Drive Mode (not the ask-the-user PR Triage scaffold); CLOSED-not-merged PR URL keeps existing PR Triage Mode; MERGED PR URL reports and stops.
- **New PR Drive Mode section** with the 7 workflow steps from #395 and the 6 hard rules verbatim (no force-push / no `--no-verify` / one scoped fix per commit / refuse on non-fixable / cap on existing PR-merge loop caps / no agent self-approval).
- **Failure Modes To Avoid** gains six PR-Drive-Mode-specific entries.

### /clud-fix changes

- **Input section** now lists PR URLs alongside issue URLs, with `!<num>` recognized for bare-PR-number input.
- **New PR URL input subsection** documenting that a PR URL bypasses the single-issue / meta classifier and delegates to `/clud-pr` PR Drive Mode. After the child returns merged, `/clud-fix` validates against the underlying issue (if linked via `Closes #<N>`) and closes it. References #395 for the recognition rules to avoid duplication.

### Test plan

- [x] `soldr cargo test -p clud --lib skills::` → 27 passed, 0 failed
- [x] `soldr cargo test -p clud --lib skill_install::` → 15 passed, 0 failed
- [x] `bash lint` → clean
- [x] Both bundled-skill RED→GREEN guardrails satisfied (`grep -c \"RED -> GREEN\"` returns 3 for clud-pr and 2 for clud-fix)
- [ ] CI green on all 24 jobs

### Acceptance criteria from #395

- [x] `/clud-pr`'s Mode Selection routes OPEN PR URL to PR Drive Mode (not Triage's ask-the-user)
- [x] PR Drive Mode covers CI + reviews + conflicts + apply-fix + re-push
- [x] `/clud-fix`'s input doc explicitly accepts PR URL → delegates to `/clud-pr` PR Drive Mode
- [x] Hard rules section: no force-push / no `--no-verify` / one scoped fix per commit / refuse on non-fixable / cap on existing PR-merge loop caps / no agent self-approval
- [x] Both bundled-skill guardrail test suites still pass after the SKILL.md updates
- [x] Input recognition section spells out the PR-vs-issue detection rules from #395

Closes #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)