### PR TITLE
feat(skills): multi-forge support for clud-fix, clud-pr, clud-do, clud-review, clud-issue, clud-issue-triage (#396)

### DIFF
--- a/crates/clud-bin/assets/skills/clud-do/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-do/SKILL.md
@@ -38,6 +38,79 @@ Optional user hint may prefix the argument: `/clud-do fix <url>` forces
 the `/clud-fix` route; `/clud-do feat <url>` forces the `/clud-pr` route.
 User hints win outright over every other classifier signal.
 
+## Forge support
+
+This skill defaults to GitHub and the `gh` CLI for backwards compatibility. URL inputs from other forges are classified by URL prefix and routed to the matching native CLI. Bare numbers (`#<N>`) without an explicit prefix resolve their forge from the current worktree's `git remote get-url origin`.
+
+### Multi-forge URL recognition
+
+| Forge | URL prefix(es) | Native CLI | Vocabulary |
+|---|---|---|---|
+| GitHub | `github.com/<o>/<r>/(issues\|pull)/<N>` | `gh` | issue / PR (`#N`) |
+| GitLab | `gitlab.com/<g>/<p>/-/(issues\|merge_requests)/<N>` and self-hosted variants | `glab` | issue / **merge request (MR)** (`!N`) |
+| Bitbucket | `bitbucket.org/<o>/<r>/(issues\|pull-requests)/<N>` | none official; REST API | issue / PR (`#N`) |
+| Gitea | `<host>/<o>/<r>/(issues\|pulls)/<N>` | `tea` | issue / PR (`#N`) |
+| Forgejo | `<host>/<o>/<r>/(issues\|pulls)/<N>` (same patterns as Gitea) | `forgejo-cli` (early) or `tea` | issue / PR (`#N`) |
+| Self-hosted GitLab / Gitea / Forgejo | same patterns under custom domains | same CLI | same vocabulary |
+
+The classifier returns `{forge, kind, owner, repo, number, host}` for any URL input.
+
+### Bare-number resolution
+
+When the input is a bare `#<N>` or `<N>`:
+
+1. Run `git remote get-url origin` in the current worktree.
+2. Match the remote URL against the forge patterns above.
+3. Use the resolved forge for the bare-number probe (`gh pr view` for GitHub, `glab mr view` for GitLab, etc.).
+
+### Explicit prefix override
+
+Prefixes in the invocation force a specific forge and skip remote inference: `github:<N>` / `gitlab:<N>` / `bitbucket:<N>` / `gitea:<N>` / `forgejo:<N>`.
+
+### CLI abstraction
+
+All `gh` examples elsewhere in this skill are GitHub-specific. Substitute the matching native CLI per forge:
+
+- `gh issue view <N>` ↔ `glab issue view <N>` ↔ `tea issues show <N>` ↔ Bitbucket REST: `curl ... /repositories/<o>/<r>/issues/<N>`
+- `gh pr view <N>` ↔ `glab mr view <N>` ↔ `tea pulls show <N>` ↔ Bitbucket REST: `curl ... /pullrequests/<N>`
+- `gh pr merge <N> --squash` ↔ `glab mr merge <N> --squash` ↔ `tea pulls merge <N>` ↔ Bitbucket REST: `PUT /pullrequests/<N>/merge`
+- `gh issue create` ↔ `glab issue create` ↔ `tea issues create` ↔ Bitbucket REST: `POST /repositories/<o>/<r>/issues`
+
+### Vocabulary translation
+
+Internal skill logic can keep saying "PR" generically. User-facing output uses the forge's native vocabulary:
+
+- GitHub user sees `PR #123 merged` — unchanged.
+- GitLab user sees `MR !123 merged` (note the `!` sigil GitLab uses instead of `#` for MR references).
+- Bitbucket / Gitea / Forgejo users see `PR #123 merged`.
+
+Never silently translate vocabulary in error messages — if a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+
+### Auth-token discovery
+
+Each forge has its own auth model:
+
+- **GitHub**: `gh auth status` or `GITHUB_TOKEN` env var (default).
+- **GitLab**: `glab auth status` or `GITLAB_TOKEN` / `GL_TOKEN`.
+- **Bitbucket**: App password or workspace token (e.g. `BITBUCKET_TOKEN`).
+- **Gitea / Forgejo**: per-host token (`GITEA_TOKEN`, `FORGEJO_TOKEN`).
+
+If the required CLI or token is missing, emit a clear refusal and stop:
+
+```
+forge-cli-missing: install <cli> to use clud against <forge>
+forge-auth-missing: authenticate to <forge> via <cli> auth login
+```
+
+Don't log or persist tokens; rely on the user's existing auth.
+
+### Hard rules
+
+1. **No bundled CLIs.** Discover whether `gh` / `glab` / `tea` / etc. is on PATH; refuse if not. Don't bundle tooling.
+2. **GitHub stays the path of least resistance.** Users on GitHub see no behavior change. The forge classifier only kicks in when the URL matches a non-GitHub pattern (or the user passes an explicit non-GitHub prefix).
+3. **No silent vocabulary translation in error messages.** If a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+4. **No cross-forge operations.** Never move an issue between forges, link a PR to an MR, etc. Single forge per invocation.
+
 ## Hard Rules
 
 1. **Classify, dispatch, pass through. Never code, never branch, never set

--- a/crates/clud-bin/assets/skills/clud-fix/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-fix/SKILL.md
@@ -55,6 +55,79 @@ applies here. See #395 for the spec.
 This makes `/clud-fix` symmetric: issue URL → "fix this issue end-to-end";
 PR URL → "drive this PR end-to-end through merge + validation."
 
+## Forge support
+
+This skill defaults to GitHub and the `gh` CLI for backwards compatibility. URL inputs from other forges are classified by URL prefix and routed to the matching native CLI. Bare numbers (`#<N>`) without an explicit prefix resolve their forge from the current worktree's `git remote get-url origin`.
+
+### Multi-forge URL recognition
+
+| Forge | URL prefix(es) | Native CLI | Vocabulary |
+|---|---|---|---|
+| GitHub | `github.com/<o>/<r>/(issues\|pull)/<N>` | `gh` | issue / PR (`#N`) |
+| GitLab | `gitlab.com/<g>/<p>/-/(issues\|merge_requests)/<N>` and self-hosted variants | `glab` | issue / **merge request (MR)** (`!N`) |
+| Bitbucket | `bitbucket.org/<o>/<r>/(issues\|pull-requests)/<N>` | none official; REST API | issue / PR (`#N`) |
+| Gitea | `<host>/<o>/<r>/(issues\|pulls)/<N>` | `tea` | issue / PR (`#N`) |
+| Forgejo | `<host>/<o>/<r>/(issues\|pulls)/<N>` (same patterns as Gitea) | `forgejo-cli` (early) or `tea` | issue / PR (`#N`) |
+| Self-hosted GitLab / Gitea / Forgejo | same patterns under custom domains | same CLI | same vocabulary |
+
+The classifier returns `{forge, kind, owner, repo, number, host}` for any URL input.
+
+### Bare-number resolution
+
+When the input is a bare `#<N>` or `<N>`:
+
+1. Run `git remote get-url origin` in the current worktree.
+2. Match the remote URL against the forge patterns above.
+3. Use the resolved forge for the bare-number probe (`gh pr view` for GitHub, `glab mr view` for GitLab, etc.).
+
+### Explicit prefix override
+
+Prefixes in the invocation force a specific forge and skip remote inference: `github:<N>` / `gitlab:<N>` / `bitbucket:<N>` / `gitea:<N>` / `forgejo:<N>`.
+
+### CLI abstraction
+
+All `gh` examples elsewhere in this skill are GitHub-specific. Substitute the matching native CLI per forge:
+
+- `gh issue view <N>` ↔ `glab issue view <N>` ↔ `tea issues show <N>` ↔ Bitbucket REST: `curl ... /repositories/<o>/<r>/issues/<N>`
+- `gh pr view <N>` ↔ `glab mr view <N>` ↔ `tea pulls show <N>` ↔ Bitbucket REST: `curl ... /pullrequests/<N>`
+- `gh pr merge <N> --squash` ↔ `glab mr merge <N> --squash` ↔ `tea pulls merge <N>` ↔ Bitbucket REST: `PUT /pullrequests/<N>/merge`
+- `gh issue create` ↔ `glab issue create` ↔ `tea issues create` ↔ Bitbucket REST: `POST /repositories/<o>/<r>/issues`
+
+### Vocabulary translation
+
+Internal skill logic can keep saying "PR" generically. User-facing output uses the forge's native vocabulary:
+
+- GitHub user sees `PR #123 merged` — unchanged.
+- GitLab user sees `MR !123 merged` (note the `!` sigil GitLab uses instead of `#` for MR references).
+- Bitbucket / Gitea / Forgejo users see `PR #123 merged`.
+
+Never silently translate vocabulary in error messages — if a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+
+### Auth-token discovery
+
+Each forge has its own auth model:
+
+- **GitHub**: `gh auth status` or `GITHUB_TOKEN` env var (default).
+- **GitLab**: `glab auth status` or `GITLAB_TOKEN` / `GL_TOKEN`.
+- **Bitbucket**: App password or workspace token (e.g. `BITBUCKET_TOKEN`).
+- **Gitea / Forgejo**: per-host token (`GITEA_TOKEN`, `FORGEJO_TOKEN`).
+
+If the required CLI or token is missing, emit a clear refusal and stop:
+
+```
+forge-cli-missing: install <cli> to use clud against <forge>
+forge-auth-missing: authenticate to <forge> via <cli> auth login
+```
+
+Don't log or persist tokens; rely on the user's existing auth.
+
+### Hard rules
+
+1. **No bundled CLIs.** Discover whether `gh` / `glab` / `tea` / etc. is on PATH; refuse if not. Don't bundle tooling.
+2. **GitHub stays the path of least resistance.** Users on GitHub see no behavior change. The forge classifier only kicks in when the URL matches a non-GitHub pattern (or the user passes an explicit non-GitHub prefix).
+3. **No silent vocabulary translation in error messages.** If a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+4. **No cross-forge operations.** Never move an issue between forges, link a PR to an MR, etc. Single forge per invocation.
+
 ## Goal Ownership
 
 When the user invokes `/goal $clud-fix <issue-or-issue-url>`, this skill owns

--- a/crates/clud-bin/assets/skills/clud-issue-triage/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-issue-triage/SKILL.md
@@ -17,6 +17,79 @@ Triage GitHub issues for closeable resolution and un-addressed CodeRabbit follow
 3. **Bulk mode = main scans, sub-agents triage in parallel git worktrees.** The main agent never does per-issue triage in bulk mode. It enumerates and filters the candidate set, then dispatches one sub-agent per issue in a single tool-use block. Each sub-agent runs in its own `.claude/worktrees/triage-<num>/`.
 4. **Nothing left in the repo when done.** Every worktree gets `git worktree remove`'d after its sub-agent finishes. Same `.gitignore` gate and stale-worktree rules as `/clud-pr`.
 
+## Forge support
+
+This skill defaults to GitHub and the `gh` CLI for backwards compatibility. URL inputs from other forges are classified by URL prefix and routed to the matching native CLI. Bare numbers (`#<N>`) without an explicit prefix resolve their forge from the current worktree's `git remote get-url origin`.
+
+### Multi-forge URL recognition
+
+| Forge | URL prefix(es) | Native CLI | Vocabulary |
+|---|---|---|---|
+| GitHub | `github.com/<o>/<r>/(issues\|pull)/<N>` | `gh` | issue / PR (`#N`) |
+| GitLab | `gitlab.com/<g>/<p>/-/(issues\|merge_requests)/<N>` and self-hosted variants | `glab` | issue / **merge request (MR)** (`!N`) |
+| Bitbucket | `bitbucket.org/<o>/<r>/(issues\|pull-requests)/<N>` | none official; REST API | issue / PR (`#N`) |
+| Gitea | `<host>/<o>/<r>/(issues\|pulls)/<N>` | `tea` | issue / PR (`#N`) |
+| Forgejo | `<host>/<o>/<r>/(issues\|pulls)/<N>` (same patterns as Gitea) | `forgejo-cli` (early) or `tea` | issue / PR (`#N`) |
+| Self-hosted GitLab / Gitea / Forgejo | same patterns under custom domains | same CLI | same vocabulary |
+
+The classifier returns `{forge, kind, owner, repo, number, host}` for any URL input.
+
+### Bare-number resolution
+
+When the input is a bare `#<N>` or `<N>`:
+
+1. Run `git remote get-url origin` in the current worktree.
+2. Match the remote URL against the forge patterns above.
+3. Use the resolved forge for the bare-number probe (`gh pr view` for GitHub, `glab mr view` for GitLab, etc.).
+
+### Explicit prefix override
+
+Prefixes in the invocation force a specific forge and skip remote inference: `github:<N>` / `gitlab:<N>` / `bitbucket:<N>` / `gitea:<N>` / `forgejo:<N>`.
+
+### CLI abstraction
+
+All `gh` examples elsewhere in this skill are GitHub-specific. Substitute the matching native CLI per forge:
+
+- `gh issue view <N>` ↔ `glab issue view <N>` ↔ `tea issues show <N>` ↔ Bitbucket REST: `curl ... /repositories/<o>/<r>/issues/<N>`
+- `gh pr view <N>` ↔ `glab mr view <N>` ↔ `tea pulls show <N>` ↔ Bitbucket REST: `curl ... /pullrequests/<N>`
+- `gh pr merge <N> --squash` ↔ `glab mr merge <N> --squash` ↔ `tea pulls merge <N>` ↔ Bitbucket REST: `PUT /pullrequests/<N>/merge`
+- `gh issue create` ↔ `glab issue create` ↔ `tea issues create` ↔ Bitbucket REST: `POST /repositories/<o>/<r>/issues`
+
+### Vocabulary translation
+
+Internal skill logic can keep saying "PR" generically. User-facing output uses the forge's native vocabulary:
+
+- GitHub user sees `PR #123 merged` — unchanged.
+- GitLab user sees `MR !123 merged` (note the `!` sigil GitLab uses instead of `#` for MR references).
+- Bitbucket / Gitea / Forgejo users see `PR #123 merged`.
+
+Never silently translate vocabulary in error messages — if a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+
+### Auth-token discovery
+
+Each forge has its own auth model:
+
+- **GitHub**: `gh auth status` or `GITHUB_TOKEN` env var (default).
+- **GitLab**: `glab auth status` or `GITLAB_TOKEN` / `GL_TOKEN`.
+- **Bitbucket**: App password or workspace token (e.g. `BITBUCKET_TOKEN`).
+- **Gitea / Forgejo**: per-host token (`GITEA_TOKEN`, `FORGEJO_TOKEN`).
+
+If the required CLI or token is missing, emit a clear refusal and stop:
+
+```
+forge-cli-missing: install <cli> to use clud against <forge>
+forge-auth-missing: authenticate to <forge> via <cli> auth login
+```
+
+Don't log or persist tokens; rely on the user's existing auth.
+
+### Hard rules
+
+1. **No bundled CLIs.** Discover whether `gh` / `glab` / `tea` / etc. is on PATH; refuse if not. Don't bundle tooling.
+2. **GitHub stays the path of least resistance.** Users on GitHub see no behavior change. The forge classifier only kicks in when the URL matches a non-GitHub pattern (or the user passes an explicit non-GitHub prefix).
+3. **No silent vocabulary translation in error messages.** If a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+4. **No cross-forge operations.** Never move an issue between forges, link a PR to an MR, etc. Single forge per invocation.
+
 ## Code Change Rule
 
 When this skill files a follow-up issue for a bug fix or feature implementation, the follow-up must require RED -> GREEN evidence: a focused failing test/repro first, then the implementation that turns that signal green.

--- a/crates/clud-bin/assets/skills/clud-issue/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-issue/SKILL.md
@@ -17,6 +17,79 @@ File a GitHub issue informed by real research and a real conversation. Four hard
 3. **Surface strong duplicates only** — search existing issues; mention related issues *only* when similarity is strong (same component + overlapping intent). Don't pad the report with weak matches.
 4. **Summary + URL last.** End with a short summary of what was filed and the URL — nothing else.
 
+## Forge support
+
+This skill defaults to GitHub and the `gh` CLI for backwards compatibility. URL inputs from other forges are classified by URL prefix and routed to the matching native CLI. Bare numbers (`#<N>`) without an explicit prefix resolve their forge from the current worktree's `git remote get-url origin`.
+
+### Multi-forge URL recognition
+
+| Forge | URL prefix(es) | Native CLI | Vocabulary |
+|---|---|---|---|
+| GitHub | `github.com/<o>/<r>/(issues\|pull)/<N>` | `gh` | issue / PR (`#N`) |
+| GitLab | `gitlab.com/<g>/<p>/-/(issues\|merge_requests)/<N>` and self-hosted variants | `glab` | issue / **merge request (MR)** (`!N`) |
+| Bitbucket | `bitbucket.org/<o>/<r>/(issues\|pull-requests)/<N>` | none official; REST API | issue / PR (`#N`) |
+| Gitea | `<host>/<o>/<r>/(issues\|pulls)/<N>` | `tea` | issue / PR (`#N`) |
+| Forgejo | `<host>/<o>/<r>/(issues\|pulls)/<N>` (same patterns as Gitea) | `forgejo-cli` (early) or `tea` | issue / PR (`#N`) |
+| Self-hosted GitLab / Gitea / Forgejo | same patterns under custom domains | same CLI | same vocabulary |
+
+The classifier returns `{forge, kind, owner, repo, number, host}` for any URL input.
+
+### Bare-number resolution
+
+When the input is a bare `#<N>` or `<N>`:
+
+1. Run `git remote get-url origin` in the current worktree.
+2. Match the remote URL against the forge patterns above.
+3. Use the resolved forge for the bare-number probe (`gh pr view` for GitHub, `glab mr view` for GitLab, etc.).
+
+### Explicit prefix override
+
+Prefixes in the invocation force a specific forge and skip remote inference: `github:<N>` / `gitlab:<N>` / `bitbucket:<N>` / `gitea:<N>` / `forgejo:<N>`.
+
+### CLI abstraction
+
+All `gh` examples elsewhere in this skill are GitHub-specific. Substitute the matching native CLI per forge:
+
+- `gh issue view <N>` ↔ `glab issue view <N>` ↔ `tea issues show <N>` ↔ Bitbucket REST: `curl ... /repositories/<o>/<r>/issues/<N>`
+- `gh pr view <N>` ↔ `glab mr view <N>` ↔ `tea pulls show <N>` ↔ Bitbucket REST: `curl ... /pullrequests/<N>`
+- `gh pr merge <N> --squash` ↔ `glab mr merge <N> --squash` ↔ `tea pulls merge <N>` ↔ Bitbucket REST: `PUT /pullrequests/<N>/merge`
+- `gh issue create` ↔ `glab issue create` ↔ `tea issues create` ↔ Bitbucket REST: `POST /repositories/<o>/<r>/issues`
+
+### Vocabulary translation
+
+Internal skill logic can keep saying "PR" generically. User-facing output uses the forge's native vocabulary:
+
+- GitHub user sees `PR #123 merged` — unchanged.
+- GitLab user sees `MR !123 merged` (note the `!` sigil GitLab uses instead of `#` for MR references).
+- Bitbucket / Gitea / Forgejo users see `PR #123 merged`.
+
+Never silently translate vocabulary in error messages — if a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+
+### Auth-token discovery
+
+Each forge has its own auth model:
+
+- **GitHub**: `gh auth status` or `GITHUB_TOKEN` env var (default).
+- **GitLab**: `glab auth status` or `GITLAB_TOKEN` / `GL_TOKEN`.
+- **Bitbucket**: App password or workspace token (e.g. `BITBUCKET_TOKEN`).
+- **Gitea / Forgejo**: per-host token (`GITEA_TOKEN`, `FORGEJO_TOKEN`).
+
+If the required CLI or token is missing, emit a clear refusal and stop:
+
+```
+forge-cli-missing: install <cli> to use clud against <forge>
+forge-auth-missing: authenticate to <forge> via <cli> auth login
+```
+
+Don't log or persist tokens; rely on the user's existing auth.
+
+### Hard rules
+
+1. **No bundled CLIs.** Discover whether `gh` / `glab` / `tea` / etc. is on PATH; refuse if not. Don't bundle tooling.
+2. **GitHub stays the path of least resistance.** Users on GitHub see no behavior change. The forge classifier only kicks in when the URL matches a non-GitHub pattern (or the user passes an explicit non-GitHub prefix).
+3. **No silent vocabulary translation in error messages.** If a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+4. **No cross-forge operations.** Never move an issue between forges, link a PR to an MR, etc. Single forge per invocation.
+
 ## Code Change Rule
 
 If the issue is for a bug fix or feature implementation, acceptance criteria must require RED -> GREEN evidence: a focused failing test/repro before coding, followed by the implementation that turns that signal green.

--- a/crates/clud-bin/assets/skills/clud-pr/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-pr/SKILL.md
@@ -47,7 +47,79 @@ Before mode selection, classify the input to distinguish PR URLs, issue URLs, an
 
 If the input is a bare number and both `gh pr view` and `gh issue view` succeed, that's a contradiction of GitHub's namespace rule — refuse with `unknown-reference` and stop. If neither succeeds, refuse with `unknown-reference` and stop.
 
-Multi-forge support (GitLab MRs, Bitbucket PRs, Gitea/Forgejo pulls, self-hosted variants) is tracked separately and not in scope for this section; all examples and probes here assume GitHub.
+All `gh` examples below are GitHub-specific. The skill supports other forges via the `## Forge support` section below — substitute the matching native CLI per forge.
+
+## Forge support
+
+This skill defaults to GitHub and the `gh` CLI for backwards compatibility. URL inputs from other forges are classified by URL prefix and routed to the matching native CLI. Bare numbers (`#<N>`) without an explicit prefix resolve their forge from the current worktree's `git remote get-url origin`.
+
+### Multi-forge URL recognition
+
+| Forge | URL prefix(es) | Native CLI | Vocabulary |
+|---|---|---|---|
+| GitHub | `github.com/<o>/<r>/(issues\|pull)/<N>` | `gh` | issue / PR (`#N`) |
+| GitLab | `gitlab.com/<g>/<p>/-/(issues\|merge_requests)/<N>` and self-hosted variants | `glab` | issue / **merge request (MR)** (`!N`) |
+| Bitbucket | `bitbucket.org/<o>/<r>/(issues\|pull-requests)/<N>` | none official; REST API | issue / PR (`#N`) |
+| Gitea | `<host>/<o>/<r>/(issues\|pulls)/<N>` | `tea` | issue / PR (`#N`) |
+| Forgejo | `<host>/<o>/<r>/(issues\|pulls)/<N>` (same patterns as Gitea) | `forgejo-cli` (early) or `tea` | issue / PR (`#N`) |
+| Self-hosted GitLab / Gitea / Forgejo | same patterns under custom domains | same CLI | same vocabulary |
+
+The classifier returns `{forge, kind, owner, repo, number, host}` for any URL input.
+
+### Bare-number resolution
+
+When the input is a bare `#<N>` or `<N>`:
+
+1. Run `git remote get-url origin` in the current worktree.
+2. Match the remote URL against the forge patterns above.
+3. Use the resolved forge for the bare-number probe (`gh pr view` for GitHub, `glab mr view` for GitLab, etc.).
+
+### Explicit prefix override
+
+Prefixes in the invocation force a specific forge and skip remote inference: `github:<N>` / `gitlab:<N>` / `bitbucket:<N>` / `gitea:<N>` / `forgejo:<N>`.
+
+### CLI abstraction
+
+All `gh` examples elsewhere in this skill are GitHub-specific. Substitute the matching native CLI per forge:
+
+- `gh issue view <N>` ↔ `glab issue view <N>` ↔ `tea issues show <N>` ↔ Bitbucket REST: `curl ... /repositories/<o>/<r>/issues/<N>`
+- `gh pr view <N>` ↔ `glab mr view <N>` ↔ `tea pulls show <N>` ↔ Bitbucket REST: `curl ... /pullrequests/<N>`
+- `gh pr merge <N> --squash` ↔ `glab mr merge <N> --squash` ↔ `tea pulls merge <N>` ↔ Bitbucket REST: `PUT /pullrequests/<N>/merge`
+
+### Vocabulary translation
+
+Internal skill logic can keep saying "PR" generically. User-facing output uses the forge's native vocabulary:
+
+- GitHub user sees `PR #123 merged` — unchanged.
+- GitLab user sees `MR !123 merged` (note the `!` sigil GitLab uses instead of `#` for MR references).
+- Bitbucket / Gitea / Forgejo users see `PR #123 merged`.
+
+Never silently translate vocabulary in error messages — if a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+
+### Auth-token discovery
+
+Each forge has its own auth model:
+
+- **GitHub**: `gh auth status` or `GITHUB_TOKEN` env var (default).
+- **GitLab**: `glab auth status` or `GITLAB_TOKEN` / `GL_TOKEN`.
+- **Bitbucket**: App password or workspace token (e.g. `BITBUCKET_TOKEN`).
+- **Gitea / Forgejo**: per-host token (`GITEA_TOKEN`, `FORGEJO_TOKEN`).
+
+If the required CLI or token is missing, emit a clear refusal and stop:
+
+```
+forge-cli-missing: install <cli> to use clud against <forge>
+forge-auth-missing: authenticate to <forge> via <cli> auth login
+```
+
+Don't log or persist tokens; rely on the user's existing auth.
+
+### Hard rules
+
+1. **No bundled CLIs.** Discover whether `gh` / `glab` / `tea` / etc. is on PATH; refuse if not. Don't bundle tooling.
+2. **GitHub stays the path of least resistance.** Users on GitHub see no behavior change. The forge classifier only kicks in when the URL matches a non-GitHub pattern (or the user passes an explicit non-GitHub prefix).
+3. **No silent vocabulary translation in error messages.** If a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+4. **No cross-forge operations.** Never move an issue between forges, link a PR to an MR, etc. Single forge per invocation.
 
 ## Mode Selection
 

--- a/crates/clud-bin/assets/skills/clud-review/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-review/SKILL.md
@@ -41,6 +41,79 @@ validation at the local level).
   issue-test discovery step below; otherwise inferred from branch /
   commit messages.
 
