### PR TITLE
feat(tools,skills): /clud-git-diff — native OS webview with file picker + Beyond Compare dual-pane diff (#445)

### DIFF
--- a/crates/clud-bin/assets/skills/clud-git-diff/SKILL.md
+++ b/crates/clud-bin/assets/skills/clud-git-diff/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: clud-git-diff
+description: Show a git diff in a native OS webview window (Beyond Compare-style dual-pane with file picker on the left) via the bundled git/clud-git-diff.py tool. Invoke when the user asks to visually review changes between revisions.
+triggers:
+  - When the user asks to see a git diff visually, in a window, or in a viewer
+  - When the user asks "show me the diff between X and Y" / "what changed since N commits ago" / "diff HEAD..HEAD~10"
+  - When the user references file pickers, side-by-side diffs, Beyond Compare, GUI diff, or webview diff
+  - When the user says "/clud-diff", "diff history", or "review changes"
+---
+<!-- managed-by: clud -->
+
+# /clud-git-diff
+
+Open a native OS-level webview window that shows a git diff with:
+
+- **Left panel** — file picker listing every file that changed in the diff. Click a file to load it in the right panel.
+- **Right panel** — Beyond Compare-style **dual-pane** view (before/after columns) of the selected file, with synchronized scrolling between the two columns, per-line numbers, and per-hunk headers.
+
+The viewer is the only window the user has to manage. Closing it (via the OS X button) returns control to the agent.
+
+Three hard rules:
+
+1. **Always invoke the bundled tool**, never write an ad-hoc HTML file or open the default browser. The bundled tool guarantees the side-by-side layout, the synchronized scroll, and the native window — those are the contract.
+2. **Default the revision range to `HEAD~10..HEAD`** when the user doesn't specify one. They almost always want "recent history" not the full repo lifetime.
+3. **The agent BLOCKS on the tool until the window closes.** The Python script's `webview.start()` is a blocking call; do not background it or move on prematurely. When the user closes the window, the tool returns and the agent picks up.
+
+## How to invoke
+
+```bash
+clud tool run git/clud-git-diff.py [LEFT [RIGHT]]
+```
+
+Argument shape:
+
+- `LEFT` (positional, default `HEAD~10`) — git revision spec for the "before" side. Anything `git rev-parse` accepts: SHA, branch, tag, `HEAD~N`, `<branch>@{N}`.
+- `RIGHT` (positional, default `HEAD`) — same shape, the "after" side.
+
+Example invocations and what they show:
+
+| User asks | Invoke with |
+|---|---|
+| "Show me the diff of the last 10 commits" | `clud tool run git/clud-git-diff.py HEAD~10 HEAD` |
+| "What changed since main?" | `clud tool run git/clud-git-diff.py main HEAD` |
+| "Diff this branch against main" | `clud tool run git/clud-git-diff.py main HEAD` |
+| "Show me what's in PR #N" (after fetching) | `clud tool run git/clud-git-diff.py main pr/N` |
+| "Diff abc123 and def456" | `clud tool run git/clud-git-diff.py abc123 def456` |
+| "Show me the diff" (no range) | `clud tool run git/clud-git-diff.py` — defaults to `HEAD~10..HEAD` |
+
+## Workflow
+
+1. **Recognize the trigger.** The user wants to *see* a diff — they used words like "show", "view", "look at", "visual", or referenced specific revisions. They're not asking for a text dump (that's `git diff`).
+2. **Resolve the range.** Pick `LEFT` and `RIGHT` from what they said. If ambiguous, prefer `HEAD~10..HEAD`. Don't ask — surface what you chose in your one-line acknowledgment so they can correct on the next message if needed.
+3. **Invoke the tool.** `clud tool run git/clud-git-diff.py <left> <right>`.
+4. **Block until the window closes.** The tool exits when the user closes the native window; the agent's subprocess wait returns at that point. Do not poll, do not assume — just wait.
+5. **Pick up cleanly.** After the tool returns, briefly acknowledge: "diff viewer closed" and stand ready for the next message.
+
+## Trigger phrases (be generous)
+
+- "Show me a diff of the last N commits"
+- "What's the diff between X and Y"
+- "Open a diff viewer for…"
+- "Show me what changed in [range]"
+- "Visual diff of …"
+- "I want to review the changes from …"
+- "Beyond Compare style" (this skill's UX is explicitly modeled on Beyond Compare)
+- "Diff with a file picker"
+
+When in doubt: invoke the tool. The viewer is cheap to dismiss; not invoking it when the user wanted visual review is the worse failure.
+
+## Hard rules
+
+1. **Bundled tool only.** No ad-hoc HTML, no browser launches, no `git diff` text dumps when the user asked for a viewer.
+2. **Default to `HEAD~10..HEAD`** when the range isn't specified.
+3. **Don't background the tool.** It's blocking by design.
+4. **Don't write to stdout while the viewer is open.** The user is in the window, not the terminal.
+5. **Don't prefetch or speculate ranges** the user didn't ask for. If they say "last 5 commits" you use `HEAD~5..HEAD`, not `HEAD~10..HEAD`.
+6. **One viewer at a time.** Don't spawn multiple windows in parallel.
+7. **RED -> GREEN** still applies for any code changes the user makes after reviewing — the viewer doesn't modify anything, but the agent's follow-up edits do.
+
+## Failure modes to avoid
+
+- **Falling back to `git diff` text** when the user asked to *see* the diff. They asked for a viewer; give them the viewer.
+- **Opening the OS default browser** instead of the bundled webview tool. The bundled tool gives the side-by-side + file picker layout — `webbrowser.open()` on raw HTML does not.
+- **Resolving the range to something the user didn't ask for.** If they say "last 5 commits" don't show 10. Echo back what you chose.
+- **Continuing while the viewer is open.** The user is reviewing; wait for them.
+- **Reinventing the renderer.** Beyond Compare-style alignment, line numbers, sync-scroll, file picker — those are non-trivial. The bundled tool already does them.
+
+## When NOT to use this
+
+- The user asked for a one-line diff stat (`git diff --stat`) — that's a text op, no viewer needed.
+- The user is in a non-interactive environment (CI, headless container) — the webview needs a display.
+- The user explicitly asked for "the text" or "the raw diff" — they want stdout, not a window.
+- The diff is for a single file and the user already named it — `git diff <file>` to terminal is fine.
+
+## Related
+
+- `crates/clud-bin/assets/tools/git/clud-git-diff.py` — the bundled tool source.
+- Issue #445 — original request that motivated this skill.
+- `clud tool run` — the dispatch entrypoint (sets `UV_CACHE_DIR` per the three-layer enforcement from #408).
+- `pywebview` upstream — native OS webview wrapper used by the tool. WebView2 on Windows, WKWebView on macOS, WebKitGTK on Linux.

--- a/crates/clud-bin/assets/tools/git/clud-git-diff.py
+++ b/crates/clud-bin/assets/tools/git/clud-git-diff.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pywebview>=5.3",
+# ]
+# ///
+# managed-by: clud
+"""Native OS webview diff viewer with file picker + Beyond Compare-style
+side-by-side dual-pane diff.
+
+Layout:
+    [ file list ] | [ before (old) ] | [ after (new) ]
+
+Click a file in the left panel → its dual-pane diff renders to the
+right with synchronized scrolling between the two columns.
+
+Usage:
+    uv run --no-project demo/diff_webview.py [LEFT [RIGHT]]
+
+Default range: HEAD~10..HEAD
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+import webview
+
+
+# ---------- diff parsing ----------
+
+
+@dataclass
+class Hunk:
+    old_start: int
+    new_start: int
+    raw_lines: list[tuple[str, str]] = field(default_factory=list)
+    # raw_lines: list of (kind, text) where kind ∈ {" ", "-", "+"}.
+
+
+@dataclass
+class FileDiff:
+    path: str
+    header_lines: list[str] = field(default_factory=list)
+    hunks: list[Hunk] = field(default_factory=list)
+
+
+def get_diff(rev_left: str, rev_right: str) -> str:
+    result = subprocess.run(  # noqa: S603, S607
+        ["git", "diff", "--no-color", f"{rev_left}..{rev_right}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 and not result.stdout:
+        return f"git diff failed (exit {result.returncode}):\n{result.stderr}"
+    return result.stdout
+
+
+def parse_diff(diff_text: str) -> list[FileDiff]:
+    files: list[FileDiff] = []
+    current: FileDiff | None = None
+    current_hunk: Hunk | None = None
+    file_pattern = re.compile(r"^diff --git a/(.+?) b/(.+?)$")
+    hunk_pattern = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+    for raw in diff_text.splitlines():
+        if raw.startswith("diff --git "):
+            if current is not None:
+                if current_hunk is not None:
+                    current.hunks.append(current_hunk)
+                    current_hunk = None
+                files.append(current)
+            m = file_pattern.match(raw)
+            path = m.group(2) if m else "?"
+            current = FileDiff(path=path, header_lines=[raw])
+            current_hunk = None
+        elif current is None:
+            # Preamble before the first `diff --git` — skip.
+            continue
+        elif raw.startswith("@@"):
+            if current_hunk is not None:
+                current.hunks.append(current_hunk)
+            m = hunk_pattern.match(raw)
+            old_start = int(m.group(1)) if m else 1
+            new_start = int(m.group(2)) if m else 1
+            current_hunk = Hunk(old_start=old_start, new_start=new_start)
+        elif current_hunk is not None:
+            if not raw:
+                current_hunk.raw_lines.append((" ", ""))
+            elif raw[0] in " +-":
+                current_hunk.raw_lines.append((raw[0], raw[1:]))
+            # "\ No newline at end of file" etc. just gets dropped.
+        else:
+            # File header lines (index, ---, +++).
+            current.header_lines.append(raw)
+
+    if current is not None:
+        if current_hunk is not None:
+            current.hunks.append(current_hunk)
+        files.append(current)
+    return files
+
+
+def hunk_to_side_by_side(
+    hunk: Hunk,
+) -> tuple[list[dict], list[dict]]:
+    """Convert a hunk's unified-diff lines into two parallel column
+    arrays (left = old/before, right = new/after) with line numbers
+    and per-row kind tags."""
+    left: list[dict] = []
+    right: list[dict] = []
+    pending_l: list[str] = []
+    pending_r: list[str] = []
+    old_ln = hunk.old_start
+    new_ln = hunk.new_start
+
+    def flush() -> None:
+        nonlocal old_ln, new_ln
+        n = max(len(pending_l), len(pending_r))
+        for i in range(n):
+            if i < len(pending_l):
+                left.append({"ln": old_ln, "kind": "del", "text": pending_l[i]})
+                old_ln += 1
+            else:
+                left.append({"ln": None, "kind": "blank", "text": ""})
+            if i < len(pending_r):
+                right.append({"ln": new_ln, "kind": "add", "text": pending_r[i]})
+                new_ln += 1
+            else:
+                right.append({"ln": None, "kind": "blank", "text": ""})
+        pending_l.clear()
+        pending_r.clear()
+
+    for kind, text in hunk.raw_lines:
+        if kind == " ":
+            flush()
+            left.append({"ln": old_ln, "kind": "ctx", "text": text})
+            right.append({"ln": new_ln, "kind": "ctx", "text": text})
+            old_ln += 1
+            new_ln += 1
+        elif kind == "-":
+            pending_l.append(text)
+        elif kind == "+":
+            pending_r.append(text)
+    flush()
+    return left, right
+
+
+def file_to_payload(file: FileDiff) -> dict:
+    sections: list[dict] = []
+    for hunk in file.hunks:
+        left, right = hunk_to_side_by_side(hunk)
+        header = f"@@ -{hunk.old_start} +{hunk.new_start} @@"
+        sections.append({"header": header, "left": left, "right": right})
+    return {"path": file.path, "sections": sections}
+
+
+# ---------- rendering ----------
+
+
+def render_html(rev_left: str, rev_right: str, files: list[FileDiff]) -> str:
+    payloads = [file_to_payload(f) for f in files]
+    data_json = json.dumps(payloads)
+    nav_items = []
+    for i, f in enumerate(files):
+        escaped = html.escape(f.path)
+        nav_items.append(
+            f'<a class="nav-item" data-idx="{i}" href="#">{escaped}</a>'
+        )
+    nav = (
+        "\n".join(nav_items)
+        if nav_items
+        else '<p class="empty">(no files changed)</p>'
+    )
+    title = f"git diff {html.escape(rev_left)}..{html.escape(rev_right)}"
+    file_count = len(files)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+* {{ box-sizing: border-box; }}
+html, body {{ margin: 0; padding: 0; height: 100vh; overflow: hidden; }}
+body {{ font-family: ui-monospace, SFMono-Regular, "Cascadia Mono",
+       Menlo, Consolas, monospace;
+       background: #1e1e1e; color: #d4d4d4;
+       display: grid;
+       grid-template-columns: 320px 1fr 1fr;
+       grid-template-rows: auto 1fr; }}
+header {{ grid-column: 1 / -1;
+          padding: 0.7rem 1.25rem;
+          background: #252526;
+          border-bottom: 1px solid #3c3c3c;
+          font-size: 0.85rem; color: #ccc; }}
+header h1 {{ margin: 0; font-size: 0.92rem; font-weight: 500; color: #cccccc; }}
+header .meta {{ font-size: 0.72rem; color: #888; margin-top: 0.15rem; }}
+aside {{ grid-row: 2;
+         background: #252526;
+         border-right: 1px solid #3c3c3c;
+         overflow-y: auto; }}
+aside h2 {{ position: sticky; top: 0; background: #252526;
+            margin: 0; padding: 0.7rem 1rem 0.5rem;
+            font-size: 0.72rem; text-transform: uppercase;
+            letter-spacing: 0.05em; color: #888;
+            border-bottom: 1px solid #3c3c3c; font-weight: 600; }}
+.nav-item {{ display: block; padding: 0.4rem 1rem;
+             font-size: 0.8rem; color: #cccccc;
+             text-decoration: none; border-left: 3px solid transparent;
+             white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+             cursor: pointer; }}
+.nav-item:hover {{ background: #2a2d2e; }}
+.nav-item.active {{ background: #094771; border-left-color: #0e639c; color: #fff; }}
+.pane {{ grid-row: 2; overflow: auto; }}
+.pane.left  {{ border-right: 1px solid #3c3c3c; }}
+.pane.right {{ }}
+.pane .pane-title {{ position: sticky; top: 0;
+                      padding: 0.55rem 1rem; font-size: 0.72rem;
+                      letter-spacing: 0.05em; text-transform: uppercase;
+                      background: #1f2226; color: #888;
+                      border-bottom: 1px solid #2a2d2e; z-index: 5; }}
+.hunk-header {{ padding: 0.4rem 1rem; color: #4ec9b0; background: #2a2d2e;
+                font-size: 0.78rem; }}
+.row {{ display: flex; font-size: 0.82rem; line-height: 1.45;
+        white-space: pre; }}
+.row .ln {{ flex: 0 0 4ch; padding: 0 0.5rem; text-align: right;
+            color: #555; user-select: none; }}
+.row .text {{ flex: 1 1 auto; padding-right: 0.5rem; min-width: 0;
+              overflow: hidden; text-overflow: ellipsis; }}
+.row.ctx   {{ color: #888; }}
+.row.add   {{ background: rgba(101, 153, 63, 0.18); color: #b5cea8; }}
+.row.del   {{ background: rgba(204, 78, 78, 0.18); color: #ce9178; }}
+.row.blank {{ background: #1a1a1a; color: #444; }}
+.empty {{ padding: 2rem 1.5rem; color: #888; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>{title}</h1>
+  <div class="meta">{file_count} file{'s' if file_count != 1 else ''} changed —
+                    select one on the left to see its dual-pane diff.
+                    Close this window to return to the agent.</div>
+</header>
+<aside>
+  <h2>Files</h2>
+  {nav}
+</aside>
+<div class="pane left"><div class="pane-title">Before ({html.escape(rev_left)})</div>
+<div id="leftBody"></div></div>
+<div class="pane right"><div class="pane-title">After ({html.escape(rev_right)})</div>
+<div id="rightBody"></div></div>
+<script>
+const PAYLOADS = {data_json};
+const leftBody  = document.getElementById('leftBody');
+const rightBody = document.getElementById('rightBody');
+const items     = document.querySelectorAll('.nav-item');
+
+function renderColumn(target, rows) {{
+  const html = rows.map(r => {{
+    const ln = r.ln === null ? '' : r.ln;
+    const text = r.text
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;') || '&nbsp;';
+    return `<div class="row ${{r.kind}}"><span class="ln">${{ln}}</span><span class="text">${{text}}</span></div>`;
+  }}).join('');
+  return html;
+}}
+
+function showFile(idx) {{
+  items.forEach(i => i.classList.toggle('active', Number(i.dataset.idx) === idx));
+  const file = PAYLOADS[idx];
+  if (!file) {{
+    leftBody.innerHTML  = '<p class="empty">(nothing to show)</p>';
+    rightBody.innerHTML = '<p class="empty">(nothing to show)</p>';
+    return;
+  }}
+  let leftHtml = '', rightHtml = '';
+  for (const section of file.sections) {{
+    leftHtml  += `<div class="hunk-header">${{section.header}}</div>` + renderColumn(null, section.left);
+    rightHtml += `<div class="hunk-header">${{section.header}}</div>` + renderColumn(null, section.right);
+  }}
+  leftBody.innerHTML  = leftHtml  || '<p class="empty">(no hunks)</p>';
+  rightBody.innerHTML = rightHtml || '<p class="empty">(no hunks)</p>';
+}}
+
+items.forEach(item => {{
+  item.addEventListener('click', ev => {{
+    ev.preventDefault();
+    showFile(Number(item.dataset.idx));
+  }});
+}});
+
+// Synchronized scrolling between the two panes.
+const leftPane  = document.querySelector('.pane.left');
+const rightPane = document.querySelector('.pane.right');
+let syncing = false;
+function syncFrom(src, dst) {{
+  if (syncing) return;
+  syncing = true;
+  dst.scrollTop = src.scrollTop;
+  requestAnimationFrame(() => {{ syncing = false; }});
+}}
+leftPane.addEventListener('scroll',  () => syncFrom(leftPane,  rightPane));
+rightPane.addEventListener('scroll', () => syncFrom(rightPane, leftPane));
+
+if (PAYLOADS.length > 0) showFile(0);
+</script>
+</body>
+</html>"""
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    rev_left = args[0] if len(args) >= 1 else "HEAD~10"
+    rev_right = args[1] if len(args) >= 2 else "HEAD"
+
+    diff = get_diff(rev_left, rev_right)
+    files = parse_diff(diff)
+    page = render_html(rev_left, rev_right, files)
+
+    title = f"git diff {rev_left}..{rev_right}"
+    print(
+        f"clud diff demo: opening native webview "
+        f"({len(files)} file{'s' if len(files) != 1 else ''})…",
+        flush=True,
+    )
+    webview.create_window(title, html=page, width=1600, height=950)
+    webview.start()  # blocks until user closes the window
+    print("clud diff demo: closed", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/clud-bin/src/skill_install.rs
+++ b/crates/clud-bin/src/skill_install.rs
@@ -57,6 +57,10 @@ const BUNDLED_SKILLS: &[Skill] = &[
         content: include_str!("../assets/skills/clud-git/SKILL.md"),
     },
     Skill {
+        name: "clud-git-diff",
+        content: include_str!("../assets/skills/clud-git-diff/SKILL.md"),
+    },
+    Skill {
         name: "clud-python-lint-deadcode",
         content: include_str!("../assets/skills/clud-python-lint-deadcode/SKILL.md"),
     },

--- a/crates/clud-bin/src/skills.rs
+++ b/crates/clud-bin/src/skills.rs
@@ -75,6 +75,10 @@ pub const BUNDLED_SKILLS: &[BundledSkill] = &[
         skill_md: include_str!("../assets/skills/clud-git/SKILL.md"),
     },
     BundledSkill {
+        name: "clud-git-diff",
+        skill_md: include_str!("../assets/skills/clud-git-diff/SKILL.md"),
+    },
+    BundledSkill {
         name: "clud-python-lint-deadcode",
         skill_md: include_str!("../assets/skills/clud-python-lint-deadcode/SKILL.md"),
     },

--- a/crates/clud-bin/src/tools.rs
+++ b/crates/clud-bin/src/tools.rs
@@ -123,6 +123,19 @@ pub const BUNDLED_TOOLS: &[BundledTool] = &[
         quiet_ok: false,
     },
     BundledTool {
+        rel_path: "git/clud-git-diff.py",
+        body: include_str!("../assets/tools/git/clud-git-diff.py"),
+        // Native OS webview diff viewer (pywebview). The world (git
+        // history) owns the state; killing the process just closes the
+        // window — `Resumable`. The viewer is silent while the user
+        // reads, so `quiet_ok` suppresses the progress watchdog.
+        // 60-minute ceiling because a deep code review can take a while.
+        kill_semantics: KillSemantics::Resumable,
+        command_timeout: DEFAULT_KILLABLE_TIMEOUT,
+        progress_timeout: None,
+        quiet_ok: true,
+    },
+    BundledTool {
         rel_path: "hooks/block-bad-cmd.py",
         body: include_str!("../assets/tools/hooks/block-bad-cmd.py"),
         // PreToolUse hook: reads a small JSON blob from stdin, decides


### PR DESCRIPTION
Closes #445. New bundled tool + paired skill /clud-git-diff. Launches a native OS webview window (pywebview) with file picker on the left + Beyond Compare-style dual-pane (before/after) on the right with synchronized scrolling. Default range HEAD~10..HEAD. Both share the clud-git-diff name for findability. 54 guardrail tests pass; lint clean. Verified live on this repo.