### PR TITLE
feat(runner): CPU-burn banner in foreground clud terminal (#466)

### DIFF
--- a/crates/clud-bin/src/README.md
+++ b/crates/clud-bin/src/README.md
@@ -145,6 +145,17 @@ Skills and hooks:
 
 Diagnostics and misc:
 
+- `cpu_banner.rs` - issue #466: foreground CPU-burn banner. Spawns one
+  background `sysinfo` sampler that ticks every 2 s, sums `cpu_usage()` +
+  `memory()` over the parent-PID subtree rooted at our originator, and emits
+  `[clud] cpu N % · X.Y / Z cores · …` to stderr when subtree CPU crosses
+  `max(50 %, 0.20 × num_cpus × 100 %)` for 3 sustained ticks. Hysteretic
+  drop-out at 0.7×; 30 s heartbeat while sustained; clear-banner only after
+  ≥ 60 s episodes. Wired into `runner::run_plan_subprocess` and
+  `runner::run_plan_pty` via a `BannerWatcher` whose `Drop` joins the
+  thread. Suppressed by `--no-cpu-banner`, `--dry-run`, `--detach`,
+  `--detachable`, `--repeat`, and `[foreground.cpu_banner] enabled = false`
+  in `~/.clud/settings.json`. Slice of #463 (`clud top`).
 - `verbose_log.rs` - launch-clock + opt-in file logging
   (`CLUD_VERBOSE_LOG_DIR`); `log()` writes timestamped lines to the per-launch
   log file.

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -153,6 +153,15 @@ pub struct Args {
     #[arg(long = "explain-orphans")]
     pub explain_orphans: bool,
 
+    /// Issue #466: suppress the foreground CPU-burn banner for this
+    /// invocation. Banner is otherwise on by default; it polls the subtree
+    /// CPU every 2 s and emits `[clud] cpu N % …` to stderr when subtree
+    /// CPU crosses `max(50 %, 0.20 × num_cpus × 100 %)` for 3 sustained
+    /// ticks. Permanent opt-out via `[foreground.cpu_banner] enabled =
+    /// false` in `~/.clud/settings.json`.
+    #[arg(long = "no-cpu-banner")]
+    pub no_cpu_banner: bool,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 

--- a/crates/clud-bin/src/clud_settings.rs
+++ b/crates/clud-bin/src/clud_settings.rs
@@ -299,6 +299,52 @@ pub fn load_rust_optimize_settings_at(
     rust_optimize_from_json(&document)
 }
 
+/// Settings for the foreground CPU-burn banner (#466). Defaults: enabled,
+/// 30 s heartbeat. JSON shape:
+///
+/// ```json
+/// { "foreground": { "cpu_banner": { "enabled": false, "heartbeat_secs": 60 } } }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CpuBannerSettings {
+    pub enabled: bool,
+    pub heartbeat_secs: u64,
+}
+
+impl Default for CpuBannerSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            heartbeat_secs: 30,
+        }
+    }
+}
+
+pub fn load_cpu_banner_settings() -> Result<CpuBannerSettings, SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    load_cpu_banner_settings_at(&home)
+}
+
+pub fn load_cpu_banner_settings_at(home: &Path) -> Result<CpuBannerSettings, SettingsError> {
+    let lock_path = home.join(CLUD_DIR_NAME).join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+    let document = read_settings_or_legacy(home)?;
+    let mut out = CpuBannerSettings::default();
+    let Some(section) = document
+        .get("foreground")
+        .and_then(|item| item.get("cpu_banner"))
+    else {
+        return Ok(out);
+    };
+    if let Some(enabled) = section.get("enabled").and_then(Value::as_bool) {
+        out.enabled = enabled;
+    }
+    if let Some(secs) = section.get("heartbeat_secs").and_then(Value::as_u64) {
+        out.heartbeat_secs = secs;
+    }
+    Ok(out)
+}
+
 fn with_settings_document<F>(home: &Path, mutate: F) -> Result<(), SettingsError>
 where
     F: FnOnce(&mut Value),
@@ -895,5 +941,38 @@ mod tests {
             !load_shell_disable_powershell_for_backend_at(home.path(), Backend::Codex).unwrap(),
             "codex override should override top-level"
         );
+    }
+
+    #[test]
+    fn cpu_banner_defaults_when_settings_missing() {
+        let home = tempdir().unwrap();
+        let got = load_cpu_banner_settings_at(home.path()).unwrap();
+        assert_eq!(got, CpuBannerSettings::default());
+    }
+
+    #[test]
+    fn cpu_banner_reads_enabled_override() {
+        let home = tempdir().unwrap();
+        let path = settings_path_at(home.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, r#"{"foreground":{"cpu_banner":{"enabled":false}}}"#).unwrap();
+        let got = load_cpu_banner_settings_at(home.path()).unwrap();
+        assert!(!got.enabled);
+        assert_eq!(got.heartbeat_secs, 30, "default heartbeat preserved");
+    }
+
+    #[test]
+    fn cpu_banner_reads_heartbeat_override() {
+        let home = tempdir().unwrap();
+        let path = settings_path_at(home.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"{"foreground":{"cpu_banner":{"heartbeat_secs":120}}}"#,
+        )
+        .unwrap();
+        let got = load_cpu_banner_settings_at(home.path()).unwrap();
+        assert!(got.enabled, "default enabled preserved");
+        assert_eq!(got.heartbeat_secs, 120);
     }
 }

