### PR TITLE
feat(runner): wire shell.disable_powershell into backend env (closes #447, PR 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- New `shell.disable_powershell` toggle in `~/.clud/settings.json` (default
+  `false`, per-backend overrides under `shell.claude` / `shell.codex`). When
+  enabled for the active backend, clud now injects `CLUD_DISABLE_POWERSHELL=1`
+  into the child env so skills can branch on it. For Claude specifically,
+  clud also injects `CLAUDE_CODE_USE_POWERSHELL_TOOL=0` and points
+  `CLAUDE_CODE_GIT_BASH_PATH` at a lazily-fetched portable Git Bash bundle
+  vendored from `zackees/zcmds_win32` (~9 MB, sha256-pinned, cached at
+  `~/.clud/vendor/win32/git-bash-bin-<sha[..12]>/`). Driven by FastLED #3336:
+  Claude on Windows defaults to PowerShell, which silently breaks
+  bash-native tooling (DTR/RTS-less serial, `&&` parser error, `.py`
+  file-association semantics). See zackees/clud#447.
+
 ## 2.0.19 - 2026-06-07
 
 - `/clud-pr` and other bundled skills now install under `~/.codex/skills/`

--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -40,7 +40,18 @@ Entry and orchestration:
   `mod ...`.
 - `runner.rs` - per-iteration subprocess- and PTY-mode runner for a single
   `LaunchPlan`; owns child-env construction, stream-json fallback,
-  Ctrl-C-aware teardown, and OLE drag-drop registration wiring.
+  Ctrl-C-aware teardown, and OLE drag-drop registration wiring. The
+  backend-aware `child_env_for_backend` reads
+  `~/.clud/settings.json::shell.disable_powershell` and, for Claude, injects
+  the two undocumented kill-switch env vars `CLAUDE_CODE_USE_POWERSHELL_TOOL=0`
+  + `CLAUDE_CODE_GIT_BASH_PATH` (resolved via
+  [`shell/`](shell/README.md)) — see issue #447.
+- `shell/` - shell-policy plumbing: lazy fetch of a vendored portable Git
+  Bash bundle (`shell/git_bash_resolver.rs`) so callers can hand
+  `CLAUDE_CODE_GIT_BASH_PATH` to Claude Code without depending on a
+  system-wide Git for Windows install. Manifest at
+  `vendor/win32/git-bash-bin.toml`; cache at
+  `~/.clud/vendor/win32/git-bash-bin-<sha[..12]>/`.
 - `startup.rs` - launch-time helpers factored out of `main.rs`: drag-target
   gating (`--no-dnd`, `--dry-run`), session-cap enforcement, Ctrl+C flag
   installer.

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -6,8 +6,11 @@
 //! the OLE drag-drop registration.
 
 use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::backend::Backend;
+use crate::clud_settings;
 use crate::command;
 use crate::console_setup::enable_console_vt_input;
 use crate::loop_artifacts;
@@ -93,6 +96,97 @@ pub fn child_env() -> Vec<(String, String)> {
     env
 }
 