+## Forge support
+
+This skill defaults to GitHub and the `gh` CLI for backwards compatibility. URL inputs from other forges are classified by URL prefix and routed to the matching native CLI. Bare numbers (`#<N>`) without an explicit prefix resolve their forge from the current worktree's `git remote get-url origin`.
+
+### Multi-forge URL recognition
+
+| Forge | URL prefix(es) | Native CLI | Vocabulary |
+|---|---|---|---|
+| GitHub | `github.com/<o>/<r>/(issues\|pull)/<N>` | `gh` | issue / PR (`#N`) |
+| GitLab | `gitlab.com/<g>/<p>/-/(issues\|merge_requests)/<N>` and self-hosted variants | `glab` | issue / **merge request (MR)** (`!N`) |
+| Bitbucket | `bitbucket.org/<o>/<r>/(issues\|pull-requests)/<N>` | none official; REST API | issue / PR (`#N`) |
+| Gitea | `<host>/<o>/<r>/(issues\|pulls)/<N>` | `tea` | issue / PR (`#N`) |
+| Forgejo | `<host>/<o>/<r>/(issues\|pulls)/<N>` (same patterns as Gitea) | `forgejo-cli` (early) or `tea` | issue / PR (`#N`) |
+| Self-hosted GitLab / Gitea / Forgejo | same patterns under custom domains | same CLI | same vocabulary |
+
+The classifier returns `{forge, kind, owner, repo, number, host}` for any URL input.
+
+### Bare-number resolution
+
+When the input is a bare `#<N>` or `<N>`:
+
+1. Run `git remote get-url origin` in the current worktree.
+2. Match the remote URL against the forge patterns above.
+3. Use the resolved forge for the bare-number probe (`gh pr view` for GitHub, `glab mr view` for GitLab, etc.).
+
+### Explicit prefix override
+
+Prefixes in the invocation force a specific forge and skip remote inference: `github:<N>` / `gitlab:<N>` / `bitbucket:<N>` / `gitea:<N>` / `forgejo:<N>`.
+
+### CLI abstraction
+
+All `gh` examples elsewhere in this skill are GitHub-specific. Substitute the matching native CLI per forge:
+
+- `gh issue view <N>` ↔ `glab issue view <N>` ↔ `tea issues show <N>` ↔ Bitbucket REST: `curl ... /repositories/<o>/<r>/issues/<N>`
+- `gh pr view <N>` ↔ `glab mr view <N>` ↔ `tea pulls show <N>` ↔ Bitbucket REST: `curl ... /pullrequests/<N>`
+- `gh pr merge <N> --squash` ↔ `glab mr merge <N> --squash` ↔ `tea pulls merge <N>` ↔ Bitbucket REST: `PUT /pullrequests/<N>/merge`
+- `gh issue create` ↔ `glab issue create` ↔ `tea issues create` ↔ Bitbucket REST: `POST /repositories/<o>/<r>/issues`
+
+### Vocabulary translation
+
+Internal skill logic can keep saying "PR" generically. User-facing output uses the forge's native vocabulary:
+
+- GitHub user sees `PR #123 merged` — unchanged.
+- GitLab user sees `MR !123 merged` (note the `!` sigil GitLab uses instead of `#` for MR references).
+- Bitbucket / Gitea / Forgejo users see `PR #123 merged`.
+
+Never silently translate vocabulary in error messages — if a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+
+### Auth-token discovery
+
+Each forge has its own auth model:
+
+- **GitHub**: `gh auth status` or `GITHUB_TOKEN` env var (default).
+- **GitLab**: `glab auth status` or `GITLAB_TOKEN` / `GL_TOKEN`.
+- **Bitbucket**: App password or workspace token (e.g. `BITBUCKET_TOKEN`).
+- **Gitea / Forgejo**: per-host token (`GITEA_TOKEN`, `FORGEJO_TOKEN`).
+
+If the required CLI or token is missing, emit a clear refusal and stop:
+
+```
+forge-cli-missing: install <cli> to use clud against <forge>
+forge-auth-missing: authenticate to <forge> via <cli> auth login
+```
+
+Don't log or persist tokens; rely on the user's existing auth.
+
+### Hard rules
+
+1. **No bundled CLIs.** Discover whether `gh` / `glab` / `tea` / etc. is on PATH; refuse if not. Don't bundle tooling.
+2. **GitHub stays the path of least resistance.** Users on GitHub see no behavior change. The forge classifier only kicks in when the URL matches a non-GitHub pattern (or the user passes an explicit non-GitHub prefix).
+3. **No silent vocabulary translation in error messages.** If a GitLab MR is mentioned, the message says `MR !123`, not `PR #123`.
+4. **No cross-forge operations.** Never move an issue between forges, link a PR to an MR, etc. Single forge per invocation.
+
 ## Hard Rules
 
 1. **Pre-push only.** `/clud-review` reads the local diff; it does NOT


