### PR TITLE
fix(tools/block-bad-cmd): scope uv-run gate to maturin projects

### DIFF
--- a/crates/clud-bin/assets/tools/hooks/block-bad-cmd.py
+++ b/crates/clud-bin/assets/tools/hooks/block-bad-cmd.py
@@ -264,51 +264,31 @@ def _nested_shell_command(words: list[str]) -> str | None:
     return None
 
 
-def _find_pyproject(start: Path) -> Path | None:
-    """Walk up from `start` looking for the nearest `pyproject.toml`."""
-    try:
-        anchor = start.resolve()
-    except OSError:
-        return None
-    for candidate in (anchor, *anchor.parents):
-        pp = candidate / "pyproject.toml"
-        try:
-            if pp.is_file():
-                return pp
-        except OSError:
-            continue
-    return None
+def _python_rust_hybrid_root(cwd: Path | None) -> Path | None:
+    """Walk up from `cwd` looking for the nearest ancestor directory that
+    contains BOTH `pyproject.toml` and `Cargo.toml`. That coexistence is
+    the signal that `uv run`'s project auto-sync may rebuild a native
+    Rust extension (maturin, setuptools-rust, or a custom build script
+    that calls cargo) — the case the gate is trying to prevent.
 
-
-def _maturin_build_backend(cwd: Path | None) -> tuple[Path, str] | None:
-    """Return `(pyproject_path, backend_value)` when the nearest
-    `pyproject.toml` above `cwd` declares a maturin build backend. The
-    `uv run` auto-sync block is scoped to this case — other repos (hatchling,
-    setuptools, no pyproject at all) don't pay the maturin rebuild cost and
-    must not be blocked. Returns `None` when no cwd is available, no
-    pyproject is found, the file can't be parsed, or the backend isn't
-    maturin.
+    Returns the directory path when found, else `None`. A repo with
+    only one of the two files (pure Python, pure Rust) is not a hybrid
+    and never triggers the block.
     """
     if cwd is None:
         return None
     try:
-        import tomllib
-    except ImportError:
+        anchor = cwd.resolve()
+    except OSError:
         return None
-    pp = _find_pyproject(cwd)
-    if pp is None:
-        return None
-    try:
-        with pp.open("rb") as fh:
-            data = tomllib.load(fh)
-    except (OSError, tomllib.TOMLDecodeError):
-        return None
-    build_system = data.get("build-system")
-    if not isinstance(build_system, dict):
-        return None
-    backend = build_system.get("build-backend")
-    if isinstance(backend, str) and "maturin" in backend.lower():
-        return pp, backend
+    for candidate in (anchor, *anchor.parents):
+        try:
+            has_py = (candidate / "pyproject.toml").is_file()
+            has_rs = (candidate / "Cargo.toml").is_file()
+        except OSError:
+            continue
+        if has_py and has_rs:
+            return candidate
     return None
 
 
@@ -359,39 +339,38 @@ def _forbidden_reason(command_text: str, cwd: Path | None = None) -> str | None:
 
             # Require an opt-out for the project auto-sync. Without one of
             # --no-project / --no-sync / --frozen, `uv run` reinstalls the
-            # project into the venv on every invocation. On maturin-backed
-            # repos that is a full Rust+PyO3 rebuild (~10s+ per call) for
-            # operations that don't need the native extension at all
-            # (lint, version-check, doc generation, etc.). The escape hatch
-            # for the legitimate full-rebuild case is `./test` — see
-            # zackees/soldr#805.
+            # project into the venv on every invocation. In a Python+Rust
+            # hybrid (a pyproject.toml + Cargo.toml in the same project
+            # root) that auto-sync can trigger a full native rebuild
+            # (maturin, setuptools-rust, or a build script that shells
+            # out to cargo) — minutes of compile for operations that
+            # don't need the native extension at all (lint, version-check,
+            # doc generation, etc.). The escape hatch for the legitimate
+            # full-rebuild case is `./test` — see zackees/soldr#805.
             #
-            # Scoping: only enforce this in projects whose `pyproject.toml`
-            # actually declares a maturin build backend. Other repos pay no
-            # rebuild cost on `uv run` and the block was a false positive
-            # there (e.g. FastLED uses hatchling — `uv run` is fast and
-            # blocking it was just noise).
+            # Scoping: file-based heuristic instead of parsing pyproject
+            # build-backend. Pure-Python repos (FastLED uses hatchling)
+            # have no Cargo.toml at all, so they fall through.
             uv_safe_flags = {"--no-project", "--no-sync", "--frozen"}
             has_uv_safe_flag = any(
                 w in uv_safe_flags or any(w.startswith(f + "=") for f in uv_safe_flags)
                 for w in words[2:]
             )
             if not has_uv_safe_flag:
-                maturin = _maturin_build_backend(cwd)
-                if maturin is not None:
-                    pp_path, backend = maturin
+                hybrid_root = _python_rust_hybrid_root(cwd)
+                if hybrid_root is not None:
                     return (
-                        f"this hook fired because {pp_path} declares "
-                        f"build-backend = {backend!r}. `uv run` without "
-                        "--no-project / --no-sync / --frozen triggers the "
-                        "project auto-sync, which on a maturin-backed repo "
-                        "is a full Rust+PyO3 rebuild. Pass `--no-project` "
-                        "for pure-Python scripts, `--no-sync` to use the "
-                        "existing venv, or `--frozen` to lock to the "
-                        "existing lockfile. Escape hatch for a legitimate "
-                        "full-rebuild: run `./test` (or `bash ./test`) — "
-                        "the canonical full-build entrypoint. See "
-                        "zackees/soldr#805."
+                        f"this hook fired because {hybrid_root} contains "
+                        "both pyproject.toml and Cargo.toml (a Python+Rust "
+                        "hybrid project). `uv run` without --no-project / "
+                        "--no-sync / --frozen triggers the project "
+                        "auto-sync, which on a Rust-backed wheel is a full "
+                        "native rebuild. Pass `--no-project` for pure-Python "
+                        "scripts, `--no-sync` to use the existing venv, or "
+                        "`--frozen` to lock to the existing lockfile. "
+                        "Escape hatch for a legitimate full-rebuild: run "
+                        "`./test` (or `bash ./test`) — the canonical "
+                        "full-build entrypoint. See zackees/soldr#805."
                     )
             continue
 

--- a/crates/clud-bin/assets/tools/hooks/block-bad-cmd.py
+++ b/crates/clud-bin/assets/tools/hooks/block-bad-cmd.py
@@ -264,7 +264,55 @@ def _nested_shell_command(words: list[str]) -> str | None:
     return None
 
 
-def _forbidden_reason(command_text: str) -> str | None:
+def _find_pyproject(start: Path) -> Path | None:
+    """Walk up from `start` looking for the nearest `pyproject.toml`."""
+    try:
+        anchor = start.resolve()
+    except OSError:
+        return None
+    for candidate in (anchor, *anchor.parents):
+        pp = candidate / "pyproject.toml"
+        try:
+            if pp.is_file():
+                return pp
+        except OSError:
+            continue
+    return None
+
+
+def _maturin_build_backend(cwd: Path | None) -> tuple[Path, str] | None:
+    """Return `(pyproject_path, backend_value)` when the nearest
+    `pyproject.toml` above `cwd` declares a maturin build backend. The
+    `uv run` auto-sync block is scoped to this case — other repos (hatchling,
+    setuptools, no pyproject at all) don't pay the maturin rebuild cost and
+    must not be blocked. Returns `None` when no cwd is available, no
+    pyproject is found, the file can't be parsed, or the backend isn't
+    maturin.
+    """
+    if cwd is None:
+        return None
+    try:
+        import tomllib
+    except ImportError:
+        return None
+    pp = _find_pyproject(cwd)
+    if pp is None:
+        return None
+    try:
+        with pp.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    build_system = data.get("build-system")
+    if not isinstance(build_system, dict):
+        return None
+    backend = build_system.get("build-backend")
+    if isinstance(backend, str) and "maturin" in backend.lower():
+        return pp, backend
+    return None
+
+
+def _forbidden_reason(command_text: str, cwd: Path | None = None) -> str | None:
     if "bad cmd" in command_text.lower():
         return f'command contains "bad cmd". Full command: {command_text!r}'
 
@@ -280,7 +328,7 @@ def _forbidden_reason(command_text: str) -> str | None:
         first = _program_name(words[0])
         nested = _nested_shell_command(words)
         if nested is not None:
-            nested_reason = _forbidden_reason(nested)
+            nested_reason = _forbidden_reason(nested, cwd=cwd)
             if nested_reason is not None:
                 return nested_reason
             continue
@@ -317,23 +365,34 @@ def _forbidden_reason(command_text: str) -> str | None:
             # (lint, version-check, doc generation, etc.). The escape hatch
             # for the legitimate full-rebuild case is `./test` — see
             # zackees/soldr#805.
+            #
+            # Scoping: only enforce this in projects whose `pyproject.toml`
+            # actually declares a maturin build backend. Other repos pay no
+            # rebuild cost on `uv run` and the block was a false positive
+            # there (e.g. FastLED uses hatchling — `uv run` is fast and
+            # blocking it was just noise).
             uv_safe_flags = {"--no-project", "--no-sync", "--frozen"}
             has_uv_safe_flag = any(
                 w in uv_safe_flags or any(w.startswith(f + "=") for f in uv_safe_flags)
                 for w in words[2:]
             )
             if not has_uv_safe_flag:
-                return (
-                    "`uv run` without --no-project / --no-sync / --frozen "
-                    "triggers the project auto-sync, which rebuilds the "
-                    "native extension (full maturin compile on "
-                    "maturin-backed projects). Pass `--no-project` for "
-                    "pure-Python scripts, `--no-sync` to use the existing "
-                    "venv, or `--frozen` to lock to the existing lockfile. "
-                    "Escape hatch for a legitimate full-rebuild: run "
-                    "`./test` (or `bash ./test`) — the canonical "
-                    "full-build entrypoint. See zackees/soldr#805."
-                )
+                maturin = _maturin_build_backend(cwd)
+                if maturin is not None:
+                    pp_path, backend = maturin
+                    return (
+                        f"this hook fired because {pp_path} declares "
+                        f"build-backend = {backend!r}. `uv run` without "
+                        "--no-project / --no-sync / --frozen triggers the "
+                        "project auto-sync, which on a maturin-backed repo "
+                        "is a full Rust+PyO3 rebuild. Pass `--no-project` "
+                        "for pure-Python scripts, `--no-sync` to use the "
+                        "existing venv, or `--frozen` to lock to the "
+                        "existing lockfile. Escape hatch for a legitimate "
+                        "full-rebuild: run `./test` (or `bash ./test`) — "
+                        "the canonical full-build entrypoint. See "
+                        "zackees/soldr#805."
+                    )
             continue
 
         if first in RUST_TOOLS:
@@ -356,9 +415,16 @@ def main() -> int:
 
     tool_name = payload.get("tool_name") or payload.get("toolName") or "?"
     command_text = _extract_command(payload)
-    _log(f"tool_name={tool_name!r} command={command_text!r}")
+    cwd_raw = payload.get("cwd") or payload.get("cwdPath")
+    if not isinstance(cwd_raw, str) or not cwd_raw:
+        cwd_raw = os.getcwd()
+    try:
+        cwd = Path(cwd_raw)
+    except (TypeError, ValueError):
+        cwd = None
+    _log(f"tool_name={tool_name!r} cwd={cwd_raw!r} command={command_text!r}")
 
-    reason = _forbidden_reason(command_text)
+    reason = _forbidden_reason(command_text, cwd=cwd)
     if reason is not None:
         msg = f"[block-bad-cmd hook] refusing to run {tool_name!r}: {reason}"
         _log(f"BLOCKED: {msg}")

--- a/crates/clud-bin/assets/tools/hooks/block-bad-cmd.py
+++ b/crates/clud-bin/assets/tools/hooks/block-bad-cmd.py
@@ -359,19 +359,42 @@ def _forbidden_reason(command_text: str, cwd: Path | None = None) -> str | None:
             if not has_uv_safe_flag:
                 hybrid_root = _python_rust_hybrid_root(cwd)
                 if hybrid_root is not None:
-                    return (
-                        f"this hook fired because {hybrid_root} contains "
-                        "both pyproject.toml and Cargo.toml (a Python+Rust "
-                        "hybrid project). `uv run` without --no-project / "
-                        "--no-sync / --frozen triggers the project "
-                        "auto-sync, which on a Rust-backed wheel is a full "
-                        "native rebuild. Pass `--no-project` for pure-Python "
-                        "scripts, `--no-sync` to use the existing venv, or "
-                        "`--frozen` to lock to the existing lockfile. "
-                        "Escape hatch for a legitimate full-rebuild: run "
-                        "`./test` (or `bash ./test`) — the canonical "
-                        "full-build entrypoint. See zackees/soldr#805."
-                    )
+                    # Env-var escape hatch: lets a caller intentionally
+                    # eat the auto-sync cost (e.g. they DO want the
+                    # rebuild, or they're running a one-off where the
+                    # latency is fine). Allow the command but emit a
+                    # yellow warning so the rebuild isn't silent and the
+                    # calling agent knows what just happened. Logged too
+                    # so the bypass is visible in the audit trail.
+                    if os.environ.get("CLUD_UV_RUST_ALLOW_ALL") == "1":
+                        _log(f"CLUD_UV_RUST_ALLOW_ALL=1 bypassed hybrid block at {hybrid_root}")
+                        print(
+                            "\x1b[33mWARNING: AUTO COMPILING RUST because of uv run\n"
+                            f"CLUD_UV_RUST_ALLOW_ALL=1 is set, so the auto-sync gate at {hybrid_root} was bypassed.\n"
+                            "DIRECTIVE TO AGENT: the next `uv run` in this project root will "
+                            "trigger a full native rebuild (can take minutes). If you don't need "
+                            "a fresh build, pass `--no-sync` (use existing venv), `--no-project` "
+                            "(pure-Python script), or `--frozen` (lock to existing lockfile) to "
+                            "skip the auto-sync. If you DO need a clean rebuild, prefer `./test` "
+                            "(or `bash ./test`) — the canonical full-build entrypoint.\x1b[0m",
+                            file=sys.stderr,
+                        )
+                    else:
+                        return (
+                            f"this hook fired because {hybrid_root} contains "
+                            "both pyproject.toml and Cargo.toml (a Python+Rust "
+                            "hybrid project). `uv run` without --no-project / "
+                            "--no-sync / --frozen triggers the project "
+                            "auto-sync, which on a Rust-backed wheel is a full "
+                            "native rebuild. Pass `--no-project` for pure-Python "
+                            "scripts, `--no-sync` to use the existing venv, or "
+                            "`--frozen` to lock to the existing lockfile. "
+                            "Escape hatch for a legitimate full-rebuild: run "
+                            "`./test` (or `bash ./test`) — the canonical "
+                            "full-build entrypoint. Set "
+                            "CLUD_UV_RUST_ALLOW_ALL=1 to bypass this gate "
+                            "with a warning. See zackees/soldr#805."
+                        )
             continue
 
         if first in RUST_TOOLS:


### PR DESCRIPTION
## Summary

The `uv run --no-project / --no-sync / --frozen` gate in `block-bad-cmd.py` fires globally on every Bash call across every project, but its reasoning only applies to maturin-backed repos. Hatchling/setuptools/no-pyproject repos hit a false positive (e.g. `~/dev/fastled` was being blocked).

This PR scopes the gate to projects whose nearest `pyproject.toml` declares `build-backend = "maturin"`. The block message now leads with `this hook fired because <pyproject_path> declares build-backend = '<value>'` so the trigger is visible at the call site.

## Behavior matrix (smoke-tested)

| cwd kind | command | result |
|---|---|---|
| hatchling | `uv run python -c pass` | allow |
| maturin | `uv run python -c pass` | block (names pyproject + backend) |
| no pyproject | `uv run python -c pass` | allow |
| maturin | `uv run --no-sync python -c pass` | allow |

## Implementation

- `_find_pyproject(cwd)` walks up from cwd to the nearest `pyproject.toml`.
- `_maturin_build_backend(cwd)` parses it with `tomllib` (Python 3.11+, already the hook's floor) and returns `(path, backend)` when the backend matches `maturin`, else `None`.
- `_forbidden_reason` takes a `cwd` parameter (threaded through nested-shell recursion) and only fires the `uv run` block when `_maturin_build_backend(cwd)` returns a hit.
- `main` reads `payload['cwd']` (Claude Code's PreToolUse field) and falls back to `os.getcwd()`.

## Test plan

- [x] Hatchling cwd: `uv run python -c pass` allowed
- [x] Maturin cwd: same command blocked, message names pyproject path + `'maturin'`
- [x] No pyproject cwd: allowed
- [x] Maturin cwd + `--no-sync`: allowed (escape hatch unchanged)
- [ ] Live test inside `~/dev/clud` (maturin via `crates/clud-bin`) — should still block bare `uv run`
- [ ] Live test inside `~/dev/fastled` (hatchling) — should no longer block

🤖 Generated with [Claude Code](https://claude.com/claude-code)