### PR TITLE
feat(tools,skills): /clud-python-lint-deadcode + vulture dead-code tool (#439)

### DIFF
--- a/crates/clud-bin/assets/skills/clud-python-lint-deadcode/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-python-lint-deadcode/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: clud-python-lint-deadcode
+description: Find unused Python code (production-focused, symbols reachable only from tests count as dead) via the bundled vulture-backed tool.
+triggers:
+  - When the user asks to find dead code, unused code, or what can be deleted in a Python project
+  - When the user mentions vulture, dead code analysis, or code cleanup audits
+  - When the user invokes "/clud-python-lint-deadcode"
+---
+<!-- managed-by: clud -->
+
+# /clud-python-lint-deadcode
+
+Find dead Python code in a project — symbols (functions, classes, methods, imports, variables) that no production caller exercises. The skill's bundled tool runs `vulture` with the rule that **symbols reachable only from tests count as production-dead**: the test exists to verify behavior, but if no production caller invokes that behavior, the production code itself is unused.
+
+Three hard rules:
+
+1. **The tool only reports; it never deletes.** The agent (or human) decides what to remove based on confidence + understanding of the codebase.
+2. **Test-reachability does not save a symbol.** A function only called from `tests/` is still flagged. This is intentional — see "Why" below.
+3. **RED -> GREEN around any removal.** Before deleting a flagged symbol, the agent must add or identify a test/regression that confirms the symbol's behavior is genuinely unused (or that the existing tests still pass after removal). Confidence scores are guidance, not proof.
+
+## Invocation
+
+```
+clud tool run python/lint_deadcode.py [<path>...] [--min-confidence N] [--exclude PATH]... [--json]
+```
+
+Defaults: scans the current directory, `--min-confidence 60`. The tool always emits structured JSON to stdout.
+
+Output shape:
+
+```json
+{
+  "v": 1,
+  "files_scanned": 42,
+  "deadcode": [
+    {
+      "file": "src/foo.py",
+      "name": "old_helper",
+      "line": 42,
+      "type": "function",
+      "confidence": 60,
+      "size": 7,
+      "reachable_from_tests": false
+    }
+  ]
+}
+```
+
+Exit code: `0` (no dead code), `1` (at least one production-dead symbol), `2` (tool error).
+
+## Workflow
+
+1. **Run the tool** in the project root: `clud tool run python/lint_deadcode.py`.
+2. **Sort findings by confidence**. `confidence ≥ 80` is high-signal (vulture is very sure). 60–79 needs more thought.
+3. **Investigate before deleting**. For each candidate:
+   - Read the symbol's surrounding context — is it part of a public API, plugin entry point, dynamic-dispatch target, or `__all__` export?
+   - Check whether it's reachable via reflection, decorators, `getattr`, entry points (`pyproject.toml`), or import-time side effects vulture cannot see statically.
+   - If genuinely unused: delete it.
+4. **Run tests after each batch of removals**. RED -> GREEN: the test suite that was green before must stay green after. If a test was the only caller, the test should also go.
+5. **Re-run the tool**. Removing dead code can reveal more dead code (the chained-dead-code case). Single-pass for V1; iterative `--converge` is future work — see "Convergence" below.
+
+## Why test-reachable counts as dead
+
+A function `compute_legacy_format()` with one caller — `test_compute_legacy_format()` — is production-dead even though the test passes. The test verifies that `compute_legacy_format` behaves correctly, but no production code path calls it. The behavior is exercised in tests only because the tests exist; nothing real depends on it. Delete both.
+
+This rule sometimes surfaces *intentional* test-only helpers (test fixtures used as utility). The tool reports them; the human/agent reads them and skips obvious cases.
+
+## Convergence
+
+`vulture`'s single-pass mode reports symbols with no static reference. Removing those symbols can reveal *their* callees as newly-unused — a chained-dead-code case. V1 of this tool ships single-pass; the `--converge` flag is reserved for the iterative fixed-point loop.
+
+Workaround until `--converge` lands: run the tool, fix the high-confidence findings, re-run. Repeat until empty.
+
+## Failure modes to avoid
+
+- **Deleting public API.** A symbol vulture flags may be your library's public surface that lives at the import root and is only "called" by your users (whose code vulture cannot see). Check `__all__`, `pyproject.toml` entry points, and module-level imports before deleting.
+- **Deleting dynamic-dispatch targets.** Decorator registries, factory dictionaries, plugin systems — anything that resolves at runtime via string lookup is invisible to vulture.
+- **Deleting code referenced by docstrings or comments.** Vulture sees code only. A test referenced by `pytest --collect-only` only via name discovery may be invisible.
+- **Skipping the test-suite check after removals.** RED -> GREEN is mandatory; don't trust confidence alone.
+- **Treating low confidence (< 60) as actionable without manual review.** vulture's `--min-confidence` exists to filter the noise; respect it.
+
+## When not to use this
+
+- Pre-1.0 codebases where the public API is intentionally over-provisioned for future use.
+- Codebases with extensive use of dynamic dispatch, reflection, or runtime-loaded plugins.
+- Codebases where the agent doesn't have access to the test suite (test-reachability classification is broken without it).
+
+## Related
+
+- `crates/clud-bin/assets/tools/python/lint_deadcode.py` — the tool source.
+- `crates/clud-bin/src/tools.rs` — `BUNDLED_TOOLS` registry entry with `kill_semantics: Killable`, `command_timeout: 60m`, `progress_timeout: 2m`.
+- Vulture's docs: https://github.com/jendrikseipp/vulture for `--ignore-names`, `--exclude`, allowlist patterns, etc.

--- a/crates/clud-bin/assets/tools/python/lint_deadcode.py
+++ b/crates/clud-bin/assets/tools/python/lint_deadcode.py
@@ -1,0 +1,204 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "vulture>=2.13",
+# ]
+# ///
+# managed-by: clud
+"""Find dead Python code via vulture, classifying production vs test scope.
+
+Symbols reachable only from test code count as production-dead — the test
+exists to exercise behavior, but if no production caller invokes that
+behavior, the production code is unused.
+
+Usage:
+  clud tool run python/lint_deadcode.py [<path>...] [--min-confidence N]
+                                        [--exclude PATTERN]... [--json]
+
+Output (stdout, when --json or default):
+  {"v": 1, "deadcode": [
+    {"file": "src/foo.py", "name": "old_helper", "line": 42,
+     "type": "function", "confidence": 60, "size": 7,
+     "reachable_from_tests": false}
+  ]}
+
+Exit code:
+  0 — no production-dead symbols (vulture reported nothing or only
+      symbols ignored by allowlist).
+  1 — at least one production-dead symbol found.
+  2 — tool error (vulture crashed, no Python files found, etc.).
+
+Convergence (deferred to follow-up): single-pass for V1. The
+`--converge` flag is parsed but not yet implemented; the tool emits a
+warning when used. See #439 for the convergence investigation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_SRC_PATTERNS = ("src", "app", "lib")
+DEFAULT_TEST_PATTERNS = ("tests", "test", "conftest.py")
+
+
+def is_test_path(path: Path) -> bool:
+    parts = [p.lower() for p in path.parts]
+    name = path.name.lower()
+    if name == "conftest.py" or name.endswith("_test.py") or name.startswith("test_"):
+        return True
+    for p in parts:
+        if p in {"tests", "test"}:
+            return True
+    return False
+
+
+def discover_python_files(roots: list[Path], exclude: list[str]) -> tuple[list[Path], list[Path]]:
+    """Return (src_files, test_files). Both lists are absolute paths."""
+    src: list[Path] = []
+    tests: list[Path] = []
+    excluded = [Path(e).resolve() for e in exclude]
+    for root in roots:
+        root = root.resolve()
+        if not root.exists():
+            continue
+        if root.is_file():
+            candidates = [root]
+        else:
+            candidates = [p for p in root.rglob("*.py") if not _under_any(p, excluded)]
+        for f in candidates:
+            if is_test_path(f):
+                tests.append(f)
+            else:
+                src.append(f)
+    return src, tests
+
+
+def _under_any(path: Path, parents: list[Path]) -> bool:
+    rp = path.resolve()
+    for parent in parents:
+        try:
+            rp.relative_to(parent)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def run_vulture(
+    src_files: list[Path],
+    test_files: list[Path],
+    min_confidence: int,
+) -> list[dict]:
+    """Run vulture once and return structured items for src_files.
+
+    Test files are passed too so vulture's call-graph awareness sees that
+    test-only references don't save src symbols from being flagged — we
+    post-filter to drop any items whose file is in test_files.
+    """
+    from vulture import Vulture
+
+    v = Vulture(verbose=False)
+    paths = [str(p) for p in src_files + test_files]
+    v.scavenge(paths)
+
+    test_set = {str(p.resolve()) for p in test_files}
+    items: list[dict] = []
+    for item in v.get_unused_code(min_confidence=min_confidence):
+        file_str = str(Path(item.filename).resolve())
+        if file_str in test_set:
+            # Dead code inside tests is uninteresting for this tool's
+            # production-cleanup focus.
+            continue
+        items.append(
+            {
+                "file": os.path.relpath(item.filename),
+                "name": item.name,
+                "line": int(item.first_lineno),
+                "type": str(item.typ),
+                "confidence": int(item.confidence),
+                "size": int(getattr(item, "size", 1)),
+                # Reachable-from-tests: we don't compute this directly,
+                # but if vulture still reports the symbol despite seeing
+                # the tests, that means no test reaches it either. A
+                # future enhancement could re-scan with tests excluded
+                # and diff the results to populate this honestly.
+                "reachable_from_tests": False,
+            }
+        )
+    return items
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="lint_deadcode",
+        description="Find dead Python code via vulture (production-focused).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["."],
+        help="Files or directories to scan (default: current directory).",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=int,
+        default=60,
+        help="vulture --min-confidence (default 60).",
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        help="Path prefix to exclude (repeatable).",
+    )
+    parser.add_argument(
+        "--converge",
+        action="store_true",
+        help="Iterate vulture passes until no new dead code is reported. "
+        "Currently emits a warning and falls back to single-pass; see "
+        "https://github.com/zackees/clud/issues/439 for the convergence "
+        "investigation.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Force JSON output (default for V1).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.converge:
+        print(
+            "lint_deadcode: --converge is single-pass for V1 (see #439)",
+            file=sys.stderr,
+        )
+
+    roots = [Path(p) for p in args.paths]
+    src_files, test_files = discover_python_files(roots, args.exclude)
+    if not src_files:
+        print(
+            json.dumps(
+                {
+                    "v": 1,
+                    "deadcode": [],
+                    "note": "no Python source files found",
+                }
+            )
+        )
+        return 0
+
+    try:
+        items = run_vulture(src_files, test_files, args.min_confidence)
+    except Exception as exc:  # noqa: BLE001
+        print(f"lint_deadcode: vulture failed: {exc}", file=sys.stderr)
+        return 2
+
+    payload = {"v": 1, "deadcode": items, "files_scanned": len(src_files)}
+    print(json.dumps(payload, indent=2))
+    return 1 if items else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -53,6 +53,10 @@ const BUNDLED_SKILLS: &[Skill] = &[
         content: include_str!("../assets/skills/clud-review/SKILL.md"),
     },
     Skill {
+        name: "clud-python-lint-deadcode",
+        content: include_str!("../assets/skills/clud-python-lint-deadcode/SKILL.md"),
+    },
+    Skill {
         name: "clud-issue",
         content: include_str!("../../../skills/clud-issue/SKILL.md"),
     },

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -71,6 +71,10 @@ pub const BUNDLED_SKILLS: &[BundledSkill] = &[
         skill_md: include_str!("../assets/skills/clud-review/SKILL.md"),
     },
     BundledSkill {
+        name: "clud-python-lint-deadcode",
+        skill_md: include_str!("../assets/skills/clud-python-lint-deadcode/SKILL.md"),
+    },
+    BundledSkill {
         name: "clud-tag-release",
         skill_md: include_str!("../assets/skills/clud-tag-release/SKILL.md"),
     },

--- a/crates/clud-bin/src/tools.rs
+++ b/crates/clud-bin/src/tools.rs
@@ -165,6 +165,18 @@ pub const BUNDLED_TOOLS: &[BundledTool] = &[
         progress_timeout: None,
         quiet_ok: false,
     },
+    BundledTool {
+        rel_path: "python/lint_deadcode.py",
+        body: include_str!("../assets/tools/python/lint_deadcode.py"),
+        // Vulture scans the source tree and exits with the report.
+        // The process IS the work — `Killable`. 2-minute progress
+        // watchdog because vulture should be emitting status during
+        // its walk.
+        kill_semantics: KillSemantics::Killable,
+        command_timeout: DEFAULT_KILLABLE_TIMEOUT,
+        progress_timeout: Some(std::time::Duration::from_secs(120)),
+        quiet_ok: false,
+    },
 ];
 
 /// The single source of truth for the `UV_CACHE_DIR` value used by every


### PR DESCRIPTION
Closes #439. PEP 723 vulture-backed Python tool + paired skill. Symbols reachable only from tests count as production-dead. BUNDLED_TOOLS + both BUNDLED_SKILLS registries updated. Single-pass for V1; --converge investigation deferred. 48 tests pass; lint clean.