### PR DESCRIPTION
## Summary

Implements the multi-forge spec from #396 verbatim. **Pure SKILL.md edits across all 6 bundled skills** — no Rust or Python code changes. The skills operate at the agent-prompt layer; teaching forge-awareness is a text-level change. Bundled-skill guardrails (frontmatter parse + `RED -> GREEN` presence) still pass.

A canonical `## Forge support` section is now present in every bundled skill, covering:

- **Multi-forge URL recognition table** — GitHub, GitLab, Bitbucket, Gitea, Forgejo + self-hosted variants — with URL prefix patterns, native CLI, and forge-native vocabulary.
- **Bare-number resolution** — when input is `#<N>` or `<N>`, resolve the forge from `git remote get-url origin`.
- **Explicit prefix override** — `gitlab:<N>`, `bitbucket:<N>`, `gitea:<N>`, `forgejo:<N>` force a specific forge.
- **CLI abstraction** — `gh` ↔ `glab` / `tea` / Bitbucket REST mapping table for `issue view`, `pr view`, `pr merge`, `issue create`.
- **Vocabulary translation** — internal logic says "PR" generically; user-facing output uses `MR !N` for GitLab and `PR #N` for the rest. Never silently translate in error messages.
- **Auth-token discovery** — per-forge tokens (`GITHUB_TOKEN`, `GITLAB_TOKEN` / `GL_TOKEN`, `BITBUCKET_TOKEN`, `GITEA_TOKEN`, `FORGEJO_TOKEN`) with `forge-cli-missing` / `forge-auth-missing` refusal terminals.
- **Hard rules** — no bundled CLIs / GitHub stays default / no silent vocabulary translation / no cross-forge operations.

