### PR TITLE
feat(tools): tee + JSONL writer + tool run wrapper (slice 2 of #427)

### DIFF
--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -44,6 +44,7 @@ pub mod subprocess;
 pub mod symbols;
 pub mod tool_install;
 pub mod tool_run;
+pub mod tool_tee;
 pub mod tools;
 pub mod trampoline;
 pub mod trash;

--- a/crates/clud-bin/src/tool_run.rs
+++ b/crates/clud-bin/src/tool_run.rs
@@ -21,14 +21,23 @@
 use std::ffi::OsString;
 use std::io;
 use std::path::PathBuf;
+use std::time::Duration;
 
-use running_process::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+use running_process::{
+    CommandSpec, NativeProcess, ProcessConfig, ProcessError, StderrMode, StdinMode,
+};
 
 use crate::session_index::{
     allocate_next_id, append_event, unix_millis_now, IndexEvent, SessionContext,
 };
 use crate::tool_install::tools_root;
+use crate::tool_tee::TeeWriter;
 use crate::tools::clud_uv_cache_dir;
+
+/// Poll interval for draining captured stdout/stderr into the tee writer.
+/// 100ms keeps the visual feel of live output without burning CPU on
+/// idle tools; the captured-output API is lock-cheap so this is fine.
+const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Resolve and execute a bundled tool by relative path. Returns the
 /// inner `uv` process's exit code so the CLI can surface it verbatim.
@@ -67,30 +76,29 @@ pub fn run(rel_path: &str, args: &[String]) -> io::Result<i32> {
 
     let env: Vec<(String, String)> = build_child_env(&cache_dir);
 
-    // Slice 1 of #427: record a Started event in the session index when
-    // a clud session is active. When `SessionContext::from_env()` returns
-    // None (CI / minimal / no-daemon case) we silently skip — the tool
-    // still runs, just without lifecycle tracking. Slice 2 will replace
-    // the placeholder PID/start_time with values captured from the
-    // running subprocess.
+    // Resolve session context up front. None means no daemon / CI fallback;
+    // we run the tool in plain passthrough mode (no capture, no tee, no
+    // index — same behavior as before #427 slice 1).
     let session_ctx = SessionContext::from_env();
     let tool_id = session_ctx
         .as_ref()
         .and_then(|ctx| allocate_next_id(ctx).ok());
-    if let (Some(ctx), Some(tool_id)) = (session_ctx.as_ref(), tool_id) {
-        let _ = append_event(
-            ctx,
-            &IndexEvent::Started {
-                tool_id,
-                tool: rel_path.to_string(),
-                args: args.to_vec(),
-                pid: 0,            // slice 2 fills this with the spawned subprocess PID
-                pid_start_time: 0, // slice 2 fills this with the OS start time
-                started_at_ms: unix_millis_now(),
-            },
-        );
-    }
 
+    // Two execution modes:
+    //   - With session: capture + tee + index lifecycle events.
+    //   - Without session: original passthrough (no capture, no tee).
+    // The session-less path keeps `clud tool run` runnable in CI / minimal
+    // containers where the daemon isn't present.
+    match (session_ctx.as_ref(), tool_id) {
+        (Some(ctx), Some(tool_id)) => run_with_session(ctx, tool_id, rel_path, args, argv, env),
+        _ => run_passthrough(argv, env),
+    }
+}
+
+/// Plain passthrough: child stdout/stderr go straight to the caller's
+/// terminal, no capture, no JSONL log. Pre-slice-2 behavior, retained for
+/// the no-daemon / CI fallback case.
+fn run_passthrough(argv: Vec<String>, env: Vec<(String, String)>) -> io::Result<i32> {
     let process = NativeProcess::new(ProcessConfig {
         command: CommandSpec::Argv(argv),
         cwd: None,
@@ -103,20 +111,95 @@ pub fn run(rel_path: &str, args: &[String]) -> io::Result<i32> {
         nice: None,
     });
     process.start().map_err(io::Error::other)?;
-    let exit_code = process.wait(None).map_err(io::Error::other)?;
+    process.wait(None).map_err(io::Error::other)
+}
 
-    if let (Some(ctx), Some(tool_id)) = (session_ctx.as_ref(), tool_id) {
-        let _ = append_event(
-            ctx,
-            &IndexEvent::Finished {
-                tool_id,
-                exit_code,
-                ended_at_ms: unix_millis_now(),
-            },
-        );
-    }
+/// Session-attached run: capture stdout/stderr through `running_process`,
+/// poll-drain into the [`TeeWriter`] every 100ms (so the user still sees
+/// live output, modulo the poll interval), and append Started/Finished
+/// events to the session index.
+fn run_with_session(
+    ctx: &SessionContext,
+    tool_id: u32,
+    rel_path: &str,
+    args: &[String],
+    argv: Vec<String>,
+    env: Vec<(String, String)>,
+) -> io::Result<i32> {
+    // Open the per-invocation log dir + JSONL writers BEFORE starting the
+    // subprocess so any open-time failure surfaces immediately (no
+    // half-spawned child with no log destination).
+    let log_dir = ctx.tool_log_dir(tool_id);
+    let mut tee = TeeWriter::open(&log_dir)?;
+
+    let process = NativeProcess::new(ProcessConfig {
+        command: CommandSpec::Argv(argv),
+        cwd: None,
+        env: Some(env),
+        capture: true,
+        stderr_mode: StderrMode::Pipe,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Inherit,
+        nice: None,
+    });
+    process.start().map_err(io::Error::other)?;
+
+    let _ = append_event(
+        ctx,
+        &IndexEvent::Started {
+            tool_id,
+            tool: rel_path.to_string(),
+            args: args.to_vec(),
+            // The actual subprocess PID/start_time come from the daemon's
+            // process-tree view; capturing them through running_process
+            // would need a dedicated API. For now record what we know.
+            pid: 0,
+            pid_start_time: 0,
+            started_at_ms: unix_millis_now(),
+        },
+    );
+
+    // Poll-drain loop. `wait(Some(100ms))` returns `Err(ProcessError::Timeout)`
+    // while the child is still running; we drain captured output each
+    // iteration and emit it via the tee. On `Ok` (child exited), we do a
+    // final drain so any output written during the last 100ms still lands
+    // in the log.
+    let mut emitted = 0usize;
+    let exit_code = loop {
+        match process.wait(Some(DRAIN_POLL_INTERVAL)) {
+            Ok(code) => break code,
+            Err(ProcessError::Timeout) => {
+                emitted = drain_into_tee(&process, &mut tee, emitted);
+            }
+            Err(other) => return Err(io::Error::other(other)),
+        }
+    };
+    let _ = drain_into_tee(&process, &mut tee, emitted);
+    let _ = tee.flush();
+
+    let _ = append_event(
+        ctx,
+        &IndexEvent::Finished {
+            tool_id,
+            exit_code,
+            ended_at_ms: unix_millis_now(),
+        },
+    );
 
     Ok(exit_code)
+}
+
+/// Drain captured combined output from `emitted..` and route it through
+/// the tee writer. Returns the new emitted index. Best-effort: emit
+/// errors are swallowed so a failing tee write never prevents the tool
+/// from completing.
+fn drain_into_tee(process: &NativeProcess, tee: &mut TeeWriter, emitted: usize) -> usize {
+    let combined = process.captured_combined();
+    if combined.len() > emitted {
+        let _ = tee.emit_batch(&combined[emitted..]);
+    }
+    combined.len()
 }
 
 /// Resolve a bundled-tool path under the supplied tools-root. Trivially

--- a/crates/clud-bin/src/tool_tee.rs
+++ b/crates/clud-bin/src/tool_tee.rs
@@ -1,0 +1,264 @@
+//! Tee writer for `clud tool run`. Slice 2 of #427.
+//!
+//! Drains `running_process::NativeProcess::captured_combined()` periodically
+//! and writes each `StreamEvent` to:
+//!
+//! 1. The caller's real stdout or stderr (byte-faithful passthrough so the
+//!    user sees the output live, modulo the poll interval).
+//! 2. `<log_dir>/stdout.jsonl` or `<log_dir>/stderr.jsonl` — the
+//!    per-stream JSONL log.
+//! 3. `<log_dir>/combined.jsonl` — the time-ordered merged log.
+//!
+//! Each JSONL line follows the schema-versioned shape:
+//!
+//! ```jsonl
+//! {"v":1,"ts_ms":1700000000000,"stream":"stdout","bytes":"...base64..."}
+//! ```
+//!
+//! Bytes are base64-encoded because terminal output can contain arbitrary
+//! binary (ANSI escapes, UTF-8 partial sequences across chunk boundaries).
+//! Encoding once keeps the JSONL parseable without forcing the producer to
+//! flush only at line boundaries.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::engine::general_purpose::STANDARD_NO_PAD;
+use base64::Engine;
+use running_process::{StreamEvent, StreamKind};
+use serde_json::json;
+
+/// JSONL schema version for tee log lines. Bumped only by intentional
+/// schema changes; readers must tolerate unknown keys within a version.
+pub const TEE_SCHEMA_VERSION: u32 = 1;
+
+/// Owns the three JSONL log files plus the caller's stdout/stderr handles
+/// for one tool invocation. Built by [`TeeWriter::open`] inside the
+/// per-invocation log directory.
+pub struct TeeWriter {
+    stdout_log: File,
+    stderr_log: File,
+    combined_log: File,
+}
+
+impl TeeWriter {
+    /// Open (or create) the three JSONL files under `log_dir`. The dir
+    /// is created if missing.
+    pub fn open(log_dir: &Path) -> io::Result<Self> {
+        fs::create_dir_all(log_dir)?;
+        Ok(Self {
+            stdout_log: open_append(&log_dir.join("stdout.jsonl"))?,
+            stderr_log: open_append(&log_dir.join("stderr.jsonl"))?,
+            combined_log: open_append(&log_dir.join("combined.jsonl"))?,
+        })
+    }
+
+    /// Route one `StreamEvent`:
+    ///
+    /// 1. Write bytes to the caller's matching real stream.
+    /// 2. Append a JSONL line to the matching per-stream log.
+    /// 3. Append the same line to the combined log.
+    pub fn emit(&mut self, event: &StreamEvent) -> io::Result<()> {
+        let ts_ms = unix_millis_now();
+        let stream_name = match event.stream {
+            StreamKind::Stdout => "stdout",
+            StreamKind::Stderr => "stderr",
+        };
+        // Passthrough to the caller's real terminal first so the user sees
+        // output without waiting for the JSONL flush.
+        match event.stream {
+            StreamKind::Stdout => {
+                let mut out = io::stdout().lock();
+                out.write_all(&event.line)?;
+                out.flush()?;
+            }
+            StreamKind::Stderr => {
+                let mut err = io::stderr().lock();
+                err.write_all(&event.line)?;
+                err.flush()?;
+            }
+        }
+        // Single buffered `write_all` per the #373 race-fix pattern so a
+        // concurrent reader doing `read_to_string` cannot hit EOF mid-object.
+        let encoded = STANDARD_NO_PAD.encode(&event.line);
+        let value = json!({
+            "v": TEE_SCHEMA_VERSION,
+            "ts_ms": ts_ms,
+            "stream": stream_name,
+            "bytes": encoded,
+        });
+        let mut buf = serde_json::to_vec(&value)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        buf.push(b'\n');
+        match event.stream {
+            StreamKind::Stdout => self.stdout_log.write_all(&buf)?,
+            StreamKind::Stderr => self.stderr_log.write_all(&buf)?,
+        };
+        self.combined_log.write_all(&buf)?;
+        Ok(())
+    }
+
+    /// Drain a batch of events in order. Returns the number successfully
+    /// emitted. Stops on the first emit error and returns it so the caller
+    /// can decide whether to keep going.
+    pub fn emit_batch(&mut self, events: &[StreamEvent]) -> io::Result<usize> {
+        let mut n = 0;
+        for event in events {
+            self.emit(event)?;
+            n += 1;
+        }
+        Ok(n)
+    }
+
+    /// Flush all three JSONL files. Called at the very end of the tool
+    /// invocation so the on-disk log is intact even if the parent dies
+    /// immediately afterward.
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.stdout_log.flush()?;
+        self.stderr_log.flush()?;
+        self.combined_log.flush()
+    }
+}
+
+fn open_append(path: &Path) -> io::Result<File> {
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
+fn unix_millis_now() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD_NO_PAD;
+    use base64::Engine;
+    use tempfile::TempDir;
+
+    fn read_lines(path: &Path) -> Vec<serde_json::Value> {
+        fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn open_creates_log_dir() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path().join("nested").join("does_not_exist");
+        let _w = TeeWriter::open(&log_dir).unwrap();
+        assert!(log_dir.join("stdout.jsonl").exists());
+        assert!(log_dir.join("stderr.jsonl").exists());
+        assert!(log_dir.join("combined.jsonl").exists());
+    }
+
+    #[test]
+    fn emit_writes_one_jsonl_line_per_call() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path();
+        let mut w = TeeWriter::open(log_dir).unwrap();
+        w.emit(&StreamEvent {
+            stream: StreamKind::Stdout,
+            line: b"hello\n".to_vec(),
+        })
+        .unwrap();
+        w.flush().unwrap();
+        let stdout_lines = read_lines(&log_dir.join("stdout.jsonl"));
+        assert_eq!(stdout_lines.len(), 1);
+        assert_eq!(stdout_lines[0]["v"], 1);
+        assert_eq!(stdout_lines[0]["stream"], "stdout");
+        let encoded = stdout_lines[0]["bytes"].as_str().unwrap();
+        let decoded = STANDARD_NO_PAD.decode(encoded).unwrap();
+        assert_eq!(decoded, b"hello\n");
+        // Stderr log exists but is empty.
+        assert!(log_dir.join("stderr.jsonl").exists());
+        assert!(read_lines(&log_dir.join("stderr.jsonl")).is_empty());
+    }
+
+    #[test]
+    fn emit_routes_stderr_separately_and_into_combined() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path();
+        let mut w = TeeWriter::open(log_dir).unwrap();
+        w.emit(&StreamEvent {
+            stream: StreamKind::Stdout,
+            line: b"out".to_vec(),
+        })
+        .unwrap();
+        w.emit(&StreamEvent {
+            stream: StreamKind::Stderr,
+            line: b"err".to_vec(),
+        })
+        .unwrap();
+        w.flush().unwrap();
+        let stdout = read_lines(&log_dir.join("stdout.jsonl"));
+        let stderr = read_lines(&log_dir.join("stderr.jsonl"));
+        let combined = read_lines(&log_dir.join("combined.jsonl"));
+        assert_eq!(stdout.len(), 1);
+        assert_eq!(stderr.len(), 1);
+        assert_eq!(
+            combined.len(),
+            2,
+            "combined holds events from both streams in order"
+        );
+        assert_eq!(combined[0]["stream"], "stdout");
+        assert_eq!(combined[1]["stream"], "stderr");
+    }
+
+    #[test]
+    fn emit_batch_handles_multiple_events_in_order() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path();
+        let mut w = TeeWriter::open(log_dir).unwrap();
+        let events = vec![
+            StreamEvent {
+                stream: StreamKind::Stdout,
+                line: b"line1\n".to_vec(),
+            },
+            StreamEvent {
+                stream: StreamKind::Stdout,
+                line: b"line2\n".to_vec(),
+            },
+            StreamEvent {
+                stream: StreamKind::Stderr,
+                line: b"warning\n".to_vec(),
+            },
+        ];
+        let n = w.emit_batch(&events).unwrap();
+        assert_eq!(n, 3);
+        w.flush().unwrap();
+        let combined = read_lines(&log_dir.join("combined.jsonl"));
+        assert_eq!(combined.len(), 3);
+        let stdout = read_lines(&log_dir.join("stdout.jsonl"));
+        assert_eq!(stdout.len(), 2);
+        let stderr = read_lines(&log_dir.join("stderr.jsonl"));
+        assert_eq!(stderr.len(), 1);
+    }
+
+    #[test]
+    fn emit_handles_arbitrary_binary_bytes() {
+        let tmp = TempDir::new().unwrap();
+        let log_dir = tmp.path();
+        let mut w = TeeWriter::open(log_dir).unwrap();
+        // ANSI escape + partial UTF-8 sequence + raw bytes.
+        let blob = b"\x1b[31mred\x1b[0m\xc3\xa9\x00\xff";
+        w.emit(&StreamEvent {
+            stream: StreamKind::Stdout,
+            line: blob.to_vec(),
+        })
+        .unwrap();
+        w.flush().unwrap();
+        let stdout = read_lines(&log_dir.join("stdout.jsonl"));
+        assert_eq!(stdout.len(), 1);
+        let decoded = STANDARD_NO_PAD
+            .decode(stdout[0]["bytes"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(decoded, blob);
+    }
+}


### PR DESCRIPTION
## Summary

Slice 2 of #427. Restructures \`clud tool run\` to capture child stdout/stderr through \`running_process\` and tee the output to per-invocation JSONL logs while passing it through to the caller's terminal. Builds on slice 1's session index + log-dir layout.

Closes #429.

## Two execution modes

Selected by \`SessionContext::from_env()\`:
- **With session**: capture + tee + index lifecycle events.
- **Without session** (CI / no-daemon): plain passthrough — no capture, no tee, no index. Same as pre-slice-2 behavior so the subcommand stays usable in minimal containers.

## New \`tool_tee\` module

- \`TeeWriter::open\` creates \`stdout.jsonl\` / \`stderr.jsonl\` / \`combined.jsonl\` under the per-invocation log dir.
- \`TeeWriter::emit\` routes one \`StreamEvent\` to: (a) the caller's matching real stream for byte-faithful passthrough, (b) the per-stream JSONL log, (c) the merged \`combined.jsonl\`.
- JSONL shape: \`{\"v\":1,\"ts_ms\":...,\"stream\":\"stdout|stderr\",\"bytes\":\"<base64>\"}\` — base64 (NO_PAD) so ANSI escapes, partial-UTF8 chunk boundaries, and binary content survive intact.
- Single buffered \`write_all\` per line per the #373 race-fix pattern.

## Poll-drain loop in \`tool_run.rs\`

- \`wait(Some(100ms))\` returns \`Err(ProcessError::Timeout)\` while the child is still running; each tick drains \`captured_combined()[emitted..]\` through the tee writer.
- On \`Ok(exit_code)\`: one final drain catches output written during the last poll interval, then \`tee.flush()\`.
- 100ms balances visual liveness against CPU/lock overhead.

## Test plan

- [x] 5 new \`tool_tee\` tests: log dir creation, single-event emit, separate stream routing into combined log, batch emit ordering, arbitrary binary bytes (ANSI + partial UTF-8 + null + 0xff) survive round-trip.
- [x] All 31 existing \`session_index / tools / tool_install / tool_run\` tests still pass (36 total).
- [x] \`bash lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)