### PR TITLE
feat(skills): scope-expansion branch for /clud-pr and /clud-fix (#417)

### DIFF
--- a/crates/clud-bin/assets/skills/clud-fix/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-fix/SKILL.md
@@ -136,8 +136,10 @@ the outer goal until the issue-level completion condition is proven.
 For a single issue, use a goal equivalent to:
 
 ```text
-/goal Fix issue #N: PR(s) merged to main, issue closed, and reported reproduction validated fixed on current main.
+/goal Fix issue #N: all relevant PRs merged to main, any dependent issues closed (including their PRs), this issue closed, and the reported reproduction validated fixed on current main.
 ```
+
+The "all relevant PRs" / "dependent issues" phrasing is deliberate. When a fix legitimately needs more than one PR — a foundation PR plus follow-up slice PRs — the inner `/goal` text must already authorize that scope so the Stop hook does not wedge on a single-PR literal reading. See the "Scope Expansion" section below for the mid-flight pivot mechanics that satisfy this broader goal.
 
 For a meta/parent/burn-down issue, use a goal equivalent to:
 
@@ -310,6 +312,16 @@ All conditions are mandatory:
    evidence." [[clud-pr]] owns the disposable worktree, RED -> GREEN cycle,
    lint/test gates, PR creation, CI/review fix loop, and merge mode.
 
+7a. **Scope-expansion check.** Before validating on main, inspect [[clud-pr]]'s
+   returned evidence. If the merged PR's body references the issue with
+   `Refs #<num>` instead of `Closes #<num>` — i.e. the work is foundation-only
+   and additional PRs are needed to ship the user-visible feature this issue
+   tracks — the single-issue goal is not satisfiable by this PR alone. Pivot
+   to meta mode per the **Scope Expansion** section below before continuing
+   to step 8. Do not silently declare the goal done; do not also try to close
+   the issue. Validation (step 8) still runs after the meta-mode burn-down
+   completes, against the final state of main.
+
 8. **Validate on main.** After merge, run:
 
    ```bash
@@ -330,6 +342,57 @@ All conditions are mandatory:
 
 10. **Report.** Return the merged PR URL(s), the closed issue URL, and validation
    evidence.
+
+## Scope Expansion (Single-Issue → Meta Pivot)
+
+A single-issue run can discover mid-implementation that the user's stated goal
+cannot be satisfied by one PR. The trigger is observable: [[clud-pr]] returns
+evidence of a merged PR whose body has `Refs #<num>` instead of `Closes #<num>`
+because the work is foundation-only and additional PRs are needed to ship the
+user-visible feature the issue tracks.
+
+When that happens, do not declare the goal done. Pivot to meta mode:
+
+1. **Surface the expansion explicitly.** One-line user-visible report:
+
+   ```text
+   scope-expansion detected: <one-sentence reason>. Filing sub-issues and continuing in meta mode.
+   ```
+
+2. **File sub-issues** that decompose the remaining work. Each sub-issue gets:
+
+   - a focused acceptance checklist
+   - file-level scope notes (which modules, files, or RPCs each slice touches)
+   - `Parent: tracked by #<N>` pointer to the original issue
+   - `Out of scope (handled in later slices)` pointer to its successors
+   - the canonical `Closes #<sub-N>` keyword in its eventual PR body
+
+3. **Convert the parent into a meta.** Update the parent issue's title prefix
+   to `meta(...)` and prepend a `## Slice burn-down` checklist section pointing
+   at the new sub-issues. The parent now matches the meta-issue classifier so
+   subsequent runs route to the Meta workflow automatically.
+
+4. **Re-enter the Meta workflow** against the parent. The outer `/goal` stays
+   installed and is now reachable because the meta workflow closes each
+   sub-issue in sequence, ticks the parent checklist, and closes the parent.
+
+5. **Per-sub-issue caps still apply.** Runaway scope expansion is bounded by
+   the existing per-sub-issue PR cap (10) and validation retry cap (2). The
+   outer meta loop has no cap, same as today's meta workflow.
+
+This pivot is the **mid-flight equivalent** of the meta workflow's enumeration
+step — scope discovered during implementation is no different from scope
+enumerated at intake. The distinction from manufactured meta-level work
+(forbidden — see Failure Modes) is that scope-expansion sub-issues correspond
+to observable, deferred work the parent issue's intent demands; manufactured
+sub-issues are fabricated to extend an idle loop.
+
+This branch was added because of an incident where the foundation PR for a
+multi-slice feature was opened with `Refs #N` (not `Closes #N`), merged, and
+then the run stopped — leaving the outer user `/goal` ("issue closed +
+feature verified fixed") wedged. The skill correctly recognized the literal
+goal was unsatisfiable but did not take the obvious next step of filing the
+follow-up sub-issues and continuing. The pivot above is that next step.
 
 ## Meta / Parent / Burn-Down Workflow
 
@@ -452,7 +515,12 @@ This skill must work the same through clud for Claude and Codex:
 - Depending on a standalone merge skill; use [[clud-pr]] PR merge mode.
 - Treating a checked checklist item as proof without verifying the child issue
   state on GitHub.
-- Manufacturing new child issues after the open-child list is empty.
+- Manufacturing new child issues to keep an idle meta loop fed when the
+  open-child list is empty. Filing sub-issues to capture
+  legitimately-deferred scope discovered mid-implementation IS allowed (see
+  Scope Expansion); fabricating arbitrary work to extend an idle loop is
+  NOT. The distinction: are the sub-issues backed by scope the parent
+  issue's intent demands, or invented to satisfy a literal goal text?
 - Treating a user-installed outer `/goal /clud-fix <url>` wrap as authoritative.
   This skill owns its `/goal` lifecycle (see Goal Ownership). An outer wrap
   installs a parallel hook whose literal text the evaluator reads as a strict

--- a/crates/clud-bin/assets/skills/clud-pr/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-pr/SKILL.md
@@ -231,6 +231,25 @@ Invoked when Mode Selection resolves to **PR URL / number, OPEN**. The intent is
 9. **Clean tree gate.** Run `git status` inside the worktree. Commit source changes that belong in the PR. Delete tmp, scratch, and build artifacts. The worktree must be clean before push.
 10. **Commit.** Use a conventional commit. Reference the issue when one exists (`Closes #<num>` in the commit body or PR body). For freeform tasks, summarize the task instead.
 11. **Push and open PR.** `git push -u origin <branch>`, then `gh pr create`. The body should include the issue link when present, a concise summary, and tests run.
+11a. **Scope-Expansion Checkpoint.** After the PR is opened, audit honestly: does this PR alone close the user's stated issue? Concrete tells that one PR is **not** enough:
+
+   - The PR body uses `Refs #<num>` instead of `Closes #<num>` because the work is foundation/scaffolding-only and follow-up PRs are required for the user-visible feature.
+   - The "Out of scope" / "Deferred follow-ups" section of the PR body names additional discrete work items.
+   - The implementation revealed dependent issues (in this repo or a sibling repo) that must also close before the user's stated goal is satisfied.
+
+   If any of those hold, surface the expansion explicitly:
+
+   ```text
+   scope-expansion detected: <one-sentence reason>. Filing sub-issues and handing off to /clud-fix meta mode.
+   ```
+
+   Then:
+   - File sub-issues for each remaining slice (focused acceptance checklist, file-level scope notes, `Parent: tracked by #<N>` pointer).
+   - Convert the parent issue into a meta — update title prefix to `meta(...)`, prepend a `## Slice burn-down` checklist section pointing at the new sub-issues.
+   - In your final response, recommend the user run `/clud-fix #<parent-num>` (or, if the parent run was already inside [[clud-fix]] meta mode, hand back to the outer orchestrator). The outer `/goal` (if any) stays installed and is now reachable because /clud-fix will drive the meta burn-down to closure.
+
+   When this checkpoint does NOT trip — the PR genuinely closes the issue — proceed to step 12.
+
 12. **Remove the worktree.** Follow the **Tear down** process-audit pattern in the Worktree Workspace section: wait for useful matching subprocesses, stop only exact abandoned/timed-out matching process trees, then run `git worktree remove`, `git worktree prune`, confirm the entry is gone, and verify the main checkout's `git status` is clean.
 13. **Final response.** Give the PR URL and any essential test note. Keep it short.
 
@@ -240,7 +259,7 @@ Invoked when Mode Selection resolves to **PR URL / number, OPEN**. The intent is
 - Treating a freeform sentence as if it must have an issue number.
 - Implementing a closed issue or an issue already resolved on the default branch.
 - Calling an issue resolved when its PR merged only into a stack branch.
-- Creating multiple PRs for one requested task.
+- Creating multiple PRs without surfacing scope-expansion to the user. One PR is the default outcome; when implementation reveals the task legitimately needs multiple PRs to satisfy the user's stated goal, the right pivot is to hand off to [[clud-fix]] meta mode (file sub-issues, convert parent to meta — see the **Scope-Expansion Checkpoint** step below). Silently chaining multiple PRs without that surfacing IS still the failure mode.
 - Implementing before proving RED, or claiming coverage from a test that never failed for the bug/requirement.
 - Replacing an outer [[clud-fix]] `/goal` with a narrower PR-level goal while in delegated mode.
 - Pushing with a dirty worktree or leaving `.claude/worktrees/<branch>/` behind.


### PR DESCRIPTION
## Summary

When implementation reveals that one PR can't satisfy the user's stated goal, both `/clud-pr` and `/clud-fix` now pivot to filing sub-issues + handing off to `/clud-fix` meta mode rather than declaring done or wedging on an unsatisfiable outer \`/goal\`.

Closes #417.

## Motivating incident

PR #415 (foundation slice of #408) merged with \`Refs #408\` because the full feature spans multiple PRs. Outer user \`/goal\` said \"issue closed + feature verified fixed.\" The skill correctly recognized the literal goal was unsatisfiable by that one PR but stopped there — it didn't take the obvious next step of filing the follow-up sub-issues and continuing. The pivot added by this PR is that next step.

## Changes

### \`crates/clud-bin/assets/skills/clud-fix/SKILL.md\`

- Single-issue \`/goal\` template updated to authorize broader scope: *\"all relevant PRs merged ... any dependent issues closed (including their PRs) ... this issue closed ... reported reproduction validated.\"*
- New step **7a (scope-expansion check)** in Single-Issue Workflow — triggered when \`/clud-pr\` returns a \`Refs #N\` PR instead of \`Closes #N\`.
- New \`## Scope Expansion (Single-Issue → Meta Pivot)\` section documenting the 5-step pivot (surface, file sub-issues, convert parent to meta, re-enter Meta workflow, per-sub-issue caps).
- \"Manufacturing new child issues\" failure mode carved out — legitimately-deferred scope sub-issues are allowed; fabricating idle-loop fuel is not.

### \`crates/clud-bin/assets/skills/clud-pr/SKILL.md\`

- New step **11a (Scope-Expansion Checkpoint)** in Task To PR Workflow after \`gh pr create\`. Audits the just-opened PR: does it close the user's stated issue, or does it have \`Refs #N\` + \"deferred follow-ups\" + dependent issues?
- \"Creating multiple PRs for one requested task\" failure mode requalified — silently chaining PRs is still the failure; surfacing scope-expansion + pivoting to \`/clud-fix\` meta mode is the right response.

### Intentionally NOT changed

- \`/clud-fix-quick\` — speed-mode sibling stays narrow by design (its \"When NOT to use\" already covers this).
- \`/clud-pr-merge\` — merge skill correctly stays single-PR-scoped; orchestration belongs at \`/clud-fix\`.

## Test plan

- [x] \`soldr cargo test -p clud --lib skills::\` — 27 passed.
- [x] \`soldr cargo test -p clud --lib skill_install::\` — 15 passed, including \`every_bundled_skill_includes_red_green_rule\` (RED→GREEN clauses preserved in both modified skills).
- [x] \`bash lint\` — clean.
- [x] Worktree torn down; main checkout \`git status\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)