In `clud-pr` the section slots into the existing "Input Recognition" flow (replacing the prior "tracked separately" placeholder added by #397). In the other five skills it appears after the first input/intake section so the recognition rules are visible before any `gh` invocation in the workflow.

## Tests

- [x] `soldr cargo test -p clud --lib skills::` → 27 passed, 0 failed
- [x] `soldr cargo test -p clud --lib skill_install::` → 15 passed, 0 failed
- [x] `bash lint` → clean (cargo fmt + clippy + ruff)
- [x] All 6 skills retain ≥1 `RED -> GREEN` occurrence (clud-fix 2, clud-pr 3, clud-do 1, clud-review 5, clud-issue 2, clud-issue-triage 2)

## Acceptance criteria from #396

- [x] URL classifier prose returns `{forge, kind, owner, repo, number, host}` shape
- [x] `/clud-fix <gitlab-issue-url>` documented to run via `glab`
- [x] `/clud-pr <gitea-pr-url>` documented to drive via `tea`
- [x] User-facing output uses forge's native vocabulary (`MR !N` vs `PR #N`)
- [x] Missing CLI / token refusal terminals are forge-specific and explicit
- [x] Bundled-skill guardrail test suites still pass

## Out of scope (per #396)

- Migrating skills off `gh` for GitHub.
- A unified clud-side CLI mimicking `gh` / `glab` / `tea`.
- Supporting SourceForge, Phabricator, etc.
- Cross-forge linking.

Closes #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)