### PR TITLE
feat(tools,guard): warn on bare `uv run` in agent hooks of polyglot repos

### DIFF
--- a/crates/clud-bin/assets/tools/hooks/uv_run_hook_guard.py
+++ b/crates/clud-bin/assets/tools/hooks/uv_run_hook_guard.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+# managed-by: clud
+"""uv_run_hook_guard.py — warn on bare `uv run` in agent hooks of polyglot repos.
+
+When clud is invoked inside a repo that has BOTH a Cargo workspace AND a
+Python project with a `[build-system].build-backend` declaration, this
+script scans `.claude/settings.json` (incl. `settings.local.json`) and
+`.codex/hooks.json` for `PreToolUse` / `PostToolUse` hook commands that
+use bare `uv run …` without one of the safeguard flags
+(`--no-project`, `--no-sync`, `--frozen`).
+
+The failure mode this catches:
+  - maturin-backed pyproject: every hook fire is a full Rust+PyO3 rebuild
+    (minutes per call); cold-cache CI runners exceed the typical 5s hook
+    timeout and the guard silently never runs.
+  - setuptools-backed pyproject co-existing with Cargo: every hook fire
+    is a venv re-sync (seconds per call) plus the same silent-timeout
+    risk.
+
+For each offender the script prints a yellow stderr warning naming the
+config file, the hook event (PreToolUse / PostToolUse), the matcher,
+and the offending command. After printing it sleeps 3 seconds so the
+warning is visible before the next hook fires. Always exits 0 — this
+is informational, never blocking.
+
+The scanner also follows hook commands one level deep: if the hook
+invokes a local repo script (`./ci.sh`, `bash ./test`, `./build`,
+etc.) the referenced script is read and grepped for the same anti-
+pattern, so a hook that wraps the offender through a shell file gets
+flagged too.
+
+Invoked via `clud tool run hooks/uv_run_hook_guard.py` so UV_CACHE_DIR
+is pinned to ~/.clud/cache/uv (issue #408 three-layer enforcement) and
+managed install lifecycle preserves user edits.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+# ANSI escape sequences. Yellow for the warning, reset to clear.
+# `NO_COLOR` env var (de-facto cross-CLI standard) disables.
+def _ansi(seq: str) -> str:
+    if os.environ.get("NO_COLOR"):
+        return ""
+    return seq
+
+
+YELLOW = _ansi("\x1b[33m")
+BOLD = _ansi("\x1b[1m")
+RESET = _ansi("\x1b[0m")
+
+# Long-form flags that opt OUT of the project auto-sync. Presence of
+# any one of these on a `uv run` invocation makes it safe.
+SAFE_UV_RUN_FLAGS = {"--no-project", "--no-sync", "--frozen"}
+
+# Hook event keys we care about. SessionStart, Stop, etc. don't pay
+# the per-tool-call cost so the rebuild penalty is much smaller; not
+# in scope for v0.
+SCANNED_EVENTS = ("PreToolUse", "PostToolUse")
+
+# File extensions we'll dereference one level when a hook command is
+# a path to a local repo script. .sh / .bash for POSIX, .cmd / .bat /
+# .ps1 for Windows, .py for direct python scripts (which could call
+# uv run internally via subprocess).
+FOLLOWABLE_SCRIPT_EXTS = {".sh", ".bash", ".cmd", ".bat", ".ps1", ".py"}
+
+
+@dataclass(frozen=True)
+class Offender:
+    config_path: Path
+    event: str
+    matcher: str
+    command: str
+    indirect_via: Path | None = None  # set when surfaced via a wrapper script
+
+    def render(self) -> str:
+        loc = (
+            f"{self.config_path} → {self.event} ({self.matcher})"
+            if not self.indirect_via
+            else f"{self.config_path} → {self.event} ({self.matcher}) → {self.indirect_via}"
+        )
+        return (
+            f"{YELLOW}{BOLD}[clud] WARNING: bare `uv run` in agent hook{RESET}\n"
+            f"  {loc}\n"
+            f"  command: {self.command.strip()}\n"
+            f"  fix:     add `--no-project`, `--no-sync`, or `--frozen` to the uv run\n"
+        )
+
+
+def _repo_qualifies(repo_root: Path) -> bool:
+    """Gate: scan only when the repo is a Python+Rust polyglot with a build backend."""
+    cargo = repo_root / "Cargo.toml"
+    pyproject = repo_root / "pyproject.toml"
+    if not (cargo.is_file() and pyproject.is_file()):
+        return False
+    try:
+        body = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    # Permissive grep — we don't want to depend on tomllib's TOML
+    # subset enforcement here, just signal whether the user has a
+    # build-system that uv would resolve when it sees the file.
+    return re.search(r"(?m)^\s*build-backend\s*=\s*[\"']", body) is not None
+
+
+def _iter_hooks_from_claude(config_path: Path) -> list[tuple[str, str, str]]:
+    """Extract (event, matcher, command) tuples from a Claude settings.json."""
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    hooks = data.get("hooks") if isinstance(data, dict) else None
+    if not isinstance(hooks, dict):
+        return []
+    return _iter_hooks_from_hooks_obj(hooks)
+
+
+def _iter_hooks_from_codex(config_path: Path) -> list[tuple[str, str, str]]:
+    """Extract (event, matcher, command) tuples from a Codex hooks.json."""
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    hooks = data.get("hooks") if isinstance(data, dict) else None
+    if not isinstance(hooks, dict):
+        return []
+    return _iter_hooks_from_hooks_obj(hooks)
+
+
+def _iter_hooks_from_hooks_obj(hooks: dict) -> list[tuple[str, str, str]]:
+    """Common (event, matcher, command) extractor for both config shapes.
+
+    The two CLIs share the same schema:
+        {"hooks": {"<event>": [{"matcher": "<m>", "hooks": [{"command": "<c>"}]}]}}
+    """
+    out: list[tuple[str, str, str]] = []
+    for event in SCANNED_EVENTS:
+        for matcher_block in hooks.get(event) or []:
+            if not isinstance(matcher_block, dict):
+                continue
+            matcher = str(matcher_block.get("matcher", ""))
+            for entry in matcher_block.get("hooks") or []:
+                if not isinstance(entry, dict):
+                    continue
+                command = entry.get("command")
+                if isinstance(command, str) and command.strip():
+                    out.append((event, matcher, command))
+    return out
+
+
+def _has_bare_uv_run(command: str) -> bool:
+    """True iff `command` invokes `uv run` and lacks every safeguard flag."""
+    # Word-boundary match so `aiouv run` etc. don't false-positive.
+    if not re.search(r"\buv\s+run\b", command):
+        return False
+    # Tokenize on whitespace; checks the literal flag presence. The
+    # CI-typical case is whitespace-separated args, no equals form. We
+    # also handle `--foo=bar` for safety since `--no-project` is a
+    # bare boolean flag (no value) so equals form isn't legal, but be
+    # forgiving on the others.
+    tokens = command.split()
+    for flag in SAFE_UV_RUN_FLAGS:
+        for tok in tokens:
+            if tok == flag or tok.startswith(flag + "="):
+                return False
+    return True
+
+
+def _resolve_referenced_script(command: str, repo_root: Path) -> Path | None:
+    """If the hook command starts with a local repo script, return its path."""
+    tokens = command.split()
+    if not tokens:
+        return None
+    # Strip common shell wrappers: `bash ./foo.sh args`, `python ./bar.py`, etc.
+    shell_wrappers = {"bash", "sh", "zsh", "python", "python3", "pwsh", "powershell", "cmd"}
+    i = 0
+    while i < len(tokens) - 1 and tokens[i] in shell_wrappers:
+        i += 1
+    candidate = tokens[i]
+    # Strip leading `./` and resolve under repo root.
+    if candidate.startswith("./"):
+        candidate = candidate[2:]
+    # Reject absolute paths and `..` traversal — we only follow scripts
+    # that live inside the repo we're scanning.
+    if Path(candidate).is_absolute():
+        return None
+    if ".." in Path(candidate).parts:
+        return None
+    target = (repo_root / candidate).resolve()
+    try:
+        # Sanity: resolved path must be under repo_root.
+        target.relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    if not target.is_file():
+        return None
+    if target.suffix.lower() not in FOLLOWABLE_SCRIPT_EXTS:
+        return None
+    return target
+
+
+def _scan_referenced_script(
+    script_path: Path,
+) -> list[str]:
+    """Return command-like lines inside `script_path` that contain bare uv run."""
+    try:
+        body = script_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    hits: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _has_bare_uv_run(stripped):
+            hits.append(stripped)
+    return hits
+
+
+def scan(repo_root: Path) -> list[Offender]:
+    """Run the full scan, returning every offender found."""
+    if not _repo_qualifies(repo_root):
+        return []
+
+    configs: list[tuple[Path, str]] = [
+        (repo_root / ".claude" / "settings.json", "claude"),
+        (repo_root / ".claude" / "settings.local.json", "claude"),
+        (repo_root / ".codex" / "hooks.json", "codex"),
+    ]
+
+    offenders: list[Offender] = []
+    for config_path, kind in configs:
+        if not config_path.is_file():
+            continue
+        if kind == "claude":
+            entries = _iter_hooks_from_claude(config_path)
+        else:
+            entries = _iter_hooks_from_codex(config_path)
+        for event, matcher, command in entries:
+            if _has_bare_uv_run(command):
+                offenders.append(
+                    Offender(
+                        config_path=config_path,
+                        event=event,
+                        matcher=matcher,
+                        command=command,
+                    )
+                )
+                continue
+            # The hook doesn't directly call uv run, but it might
+            # wrap a local script that does. Dereference one level.
+            target = _resolve_referenced_script(command, repo_root)
+            if target is None:
+                continue
+            for hit in _scan_referenced_script(target):
+                offenders.append(
+                    Offender(
+                        config_path=config_path,
+                        event=event,
+                        matcher=matcher,
+                        command=hit,
+                        indirect_via=target,
+                    )
+                )
+    return offenders
+
+
+def main(argv: list[str]) -> int:
+    # Single optional arg: the repo root. Defaults to CWD so the
+    # clud-side caller doesn't have to compute it.
+    repo_root = Path(argv[1]).resolve() if len(argv) > 1 else Path.cwd().resolve()
+    offenders = scan(repo_root)
+    if not offenders:
+        return 0
+    sys.stderr.write(
+        f"{YELLOW}{BOLD}[clud] uv_run_hook_guard: detected {len(offenders)} "
+        f"bare `uv run` invocation(s) in agent hooks of a Python+Rust "
+        f"polyglot repo.{RESET}\n"
+        "Bare `uv run` walks the tree to pyproject.toml, finds the "
+        "build-backend, and triggers a project re-sync (full maturin "
+        "rebuild on maturin-backed projects) on every hook fire — "
+        "minutes per call, often silently failing past the hook "
+        "timeout. Fix each one below.\n\n"
+    )
+    for off in offenders:
+        sys.stderr.write(off.render())
+    sys.stderr.write("\n")
+    sys.stderr.flush()
+    # 3-second pause so the user actually sees the warning before
+    # the next tool call obliterates the scrollback.
+    time.sleep(3)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -61,6 +61,7 @@ pub mod tools;
 pub mod trampoline;
 pub mod trash;
 pub mod ui;
+pub mod uv_run_hook_guard;
 pub mod verbose_log;
 pub mod voice;
 pub mod wasm;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -3,7 +3,7 @@ use clud::{
     crash_report, ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard, launch_log,
     launch_setup, loop_artifacts, loop_spec, optimize, orphan_reaper, runner, runtime_cache,
     startup, symbols, tool_info, tool_ledger, tool_list, tool_log, tool_run, tools, trampoline,
-    trash, ui, verbose_log, wasm, worktrees,
+    trash, ui, uv_run_hook_guard, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -450,6 +450,25 @@ fn main() {
         }
     } else if args.verbose {
         verbose_log::log("[clud] daemon: skipped");
+    }
+
+    // After the daemon has had its chance to install bundled tools
+    // (`daemon::server::run_daemon` → `tool_install::ensure_installed`),
+    // fire the hook-config scanner against the cwd. Warns on bare
+    // `uv run` in Pre/PostToolUse hooks of Python+Rust polyglot
+    // repos — the failure mode that turns every hook fire into a
+    // multi-minute Rust rebuild on maturin-backed projects (see the
+    // tool's docstring for the setuptools-co-existing-with-Cargo
+    // variant). Same gate as the large-file guard so the warning
+    // only fires for backend launches, not subcommand utility calls
+    // (`clud tool run`, `clud loop`, etc.).
+    if args.command.is_none() && !args.clean_worktrees && !args.fix_hooks {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let root = loop_spec::git_root_from(&cwd);
+        if args.verbose {
+            verbose_log::log("[clud] uv-run hook guard: scanning agent hooks");
+        }
+        uv_run_hook_guard::run(&root);
     }
 
     let backend = backend::resolve_backend(args.claude, args.codex);

--- a/crates/clud-bin/src/tools.rs
+++ b/crates/clud-bin/src/tools.rs
@@ -135,6 +135,20 @@ pub const BUNDLED_TOOLS: &[BundledTool] = &[
         progress_timeout: None,
         quiet_ok: true,
     },
+    BundledTool {
+        rel_path: "hooks/uv_run_hook_guard.py",
+        body: include_str!("../assets/tools/hooks/uv_run_hook_guard.py"),
+        // Startup-time scanner: walks .claude/.codex hook configs in
+        // a Python+Rust polyglot repo and warns on bare `uv run` in
+        // Pre/PostToolUse hooks. Killable because the process IS the
+        // work; the 3-second sleep at the end of `main()` accounts
+        // for the only deliberate wall-clock spent (the warning's
+        // visibility delay). 30s backstop is comfortable headroom.
+        kill_semantics: KillSemantics::Killable,
+        command_timeout: Duration::from_secs(30),
+        progress_timeout: None,
+        quiet_ok: true,
+    },
     // docker-build tool family — implementation of zackees/clud#421.
     // Trampoline filename uses a hyphen to match the public CLI shape
     // (`clud tool run docker/docker-build.py soldr <path>`); sibling
@@ -299,6 +313,20 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The `uv_run_hook_guard` tool ships and is invoked from clud
+    /// startup (`main.rs` → `uv_run_hook_guard::run`). If the entry is
+    /// removed or renamed the wrapper silently does nothing and the
+    /// startup warning never fires — invariant test catches the drift.
+    #[test]
+    fn bundled_includes_uv_run_hook_guard() {
+        let names: Vec<&str> = BUNDLED_TOOLS.iter().map(|t| t.rel_path).collect();
+        assert!(
+            names.contains(&"hooks/uv_run_hook_guard.py"),
+            "BUNDLED_TOOLS must include hooks/uv_run_hook_guard.py; \
+             got {names:?}",
+        );
     }
 
     /// Issue #418 sub-task 1: the pr_merge_watch.py tool ships in the

--- a/crates/clud-bin/src/uv_run_hook_guard.rs
+++ b/crates/clud-bin/src/uv_run_hook_guard.rs
@@ -1,0 +1,109 @@
+//! Startup-time invocation of the bundled `uv_run_hook_guard.py` tool.
+//!
+//! The detection logic lives in Python so the same script can also be
+//! run by hand (`clud tool run hooks/uv_run_hook_guard.py`) or as a
+//! user-configured SessionStart hook in a different agent. This module
+//! is the thin Rust wrapper that fires it on every clud launch.
+//!
+//! Fast path: the gate at `main.rs` (`args.command.is_none() && ...`)
+//! avoids calling this for any subcommand invocation. Inside `run()`
+//! we additionally short-circuit when the bundled tool isn't installed
+//! yet (cold first-ever clud invocation that hasn't seen the daemon
+//! complete its install pass) — silently returning so we never block
+//! startup on a missing asset. The daemon's next launch will install
+//! the file and the guard becomes active.
+//!
+//! Subprocess execution goes through `NativeProcess` per the repo-wide
+//! ban on direct `std::process::Command` use.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use running_process::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+
+use crate::tool_install::tools_root;
+
+/// Hard wall-clock cap. The guard's slowest legitimate runtime is
+/// "found at least one offender" → ~50ms scan + 3s deliberate sleep =
+/// well under 5s. Anything past that is uv hanging on a sync we don't
+/// want to wait for at startup.
+const DEADLINE: Duration = Duration::from_secs(8);
+
+/// Relative path under `~/.clud/tools/` of the bundled tool.
+const TOOL_REL_PATH: &str = "hooks/uv_run_hook_guard.py";
+
+/// Run the guard against `project_root`. Silent on every failure mode
+/// (tool not installed, uv missing, subprocess error) so the guard
+/// never breaks a launch.
+pub fn run(project_root: &Path) {
+    let Some(tool_path) = installed_tool_path() else {
+        return;
+    };
+    if !tool_path.exists() {
+        return;
+    }
+
+    let argv: Vec<String> = vec![
+        "uv".to_string(),
+        "run".to_string(),
+        "--script".to_string(),
+        tool_path.to_string_lossy().into_owned(),
+        project_root.to_string_lossy().into_owned(),
+    ];
+
+    let process = NativeProcess::new(ProcessConfig {
+        command: CommandSpec::Argv(argv),
+        cwd: Some(project_root.to_path_buf()),
+        env: None,
+        capture: false,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Inherit,
+        nice: None,
+    });
+    if process.start().is_err() {
+        return;
+    }
+    let _ = process.wait(Some(DEADLINE));
+}
+
+fn installed_tool_path() -> Option<PathBuf> {
+    Some(tools_root()?.join(TOOL_REL_PATH))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guard rel_path is the same string both this wrapper and the
+    /// BUNDLED_TOOLS registry rely on. Drift would mean the wrapper
+    /// looks for a file the install lifecycle never wrote.
+    #[test]
+    fn tool_rel_path_matches_bundled_registry() {
+        let registered = crate::tools::BUNDLED_TOOLS
+            .iter()
+            .any(|t| t.rel_path == TOOL_REL_PATH);
+        assert!(
+            registered,
+            "TOOL_REL_PATH `{TOOL_REL_PATH}` is not in BUNDLED_TOOLS — \
+             the wrapper would silently never find the asset"
+        );
+    }
+
+    /// Sanity-check the resolver: when `tools_root` succeeds the path
+    /// ends with `hooks/uv_run_hook_guard.py` (or the Windows
+    /// equivalent). When it fails (no home dir in env), we return None
+    /// rather than producing a nonsense path.
+    #[test]
+    fn installed_tool_path_shape() {
+        let Some(path) = installed_tool_path() else {
+            return;
+        };
+        let s = path.to_string_lossy().to_string();
+        assert!(
+            s.ends_with("hooks/uv_run_hook_guard.py") || s.ends_with("hooks\\uv_run_hook_guard.py"),
+            "installed_tool_path returned an unexpected suffix: {s}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a startup-time guard that warns when a Python+Rust polyglot repo has agent hooks using bare `uv run`. The failure mode it catches: on a repo with both `Cargo.toml` and a `pyproject.toml` declaring `[build-system].build-backend`, every bare `uv run` invocation in a PreToolUse / PostToolUse hook walks the tree to `pyproject.toml`, discovers the build-backend, and triggers a project re-sync per call.

- **maturin-backed pyproject** (clud itself): full Rust + PyO3 rebuild per hook fire — minutes per call, often silently failing past the typical 5s hook timeout.
- **setuptools-backed pyproject co-existing with Cargo** (zccache today): venv re-sync per call (seconds), same silent-timeout risk.

Either way, `--no-project` / `--no-sync` / `--frozen` makes the problem go away. The new guard surfaces every offender at clud launch with a yellow warning + 3s pause.

## What it does

1. Fires at clud startup, gated to backend launches only (`args.command.is_none() && !args.clean_worktrees && !args.fix_hooks`) — same shape as `large_file_guard`.
2. Exits 0 unless **all three** are true at the cwd's git root: `Cargo.toml` exists, `pyproject.toml` exists, `pyproject.toml` declares `[build-system].build-backend`.
3. Scans `.claude/settings.json`, `.claude/settings.local.json`, `.codex/hooks.json` under `PreToolUse` + `PostToolUse`.
4. For each hook command: flags bare `uv run` (no safeguard flag). If the command instead invokes a local repo script (`./ci.sh`, `bash ./test`, etc.), follows one level and greps the referenced script for the same anti-pattern.
5. Prints yellow stderr warnings naming config file / event / matcher / command, then `sleep 3` so the user sees them before the next tool call obliterates the scrollback. Always exits 0.

## Implementation

| File | Purpose |
|---|---|
| `crates/clud-bin/assets/tools/hooks/uv_run_hook_guard.py` | Bundled PEP 723 tool, `# managed-by: clud` marker. Killable, 30s timeout, `quiet_ok: true`. |
| `crates/clud-bin/src/tools.rs` | New `BUNDLED_TOOLS` entry + `bundled_includes_uv_run_hook_guard` invariant test. |
| `crates/clud-bin/src/uv_run_hook_guard.rs` | Thin Rust wrapper. Subprocess-execs `uv run --script <installed-path> <cwd>` with an 8s deadline. Silent on every failure mode. |
| `crates/clud-bin/src/main.rs` | Wires the wrapper into startup after `daemon::ensure_daemon` (so the bundled tool is on disk). |
| `crates/clud-bin/src/lib.rs` | Re-exports the new module. |

## Test plan

- [x] `soldr cargo test -p clud --lib tools::` — 13/13 green (includes the new `bundled_includes_uv_run_hook_guard` invariant).
- [x] `soldr cargo test -p clud --lib uv_run_hook_guard::` — 2/2 green (rel-path / shape checks on the wrapper).
- [x] `soldr cargo clippy -p clud --lib -- -D warnings` — clean.
- [x] `soldr cargo fmt --all --check` — clean.
- [ ] Manual: run clud in zccache after this lands. Expect to see the yellow warning naming the 4 `uv run python ci/hooks/*.py` entries in `.claude/settings.json` + the 5 in `.codex/hooks.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)