### PR TITLE
feat(shell): vendored git-bash-bin resolver (refs #447, PR 2/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,7 +433,8 @@ dependencies = [
  "tempfile",
  "terminal_size",
  "tiny_http",
- "toml_edit",
+ "toml",
+ "toml_edit 0.25.11+spec-1.1.0",
  "ureq",
  "vt100",
  "vte",
@@ -433,6 +443,7 @@ dependencies = [
  "whisper-rs",
  "windows 0.61.3",
  "windows-core 0.61.2",
+ "zip",
 ]
 
 [[package]]
@@ -656,6 +667,17 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "derive_more"
@@ -1959,7 +1981,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2454,6 +2476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,6 +2781,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,15 +2812,29 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -2777,8 +2843,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3578,6 +3650,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -3830,10 +3911,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/crates/clud-bin/Cargo.toml
+++ b/crates/clud-bin/Cargo.toml
@@ -63,7 +63,16 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.37"
 terminal_size = "0.4"
+# Plain serde-friendly TOML deserializer. Used by the shell::git_bash_resolver
+# manifest reader (issue #447); the existing toml_edit dep keeps round-trip
+# editing of settings.toml, but a one-shot `toml::from_str` is the cleanest
+# fit for an embedded vendor manifest.
+toml = "0.8"
 toml_edit = "0.25.11"
+# Issue #447: pure-Rust zip extraction for the vendored Git Bash bundle.
+# `deflate` is the only compression method present in git-bash-bin.zip;
+# disabling default features avoids pulling bzip2/zstd C deps.
+zip = { version = "2", default-features = false, features = ["deflate"] }
 vt100 = "0.16"
 vte = "0.15"
 wasmi = "0.40.0"

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -36,6 +36,7 @@ pub mod runtime_cache;
 pub mod session;
 pub mod session_index;
 pub mod session_registry;
+pub mod shell;
 pub mod shim_install;
 pub mod shim_resolve;
 pub mod shim_session;

--- a/crates/clud-bin/src/shell/git_bash_resolver.rs
+++ b/crates/clud-bin/src/shell/git_bash_resolver.rs
@@ -1,0 +1,451 @@
+//! Lazily fetch a pinned portable Git Bash bundle so callers can hand
+//! `CLAUDE_CODE_GIT_BASH_PATH` to Claude Code without depending on a
+//! system-wide Git for Windows install.
+//!
+//! Refs https://github.com/zackees/clud/issues/447.
+//!
+//! ## Layout
+//!
+//! Manifest: `crates/clud-bin/vendor/win32/git-bash-bin.toml`. The file is
+//! hand-edited and parsed at runtime — embed it with `include_str!` so the
+//! resolver works regardless of where the binary is launched from.
+//!
+//! Cache: `~/.clud/vendor/win32/git-bash-bin-<sha256[..12]>/` plus a sibling
+//! `git-bash-bin-<sha256[..12]>.complete` sentinel that is only written after
+//! the archive's bytes verify against the pinned sha256 and the zip extracts
+//! cleanly. A partial extraction is never reused — the sentinel's presence is
+//! the only "ready" signal.
+//!
+//! ## Failure modes
+//!
+//! - Offline / GitHub down: [`FetchError::Network`]. Callers should suggest
+//!   the user set `CLAUDE_CODE_GIT_BASH_PATH` to a Git Bash already on disk.
+//! - sha256 mismatch: [`FetchError::ChecksumMismatch`]. Surfaces both the
+//!   expected and observed digest so the manifest can be bumped deliberately.
+//! - Anti-virus quarantine of extracted DLLs: surfaced as
+//!   [`FetchError::Io`]; the `clud-windows-trash` skill quarantine + retry
+//!   pattern is the documented remediation.
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+/// Manifest TOML embedded at compile time. See module docs.
+pub const EMBEDDED_MANIFEST_TOML: &str = include_str!("../../vendor/win32/git-bash-bin.toml");
+
+/// Parsed shape of `crates/clud-bin/vendor/win32/git-bash-bin.toml`.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GitBashManifest {
+    pub git_bash_bin: GitBashEntry,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GitBashEntry {
+    pub url: String,
+    pub size_bytes: u64,
+    pub sha256: String,
+    pub upstream_repo: String,
+    pub upstream_commit_sha: String,
+    pub relative_bash_path: String,
+}
+
+/// Default manifest, parsed once from the embedded TOML.
+pub fn embedded_manifest() -> Result<GitBashManifest, FetchError> {
+    toml::from_str(EMBEDDED_MANIFEST_TOML).map_err(|error| FetchError::Manifest {
+        message: format!("embedded git-bash-bin.toml malformed: {error}"),
+    })
+}
+
+/// Vendor cache root under the user home: `<home>/.clud/vendor/win32/`.
+pub fn vendor_cache_dir(home: &Path) -> PathBuf {
+    home.join(".clud").join("vendor").join("win32")
+}
+
+/// Per-archive extraction root: `<vendor>/git-bash-bin-<sha[..12]>/`.
+pub fn extraction_dir(home: &Path, sha256_hex: &str) -> PathBuf {
+    let suffix = sha256_hex.get(..12).unwrap_or(sha256_hex);
+    vendor_cache_dir(home).join(format!("git-bash-bin-{suffix}"))
+}
+
+/// Sibling sentinel file: presence means the extraction completed and
+/// verified. A partial extraction never has it.
+pub fn sentinel_path(home: &Path, sha256_hex: &str) -> PathBuf {
+    let suffix = sha256_hex.get(..12).unwrap_or(sha256_hex);
+    vendor_cache_dir(home).join(format!("git-bash-bin-{suffix}.complete"))
+}
+
+/// Absolute path the resolver returns once the bundle is ready.
+pub fn bash_exe_path(home: &Path, manifest: &GitBashManifest) -> PathBuf {
+    extraction_dir(home, &manifest.git_bash_bin.sha256)
+        .join(&manifest.git_bash_bin.relative_bash_path)
+}
+
+/// Fetch + verify + extract, returning the resolved `bash.exe` path. No-ops
+/// after the first successful run because the sentinel short-circuits.
+pub fn resolve_or_fetch_git_bash(home: &Path) -> Result<PathBuf, FetchError> {
+    let manifest = embedded_manifest()?;
+    resolve_or_fetch_with(home, &manifest, &UreqFetcher)
+}
+
+/// Test-friendly variant: caller supplies the manifest and the fetcher so
+/// integration tests can drive the resolver against a local fixture without
+/// touching the network.
+pub fn resolve_or_fetch_with(
+    home: &Path,
+    manifest: &GitBashManifest,
+    fetcher: &dyn ArchiveFetcher,
+) -> Result<PathBuf, FetchError> {
+    let entry = &manifest.git_bash_bin;
+    let sentinel = sentinel_path(home, &entry.sha256);
+    if sentinel.exists() {
+        return Ok(bash_exe_path(home, manifest));
+    }
+
+    fs::create_dir_all(vendor_cache_dir(home))?;
+
+    let archive_bytes = fetcher.fetch(&entry.url)?;
+    if archive_bytes.len() as u64 != entry.size_bytes {
+        return Err(FetchError::SizeMismatch {
+            expected: entry.size_bytes,
+            observed: archive_bytes.len() as u64,
+        });
+    }
+
+    let observed_hex = sha256_hex(&archive_bytes);
+    if !observed_hex.eq_ignore_ascii_case(&entry.sha256) {
+        return Err(FetchError::ChecksumMismatch {
+            expected: entry.sha256.clone(),
+            observed: observed_hex,
+        });
+    }
+
+    let dest = extraction_dir(home, &entry.sha256);
+    // Best-effort cleanup of a previous partial extraction. Ignore errors —
+    // if the path doesn't exist this is a no-op, and if the OS refuses we
+    // fall through to extract_zip which will surface its own error.
+    let _ = fs::remove_dir_all(&dest);
+    fs::create_dir_all(&dest)?;
+    extract_zip(&archive_bytes, &dest)?;
+
+    let resolved = dest.join(&entry.relative_bash_path);
+    if !resolved.exists() {
+        return Err(FetchError::EntryPointMissing {
+            relative: entry.relative_bash_path.clone(),
+            extraction_root: dest,
+        });
+    }
+
+    // Write the sentinel last. Anything earlier and a crash would leave a
+    // half-extracted dir advertised as ready.
+    fs::write(&sentinel, observed_hex.as_bytes())?;
+    Ok(resolved)
+}
+
+/// Abstraction over the network fetch so tests can substitute a fixture.
+pub trait ArchiveFetcher {
+    fn fetch(&self, url: &str) -> Result<Vec<u8>, FetchError>;
+}
+
+/// Default fetcher backed by `ureq`. Times out at 60 s — the bundle is ~9 MB.
+pub struct UreqFetcher;
+
+impl ArchiveFetcher for UreqFetcher {
+    fn fetch(&self, url: &str) -> Result<Vec<u8>, FetchError> {
+        let agent = ureq::AgentBuilder::new()
+            .timeout_connect(std::time::Duration::from_secs(15))
+            .timeout(std::time::Duration::from_secs(60))
+            .build();
+        let response = agent.get(url).call().map_err(|error| FetchError::Network {
+            url: url.to_string(),
+            message: error.to_string(),
+        })?;
+        let mut buf = Vec::new();
+        response
+            .into_reader()
+            .take(64 * 1024 * 1024)
+            .read_to_end(&mut buf)
+            .map_err(FetchError::Io)?;
+        Ok(buf)
+    }
+}
+
+#[derive(Debug)]
+pub enum FetchError {
+    Manifest {
+        message: String,
+    },
+    Network {
+        url: String,
+        message: String,
+    },
+    Io(io::Error),
+    Zip(String),
+    SizeMismatch {
+        expected: u64,
+        observed: u64,
+    },
+    ChecksumMismatch {
+        expected: String,
+        observed: String,
+    },
+    EntryPointMissing {
+        relative: String,
+        extraction_root: PathBuf,
+    },
+}
+
+impl std::fmt::Display for FetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FetchError::Manifest { message } => write!(f, "{message}"),
+            FetchError::Network { url, message } => {
+                write!(f, "fetch {url}: {message}")
+            }
+            FetchError::Io(error) => write!(f, "{error}"),
+            FetchError::Zip(message) => write!(f, "zip: {message}"),
+            FetchError::SizeMismatch { expected, observed } => write!(
+                f,
+                "git-bash-bin.zip size mismatch: expected {expected} bytes, observed {observed}"
+            ),
+            FetchError::ChecksumMismatch { expected, observed } => write!(
+                f,
+                "git-bash-bin.zip sha256 mismatch: expected {expected}, observed {observed}"
+            ),
+            FetchError::EntryPointMissing {
+                relative,
+                extraction_root,
+            } => write!(
+                f,
+                "extracted git-bash-bin.zip is missing {relative} (looked under {})",
+                extraction_root.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FetchError {}
+
+impl From<io::Error> for FetchError {
+    fn from(error: io::Error) -> Self {
+        FetchError::Io(error)
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_encode(&hasher.finalize())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn extract_zip(bytes: &[u8], dest: &Path) -> Result<(), FetchError> {
+    let reader = io::Cursor::new(bytes);
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|error| FetchError::Zip(error.to_string()))?;
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| FetchError::Zip(error.to_string()))?;
+        let raw_name = match entry.enclosed_name() {
+            Some(name) => name.to_path_buf(),
+            None => {
+                return Err(FetchError::Zip(format!(
+                    "rejected zip entry with unsafe path: {}",
+                    entry.name()
+                )));
+            }
+        };
+        let target = dest.join(&raw_name);
+        if entry.is_dir() {
+            fs::create_dir_all(&target)?;
+            continue;
+        }
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut out = fs::File::create(&target)?;
+        io::copy(&mut entry, &mut out)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use tempfile::tempdir;
+
+    /// Synthetic in-memory fetcher that hands back fixed bytes. Lets tests
+    /// drive the resolver without touching the network.
+    struct StaticFetcher {
+        bytes: Vec<u8>,
+    }
+
+    impl ArchiveFetcher for StaticFetcher {
+        fn fetch(&self, _url: &str) -> Result<Vec<u8>, FetchError> {
+            Ok(self.bytes.clone())
+        }
+    }
+
+    fn build_fixture_zip() -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut writer = zip::ZipWriter::new(io::Cursor::new(&mut buf));
+            let options: zip::write::FileOptions<()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            writer.start_file("git-bash-bin/bash.exe", options).unwrap();
+            writer.write_all(b"#!/fake/bash shim").unwrap();
+            writer
+                .start_file("git-bash-bin/msys-2.0.dll", options)
+                .unwrap();
+            writer.write_all(b"\x4dZ fake dll").unwrap();
+            writer.finish().unwrap();
+        }
+        buf
+    }
+
+    fn fixture_manifest(bytes: &[u8]) -> GitBashManifest {
+        GitBashManifest {
+            git_bash_bin: GitBashEntry {
+                url: "https://example.invalid/git-bash-bin.zip".to_string(),
+                size_bytes: bytes.len() as u64,
+                sha256: sha256_hex(bytes),
+                upstream_repo: "test/fixture".to_string(),
+                upstream_commit_sha: "fixture-commit".to_string(),
+                relative_bash_path: "git-bash-bin/bash.exe".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn embedded_manifest_parses() {
+        let manifest = embedded_manifest().expect("embedded manifest must parse");
+        assert_eq!(manifest.git_bash_bin.size_bytes, 9_384_477);
+        assert_eq!(
+            manifest.git_bash_bin.relative_bash_path,
+            "git-bash-bin/bash.exe"
+        );
+        assert_eq!(manifest.git_bash_bin.sha256.len(), 64, "sha256 hex length");
+    }
+
+    #[test]
+    fn extraction_dir_uses_short_sha_suffix() {
+        let home = tempdir().unwrap();
+        let dir = extraction_dir(home.path(), "1234567890abcdef1234567890abcdef");
+        let last = dir.file_name().unwrap().to_string_lossy().into_owned();
+        assert_eq!(last, "git-bash-bin-1234567890ab");
+    }
+
+    #[test]
+    fn fetch_extracts_and_writes_sentinel_when_checksum_matches() {
+        let bytes = build_fixture_zip();
+        let manifest = fixture_manifest(&bytes);
+        let home = tempdir().unwrap();
+        let fetcher = StaticFetcher {
+            bytes: bytes.clone(),
+        };
+
+        let resolved =
+            resolve_or_fetch_with(home.path(), &manifest, &fetcher).expect("fetch must succeed");
+        assert!(resolved.exists(), "bash.exe must exist at: {resolved:?}");
+        assert!(
+            sentinel_path(home.path(), &manifest.git_bash_bin.sha256).exists(),
+            "sentinel must be written after successful extract"
+        );
+        assert_eq!(resolved, bash_exe_path(home.path(), &manifest));
+    }
+
+    #[test]
+    fn fetch_short_circuits_when_sentinel_exists() {
+        let bytes = build_fixture_zip();
+        let manifest = fixture_manifest(&bytes);
+        let home = tempdir().unwrap();
+        let fetcher = StaticFetcher { bytes };
+
+        // First call extracts.
+        resolve_or_fetch_with(home.path(), &manifest, &fetcher).unwrap();
+
+        // Subsequent call must not need to extract again. Swap in a fetcher
+        // that would fail if it were consulted.
+        struct PanickyFetcher;
+        impl ArchiveFetcher for PanickyFetcher {
+            fn fetch(&self, _url: &str) -> Result<Vec<u8>, FetchError> {
+                panic!("fetcher must not be consulted after sentinel exists");
+            }
+        }
+        let resolved = resolve_or_fetch_with(home.path(), &manifest, &PanickyFetcher)
+            .expect("warm path must not consult fetcher");
+        assert_eq!(resolved, bash_exe_path(home.path(), &manifest));
+    }
+
+    #[test]
+    fn checksum_mismatch_is_a_hard_error_and_leaves_no_sentinel() {
+        let bytes = build_fixture_zip();
+        let mut manifest = fixture_manifest(&bytes);
+        // Flip a nibble in the expected hash.
+        let mut bad = manifest.git_bash_bin.sha256.clone();
+        bad.replace_range(0..1, "0");
+        manifest.git_bash_bin.sha256 = bad;
+        let home = tempdir().unwrap();
+        let fetcher = StaticFetcher { bytes };
+
+        let err = resolve_or_fetch_with(home.path(), &manifest, &fetcher)
+            .expect_err("checksum mismatch must fail");
+        match err {
+            FetchError::ChecksumMismatch { .. } => {}
+            other => panic!("expected ChecksumMismatch, got {other:?}"),
+        }
+        assert!(
+            !sentinel_path(home.path(), &manifest.git_bash_bin.sha256).exists(),
+            "sentinel must not be written when checksum fails"
+        );
+    }
+
+    #[test]
+    fn size_mismatch_is_caught_before_checksum() {
+        let bytes = build_fixture_zip();
+        let mut manifest = fixture_manifest(&bytes);
+        manifest.git_bash_bin.size_bytes += 1; // claim a different size
+        let home = tempdir().unwrap();
+        let fetcher = StaticFetcher { bytes };
+
+        let err = resolve_or_fetch_with(home.path(), &manifest, &fetcher)
+            .expect_err("size mismatch must fail");
+        match err {
+            FetchError::SizeMismatch { .. } => {}
+            other => panic!("expected SizeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_entry_point_inside_zip_is_reported() {
+        let bytes = build_fixture_zip();
+        let mut manifest = fixture_manifest(&bytes);
+        manifest.git_bash_bin.relative_bash_path = "git-bash-bin/not-there.exe".to_string();
+        let home = tempdir().unwrap();
+        let fetcher = StaticFetcher { bytes };
+
+        let err = resolve_or_fetch_with(home.path(), &manifest, &fetcher)
+            .expect_err("missing entry point must fail");
+        match err {
+            FetchError::EntryPointMissing { relative, .. } => {
+                assert_eq!(relative, "git-bash-bin/not-there.exe");
+            }
+            other => panic!("expected EntryPointMissing, got {other:?}"),
+        }
+        assert!(
+            !sentinel_path(home.path(), &manifest.git_bash_bin.sha256).exists(),
+            "sentinel must not be written when entry point is missing"
+        );
+    }
+}

--- a/crates/clud-bin/src/shell/mod.rs
+++ b/crates/clud-bin/src/shell/mod.rs
@@ -1,0 +1,12 @@
+//! Backend-shell selection plumbing for issue #447 (disable PowerShell on Windows).
+//!
+//! Currently exposes the [`git_bash_resolver`] sub-module which lazily fetches a
+//! pinned, portable Git Bash bundle so callers can point a child process at a
+//! known-good `bash.exe` without depending on the user's PATH containing
+//! "C:\\Program Files\\Git\\usr\\bin".
+//!
+//! The runner-side wiring that consumes the resolver (sets
+//! `CLAUDE_CODE_GIT_BASH_PATH` + `CLAUDE_CODE_USE_POWERSHELL_TOOL=0`) lands in
+//! a follow-up PR; this module is the storage layer.
+
+pub mod git_bash_resolver;

--- a/crates/clud-bin/vendor/win32/git-bash-bin.toml
+++ b/crates/clud-bin/vendor/win32/git-bash-bin.toml
@@ -1,0 +1,26 @@
+# Lazy-fetched portable Git Bash bundle. Resolved at runtime when
+# shell.disable_powershell=true and Claude is the active backend so
+# CLAUDE_CODE_GIT_BASH_PATH can point at a known-good bash.exe without
+# requiring a system-wide Git for Windows install.
+#
+# Refs https://github.com/zackees/clud/issues/447.
+
+[git_bash_bin]
+url = "https://github.com/zackees/zcmds_win32/raw/main/assets/git-bash-bin.zip"
+size_bytes = 9384477
+
+# sha256 of the .zip body. Compute with `sha256sum git-bash-bin.zip` or
+# `curl -sL <url> | sha256sum`. Bumping this requires bumping
+# upstream_commit_sha in lockstep.
+sha256 = "24321f20a5e02c16d09b42facfaf10cf38a1167bcf4c5116d0c3a31bb6191ba6"
+
+# Upstream pin so a force-push to zcmds_win32 main can't change the bytes
+# we resolve. The runtime fetch URL stays the raw.githubusercontent.com
+# `main` path (302 from github.com/.../raw/...), since raw.githubusercontent
+# blob fetches are content-addressable enough for the sha256 to catch any
+# drift — the pin here is documentation for whoever bumps the manifest.
+upstream_repo = "zackees/zcmds_win32"
+upstream_commit_sha = "f5eab1dc23b807bdc202d08fe19b2ff1b89308b9"
+
+# Path of the entry-point binary inside the extracted zip tree.
+relative_bash_path = "git-bash-bin/bash.exe"


### PR DESCRIPTION
## Summary

PR 2 of ~3 for #447. Lands a lazy, sha256-verified, sentinel-gated fetch+extract of a pinned portable Git Bash bundle so callers (PR 3) can hand `CLAUDE_CODE_GIT_BASH_PATH` to Claude Code without depending on a system-wide Git for Windows install.

**Storage layer only — no caller yet.** PR 3 wires `runner.rs` to consume the resolver when `shell.disable_powershell` resolves true for Claude.

Stacks on top of #456 (PR 1) — both PRs touch disjoint files (PR 1: `clud_settings.rs`; PR 2: `Cargo.toml`/`Cargo.lock`/`src/lib.rs`/new `src/shell/`/new `vendor/win32/`), so they can land in either order.

## Source archive

`zackees/zcmds_win32` already ships `assets/git-bash-bin.zip` — a 9.4 MB self-contained `git-bash-bin/` directory with `bash.exe` + dependent msys2 DLLs + coreutils, extracted from a working Git for Windows install. Its [`zcmds_win32/unix_tool_path.py::install()`](https://github.com/zackees/zcmds_win32/blob/main/zcmds_win32/unix_tool_path.py) is the reference pattern for this layout.

| Field | Value |
|---|---|
| URL | `https://github.com/zackees/zcmds_win32/raw/main/assets/git-bash-bin.zip` |
| Size | 9,384,477 bytes |
| sha256 | `24321f20a5e02c16d09b42facfaf10cf38a1167bcf4c5116d0c3a31bb6191ba6` |
| Upstream commit pin | `f5eab1dc23b807bdc202d08fe19b2ff1b89308b9` |

## Cache layout

```
~/.clud/vendor/win32/
├── git-bash-bin-24321f20a5e0/           ← extracted bundle
│   └── git-bash-bin/
│       ├── bash.exe                     ← CLAUDE_CODE_GIT_BASH_PATH (PR 3)
│       ├── msys-2.0.dll
│       └── ...
└── git-bash-bin-24321f20a5e0.complete   ← sentinel, written LAST
```

The `.complete` sentinel is written only after the bytes verify and the zip extracts cleanly. A partial extraction is never advertised as ready — its absence forces re-fetch.

## Public API

```rust
pub fn resolve_or_fetch_git_bash(home: &Path) -> Result<PathBuf, FetchError>;

// Test seam — caller supplies the manifest and the fetcher
pub fn resolve_or_fetch_with(
    home: &Path,
    manifest: &GitBashManifest,
    fetcher: &dyn ArchiveFetcher,
) -> Result<PathBuf, FetchError>;

pub trait ArchiveFetcher { fn fetch(&self, url: &str) -> Result<Vec<u8>, FetchError>; }
pub struct UreqFetcher;              // production
pub struct GitBashManifest { ... }   // parsed manifest
```

## Failure modes (explicit so PR 3 can surface actionable text)

- `FetchError::Network { url, message }` — offline / GitHub down
- `FetchError::Io(io::Error)` — disk / AV quarantine
- `FetchError::Zip(String)` — corrupt archive or unsafe entry path
- `FetchError::SizeMismatch { expected, observed }`
- `FetchError::ChecksumMismatch { expected, observed }`
- `FetchError::EntryPointMissing { relative, extraction_root }`
- `FetchError::Manifest { message }`

## New dependencies

| Crate | Purpose | Why this one |
|---|---|---|
| `toml = "0.8"` | Parse the embedded manifest | Plain serde deserializer. The existing `toml_edit` is for round-trip editing; `toml::from_str` is the cleanest fit for a read-only manifest. |
| `zip = "2"` with `default-features = false, features = ["deflate"]` | Pure-Rust archive extraction | Bundle uses deflate only. Skipping defaults avoids the bzip2/zstd C deps. |

## Tests

Seven unit tests inside the module (`shell::git_bash_resolver::tests`):

- `embedded_manifest_parses`
- `extraction_dir_uses_short_sha_suffix`
- `fetch_extracts_and_writes_sentinel_when_checksum_matches`
- `fetch_short_circuits_when_sentinel_exists` (uses a `PanickyFetcher` to prove the warm path doesn't re-fetch)
- `checksum_mismatch_is_a_hard_error_and_leaves_no_sentinel`
- `size_mismatch_is_caught_before_checksum`
- `missing_entry_point_inside_zip_is_reported`

The fixture zip is built in-process via the `zip` crate's writer, so the suite is network-free and runs in <100ms.

## Out of scope (PR 3)

- `runner.rs` env injection: `CLAUDE_CODE_GIT_BASH_PATH = resolve_or_fetch_git_bash(home)?`, `CLAUDE_CODE_USE_POWERSHELL_TOOL=0`, `CLUD_DISABLE_POWERSHELL=1`
- Layer 2 PreToolUse hooks (Claude via `hook_health/repairs.rs`, Codex via `codex_hook_normalize.rs`)
- Bundled `clud tool shell/forbid_powershell.py`
- Doctor visibility + README + CHANGELOG

## Test plan

- [x] `cargo build --lib` clean on x86_64-pc-windows-msvc
- [x] `cargo test --lib shell::git_bash_resolver::` → 7/7 pass
- [x] `cargo clippy --lib --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] No network access in tests (verified via PanickyFetcher in `fetch_short_circuits_when_sentinel_exists`)

Refs #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