+/// Wrap [`child_env`] with the per-backend shell policy from
+/// `~/.clud/settings.json`. When `shell.disable_powershell` resolves true for
+/// `backend` (issue #447):
+///
+/// - Both backends get `CLUD_DISABLE_POWERSHELL=1` so skills / CLAUDE.md
+///   content can branch on it.
+/// - Claude additionally gets `CLAUDE_CODE_USE_POWERSHELL_TOOL=0` (the
+///   undocumented env-var kill-switch extracted from the bundled binary's
+///   error strings) plus `CLAUDE_CODE_GIT_BASH_PATH` pointing at the lazily
+///   resolved vendored Git Bash (see [`crate::shell::git_bash_resolver`]).
+///   The PowerShell-tool toggle is set even if the resolver fails so Claude
+///   surfaces a hard error instead of silently falling back to PowerShell.
+/// - Codex has no equivalent env-var override (openai/codex#16717 is
+///   closed). The Codex side ships as a PreToolUse hook in a follow-up PR;
+///   here we just hand it `CLUD_DISABLE_POWERSHELL=1` for advisory use.
+///
+/// `Backend::Claude` is the case that actually changes behavior today.
+pub fn child_env_for_backend(backend: Backend) -> Vec<(String, String)> {
+    let home = clud_home_dir();
+    child_env_for_backend_at(backend, home.as_deref())
+}
+
+/// Test seam — accepts the home dir explicitly so the policy can be exercised
+/// against a temp directory without mutating the real `~/.clud/settings.json`.
+pub fn child_env_for_backend_at(backend: Backend, home: Option<&Path>) -> Vec<(String, String)> {
+    let mut env = child_env();
+    let Some(home) = home else {
+        return env;
+    };
+
+    let disable = match clud_settings::load_shell_disable_powershell_for_backend_at(home, backend) {
+        Ok(value) => value,
+        Err(_) => return env,
+    };
+    if !disable {
+        return env;
+    }
+
+    push_or_replace(&mut env, "CLUD_DISABLE_POWERSHELL", "1");
+
+    if !matches!(backend, Backend::Claude) {
+        return env;
+    }
+
+    // The PowerShell-tool toggle is set unconditionally — if the resolver
+    // below fails, Claude will hard-fail visibly with "Git Bash was not
+    // found and the PowerShell tool is disabled" rather than silently
+    // resurrecting PowerShell.
+    push_or_replace(&mut env, "CLAUDE_CODE_USE_POWERSHELL_TOOL", "0");
+
+    match crate::shell::git_bash_resolver::resolve_or_fetch_git_bash(home) {
+        Ok(path) => {
+            push_or_replace(
+                &mut env,
+                "CLAUDE_CODE_GIT_BASH_PATH",
+                &path.to_string_lossy(),
+            );
+        }
+        Err(error) => {
+            eprintln!(
+                "[clud] shell.disable_powershell=true but vendored bash fetch failed: {error}. \
+                 Set CLAUDE_CODE_GIT_BASH_PATH to a bash.exe already on disk to recover."
+            );
+        }
+    }
+
+    env
+}
+
+fn push_or_replace(env: &mut Vec<(String, String)>, key: &str, value: &str) {
+    env.retain(|(k, _)| k != key);
+    env.push((key.to_string(), value.to_string()));
+}
+
+fn clud_home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        if let Some(path) = std::env::var_os("USERPROFILE") {
+            if !path.is_empty() {
+                return Some(PathBuf::from(path));
+            }
+        }
+    }
+    if let Some(path) = std::env::var_os("HOME") {
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
+        }
+    }
+    None
+}
+
 pub fn get_terminal_size() -> (u16, u16) {
     let probe = terminal_size::terminal_size().map(|(w, h)| (w.0, h.0));
     resolve_terminal_size(probe)
@@ -170,7 +264,7 @@ pub fn run_plan_subprocess(
 
     use running_process::{NativeProcess, ProcessConfig, StderrMode, StdinMode};
 
-    let env = child_env();
+    let env = child_env_for_backend(plan.backend);
     let mut last_exit = 0i32;
 
     for iteration in 0..plan.iterations {
@@ -551,7 +645,7 @@ pub fn run_plan_pty(
         Option<()>,
     ) = (None, None);
 
-    let env = child_env();
+    let env = child_env_for_backend(plan.backend);
     let mut last_exit = 0i32;
     let terminal_capabilities = (plan.graphics.mode != crate::graphics::GraphicsMode::Off)
         .then(crate::graphics::detect_current_terminal);
@@ -823,5 +917,114 @@ mod tests {
         );
         let pyio_count = env.iter().filter(|(k, _)| k == "PYTHONIOENCODING").count();
         assert_eq!(pyio_count, 1, "PYTHONIOENCODING must appear exactly once");
+    }
+
+    fn env_lookup(env: &[(String, String)], key: &str) -> Option<String> {
+        env.iter().find(|(k, _)| k == key).map(|(_, v)| v.clone())
+    }
+
+    #[test]
+    fn child_env_for_backend_does_not_set_shell_vars_when_toggle_off() {
+        let home = tempfile::tempdir().unwrap();
+        for backend in [Backend::Claude, Backend::Codex] {
+            let env = child_env_for_backend_at(backend, Some(home.path()));
+            assert_eq!(env_lookup(&env, "CLUD_DISABLE_POWERSHELL"), None);
+            assert_eq!(env_lookup(&env, "CLAUDE_CODE_USE_POWERSHELL_TOOL"), None);
+            assert_eq!(env_lookup(&env, "CLAUDE_CODE_GIT_BASH_PATH"), None);
+        }
+    }
+
+    #[test]
+    fn child_env_for_backend_sets_clud_disable_for_both_backends_when_top_level_true() {
+        let home = tempfile::tempdir().unwrap();
+        clud_settings::save_shell_disable_powershell_at(home.path(), true).unwrap();
+
+        let codex_env = child_env_for_backend_at(Backend::Codex, Some(home.path()));
+        assert_eq!(
+            env_lookup(&codex_env, "CLUD_DISABLE_POWERSHELL").as_deref(),
+            Some("1"),
+            "Codex still gets the advisory env var so skills can branch"
+        );
+        // Codex has no env-var equivalent for the PowerShell tool itself
+        // — the load-bearing enforcement ships as a PreToolUse hook in a
+        // follow-up PR. Make sure we don't accidentally set Claude-only
+        // vars on the Codex path here.
+        assert_eq!(
+            env_lookup(&codex_env, "CLAUDE_CODE_USE_POWERSHELL_TOOL"),
+            None
+        );
+        assert_eq!(env_lookup(&codex_env, "CLAUDE_CODE_GIT_BASH_PATH"), None);
+    }
+
+    /// Pre-stage the resolver's warm-path artifacts under `home` so the
+    /// runner tests don't trigger a real 9 MB network fetch. Mirrors what
+    /// `git_bash_resolver::resolve_or_fetch_with` writes on a successful
+    /// fetch — the directory tree plus the sibling `.complete` sentinel.
+    fn warm_cache_vendored_bash(home: &Path) -> PathBuf {
+        let manifest = crate::shell::git_bash_resolver::embedded_manifest().unwrap();
+        let sha = &manifest.git_bash_bin.sha256;
+        let extraction = crate::shell::git_bash_resolver::extraction_dir(home, sha);
+        let bash_path = extraction.join(&manifest.git_bash_bin.relative_bash_path);
+        std::fs::create_dir_all(bash_path.parent().unwrap()).unwrap();
+        std::fs::write(&bash_path, b"#!/fake/bash test stub").unwrap();
+        std::fs::write(
+            crate::shell::git_bash_resolver::sentinel_path(home, sha),
+            b"warm",
+        )
+        .unwrap();
+        bash_path
+    }
+
+    #[test]
+    fn child_env_for_backend_sets_claude_kill_switch_when_claude_enabled() {
+        let home = tempfile::tempdir().unwrap();
+        clud_settings::save_shell_disable_powershell_at(home.path(), true).unwrap();
+        let expected_bash = warm_cache_vendored_bash(home.path());
+
+        let env = child_env_for_backend_at(Backend::Claude, Some(home.path()));
+        assert_eq!(
+            env_lookup(&env, "CLUD_DISABLE_POWERSHELL").as_deref(),
+            Some("1")
+        );
+        assert_eq!(
+            env_lookup(&env, "CLAUDE_CODE_USE_POWERSHELL_TOOL").as_deref(),
+            Some("0"),
+            "Claude env-var kill-switch must be set when the toggle is on"
+        );
+        assert_eq!(
+            env_lookup(&env, "CLAUDE_CODE_GIT_BASH_PATH").as_deref(),
+            Some(expected_bash.to_string_lossy().as_ref()),
+            "CLAUDE_CODE_GIT_BASH_PATH must resolve to the warm-cached bash"
+        );
+    }
+
+    #[test]
+    fn child_env_for_backend_backend_override_blocks_top_level() {
+        let home = tempfile::tempdir().unwrap();
+        clud_settings::save_shell_disable_powershell_at(home.path(), true).unwrap();
+        clud_settings::save_shell_disable_powershell_for_backend_at(
+            home.path(),
+            Backend::Claude,
+            Some(false),
+        )
+        .unwrap();
+
+        let claude_env = child_env_for_backend_at(Backend::Claude, Some(home.path()));
+        assert_eq!(
+            env_lookup(&claude_env, "CLUD_DISABLE_POWERSHELL"),
+            None,
+            "Claude override=false must short-circuit env injection"
+        );
+        assert_eq!(
+            env_lookup(&claude_env, "CLAUDE_CODE_USE_POWERSHELL_TOOL"),
+            None
+        );
+
+        let codex_env = child_env_for_backend_at(Backend::Codex, Some(home.path()));
+        assert_eq!(
+            env_lookup(&codex_env, "CLUD_DISABLE_POWERSHELL").as_deref(),
+            Some("1"),
+            "Codex with null override should still inherit top-level true"
+        );
     }
 }

--- a/crates/clud-bin/src/shell/README.md
+++ b/crates/clud-bin/src/shell/README.md
@@ -1,0 +1,49 @@
+# shell/
+
+Backend-shell selection plumbing for [issue #447](https://github.com/zackees/clud/issues/447) — the
+"disable PowerShell on Windows" toggle.
+
+## Why this module exists
+
+Both Claude Code and Codex CLI default to PowerShell on Windows. PowerShell
+silently breaks bash-native tooling:
+
+- `System.IO.Ports.SerialPort` drops bytes without explicit DTR/RTS
+  (FastLED [#3336](https://github.com/FastLED/FastLED/issues/3336)).
+- The Windows PowerShell 5.1 parser rejects `&&` / `||` chains.
+- `.py` invocations use file-association semantics rather than running
+  through `python`.
+- `2>&1` on native exes wraps stderr in `NativeCommandError` and flips `$?`.
+
+The user-facing toggle lives in `clud_settings::shell.disable_powershell`.
+The two enforcement layers live elsewhere:
+
+- **Layer 1 (Claude env-var kill-switch)** — `runner.rs::child_env_for_backend`
+  reads the toggle and, for Claude, injects `CLAUDE_CODE_USE_POWERSHELL_TOOL=0`
+  + `CLAUDE_CODE_GIT_BASH_PATH=<resolved>` into the child env. Both env vars
+  are undocumented but verified in the strings of the bundled `claude.exe`.
+- **Layer 2 (PreToolUse hooks)** — load-bearing for Codex (which has no
+  env-var equivalent — openai/codex#16717 is closed) and belt-and-suspenders
+  for Claude. Lands in a follow-up PR via `hook_health/repairs.rs` +
+  `codex_hook_normalize.rs`.
+
+## What's here
+
+- `mod.rs` — module root.
+- `git_bash_resolver.rs` — lazy fetch + sha256 verify + extract of a
+  portable Git Bash bundle sourced from `zackees/zcmds_win32` (9.4 MB,
+  pinned). Cache layout:
+  `~/.clud/vendor/win32/git-bash-bin-<sha256[..12]>/git-bash-bin/bash.exe`
+  with a sibling `.complete` sentinel written **last** so a partial
+  extraction is never advertised as ready. Public API:
+  ```rust
+  pub fn resolve_or_fetch_git_bash(home: &Path) -> Result<PathBuf, FetchError>
+  ```
+
+## Manifest location
+
+`crates/clud-bin/vendor/win32/git-bash-bin.toml`. Embedded at compile time
+via `include_str!` so the resolver works regardless of where the binary is
+launched from. Bumping the manifest means bumping both `sha256` and
+`upstream_commit_sha` in lockstep — see the file's own comments for the
+recompute command.


### PR DESCRIPTION
## Summary

PR 3 of 3 for #447. Closes the loop — the toggle schema from #456 and the vendored bash resolver from #458 are now actually consumed at backend-spawn time.

When `shell.disable_powershell` resolves true for the active backend (top-level toggle, or per-backend override under `shell.claude` / `shell.codex`), `runner.rs` now injects the matching env vars into the child process:

| Env var | Backend | Value | Effect |
|---|---|---|---|
| `CLUD_DISABLE_POWERSHELL` | both | `1` | Advisory — skills / CLAUDE.md content can branch on it |
| `CLAUDE_CODE_USE_POWERSHELL_TOOL` | Claude | `0` | **Undocumented kill-switch** — verified in the bundled `claude.exe` strings: `"Claude Code on Windows requires a shell tool. Git Bash was not found and the PowerShell tool is disabled (CLAUDE_CODE_USE_POWERSHELL_TOOL=0)…"` |
| `CLAUDE_CODE_GIT_BASH_PATH` | Claude | `<resolved>` | Points at the lazily-fetched vendored Git Bash bundle from #458. Bypasses the PATH walk that would otherwise pick the first `bash.exe` (including `C:\Windows\System32\bash.exe` — the WSL launcher — if it's first on PATH). |

The PowerShell-tool toggle is set **even if the resolver fails** so Claude hard-fails visibly with the error string above rather than silently resurrecting PowerShell.

Codex has no env-var equivalent ([openai/codex#16717](https://github.com/openai/codex/issues/16717) is closed) — its load-bearing PreToolUse hook ships in a follow-up. The `CLUD_DISABLE_POWERSHELL=1` here is advisory only.

## Public API

```rust
// New
pub fn child_env_for_backend(backend: Backend) -> Vec<(String, String)>;
pub fn child_env_for_backend_at(backend: Backend, home: Option<&Path>) -> Vec<(String, String)>;

// Kept (still consumed by the pre-existing PYTHONIOENCODING test)
pub fn child_env() -> Vec<(String, String)>;
```

Both production call sites in `runner.rs` (the subprocess runner and the PTY runner) switch from `child_env()` to `child_env_for_backend(plan.backend)`.

## Tests

Four new unit tests in `runner::tests`, all network-free (the Claude test pre-stages the resolver's warm-path artifacts under a temp HOME so it short-circuits the network fetch):

- `child_env_for_backend_does_not_set_shell_vars_when_toggle_off` — default off, no env mutation
- `child_env_for_backend_sets_clud_disable_for_both_backends_when_top_level_true` — Codex sees `CLUD_DISABLE_POWERSHELL=1` but NOT Claude-only vars
- `child_env_for_backend_sets_claude_kill_switch_when_claude_enabled` — Claude sees the full kill-switch including a resolved `CLAUDE_CODE_GIT_BASH_PATH`
- `child_env_for_backend_backend_override_blocks_top_level` — `shell.claude.disable_powershell=false` short-circuits even when top-level is true

## Docs

- `CHANGELOG.md` — Unreleased entry citing the two undocumented Claude env vars and FastLED [#3336](https://github.com/FastLED/FastLED/issues/3336) as the original driver.
- `crates/clud-bin/src/README.md` — extended `runner.rs` entry; added `shell/` entry.
- New `crates/clud-bin/src/shell/README.md` — explains the three-layer model (env vars vs. PreToolUse hook) and what's shipped vs. follow-up.

## Stack

This PR is **stacked on #458**. The diff in the GitHub UI will show #458's changes until that PR merges, at which point I'll rebase this PR onto fresh main and the diff will narrow to just this PR's content (~280 insertions across 4 files).

Order of operations:
1. ✅ #456 (schema) merged
2. ⏳ #458 (resolver) — awaiting CI
3. ⏳ This PR — will be rebased clean once #458 merges

## Out of scope (deferred)

- Layer 2 PreToolUse hooks (Claude belt-and-suspenders via `hook_health/repairs.rs`, Codex load-bearing via `codex_hook_normalize.rs`)
- Bundled `clud tool shell/forbid_powershell.py`
- Doctor visibility line (clud has no `doctor` command today — would slot into `clud daemon` status output)

These are tracked back to the original issue body and don't block the user-facing behavior, since the Claude env-var kill-switch alone delivers the promised "disable PowerShell" outcome.

## Test plan

- [x] `cargo build --lib` clean on x86_64-pc-windows-msvc
- [x] `cargo test --lib runner::tests::child_env` → 5/5 pass (including pre-existing UTF-8 test)
- [x] `cargo clippy --lib --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Resolver tests still pass (no regression from PR 2)

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