--- a/crates/clud-bin/src/cpu_banner.rs
+++ b/crates/clud-bin/src/cpu_banner.rs
@@ -1,0 +1,820 @@
+//! Issue #466 (slice of #463): CPU-burn banner in the foreground clud
+//! terminal.
+//!
+//! When the foreground `clud` session's subtree (self + descendants) burns
+//! meaningful CPU, this module periodically prints a one-line status banner
+//! to stderr so the user notices before they hear the fan:
+//!
+//! ```text
+//! [clud] cpu 287 % · 2.9 / 12 cores · rss 1.42 GiB · 24 procs · 7 m
+//! ```
+//!
+//! Three pieces:
+//!
+//! - [`CpuBannerState`] — the pure state machine (crossover / sustained
+//!   heartbeat / hysteretic drop-out / suppression window). Tested
+//!   without `sysinfo`; downstream consumers can drive it from any
+//!   sampler.
+//! - [`Sampler`] — keeps one persistent `sysinfo::System` and per tick
+//!   sums `cpu_usage()` + `memory()` across the subtree rooted at
+//!   `originator_pid`. Uses the parent-PID graph (cheap), not the
+//!   env-tag scan (expensive); breakaway descendants escape this view
+//!   and are #340 territory.
+//! - [`BannerWatcher`] — background thread that joins the two on a
+//!   `tick` cadence and writes banners to stderr. Drop joins the
+//!   thread.
+//!
+//! Suppression: caller (in `main.rs`) constructs `CpuBannerCfg` with
+//! `enabled = false` for `--no-cpu-banner`, `--dry-run`, `--detach`,
+//! `--detachable`, `--repeat`, or when the settings.json toggle is off.
+
+use std::collections::HashMap;
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+/// Default tick cadence. 2 s matches the parent #463 default. Crossover
+/// fires after `DEFAULT_SUSTAINED_TICKS * DEFAULT_TICK` (= 6 s), which is
+/// inside the acceptance criterion's 6 s bound.
+pub const DEFAULT_TICK: Duration = Duration::from_secs(2);
+
+/// Default heartbeat between banner re-prints while sustained.
+pub const DEFAULT_HEARTBEAT_SECS: u64 = 30;
+
+/// Default sustained-tick count before first banner. Filters compile
+/// spikes / GC pauses.
+pub const DEFAULT_SUSTAINED_TICKS: u32 = 3;
+
+/// Hysteretic drop-out multiplier: subtree must fall below
+/// `DROP_OUT_FACTOR × trigger_pct()` before the clear-banner arms. Same
+/// anti-flap rationale as the parent #463 sampler tier demotion.
+pub const DROP_OUT_FACTOR: f32 = 0.7;
+
+/// Minimum episode length before a clear-banner is printed. Episodes
+/// shorter than this were transient spikes; clearing would be noise.
+pub const MIN_EPISODE_FOR_CLEAR_SECS: u64 = 60;
+
+/// After a clear-banner, hold the next crossover for at least this long
+/// to prevent rapid-cycle flapping during oscillating loads.
+pub const SUPPRESSION_AFTER_CLEAR_SECS: u64 = 60;
+
+/// Absolute floor for the trigger: half a core is notable on any host.
+const ABSOLUTE_FLOOR_PCT: f32 = 50.0;
+
+/// Relative fraction of host capacity that triggers the banner.
+const RELATIVE_HOST_FRACTION: f32 = 0.20;
+
+/// Caller-built configuration. `enabled = false` makes [`BannerWatcher::spawn`]
+/// a no-op and [`CpuBannerState::poll`] always return `None`.
+#[derive(Debug, Clone)]
+pub struct CpuBannerCfg {
+    pub enabled: bool,
+    pub originator_pid: u32,
+    pub num_cpus: usize,
+    pub heartbeat_secs: u64,
+    pub tick: Duration,
+    pub sustained_ticks: u32,
+}
+
+impl CpuBannerCfg {
+    pub fn new(originator_pid: u32, num_cpus: usize) -> Self {
+        Self {
+            enabled: true,
+            originator_pid,
+            num_cpus,
+            heartbeat_secs: DEFAULT_HEARTBEAT_SECS,
+            tick: DEFAULT_TICK,
+            sustained_ticks: DEFAULT_SUSTAINED_TICKS,
+        }
+    }
+
+    /// Disabled variant — caller uses this for `--no-cpu-banner`, settings
+    /// override, and the non-interactive modes that always suppress.
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            originator_pid: 0,
+            num_cpus: 1,
+            heartbeat_secs: DEFAULT_HEARTBEAT_SECS,
+            tick: DEFAULT_TICK,
+            sustained_ticks: DEFAULT_SUSTAINED_TICKS,
+        }
+    }
+
+    /// `max(50 %, 0.20 × num_cpus × 100 %)` — absolute floor (half a core
+    /// is notable on any box) combined with a relative cap (20 % of host
+    /// capacity, so we don't whine on fat boxes while clud is nibbling).
+    pub fn trigger_pct(&self) -> f32 {
+        let relative = RELATIVE_HOST_FRACTION * (self.num_cpus as f32) * 100.0;
+        ABSOLUTE_FLOOR_PCT.max(relative)
+    }
+}
+
+/// Which banner the state machine just emitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BannerKind {
+    /// First banner after subtree CPU stayed above trigger for the
+    /// configured sustained-tick count.
+    Crossover,
+    /// Heartbeat re-print while still above trigger.
+    Sustained,
+    /// Episode-ended notice, fires only if the episode lasted at least
+    /// `MIN_EPISODE_FOR_CLEAR_SECS`.
+    Clear,
+}
+
+/// One banner ready for rendering. Pure data — render via [`BannerLine::render`]
+/// (ANSI-styled) or [`BannerLine::render_plain`] (no escapes; what tests
+/// inspect).
+#[derive(Debug, Clone, PartialEq)]
+pub struct BannerLine {
+    pub kind: BannerKind,
+    pub cpu_pct: f32,
+    pub rss_bytes: u64,
+    pub proc_count: usize,
+    pub age: Duration,
+    pub num_cpus: usize,
+    pub trigger_pct: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Style {
+    None,
+    Dim,
+    Yellow,
+    Red,
+}
+
+impl BannerLine {
+    /// ANSI-styled rendering. Dim while 1×–2× over trigger, yellow
+    /// 2×–4×, red ≥ 4×; clear-banner has no styling.
+    pub fn render(&self) -> String {
+        let plain = self.render_plain();
+        match self.style() {
+            Style::None => plain,
+            Style::Dim => format!("\x1b[2m{plain}\x1b[0m"),
+            Style::Yellow => format!("\x1b[33m{plain}\x1b[0m"),
+            Style::Red => format!("\x1b[31;1m{plain}\x1b[0m"),
+        }
+    }
+
+    /// Unstyled rendering. Used by tests and any non-TTY caller.
+    pub fn render_plain(&self) -> String {
+        match self.kind {
+            BannerKind::Clear => format!(
+                "[clud] cpu back to normal · {} · {} procs · {}",
+                format_rss(self.rss_bytes),
+                self.proc_count,
+                format_age(self.age),
+            ),
+            BannerKind::Crossover | BannerKind::Sustained => format!(
+                "[clud] cpu {:.0} % · {:.1} / {} cores · rss {} · {} procs · {}",
+                self.cpu_pct,
+                self.cpu_pct / 100.0,
+                self.num_cpus,
+                format_rss(self.rss_bytes),
+                self.proc_count,
+                format_age(self.age),
+            ),
+        }
+    }
+
+    fn style(&self) -> Style {
+        if matches!(self.kind, BannerKind::Clear) {
+            return Style::None;
+        }
+        if self.trigger_pct <= 0.0 {
+            return Style::Dim;
+        }
+        let ratio = self.cpu_pct / self.trigger_pct;
+        if ratio >= 4.0 {
+            Style::Red
+        } else if ratio >= 2.0 {
+            Style::Yellow
+        } else {
+            Style::Dim
+        }
+    }
+}
+
+/// Per-tick observation. Constructed by [`Sampler::tick`] in production,
+/// or directly in unit tests.
+#[derive(Debug, Clone, Copy)]
+pub struct Sample {
+    pub at: Instant,
+    pub subtree_cpu_pct: f32,
+    pub subtree_rss_bytes: u64,
+    pub proc_count: usize,
+    /// Wall-clock age of the foreground session (sampler creation time
+    /// → now). Used as the fallback `age` for the Clear banner whose
+    /// episode-start has already been cleared.
+    pub oldest_age: Duration,
+}
+
+/// State machine. Pure: no I/O, no `sysinfo`. Drive it from any sampler.
+#[derive(Debug, Default)]
+pub struct CpuBannerState {
+    sustained_count: u32,
+    in_episode: bool,
+    episode_started_at: Option<Instant>,
+    last_print_at: Option<Instant>,
+    suppressed_until: Option<Instant>,
+}
+
+impl CpuBannerState {
+    /// Feed one tick. Returns `Some(BannerLine)` when the state machine
+    /// has crossed a threshold and the caller should print; otherwise
+    /// `None`.
+    pub fn poll(&mut self, sample: Sample, cfg: &CpuBannerCfg) -> Option<BannerLine> {
+        if !cfg.enabled {
+            return None;
+        }
+        let trigger = cfg.trigger_pct();
+        let above = sample.subtree_cpu_pct >= trigger;
+        let clear_threshold = DROP_OUT_FACTOR * trigger;
+
+        if above {
+            // Suppression check first: during a suppression window after
+            // a recent Clear banner, swallow above-ticks silently AND keep
+            // the sustained counter at zero, so the user gets the full
+            // sustained-ticks grace period once suppression lifts (anti-
+            // flap for oscillating loads). Suppression only applies while
+            // we are NOT in an episode — once in episode, heartbeats win.
+            if !self.in_episode {
+                if let Some(until) = self.suppressed_until {
+                    if sample.at < until {
+                        self.sustained_count = 0;
+                        return None;
+                    }
+                }
+            }
+            self.sustained_count = self.sustained_count.saturating_add(1);
+            if !self.in_episode {
+                if self.sustained_count >= cfg.sustained_ticks {
+                    self.in_episode = true;
+                    self.episode_started_at = Some(sample.at);
+                    self.last_print_at = Some(sample.at);
+                    self.suppressed_until = None;
+                    return Some(self.make_line(BannerKind::Crossover, sample, cfg));
+                }
+                return None;
+            }
+            // Sustained: heartbeat re-print if due.
+            let heartbeat = Duration::from_secs(cfg.heartbeat_secs);
+            if let Some(last) = self.last_print_at {
+                if sample.at.duration_since(last) >= heartbeat {
+                    self.last_print_at = Some(sample.at);
+                    return Some(self.make_line(BannerKind::Sustained, sample, cfg));
+                }
+            }
+            None
+        } else {
+            self.sustained_count = 0;
+            if !self.in_episode {
+                return None;
+            }
+            // Between 0.7× and 1.0× — stay in episode, no banner.
+            if sample.subtree_cpu_pct >= clear_threshold {
+                return None;
+            }
+            // Below clear threshold — episode ends.
+            let episode_age = self
+                .episode_started_at
+                .map(|started| sample.at.duration_since(started))
+                .unwrap_or_default();
+            self.in_episode = false;
+            self.episode_started_at = None;
+            self.last_print_at = None;
+            if episode_age >= Duration::from_secs(MIN_EPISODE_FOR_CLEAR_SECS) {
+                self.suppressed_until =
+                    Some(sample.at + Duration::from_secs(SUPPRESSION_AFTER_CLEAR_SECS));
+                return Some(self.make_line(BannerKind::Clear, sample, cfg));
+            }
+            None
+        }
+    }
+
+    fn make_line(&self, kind: BannerKind, sample: Sample, cfg: &CpuBannerCfg) -> BannerLine {
+        let age = match self.episode_started_at {
+            Some(started) => sample.at.duration_since(started),
+            None => sample.oldest_age,
+        };
+        BannerLine {
+            kind,
+            cpu_pct: sample.subtree_cpu_pct,
+            rss_bytes: sample.subtree_rss_bytes,
+            proc_count: sample.proc_count,
+            age,
+            num_cpus: cfg.num_cpus,
+            trigger_pct: cfg.trigger_pct(),
+        }
+    }
+}
+
+/// Sysinfo-backed sampler. Owns one persistent `System` and refreshes
+/// CPU + memory per tick (the cheap shape per the parent #463 cost
+/// analysis). Subtree is the parent-PID-graph walk from `originator_pid`
+/// — well-behaved descendants, not breakaway children.
+pub struct Sampler {
+    system: System,
+    started_at: Instant,
+}
+
+impl Sampler {
+    pub fn new() -> Self {
+        Self {
+            system: System::new(),
+            started_at: Instant::now(),
+        }
+    }
+
+    pub fn tick(&mut self, originator_pid: u32) -> Sample {
+        self.system.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::nothing().with_cpu().with_memory(),
+        );
+
+        let root = Pid::from_u32(originator_pid);
+        let pids = collect_subtree(&self.system, root);
+        let mut subtree_cpu_pct = 0.0_f32;
+        let mut subtree_rss = 0_u64;
+        let mut count = 0_usize;
+        for pid in &pids {
+            if let Some(proc) = self.system.process(*pid) {
+                subtree_cpu_pct += proc.cpu_usage();
+                subtree_rss += proc.memory();
+                count += 1;
+            }
+        }
+        Sample {
+            at: Instant::now(),
+            subtree_cpu_pct,
+            subtree_rss_bytes: subtree_rss,
+            proc_count: count,
+            oldest_age: self.started_at.elapsed(),
+        }
+    }
+}
+
+impl Default for Sampler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// DFS over the parent-PID graph starting at `root`. Includes `root`.
+/// Cheap (microseconds even at N=5000); the cost is dominated by the
+/// preceding `refresh_processes_specifics`.
+fn collect_subtree(system: &System, root: Pid) -> Vec<Pid> {
+    let mut children: HashMap<Pid, Vec<Pid>> = HashMap::new();
+    for (pid, proc) in system.processes() {
+        if let Some(parent) = proc.parent() {
+            children.entry(parent).or_default().push(*pid);
+        }
+    }
+    let mut stack = vec![root];
+    let mut out = vec![root];
+    while let Some(cur) = stack.pop() {
+        if let Some(kids) = children.get(&cur) {
+            for k in kids {
+                out.push(*k);
+                stack.push(*k);
+            }
+        }
+    }
+    out
+}
+
+/// Background watcher. Joins on `Drop`; call [`BannerWatcher::stop`] for
+/// explicit shutdown if you want to bound the join.
+pub struct BannerWatcher {
+    stop_tx: Option<mpsc::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl BannerWatcher {
+    /// Spawn the watcher. `enabled = false` returns an inert handle —
+    /// no thread, no banners.
+    pub fn spawn(cfg: CpuBannerCfg) -> Self {
+        if !cfg.enabled {
+            return Self {
+                stop_tx: None,
+                handle: None,
+            };
+        }
+        let (tx, rx) = mpsc::channel();
+        let handle = thread::Builder::new()
+            .name("clud-cpu-banner".into())
+            .spawn(move || run_watcher_loop(cfg, rx))
+            .ok();
+        Self {
+            stop_tx: Some(tx),
+            handle,
+        }
+    }
+
+    /// Explicit shutdown. Idempotent; safe to call before `Drop`.
+    pub fn stop(&mut self) {
+        if let Some(tx) = self.stop_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+impl Drop for BannerWatcher {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn run_watcher_loop(cfg: CpuBannerCfg, stop_rx: mpsc::Receiver<()>) {
+    let mut sampler = Sampler::new();
+    let mut state = CpuBannerState::default();
+    // Prime: sysinfo needs two refreshes for non-zero cpu_usage. Do one
+    // up-front so the first real tick has meaningful data.
+    let _ = sampler.tick(cfg.originator_pid);
+    loop {
+        if stop_rx.recv_timeout(cfg.tick).is_ok() {
+            return;
+        }
+        let sample = sampler.tick(cfg.originator_pid);
+        if let Some(line) = state.poll(sample, &cfg) {
+            eprintln!("{}", line.render());
+        }
+    }
+}
+
+fn format_rss(bytes: u64) -> String {
+    let mib = bytes as f64 / (1024.0 * 1024.0);
+    let gib = mib / 1024.0;
+    if gib >= 1.0 {
+        format!("{gib:.2} GiB")
+    } else {
+        format!("{mib:.0} MiB")
+    }
+}
+
+fn format_age(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs >= 3600 {
+        format!("{} h", secs / 3600)
+    } else if secs >= 60 {
+        format!("{} m", secs / 60)
+    } else {
+        format!("{secs} s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with(num_cpus: usize) -> CpuBannerCfg {
+        CpuBannerCfg {
+            enabled: true,
+            originator_pid: 1,
+            num_cpus,
+            heartbeat_secs: 30,
+            tick: DEFAULT_TICK,
+            sustained_ticks: DEFAULT_SUSTAINED_TICKS,
+        }
+    }
+
+    fn sample(at: Instant, cpu: f32, rss: u64, count: usize) -> Sample {
+        Sample {
+            at,
+            subtree_cpu_pct: cpu,
+            subtree_rss_bytes: rss,
+            proc_count: count,
+            oldest_age: Duration::from_secs(60),
+        }
+    }
+
+    #[test]
+    fn trigger_floor_at_50pct_for_one_cpu() {
+        assert_eq!(cfg_with(1).trigger_pct(), 50.0);
+    }
+
+    #[test]
+    fn trigger_relative_kicks_in_at_4_cpus() {
+        // 4 × 100 × 0.20 = 80 > 50 floor.
+        assert_eq!(cfg_with(4).trigger_pct(), 80.0);
+    }
+
+    #[test]
+    fn trigger_at_12_cpus_matches_issue_example() {
+        // 12 × 100 × 0.20 = 240 (within f32 rounding); user explicitly
+        // mentioned 300 % on a 12-CPU system as a value that should fire.
+        assert!((cfg_with(12).trigger_pct() - 240.0).abs() < 0.01);
+        // 300 % comfortably exceeds 240 % trigger.
+        assert!(300.0 >= cfg_with(12).trigger_pct());
+    }
+
+    #[test]
+    fn trigger_at_32_cpus_uses_relative() {
+        assert_eq!(cfg_with(32).trigger_pct(), 640.0);
+    }
+
+    #[test]
+    fn disabled_cfg_never_emits() {
+        let mut state = CpuBannerState::default();
+        let cfg = CpuBannerCfg::disabled();
+        let now = Instant::now();
+        for i in 0..10 {
+            // 100,000% would otherwise blow past every threshold.
+            let s = sample(now + Duration::from_secs(i), 100_000.0, u64::MAX, 999);
+            assert!(state.poll(s, &cfg).is_none(), "tick {i} should not emit");
+        }
+    }
+
+    #[test]
+    fn below_trigger_never_emits() {
+        let mut state = CpuBannerState::default();
+        let cfg = cfg_with(12); // trigger=240
+        let now = Instant::now();
+        for i in 0..10 {
+            let s = sample(now + Duration::from_secs(i * 2), 100.0, 1 << 30, 5);
+            assert!(state.poll(s, &cfg).is_none());
+        }
+    }
+
+    #[test]
+    fn crossover_requires_three_sustained_ticks() {
+        let mut state = CpuBannerState::default();
+        let cfg = cfg_with(1); // trigger=50
+        let now = Instant::now();
+
+        // Two ticks above: no banner yet (sustained_ticks=3).
+        for i in 0..2 {
+            let s = sample(now + Duration::from_secs(i * 2), 80.0, 0, 1);
+            assert!(state.poll(s, &cfg).is_none(), "tick {i}");
+        }
+        // Third tick fires the crossover.
+        let s = sample(now + Duration::from_secs(4), 80.0, 0, 1);
+        let line = state.poll(s, &cfg).expect("crossover should fire");
+        assert_eq!(line.kind, BannerKind::Crossover);
+        assert!((line.cpu_pct - 80.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn single_dip_resets_sustained_counter() {
+        let mut state = CpuBannerState::default();
+        let cfg = cfg_with(1);
+        let now = Instant::now();
+
+        // Two above, one below, two above → no crossover (counter reset).
+        for i in 0..2 {
+            assert!(state
+                .poll(sample(now + Duration::from_secs(i * 2), 80.0, 0, 1), &cfg)
+                .is_none());
+        }
+        assert!(state
+            .poll(sample(now + Duration::from_secs(4), 10.0, 0, 1), &cfg)
+            .is_none());
+        // Need 3 more above-ticks now.
+        for i in 0..2 {
+            assert!(
+                state
+                    .poll(
+                        sample(now + Duration::from_secs(6 + i * 2), 80.0, 0, 1),
+                        &cfg
+                    )
+                    .is_none(),
+                "post-dip tick {i} should not fire yet"
+            );
+        }
+        let line = state
+            .poll(sample(now + Duration::from_secs(10), 80.0, 0, 1), &cfg)
+            .expect("third post-dip tick fires");
+        assert_eq!(line.kind, BannerKind::Crossover);
+    }
+
+    #[test]
+    fn sustained_heartbeat_after_30s() {
+        let mut state = CpuBannerState::default();
+        let cfg = cfg_with(1);
+        let now = Instant::now();
+
+        // Drive through crossover at t=4s.
+        for i in 0..3 {
+            state.poll(sample(now + Duration::from_secs(i * 2), 80.0, 0, 1), &cfg);
+        }
+        assert!(state.in_episode);
+
+        // 28s later: no heartbeat yet.
+        assert!(state
+            .poll(sample(now + Duration::from_secs(32), 80.0, 0, 1), &cfg)
+            .is_none());
+        // 34s later (30s after last print at t=4s): heartbeat fires.
+        let line = state
+            .poll(sample(now + Duration::from_secs(34), 80.0, 0, 1), &cfg)
+            .expect("heartbeat should fire");
+        assert_eq!(line.kind, BannerKind::Sustained);
+    }
+
+    #[test]
+    fn hysteretic_dropout_only_below_07_factor() {
+        let mut state = CpuBannerState::default();
+        let cfg = cfg_with(1); // trigger=50, clear=35
+        let now = Instant::now();
+        for i in 0..3 {
+            state.poll(sample(now + Duration::from_secs(i * 2), 80.0, 0, 1), &cfg);
+        }
+        assert!(state.in_episode);
+
+        // 40% is below trigger (50) but above clear (35) → no banner,
+        // still in episode.
+        assert!(state
+            .poll(sample(now + Duration::from_secs(6), 40.0, 0, 1), &cfg)
+            .is_none());
+        assert!(
+            state.in_episode,
+            "between trigger and clear, stay in episode"
+        );
+    }
+
+    #[test]
+    fn clear_banner_fires_only_for_long_episodes() {
+        let mut state = CpuBannerState::default();
+        let cfg = cfg_with(1);
+        let now = Instant::now();
+        // Crossover at t=4s. Drop at t=10s → episode age = 6s, below
+        // MIN_EPISODE_FOR_CLEAR_SECS (60) → no clear banner.
+        for i in 0..3 {
+            state.poll(sample(now + Duration::from_secs(i * 2), 80.0, 0, 1), &cfg);
+        }
+        assert!(state
+            .poll(sample(now + Duration::from_secs(10), 0.0, 0, 1), &cfg)
+            .is_none());
+        assert!(!state.in_episode);
+    }
+
+    #[test]
+    fn clear_banner_fires_after_long_episode() {
+        let mut state = CpuBannerState::default();
+        let cfg = cfg_with(1);
+        let now = Instant::now();
+        // Crossover at t=4s. Drop at t=70s → episode age = 66s ≥ 60s.
+        for i in 0..3 {
+            state.poll(sample(now + Duration::from_secs(i * 2), 80.0, 0, 1), &cfg);
+        }
+        let line = state
+            .poll(sample(now + Duration::from_secs(70), 0.0, 0, 1), &cfg)
+            .expect("clear banner should fire");
+        assert_eq!(line.kind, BannerKind::Clear);
+    }
+
+    #[test]
+    fn suppression_holds_next_crossover_after_clear() {
+        let mut state = CpuBannerState::default();
+        let cfg = cfg_with(1);
+        let now = Instant::now();
+        // Long episode → clear → suppression armed for 60s.
+        for i in 0..3 {
+            state.poll(sample(now + Duration::from_secs(i * 2), 80.0, 0, 1), &cfg);
+        }
+        assert_eq!(
+            state
+                .poll(sample(now + Duration::from_secs(70), 0.0, 0, 1), &cfg)
+                .unwrap()
+                .kind,
+            BannerKind::Clear
+        );
+
+        // Within 60s of clear: even sustained high CPU is suppressed.
+        for i in 0..3 {
+            let s = sample(now + Duration::from_secs(72 + i * 2), 200.0, 0, 1);
+            assert!(state.poll(s, &cfg).is_none(), "tick {i} suppressed");
+        }
+        // After suppression window (clear at 70 + 60 = 130s), crossover
+        // can fire again after 3 sustained ticks.
+        for i in 0..2 {
+            let s = sample(now + Duration::from_secs(132 + i * 2), 200.0, 0, 1);
+            state.poll(s, &cfg);
+        }
+        let line = state
+            .poll(sample(now + Duration::from_secs(136), 200.0, 0, 1), &cfg)
+            .expect("crossover after suppression");
+        assert_eq!(line.kind, BannerKind::Crossover);
+    }
+
+    #[test]
+    fn render_plain_matches_acceptance_format() {
+        let line = BannerLine {
+            kind: BannerKind::Crossover,
+            cpu_pct: 287.0,
+            rss_bytes: (1.42_f64 * 1024.0 * 1024.0 * 1024.0) as u64,
+            proc_count: 24,
+            age: Duration::from_secs(7 * 60),
+            num_cpus: 12,
+            trigger_pct: 240.0,
+        };
+        let s = line.render_plain();
+        // 287 / 100 = 2.87 → formats as "2.9" with `{:.1}`.
+        assert!(
+            s.starts_with("[clud] cpu 287 % · 2.9 / 12 cores · rss 1.42 GiB"),
+            "{s}"
+        );
+        assert!(s.contains("24 procs"), "{s}");
+        assert!(s.contains("7 m"), "{s}");
+    }
+
+    #[test]
+    fn render_clear_format_has_no_cpu_number() {
+        let line = BannerLine {
+            kind: BannerKind::Clear,
+            cpu_pct: 10.0,
+            rss_bytes: 100 * 1024 * 1024,
+            proc_count: 2,
+            age: Duration::from_secs(2 * 60),
+            num_cpus: 4,
+            trigger_pct: 80.0,
+        };
+        let s = line.render_plain();
+        assert!(s.starts_with("[clud] cpu back to normal"), "{s}");
+        assert!(!s.contains('%'), "clear banner shouldn't show a pct: {s}");
+    }
+
+    #[test]
+    fn render_styles_scale_with_severity() {
+        let line = |ratio: f32| BannerLine {
+            kind: BannerKind::Crossover,
+            cpu_pct: 100.0 * ratio,
+            rss_bytes: 0,
+            proc_count: 1,
+            age: Duration::from_secs(0),
+            num_cpus: 1,
+            trigger_pct: 100.0,
+        };
+        // 1.5× → dim
+        assert!(line(1.5).render().contains("\x1b[2m"));
+        // 2.5× → yellow
+        assert!(line(2.5).render().contains("\x1b[33m"));
+        // 4.5× → red
+        assert!(line(4.5).render().contains("\x1b[31"));
+        // Clear → no style
+        let clear = BannerLine {
+            kind: BannerKind::Clear,
+            cpu_pct: 0.0,
+            rss_bytes: 0,
+            proc_count: 1,
+            age: Duration::from_secs(120),
+            num_cpus: 1,
+            trigger_pct: 100.0,
+        };
+        assert!(!clear.render().contains("\x1b["), "{}", clear.render());
+    }
+
+    #[test]
+    fn format_rss_picks_gib_at_threshold() {
+        assert_eq!(format_rss(1024 * 1024 * 1024), "1.00 GiB");
+        assert_eq!(format_rss(512 * 1024 * 1024), "512 MiB");
+        assert_eq!(format_rss(0), "0 MiB");
+    }
+
+    #[test]
+    fn format_age_buckets_into_human_units() {
+        assert_eq!(format_age(Duration::from_secs(45)), "45 s");
+        assert_eq!(format_age(Duration::from_secs(120)), "2 m");
+        assert_eq!(format_age(Duration::from_secs(7200)), "2 h");
+    }
+
+    /// Sysinfo sampler smoke test: against the test process itself.
+    /// We can't predict the exact CPU% but we can assert the call works
+    /// and returns sensible values (proc_count >= 1, RSS > 0).
+    #[test]
+    fn sampler_returns_at_least_self() {
+        let mut sampler = Sampler::new();
+        let self_pid = std::process::id();
+        // Two ticks separated by enough time for sysinfo to compute cpu%.
+        let _ = sampler.tick(self_pid);
+        std::thread::sleep(Duration::from_millis(250));
+        let s = sampler.tick(self_pid);
+        assert!(
+            s.proc_count >= 1,
+            "expected at least self in subtree, got {}",
+            s.proc_count
+        );
+        assert!(s.subtree_rss_bytes > 0, "self RSS should be non-zero");
+        assert!(
+            s.subtree_cpu_pct >= 0.0,
+            "cpu_pct should be non-negative, got {}",
+            s.subtree_cpu_pct
+        );
+    }
+
+    /// `BannerWatcher::spawn` with `enabled = false` returns an inert
+    /// handle that no-ops on `stop()` and `Drop`.
+    #[test]
+    fn disabled_watcher_is_inert() {
+        let mut w = BannerWatcher::spawn(CpuBannerCfg::disabled());
+        w.stop();
+        // Drop is fine — should not panic / hang.
+    }
+}

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -686,6 +686,7 @@ mod tests {
             keep_orphans: false,
             quiet_orphans: false,
             explain_orphans: false,
+            no_cpu_banner: false,
             command: None,
             passthrough: Vec::new(),
             codex_config_overrides: Vec::new(),

--- a/crates/clud-bin/src/hook_health/prompts.rs
+++ b/crates/clud-bin/src/hook_health/prompts.rs
@@ -201,6 +201,7 @@ pub(in crate::hook_health) fn run_backend_prompt(
         keep_orphans: false,
         quiet_orphans: false,
         explain_orphans: false,
+        no_cpu_banner: false,
         command: None,
         passthrough: args.passthrough.clone(),
         codex_config_overrides: args.codex_config_overrides.clone(),

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -14,6 +14,7 @@ pub mod command;
 pub mod console_input;
 pub mod console_setup;
 pub mod console_title;
+pub mod cpu_banner;
 pub mod crash_report;
 pub mod ctrl_c_track;
 pub mod daemon;

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,9 +1,9 @@
 use clud::{
     args, backend, backend_bootstrap, clud_settings, command, console_setup, console_title,
-    crash_report, ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard, launch_log,
-    launch_setup, loop_artifacts, loop_spec, optimize, orphan_reaper, runner, runtime_cache,
-    startup, symbols, tool_info, tool_ledger, tool_list, tool_log, tool_run, tools, trampoline,
-    trash, ui, uv_run_hook_guard, verbose_log, wasm, worktrees,
+    cpu_banner, crash_report, ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard,
+    launch_log, launch_setup, loop_artifacts, loop_spec, optimize, orphan_reaper, runner,
+    runtime_cache, startup, symbols, tool_info, tool_ledger, tool_list, tool_log, tool_run, tools,
+    trampoline, trash, ui, uv_run_hook_guard, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -705,6 +705,13 @@ fn main() {
     } else {
         None
     };
+    // Issue #466: build the CPU-burn banner cfg from CLI flags + settings.
+    // Suppressed in non-interactive modes (`--dry-run`, `--detach`,
+    // `--detachable`, `--repeat`), by `--no-cpu-banner`, and by the
+    // `[foreground.cpu_banner] enabled = false` settings toggle. Builds an
+    // inert cfg in any of those cases so `BannerWatcher::spawn` is a no-op.
+    let cpu_banner_cfg = build_cpu_banner_cfg(&args, &plan);
+
     let exit_code = if centralized {
         daemon::run_centralized_session(&args, &plan, interrupted.as_ref())
     } else {
@@ -714,6 +721,7 @@ fn main() {
                 args.verbose,
                 interrupted.as_ref(),
                 loop_session.as_mut(),
+                cpu_banner_cfg,
             ),
             backend::LaunchMode::Pty => runner::run_plan_pty(
                 &plan,
@@ -721,6 +729,7 @@ fn main() {
                 interrupted.as_ref(),
                 startup::should_register_drop_target(&args),
                 loop_session.as_mut(),
+                cpu_banner_cfg,
             ),
         }
     };
@@ -791,6 +800,35 @@ fn main() {
     };
     flush_ctrl_c_exit_event(kind, exit_code);
     std::process::exit(exit_code);
+}
+
+/// Issue #466: assemble the [`cpu_banner::CpuBannerCfg`] from CLI flags
+/// and `~/.clud/settings.json`. Returns the disabled variant whenever the
+/// banner would be wrong to print: `--no-cpu-banner`, `--dry-run`,
+/// `--detach`, `--detachable`, `--repeat`, or the
+/// `[foreground.cpu_banner] enabled = false` settings toggle. Otherwise
+/// reads `heartbeat_secs` from settings (default 30) and resolves
+/// `num_cpus` via `std::thread::available_parallelism` (no syscall on the
+/// hot path; falls back to 1 if probing fails).
+fn build_cpu_banner_cfg(args: &args::Args, plan: &command::LaunchPlan) -> cpu_banner::CpuBannerCfg {
+    if args.no_cpu_banner
+        || args.dry_run
+        || args.detach
+        || args.detachable
+        || plan.repeat_schedule.is_some()
+    {
+        return cpu_banner::CpuBannerCfg::disabled();
+    }
+    let settings = clud_settings::load_cpu_banner_settings().unwrap_or_default();
+    if !settings.enabled {
+        return cpu_banner::CpuBannerCfg::disabled();
+    }
+    let num_cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let mut cfg = cpu_banner::CpuBannerCfg::new(std::process::id(), num_cpus);
+    cfg.heartbeat_secs = settings.heartbeat_secs;
+    cfg
 }
 
 /// Write the cross-path Ctrl+C exit-timing event (issue: `clud ui` ctrl-c

--- a/crates/clud-bin/src/runner.rs
+++ b/crates/clud-bin/src/runner.rs
@@ -13,6 +13,7 @@ use crate::backend::Backend;
 use crate::clud_settings;
 use crate::command;
 use crate::console_setup::enable_console_vt_input;
+use crate::cpu_banner;
 use crate::loop_artifacts;
 use crate::loop_check::{
     check_loop_markers, check_loop_markers_with_output, loop_unconverged_exit,
@@ -259,10 +260,15 @@ pub fn run_plan_subprocess(
     verbose: bool,
     interrupted: &AtomicBool,
     mut loop_session: Option<&mut loop_artifacts::LoopSession>,
+    cpu_banner_cfg: cpu_banner::CpuBannerCfg,
 ) -> i32 {
     use std::path::PathBuf;
 
     use running_process::{NativeProcess, ProcessConfig, StderrMode, StdinMode};
+
+    // Issue #466: CPU-burn banner. Watcher thread joins on drop at function
+    // exit. Inert when cfg.enabled = false (no thread spawned).
+    let _cpu_banner = cpu_banner::BannerWatcher::spawn(cpu_banner_cfg);
 
     let env = child_env_for_backend(plan.backend);
     let mut last_exit = 0i32;
@@ -591,8 +597,14 @@ pub fn run_plan_pty(
     interrupted: &AtomicBool,
     dnd_enabled: bool,
     mut loop_session: Option<&mut loop_artifacts::LoopSession>,
+    cpu_banner_cfg: cpu_banner::CpuBannerCfg,
 ) -> i32 {
     use running_process::pty::NativePtyProcess;
+
+    // Issue #466: CPU-burn banner. Same shape as the subprocess runner —
+    // background thread joins on drop at function exit. Inert when
+    // cfg.enabled = false.
+    let _cpu_banner = cpu_banner::BannerWatcher::spawn(cpu_banner_cfg);
 
     // Enable VT input on the Windows console for the whole PTY session.
     // The raw byte pump reads from clud's stdin, so PTY mode needs the


### PR DESCRIPTION
## Summary

Closes #466 — slice of #463 covering only the foreground CPU-burn banner. All other sections of #463 (full `clud top` TUI, adaptive tiered sampler, daemon-RPC `SubtreeSummary`) stay under the parent.

Adds a one-line stderr banner that fires when the foreground `clud` session's subtree (self + parent-PID-graph descendants) burns meaningful CPU:

```
[clud] cpu 287 % · 2.9 / 12 cores · rss 1.42 GiB · 24 procs · 7 m
```

Trigger formula matches the issue spec: `max(50 %, 0.20 × num_cpus × 100 %)` — half-a-core absolute floor (so a 1-CPU laptop sees a banner at 50 %) combined with a 20 % relative cap (so a 12-CPU box's threshold is 240 % and a 32-CPU box's is 640 %, sparing fat boxes when clud is only nibbling).

## State machine

- **Crossover** after 3 sustained above-trigger ticks (≈ 6 s at 2 s cadence). Filters compile spikes / GC pauses.
- **Sustained heartbeat** every 30 s while above (configurable via `[foreground.cpu_banner] heartbeat_secs`).
- **Hysteretic drop-out** at 0.7 × trigger (anti-flap, same shape as the parent #463 sampler tier demotion).
- **Clear banner** only fires if the high-CPU episode lasted ≥ 60 s (transient spikes don't get a clear).
- **60 s suppression window** after a Clear; suppressed ticks zero out the sustained counter so the next crossover takes a fresh 3-tick grace period.

## Severity styling

| ratio (cpu_pct / trigger_pct) | style |
|---|---|
| 1.0× – 2.0× | ANSI dim |
| 2.0× – 4.0× | yellow |
| ≥ 4.0× | red, no dim |

## Wiring

| File | Change |
|---|---|
| `crates/clud-bin/src/cpu_banner.rs` (new) | State machine + `sysinfo` sampler + `BannerWatcher` whose `Drop` joins the thread |
| `crates/clud-bin/src/runner.rs` | Both `run_plan_subprocess` and `run_plan_pty` accept a `CpuBannerCfg` and hold `let _cpu_banner = BannerWatcher::spawn(cfg)` so the thread runs for the runner's lifetime |
| `crates/clud-bin/src/main.rs` | `build_cpu_banner_cfg(args, plan)` returns the disabled variant for any of: `--no-cpu-banner`, `--dry-run`, `--detach`, `--detachable`, `--repeat`, `[foreground.cpu_banner] enabled = false` |
| `crates/clud-bin/src/args.rs` | New `--no-cpu-banner` flag |
| `crates/clud-bin/src/clud_settings.rs` | `load_cpu_banner_settings_at` reads `[foreground.cpu_banner] { enabled, heartbeat_secs }` with defaults `(true, 30)` |
| `crates/clud-bin/src/lib.rs` | Module registration |
| `crates/clud-bin/src/README.md` | Per-directory index entry |
| `crates/clud-bin/src/daemon/entry.rs`, `src/hook_health/prompts.rs` | Existing `Args { … }` literals get `no_cpu_banner: false` |

## Cost discipline

In-process sampler in foreground `clud` (the daemon proc-sampler from #463 doesn't exist yet). Single persistent `sysinfo::System`, refreshed each tick with `ProcessRefreshKind::nothing().with_cpu().with_memory()` (the cheap shape per the cost-per-tick analysis on #463) — well under the 1 % CPU budget. When the daemon sampler lands (#463 follow-up), this can migrate to a `DaemonRequest::SubtreeSummary` RPC with no banner-logic changes.

Subtree is computed via the sysinfo parent-PID graph (cheap, microseconds). Breakaway descendants whose parent escaped the Job Object are invisible here — that's #340 territory, not this slice.

## Test plan

- [x] `bash lint` clean (cargo fmt + clippy + ruff).
- [x] `bash test` — all 20 new banner unit tests pass + 3 new settings tests pass; full `clud-bin` lib test suite is 1111 / 1112 (only failure is pre-existing `shim_session::tests::prepend_to_path_is_idempotent`, unrelated to this PR — uses `:` separator in a Windows-only test path).
- [x] Trigger formula validated across 1 / 4 / 12 / 32 CPU host sizes.
- [x] State machine validated for crossover (3 sustained), single-dip reset, heartbeat (30 s), hysteretic drop-out at 0.7 ×, clear gating at 60 s episode minimum, suppression flap-guard.
- [x] Sampler smoke test against the test process itself confirms sysinfo path works (proc_count ≥ 1, RSS > 0).
- [x] `BannerWatcher::spawn(CpuBannerCfg::disabled())` returns an inert handle that no-ops on Drop.

## Out of scope (parent issue #463)

- Full `clud top` TUI with tree view + tier glyphs
- Adaptive tiered sampler (Hot / Warm / Cold / Frozen) with watcher-attach boost
- Daemon-side proc sampler + `SubtreeSummary` IPC
- Reaping descendant subtree from the banner (read-only here; #340 owns reap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
