### PR TITLE
feat(optimize): use uv-run Python for zip extract instead of PowerShell

### DIFF
--- a/crates/clud-bin/assets/scripts/extract_zip.py
+++ b/crates/clud-bin/assets/scripts/extract_zip.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+# managed-by: clud
+"""extract_zip.py — extract a `.zip` archive into a destination directory.
+
+Internal helper for `clud optimize`'s soldr-binary install path. Replaces
+the previous `powershell -Command Expand-Archive` invocation so the
+zip-extract step works on hosts where PowerShell is policy-restricted
+or simply absent (and to make `shell.disable_powershell` a meaningful
+clud setting once that lands — issue tracking: forthcoming).
+
+Usage:
+
+    uv run --script extract_zip.py <archive.zip> <dest_dir>
+
+The destination directory is created if it does not exist. Any path
+traversal entries (`..` segments resolving outside dest) are rejected
+before extraction so a malicious archive cannot write above dest.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            f"usage: {sys.argv[0]} <archive.zip> <dest_dir>",
+            file=sys.stderr,
+        )
+        return 2
+    archive = Path(argv[0])
+    dest = Path(argv[1])
+    if not archive.is_file():
+        print(f"extract_zip: archive not found: {archive}", file=sys.stderr)
+        return 1
+    dest.mkdir(parents=True, exist_ok=True)
+    dest_resolved = dest.resolve()
+    with zipfile.ZipFile(archive) as zf:
+        for member in zf.infolist():
+            target = (dest_resolved / member.filename).resolve()
+            if os.path.commonpath([dest_resolved, target]) != str(dest_resolved):
+                print(
+                    f"extract_zip: refusing path-traversal entry: {member.filename}",
+                    file=sys.stderr,
+                )
+                return 1
+        zf.extractall(dest_resolved)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/crates/clud-bin/src/optimize.rs
+++ b/crates/clud-bin/src/optimize.rs
@@ -474,7 +474,50 @@ fn extract_archive(archive: &Path, temp_dir: &Path, asset: &SoldrAsset) -> Resul
     }
 }
 
+/// PEP 723 helper that extracts a `.zip` via the stdlib `zipfile` module.
+/// Embedded at compile time so the binary is self-contained; written to a
+/// temp path on demand and invoked via `uv run --script`.
+const EXTRACT_ZIP_PY: &str = include_str!("../assets/scripts/extract_zip.py");
+
 fn expand_zip(archive: &Path, temp_dir: &Path) -> Result<i32, String> {
+    // Primary path: invoke the bundled Python extractor via `uv run --script`.
+    // `--no-project` keeps the resolver from walking ancestors of CWD and
+    // accidentally syncing whatever pyproject.toml happens to be there.
+    let script_path = temp_dir.join("__clud_extract_zip.py");
+    std::fs::write(&script_path, EXTRACT_ZIP_PY)
+        .map_err(|error| format!("write extract_zip helper to temp: {error}"))?;
+    let argv = vec![
+        "uv".to_string(),
+        "run".to_string(),
+        "--no-project".to_string(),
+        "--script".to_string(),
+        script_path.to_string_lossy().to_string(),
+        archive.to_string_lossy().to_string(),
+        temp_dir.to_string_lossy().to_string(),
+    ];
+    match run_status_string(argv, None) {
+        Ok(status) => {
+            // Best-effort cleanup; if the rm fails the temp dir gets wiped
+            // by the outer caller anyway.
+            let _ = std::fs::remove_file(&script_path);
+            Ok(status)
+        }
+        Err(uv_error) => {
+            let _ = std::fs::remove_file(&script_path);
+            expand_zip_via_powershell(archive, temp_dir, &uv_error)
+        }
+    }
+}
+
+/// PowerShell fallback used only when `uv run --script` could not be
+/// spawned (uv missing from PATH). Honors the original two-step probe
+/// of `powershell.exe` then `pwsh.exe`. Will be skipped entirely when
+/// the upcoming `shell.disable_powershell` setting is true (forthcoming).
+fn expand_zip_via_powershell(
+    archive: &Path,
+    temp_dir: &Path,
+    uv_error: &str,
+) -> Result<i32, String> {
     let args = vec![
         "-NoProfile".to_string(),
         "-ExecutionPolicy".to_string(),
@@ -490,13 +533,16 @@ fn expand_zip(archive: &Path, temp_dir: &Path) -> Result<i32, String> {
             .collect(),
         None,
     )
-    .or_else(|first_error| {
+    .or_else(|powershell_error| {
         run_status_string(
             std::iter::once("pwsh".to_string()).chain(args).collect(),
             None,
         )
-        .map_err(|second_error| {
-            format!("failed to start powershell ({first_error}) or pwsh ({second_error})")
+        .map_err(|pwsh_error| {
+            format!(
+                "uv run --script unavailable ({uv_error}); PowerShell fallback also failed \
+                 (powershell: {powershell_error}; pwsh: {pwsh_error})"
+            )
         })
     })
 }


### PR DESCRIPTION
## Summary
- `clud optimize rust` was unzipping soldr release archives via `powershell -Command Expand-Archive`. On hosts where PowerShell is policy-restricted (AppLocker, locked-down enterprise images), the install path failed with no graceful alternative.
- Add `crates/clud-bin/assets/scripts/extract_zip.py` — a PEP 723 stdlib-only `zipfile` extractor — and invoke it via `uv run --no-project --script` as the primary path. PowerShell stays as fallback when `uv` is missing from PATH so existing flows don't regress.
- The Python path also rejects path-traversal entries before extracting; the prior `Expand-Archive` call did not.

## Out of scope (intentional)
The Claude / Codex Windows installers in ``crates/clud-bin/src/backend_bootstrap.rs`` continue to use PowerShell because the *upstream installers ARE PowerShell scripts* — `irm https://claude.ai/install.ps1 | iex` (Anthropic) and `irm https://chatgpt.com/codex/install.ps1 | iex` (OpenAI). Rewriting those in Python would require reimplementing the vendors' install logic (path resolution, binary download, registry/profile setup). That's out of scope here; the only ergonomics knob we get is whether to fall through to the CMD fallback (`install.cmd`) when one exists.

## Test plan
- [x] `soldr cargo build -p clud` — clean.
- [x] `soldr cargo test -p clud --lib optimize` — 15/15 pass.
- [x] `soldr cargo clippy -p clud -- -D warnings` — clean.
- [x] `soldr cargo fmt --all -- --check` — clean.
- [x] Manual smoke: created a small `.zip`, invoked the script via `uv run --no-project --script extract_zip.py` and confirmed the contents extracted correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)