### PR TITLE
feat(daemon): in-memory telemetry sink + clud log CLI + dashboard view

### DIFF
--- a/crates/clud-bin/assets/dashboard/index.html
+++ b/crates/clud-bin/assets/dashboard/index.html
@@ -136,6 +136,7 @@
     <button class="tab" data-tab="gc">Garbage</button>
     <button class="tab" data-tab="repos">Repos</button>
     <button class="tab" data-tab="ctrl-c">Ctrl-C</button>
+    <button class="tab" data-tab="telemetry">Telemetry</button>
   </div>
 
   <section id="sessions" class="active">
@@ -160,6 +161,29 @@
     </div>
   </section>
 
+  <section id="telemetry">
+    <div class="card">
+      <h2>Telemetry by parent PID <span id="telemetry-count" class="meta"></span></h2>
+      <p class="meta" style="margin: 0 0 8px;">
+        Records posted by <code>clud log</code> (issue #469, beta). One row per parent
+        PID; click to inspect individual records and their <code>CLUD_*</code> env.
+      </p>
+      <div id="telemetry-body"><p class="empty">no telemetry recorded yet.</p></div>
+    </div>
+  </section>
+
+  <section id="telemetry-detail">
+    <div style="margin-bottom: 12px;">
+      <a id="telemetry-back" style="color: var(--accent); cursor: pointer; text-decoration: none;">← Back to Telemetry</a>
+      <span style="color: var(--muted); margin: 0 8px;">/</span>
+      <span id="telemetry-detail-pid" style="font-family: ui-monospace, monospace;"></span>
+    </div>
+    <div class="card">
+      <h2>Telemetry detail <span id="telemetry-detail-count" class="meta"></span></h2>
+      <div id="telemetry-detail-body"><p class="empty">loading…</p></div>
+    </div>
+  </section>
+
   <section id="ctrl-c">
     <div class="card">
       <h2>Ctrl-C exit times <span id="ctrl-c-count" class="meta"></span></h2>
@@ -173,16 +197,63 @@
 
   <script>
     const POLL_MS = 5000;
+    const TABS = ['sessions', 'gc', 'repos', 'ctrl-c', 'telemetry'];
+    const DEFAULT_TAB = 'sessions';
     let lastState = null;
+    let currentRoute = { tab: DEFAULT_TAB, telemetryPid: null };
+
+    // Path-based routing via History API (issue #469). The daemon serves
+    // the SPA for any GET that isn't an API path, so deep-link to
+    // /telemetry/<pid> works on refresh. popstate covers browser
+    // back/forward.
+    function parsePath() {
+      const parts = location.pathname.split('/').filter(Boolean);
+      if (!parts.length) return { tab: DEFAULT_TAB, telemetryPid: null };
+      const head = parts[0];
+      if (head === 'index.html') return { tab: DEFAULT_TAB, telemetryPid: null };
+      if (head === 'telemetry') {
+        return { tab: 'telemetry', telemetryPid: parts[1] ? decodeURIComponent(parts[1]) : null };
+      }
+      if (TABS.includes(head)) return { tab: head, telemetryPid: null };
+      return { tab: DEFAULT_TAB, telemetryPid: null };
+    }
+
+    function navigate(path) {
+      if (location.pathname === path) {
+        applyRoute();
+      } else {
+        history.pushState(null, '', path);
+        applyRoute();
+      }
+    }
+
+    function applyRoute() {
+      currentRoute = parsePath();
+      const showTelemetryDetail = currentRoute.tab === 'telemetry' && currentRoute.telemetryPid;
+      document.querySelectorAll('.tab').forEach(t => {
+        t.classList.toggle('active', t.dataset.tab === currentRoute.tab);
+      });
+      document.querySelectorAll('section').forEach(s => s.classList.remove('active'));
+      if (showTelemetryDetail) {
+        document.getElementById('telemetry-detail').classList.add('active');
+        document.getElementById('telemetry-detail-pid').textContent = `pid ${currentRoute.telemetryPid}`;
+        loadTelemetryDetail(currentRoute.telemetryPid);
+      } else {
+        document.getElementById(currentRoute.tab).classList.add('active');
+      }
+    }
 
     document.querySelectorAll('.tab').forEach(tab => {
-      tab.addEventListener('click', () => {
-        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-        document.querySelectorAll('section').forEach(s => s.classList.remove('active'));
-        tab.classList.add('active');
-        document.getElementById(tab.dataset.tab).classList.add('active');
-      });
+      tab.addEventListener('click', () => navigate('/' + tab.dataset.tab));
     });
+
+    document.getElementById('telemetry-back').addEventListener('click', (ev) => {
+      ev.preventDefault();
+      if (history.length > 1) history.back();
+      else navigate('/telemetry');
+    });
+
+    window.addEventListener('popstate', applyRoute);
 
     function fmtAge(unix) {
       if (!unix) return '-';
@@ -409,6 +480,91 @@
         </table>`;
     }
 
+    function renderTelemetry(state) {
+      const rows = state.telemetry || [];
+      document.getElementById('telemetry-count').textContent = rows.length ? `(${rows.length})` : '';
+      if (!rows.length) {
+        document.getElementById('telemetry-body').innerHTML =
+          '<p class="empty">no telemetry recorded yet. Spawn a logger with <code>clud log --cmd "..." --fail-on-no-server</code> while <code>$CLUD_DAEMON_HTTP_SERVER</code> points here.</p>';
+        return;
+      }
+      const html = rows.map(r => `
+        <tr class="row-link" data-pid="${esc(r.parent_pid)}" style="cursor: pointer;">
+          <td class="id">${esc(r.parent_pid)}</td>
+          <td>${esc(r.entry_count)}</td>
+          <td class="metric" title="${esc(fmtUnixMs(r.last_at_ms))}">${esc(fmtAge(r.last_at_ms))}</td>
+        </tr>`).join('');
+      document.getElementById('telemetry-body').innerHTML = `
+        <table>
+          <thead><tr>
+            <th>parent pid</th><th>entries</th><th>last activity</th>
+          </tr></thead>
+          <tbody>${html}</tbody>
+        </table>`;
+      document.querySelectorAll('#telemetry-body tr.row-link').forEach(tr => {
+        tr.addEventListener('click', () => {
+          navigate('/telemetry/' + encodeURIComponent(tr.dataset.pid));
+        });
+      });
+    }
+
+    async function loadTelemetryDetail(pid) {
+      const body = document.getElementById('telemetry-detail-body');
+      const countEl = document.getElementById('telemetry-detail-count');
+      body.innerHTML = '<p class="empty">loading…</p>';
+      countEl.textContent = '';
+      try {
+        const resp = await fetch(`/telemetry/by-pid/${encodeURIComponent(pid)}`);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const detail = await resp.json();
+        const entries = detail.entries || [];
+        countEl.textContent = entries.length ? `(${entries.length})` : '';
+        if (!entries.length) {
+          body.innerHTML = `<p class="empty">no entries recorded for pid ${esc(pid)}.</p>`;
+          return;
+        }
+        const rows = entries.map((e, i) => `
+          <tr>
+            <td class="metric" title="${esc(fmtUnixMs(e.received_at_ms))}">${esc(fmtUnixMs(e.received_at_ms))}</td>
+            <td class="path">${esc(e.cwd || '-')}</td>
+            <td class="command">${esc(e.cmd || '-')}</td>
+            <td>
+              <button class="button subtle" data-i="${i}">env (${Object.keys(e.env || {}).length})</button>
+              <div class="env-table" id="env-row-${i}" style="display: none; margin-top: 6px;"></div>
+            </td>
+          </tr>`).join('');
+        body.innerHTML = `
+          <table>
+            <thead><tr>
+              <th>received</th><th>cwd</th><th>cmd</th><th>env</th>
+            </tr></thead>
+            <tbody>${rows}</tbody>
+          </table>`;
+        body.querySelectorAll('button[data-i]').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const i = Number(btn.dataset.i);
+            const cell = body.querySelector(`#env-row-${i}`);
+            const env = entries[i].env || {};
+            if (cell.style.display === 'none') {
+              const keys = Object.keys(env).sort();
+              if (!keys.length) {
+                cell.innerHTML = '<i class="empty">no CLUD_* vars</i>';
+              } else {
+                const html = keys.map(k => `
+                  <tr><td class="id">${esc(k)}</td><td class="path">${esc(env[k])}</td></tr>`).join('');
+                cell.innerHTML = `<table style="margin-top: 4px;"><tbody>${html}</tbody></table>`;
+              }
+              cell.style.display = '';
+            } else {
+              cell.style.display = 'none';
+            }
+          });
+        });
+      } catch (err) {
+        body.innerHTML = `<p class="empty">failed to load: ${esc(err)}</p>`;
+      }
+    }
+
     async function doPurge(body, prompt) {
       if (!confirm(prompt)) return;
       try {
@@ -439,12 +595,14 @@
         renderGc(state);
         renderRepos(state);
         renderCtrlCEvents(state);
+        renderTelemetry(state);
       } catch (err) {
         document.getElementById('daemon-meta').textContent =
           `connection lost: ${err}`;
       }
     }
 
+    applyRoute();
     refresh();
     setInterval(refresh, POLL_MS);
   </script>

--- a/crates/clud-bin/src/args.rs
+++ b/crates/clud-bin/src/args.rs
@@ -282,6 +282,24 @@ pub enum Command {
         #[command(subcommand)]
         subcommand: ToolSubcommand,
     },
+    /// Issue #469 (beta prototype): POST one telemetry event to the
+    /// always-on clud daemon's HTTP server. Captures parent PID, time,
+    /// the `cmd` string passed in, the current working directory, and
+    /// every env var beginning with `CLUD_`. The daemon URL is read
+    /// from `$CLUD_DAEMON_HTTP_SERVER`. By default missing env / unreachable
+    /// daemon are silent (exit 0) so a hook caller is never broken; with
+    /// `--fail-on-no-server` either failure causes a non-zero exit so
+    /// tests can prove a real round-trip.
+    Log {
+        /// Free-form command string describing what the caller was doing.
+        /// Stored verbatim in the telemetry record.
+        #[arg(long = "cmd", short = 'c')]
+        cmd: String,
+        /// Exit non-zero if `CLUD_DAEMON_HTTP_SERVER` is unset OR the
+        /// POST fails. Without this flag, failures are swallowed.
+        #[arg(long = "fail-on-no-server")]
+        fail_on_no_server: bool,
+    },
     /// Install and persist fast local tooling defaults.
     Optimize {
         /// Toolchain family to optimize. Defaults to Rust.
@@ -553,6 +571,8 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--stale-after",
         "--daemon",
         "--state-dir",
+        // Issue #469: `clud log --cmd "..."` arg.
+        "--cmd",
     ];
     let short_value_flags: &[&str] = &["-p", "-m", "-r"];
     let bool_flags: &[&str] = &[
@@ -588,11 +608,13 @@ fn split_known_unknown(raw: &[String]) -> (Vec<String>, Vec<String>) {
         "--demo-gfx-sixel",
         "--help",
         "--version",
+        // Issue #469: `clud log --fail-on-no-server` bool flag.
+        "--fail-on-no-server",
     ];
     let short_bool_flags: &[&str] = &["-c", "-v", "-h", "-V", "-y"];
     let subcommands: &[&str] = &[
-        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "slay", "list", "logs", "gc",
-        "ui", "trash", "tool", "optimize", "daemon", "symbols", "__daemon", "__worker",
+        "loop", "up", "rebase", "fix", "wasm", "attach", "kill", "slay", "list", "logs", "log",
+        "gc", "ui", "trash", "tool", "optimize", "daemon", "symbols", "__daemon", "__worker",
     ];
 
     let mut in_subcommand = false;

--- a/crates/clud-bin/src/command/builder.rs
+++ b/crates/clud-bin/src/command/builder.rs
@@ -143,6 +143,7 @@ pub fn build_launch_plan(args: &Args, backend: Backend, backend_path: &str) -> L
         | Some(Command::Slay)
         | Some(Command::List)
         | Some(Command::Logs { .. })
+        | Some(Command::Log { .. })
         | Some(Command::Gc { .. })
         | Some(Command::Ui { .. })
         | Some(Command::Trash { .. })

--- a/crates/clud-bin/src/daemon/http.rs
+++ b/crates/clud-bin/src/daemon/http.rs
@@ -12,12 +12,12 @@
 //! Loopback-only, no authentication — matches the trust model of the
 //! existing JSON IPC listener.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs;
 use std::io::{self, Read};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -45,6 +45,28 @@ use crate::session_registry::LiveSession;
 pub(super) type LiveSessionsProvider =
     std::sync::Arc<dyn Fn() -> Vec<LiveSession> + Send + Sync + 'static>;
 
+/// Test-only public entry point: spawn the dashboard HTTP listener for
+/// telemetry-only scenarios (no GC backend). Integration tests under
+/// `tests/telemetry_endpoint.rs` use this to wire up the server without
+/// taking on the `gc_service::RegistryMsg` type that the full
+/// `spawn_dashboard` signature otherwise leaks.
+pub fn spawn_dashboard_telemetry_only(
+    state_dir: PathBuf,
+    ipc_port: u16,
+    started_at_unix: i64,
+    telemetry: TelemetryStore,
+) -> Option<u16> {
+    let live_provider: LiveSessionsProvider = std::sync::Arc::new(Vec::new);
+    spawn_dashboard(
+        state_dir,
+        None,
+        ipc_port,
+        started_at_unix,
+        live_provider,
+        telemetry,
+    )
+}
+
 /// Production provider: reads the redb session registry under the
 /// cross-process advisory lock. Errors are swallowed so a registry
 /// hiccup never blanks the dashboard for sessions that *do* have
@@ -64,6 +86,109 @@ const DASHBOARD_HTML: &str = include_str!("../../assets/dashboard/index.html");
 /// daemon. The purge payload is two short JSON fields; 16 KiB is generous.
 const MAX_REQUEST_BODY_BYTES: usize = 16 * 1024;
 
+/// Issue #469 (beta): per-PID cap on telemetry entries. A runaway logger
+/// can't grow this past N — oldest entries get dropped first.
+const TELEMETRY_PER_PID_CAP: usize = 500;
+
+/// Issue #469 — one telemetry record submitted by `clud log`. Mirrors
+/// `log_event::TelemetryPayload` plus the daemon-added receive timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryEntry {
+    pub parent_pid: u32,
+    pub time_ms: u64,
+    pub received_at_ms: u64,
+    pub cmd: String,
+    pub cwd: String,
+    pub env: BTreeMap<String, String>,
+}
+
+/// `POST /telemetry/log` body — same shape as the entry minus the
+/// server-side `received_at_ms` timestamp (daemon assigns it).
+#[derive(Debug, Clone, Deserialize)]
+pub struct TelemetryIngest {
+    pub parent_pid: u32,
+    pub time_ms: u64,
+    pub cmd: String,
+    pub cwd: String,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+}
+
+/// Compact per-PID view returned inside `/state.json` — totals only, so
+/// the polled summary stays bounded regardless of entry count. The
+/// per-entry detail (with envs) lives behind `/telemetry/by-pid/<pid>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryPidSummary {
+    pub parent_pid: u32,
+    pub entry_count: usize,
+    pub last_at_ms: u64,
+}
+
+/// Full per-PID payload returned by `GET /telemetry/by-pid/<pid>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryPidDetail {
+    pub parent_pid: u32,
+    pub entries: Vec<TelemetryEntry>,
+}
+
+/// In-memory telemetry sink shared between the HTTP listener and any
+/// other daemon component that wants to read it. Lifetime = daemon
+/// lifetime; restart wipes it (persistence is a follow-up).
+#[derive(Debug, Default, Clone)]
+pub struct TelemetryStore {
+    inner: Arc<Mutex<TelemetryStoreInner>>,
+}
+
+#[derive(Debug, Default)]
+struct TelemetryStoreInner {
+    by_pid: HashMap<u32, VecDeque<TelemetryEntry>>,
+}
+
+impl TelemetryStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one entry. Trims the per-PID ring buffer to `TELEMETRY_PER_PID_CAP`
+    /// (drop-oldest).
+    pub fn push(&self, entry: TelemetryEntry) {
+        let mut guard = self.inner.lock().expect("telemetry store poisoned");
+        let dq = guard.by_pid.entry(entry.parent_pid).or_default();
+        dq.push_back(entry);
+        while dq.len() > TELEMETRY_PER_PID_CAP {
+            dq.pop_front();
+        }
+    }
+
+    /// Per-PID summary keyed by parent_pid, sorted by last activity desc.
+    pub fn summary(&self) -> Vec<TelemetryPidSummary> {
+        let guard = self.inner.lock().expect("telemetry store poisoned");
+        let mut rows: Vec<_> = guard
+            .by_pid
+            .iter()
+            .map(|(pid, dq)| {
+                let last_at_ms = dq.back().map(|e| e.received_at_ms).unwrap_or(0);
+                TelemetryPidSummary {
+                    parent_pid: *pid,
+                    entry_count: dq.len(),
+                    last_at_ms,
+                }
+            })
+            .collect();
+        rows.sort_by(|a, b| b.last_at_ms.cmp(&a.last_at_ms));
+        rows
+    }
+
+    /// Full per-PID detail or `None` if the PID has no entries.
+    pub fn detail(&self, pid: u32) -> Option<TelemetryPidDetail> {
+        let guard = self.inner.lock().expect("telemetry store poisoned");
+        guard.by_pid.get(&pid).map(|dq| TelemetryPidDetail {
+            parent_pid: pid,
+            entries: dq.iter().cloned().collect(),
+        })
+    }
+}
+
 /// Aggregate document returned by `GET /state.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DashboardState {
@@ -78,6 +203,11 @@ pub struct DashboardState {
     #[serde(default)]
     pub ctrl_c_events: Vec<CtrlCEvent>,
     pub stats: Stats,
+    /// Issue #469: per-PID telemetry summary (entry counts + last-seen).
+    /// Full per-entry payload (with envs) lives at `/telemetry/by-pid/<pid>`
+    /// so this list stays bounded for the 5s poller.
+    #[serde(default)]
+    pub telemetry: Vec<TelemetryPidSummary>,
 }
 
 /// Meta about the daemon serving this dashboard.
@@ -179,6 +309,7 @@ pub(super) fn spawn_dashboard(
     ipc_port: u16,
     started_at_unix: i64,
     live_sessions_provider: LiveSessionsProvider,
+    telemetry: TelemetryStore,
 ) -> Option<u16> {
     let server = match Server::http("127.0.0.1:0") {
         Ok(s) => s,
@@ -204,6 +335,7 @@ pub(super) fn spawn_dashboard(
                 ipc_port,
                 started_at_unix,
                 live_sessions_provider,
+                telemetry,
             )
         });
     match res {
@@ -222,15 +354,21 @@ fn run_dashboard_loop(
     ipc_port: u16,
     started_at_unix: i64,
     live_sessions_provider: LiveSessionsProvider,
+    telemetry: TelemetryStore,
 ) {
     for request in server.incoming_requests() {
         let method = request.method().clone();
         let url = request.url().to_string();
         let path = url.split('?').next().unwrap_or(&url).to_string();
-        match (method, path.as_str()) {
-            (Method::Get, "/") | (Method::Get, "/index.html") => {
-                respond_html(request, 200, DASHBOARD_HTML.as_bytes());
+        // Telemetry detail route — `/telemetry/by-pid/<u32>`. Matched
+        // first so the catch-all SPA fallback below never claims it.
+        if method == Method::Get {
+            if let Some(rest) = path.strip_prefix("/telemetry/by-pid/") {
+                handle_telemetry_detail(request, rest, &telemetry);
+                continue;
             }
+        }
+        match (method, path.as_str()) {
             (Method::Get, "/state.json") => {
                 handle_state(
                     request,
@@ -239,10 +377,19 @@ fn run_dashboard_loop(
                     ipc_port,
                     started_at_unix,
                     live_sessions_provider.as_ref(),
+                    &telemetry,
                 );
             }
             (Method::Post, "/gc/purge") => {
                 handle_purge(request, gc_tx.as_ref());
+            }
+            (Method::Post, "/telemetry/log") => {
+                handle_telemetry_log(request, &telemetry);
+            }
+            // Any other GET is an SPA route — serve the dashboard so the
+            // History-API router takes over (refresh + deep-links).
+            (Method::Get, _) => {
+                respond_html(request, 200, DASHBOARD_HTML.as_bytes());
             }
             _ => {
                 respond_text(request, 404, b"not found");
@@ -260,9 +407,18 @@ fn handle_state(
     ipc_port: u16,
     started_at_unix: i64,
     live_sessions_provider: &(dyn Fn() -> Vec<LiveSession> + Send + Sync),
+    telemetry: &TelemetryStore,
 ) {
     let live_sessions = live_sessions_provider();
-    match build_dashboard_state(state_dir, gc_tx, ipc_port, started_at_unix, live_sessions) {
+    let telemetry_summary = telemetry.summary();
+    match build_dashboard_state(
+        state_dir,
+        gc_tx,
+        ipc_port,
+        started_at_unix,
+        live_sessions,
+        telemetry_summary,
+    ) {
         Ok(state) => match serde_json::to_vec(&state) {
             Ok(bytes) => respond_json(request, 200, &bytes),
             Err(err) => respond_json(
@@ -333,6 +489,70 @@ fn handle_purge(mut request: Request, gc_tx: Option<&mpsc::Sender<RegistryMsg>>)
     }
 }
 
+fn handle_telemetry_log(mut request: Request, telemetry: &TelemetryStore) {
+    let body = match read_body(&mut request) {
+        Ok(b) => b,
+        Err(err) => {
+            respond_json(
+                request,
+                400,
+                json_error_bytes(&format!("read body failed: {err}")).as_slice(),
+            );
+            return;
+        }
+    };
+    let payload: TelemetryIngest = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(err) => {
+            respond_json(
+                request,
+                400,
+                json_error_bytes(&format!("invalid JSON: {err}")).as_slice(),
+            );
+            return;
+        }
+    };
+    let received_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    telemetry.push(TelemetryEntry {
+        parent_pid: payload.parent_pid,
+        time_ms: payload.time_ms,
+        received_at_ms,
+        cmd: payload.cmd,
+        cwd: payload.cwd,
+        env: payload.env,
+    });
+    respond_json(request, 200, b"{}");
+}
+
+fn handle_telemetry_detail(request: Request, pid_str: &str, telemetry: &TelemetryStore) {
+    let pid: u32 = match pid_str.parse() {
+        Ok(p) => p,
+        Err(_) => {
+            respond_json(
+                request,
+                400,
+                json_error_bytes(&format!("invalid pid: {pid_str}")).as_slice(),
+            );
+            return;
+        }
+    };
+    let detail = telemetry.detail(pid).unwrap_or(TelemetryPidDetail {
+        parent_pid: pid,
+        entries: Vec::new(),
+    });
+    match serde_json::to_vec(&detail) {
+        Ok(bytes) => respond_json(request, 200, &bytes),
+        Err(err) => respond_json(
+            request,
+            500,
+            json_error_bytes(&format!("serialize failed: {err}")).as_slice(),
+        ),
+    }
+}
+
 fn respond_purge_reply(request: Request, reply: GcReply) {
     match reply {
         GcReply::PurgeOk { removed, skipped } => {
@@ -377,6 +597,7 @@ fn build_dashboard_state(
     ipc_port: u16,
     started_at_unix: i64,
     live_sessions: Vec<LiveSession>,
+    telemetry: Vec<TelemetryPidSummary>,
 ) -> Result<DashboardState, String> {
     let now_unix = current_unix();
 
@@ -448,6 +669,7 @@ fn build_dashboard_state(
         repos,
         ctrl_c_events,
         stats,
+        telemetry,
     })
 }
 

--- a/crates/clud-bin/src/daemon/http/tests.rs
+++ b/crates/clud-bin/src/daemon/http/tests.rs
@@ -84,7 +84,8 @@ fn empty_live_provider() -> super::LiveSessionsProvider {
 #[test]
 fn build_state_with_empty_state_dir_returns_zeros() {
     let dir = tempfile::tempdir().unwrap();
-    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
+    let state =
+        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
     assert_eq!(state.stats.session_count, 0);
     assert_eq!(state.stats.live_session_count, 0);
     assert_eq!(state.stats.gc_count, 0);
@@ -113,7 +114,8 @@ fn build_state_surfaces_direct_runner_registry_rows() {
         cwd: Some("/dev/repo".to_string()),
     }];
 
-    let state = build_dashboard_state(dir.path(), None, 9999, 100, live).expect("build");
+    let state =
+        build_dashboard_state(dir.path(), None, 9999, 100, live, Vec::new()).expect("build");
     let direct: Vec<_> = state
         .sessions
         .iter()
@@ -160,7 +162,8 @@ fn build_state_surfaces_completed_foreground_launch_records() {
     )
     .unwrap();
 
-    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
+    let state =
+        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
     assert_eq!(state.sessions.len(), 1);
     let session = &state.sessions[0];
     assert_eq!(session.id, "launch-1700000000000-4242");
@@ -187,7 +190,8 @@ fn build_state_includes_session_snapshots() {
         fake_snapshot("sess-a", "test", "/dev/foo"),
     );
 
-    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
+    let state =
+        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
     assert_eq!(state.sessions.len(), 1);
     assert_eq!(state.sessions[0].id, "sess-a");
     assert_eq!(state.sessions[0].name.as_deref(), Some("test"));
@@ -232,7 +236,8 @@ fn build_state_includes_ctrl_c_events_when_present() {
         let path = edir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
         std::fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();
     }
-    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
+    let state =
+        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
     assert_eq!(state.ctrl_c_events.len(), 3);
     // Newest first
     assert_eq!(state.ctrl_c_events[0].exit_at_ms, 1_700_000_000_500 + 2_000);
@@ -257,7 +262,8 @@ fn build_state_includes_ctrl_c_profile() {
     });
     write_fake_session(dir.path(), "sess-ctrl-c", snap);
 
-    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
+    let state =
+        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
     let profile = state.sessions[0].ctrl_c.as_ref().expect("profile");
     assert_eq!(profile.cli_handoff_ms, Some(25));
     assert_eq!(profile.daemon_kill_ms, Some(64));
@@ -315,6 +321,7 @@ fn end_to_end_state_endpoint_returns_all_three_kinds() {
         9999,
         100,
         empty_live_provider(),
+        TelemetryStore::new(),
     )
     .expect("dashboard spawned");
 
@@ -365,6 +372,7 @@ fn end_to_end_purge_kind_round_trip_mutates_registry() {
         9999,
         100,
         empty_live_provider(),
+        TelemetryStore::new(),
     )
     .expect("dashboard spawned");
 
@@ -449,6 +457,7 @@ fn end_to_end_per_row_delete_only_targets_requested_id() {
         9999,
         100,
         empty_live_provider(),
+        TelemetryStore::new(),
     )
     .expect("dashboard spawned");
 

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -28,5 +28,12 @@ pub use http::{
     dashboard_url_from_info, fetch_state_json, read_dashboard_info, read_dashboard_port,
     DashboardInfo,
 };
+// Issue #469: re-exports for the telemetry integration test under
+// `tests/telemetry_endpoint.rs` which spawns the dashboard server
+// directly and asserts the full HTTP round-trip.
+pub use http::{
+    spawn_dashboard_telemetry_only, DashboardState, TelemetryEntry, TelemetryIngest,
+    TelemetryPidDetail, TelemetryPidSummary, TelemetryStore,
+};
 pub use paths::{default_state_dir, default_trash_dir};
 pub use types::{ListRow, RepoVisit, ENV_NO_DAEMON};

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -19,7 +19,7 @@ use super::daemon_events;
 use super::gc_service::{
     spawn_registry_worker_for_state, GcRequestMsg, RegistryMsg, WORKER_REPLY_TIMEOUT,
 };
-use super::http::{default_live_sessions_provider, spawn_dashboard};
+use super::http::{default_live_sessions_provider, spawn_dashboard, TelemetryStore};
 use super::io_helpers::{new_session_id, read_json_file, write_json_file};
 use super::paths::{
     daemon_events_path, daemon_info_path, session_snapshot_path, sessions_dir, spec_path, specs_dir,
@@ -87,12 +87,17 @@ pub(super) fn run_daemon(state_dir: &Path) -> i32 {
     // discover it. Bind failures are non-fatal — IPC keeps working;
     // `dashboard_port` is just `None` on this daemon instance.
     let started_at_unix = current_unix();
+    // Issue #469: in-memory telemetry sink for `clud log` POSTs. Lives
+    // only for the daemon's lifetime — restart wipes it. Persistence
+    // is a follow-up once the prototype contract stabilizes.
+    let telemetry = TelemetryStore::new();
     let dashboard_port = spawn_dashboard(
         state_dir.to_path_buf(),
         gc_tx.clone(),
         port,
         started_at_unix,
         default_live_sessions_provider(),
+        telemetry,
     );
 
     // Install bundled Python tools (`~/.clud/tools/*`) before announcing

--- a/crates/clud-bin/src/lib.rs
+++ b/crates/clud-bin/src/lib.rs
@@ -25,6 +25,7 @@ pub mod hook_health;
 pub mod large_file_guard;
 pub mod launch_log;
 pub mod launch_setup;
+pub mod log_event;
 pub mod loop_artifacts;
 pub mod loop_check;
 pub mod loop_spec;

--- a/crates/clud-bin/src/log_event.rs
+++ b/crates/clud-bin/src/log_event.rs
@@ -1,0 +1,182 @@
+//! `clud log` (issue #469): POST one telemetry event to the daemon's
+//! HTTP server.
+//!
+//! Beta-prototype scope. The logger captures its own PPID + CWD +
+//! `CLUD_*` env vars and ships them to `$CLUD_DAEMON_HTTP_SERVER`. With
+//! `--fail-on-no-server` the command exits non-zero if either the env
+//! var is unset or the POST round-trip fails — the integration test in
+//! `tests/telemetry_endpoint.rs` uses that flag to prove a real send.
+//! Without the flag, failures are swallowed (exit 0) so the eventual
+//! hook caller never breaks because the daemon is down.
+//!
+//! Discovery happens via the environment, not a fixed port: callers
+//! (the daemon, the test harness) export `CLUD_DAEMON_HTTP_SERVER=
+//! http://127.0.0.1:<port>` before invoking `clud log`.
+
+use std::collections::BTreeMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Env-var pointing at the daemon's HTTP listener. Full URL — e.g.
+/// `http://127.0.0.1:54321`. Documented in `daemon.json` once #469 wires
+/// it into the daemon-info file (out of scope for this PR; for now the
+/// caller is responsible for exporting it).
+pub const ENV_DAEMON_HTTP_SERVER: &str = "CLUD_DAEMON_HTTP_SERVER";
+
+/// HTTP POST timeout for the logger. Tight on purpose — hook callers
+/// must not block on a stuck daemon.
+const POST_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Payload posted to `POST /telemetry/log` on the daemon. Mirrors the
+/// `TelemetryEntry` shape on the receiving side, minus the daemon-added
+/// `received_at_ms` field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryPayload {
+    pub parent_pid: u32,
+    pub time_ms: u64,
+    pub cmd: String,
+    pub cwd: String,
+    pub env: BTreeMap<String, String>,
+}
+
+/// Run `clud log`. Returns the process exit code so `main.rs` can
+/// `std::process::exit` cleanly.
+pub fn run(cmd: &str, fail_on_no_server: bool) -> i32 {
+    let server = std::env::var(ENV_DAEMON_HTTP_SERVER).ok();
+    let server = match server {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            if fail_on_no_server {
+                eprintln!("[clud log] ${ENV_DAEMON_HTTP_SERVER} is unset; cannot post telemetry");
+                return 2;
+            }
+            return 0;
+        }
+    };
+
+    let payload = build_payload(cmd);
+    let url = format!("{}/telemetry/log", server.trim_end_matches('/'));
+
+    let body = match serde_json::to_vec(&payload) {
+        Ok(b) => b,
+        Err(err) => {
+            if fail_on_no_server {
+                eprintln!("[clud log] serialize failed: {err}");
+                return 3;
+            }
+            return 0;
+        }
+    };
+
+    let result = ureq::AgentBuilder::new()
+        .timeout(POST_TIMEOUT)
+        .build()
+        .post(&url)
+        .set("Content-Type", "application/json")
+        .send_bytes(&body);
+
+    match result {
+        Ok(resp) if (200..300).contains(&resp.status()) => 0,
+        Ok(resp) => {
+            if fail_on_no_server {
+                eprintln!("[clud log] {url} returned {}", resp.status());
+                return 4;
+            }
+            0
+        }
+        Err(err) => {
+            if fail_on_no_server {
+                eprintln!("[clud log] {url} failed: {err}");
+                return 5;
+            }
+            0
+        }
+    }
+}
+
+fn build_payload(cmd: &str) -> TelemetryPayload {
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let time_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let env: BTreeMap<String, String> = std::env::vars()
+        .filter(|(k, _)| k.starts_with("CLUD_"))
+        .collect();
+    TelemetryPayload {
+        parent_pid: parent_pid(),
+        time_ms,
+        cmd: cmd.to_string(),
+        cwd,
+        env,
+    }
+}
+
+/// Parent PID of the current process — i.e., the PID of whatever
+/// invoked `clud log`. On Unix this is `getppid()`. On Windows we walk
+/// the toolhelp32 snapshot for the entry whose `th32ProcessID` matches
+/// our own PID and read its `th32ParentProcessID`.
+#[cfg(unix)]
+fn parent_pid() -> u32 {
+    // SAFETY: `getppid` is always-safe libc.
+    unsafe { libc::getppid() as u32 }
+}
+
+#[cfg(windows)]
+fn parent_pid() -> u32 {
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+    let me = std::process::id();
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[Pid::from_u32(me)]),
+        true,
+        ProcessRefreshKind::nothing(),
+    );
+    sys.process(Pid::from_u32(me))
+        .and_then(|p| p.parent())
+        .map(|p| p.as_u32())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_captures_clud_env_vars_only() {
+        // Hermetic — uses temporary env mutations gated by a serial guard
+        // so parallel tests don't flake on shared process env.
+        let lock = ENV_LOCK.lock().unwrap();
+        let prev_marker = std::env::var("CLUD_TEST_MARKER_ONLY").ok();
+        let prev_other = std::env::var("PATH_LIKE_FOO").ok();
+        // SAFETY: env writes inside a process-wide serial lock; restored below.
+        unsafe {
+            std::env::set_var("CLUD_TEST_MARKER_ONLY", "42");
+            std::env::set_var("PATH_LIKE_FOO", "ignored");
+        }
+        let p = build_payload("echo hi");
+        assert_eq!(p.cmd, "echo hi");
+        assert_eq!(
+            p.env.get("CLUD_TEST_MARKER_ONLY").map(String::as_str),
+            Some("42")
+        );
+        assert!(p.env.keys().all(|k| k.starts_with("CLUD_")));
+        // Cleanup.
+        unsafe {
+            std::env::remove_var("CLUD_TEST_MARKER_ONLY");
+            if let Some(v) = prev_marker {
+                std::env::set_var("CLUD_TEST_MARKER_ONLY", v);
+            }
+            std::env::remove_var("PATH_LIKE_FOO");
+            if let Some(v) = prev_other {
+                std::env::set_var("PATH_LIKE_FOO", v);
+            }
+        }
+        drop(lock);
+    }
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+}

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -1,9 +1,9 @@
 use clud::{
     args, backend, backend_bootstrap, clud_settings, command, console_setup, console_title,
     cpu_banner, crash_report, ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard,
-    launch_log, launch_setup, loop_artifacts, loop_spec, optimize, orphan_reaper, runner,
-    runtime_cache, startup, symbols, tool_info, tool_ledger, tool_list, tool_log, tool_run, tools,
-    trampoline, trash, ui, uv_run_hook_guard, verbose_log, wasm, worktrees,
+    launch_log, launch_setup, log_event, loop_artifacts, loop_spec, optimize, orphan_reaper,
+    runner, runtime_cache, startup, symbols, tool_info, tool_ledger, tool_list, tool_log, tool_run,
+    tools, trampoline, trash, ui, uv_run_hook_guard, verbose_log, wasm, worktrees,
 };
 
 use std::io::{self, IsTerminal, Read, Write};
@@ -120,6 +120,18 @@ fn main() {
     }) = &args.command
     {
         std::process::exit(trash::run(&args, paths, *cross_volume));
+    }
+
+    // Issue #469: `clud log --cmd "..."` posts one telemetry event to
+    // the always-on daemon's HTTP server. Discovers the daemon via
+    // `$CLUD_DAEMON_HTTP_SERVER`. Self-contained; never launches an
+    // agent backend.
+    if let Some(args::Command::Log {
+        cmd,
+        fail_on_no_server,
+    }) = &args.command
+    {
+        std::process::exit(log_event::run(cmd, *fail_on_no_server));
     }
 
     // Issue #408: `clud tool run <rel_path> [args]` invokes a bundled

--- a/crates/clud-bin/tests/telemetry_endpoint.rs
+++ b/crates/clud-bin/tests/telemetry_endpoint.rs
@@ -1,0 +1,277 @@
+//! End-to-end integration test for the telemetry sink (issue #469).
+//!
+//! Spawns the daemon's HTTP listener via [`spawn_dashboard`], invokes
+//! `clud log --cmd <known> --fail-on-no-server` against it with a
+//! `CLUD_TEST_MARKER` env var, and asserts:
+//!
+//! 1. `clud log` exited 0 (proves the POST round-tripped).
+//! 2. `/state.json` shows the new entry under `telemetry` keyed by the
+//!    test process's PID.
+//! 3. `/telemetry/by-pid/<pid>` returns the full entry including the
+//!    captured `CLUD_*` env vars.
+//!
+//! Validates the entire chain: CLI → HTTP POST → in-memory sink →
+//! dashboard read.
+
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clud::daemon::{
+    spawn_dashboard_telemetry_only, DashboardState, TelemetryPidDetail, TelemetryStore,
+};
+use running_process::{
+    CommandSpec, NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode,
+};
+
+/// Path to the `clud` binary that this test crate's `cargo test` just
+/// built. Cargo sets `CARGO_BIN_EXE_<bin>` for integration tests in the
+/// same package — see the cargo book "Environment variables Cargo sets
+/// for crates".
+fn clud_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clud"))
+}
+
+#[test]
+fn telemetry_round_trip_via_clud_log_subprocess() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let telemetry = TelemetryStore::new();
+    let port =
+        spawn_dashboard_telemetry_only(dir.path().to_path_buf(), 9999, 100, telemetry.clone())
+            .expect("dashboard spawned");
+
+    // Invoke `clud log` against the spawned port. --fail-on-no-server
+    // guarantees a non-zero exit if the POST doesn't round-trip, which
+    // is exactly what we want for an end-to-end proof.
+    let known_cmd = "telemetry-test-marker-xyz";
+    let url = format!("http://127.0.0.1:{port}");
+
+    // Build the env: inherit current process's, drop any pre-existing
+    // CLUD_DAEMON_HTTP_SERVER, then layer in the two we care about so
+    // the test can assert the marker round-tripped.
+    let mut env: Vec<(String, String)> = std::env::vars().collect();
+    env.retain(|(k, _)| {
+        k != "CLUD_DAEMON_HTTP_SERVER"
+            && k != "CLUD_TEST_MARKER"
+            && k != "RUNNING_PROCESS_ORIGINATOR"
+    });
+    env.push(("CLUD_DAEMON_HTTP_SERVER".to_string(), url.clone()));
+    env.push(("CLUD_TEST_MARKER".to_string(), "42".to_string()));
+
+    let config = ProcessConfig {
+        command: CommandSpec::Argv(vec![
+            clud_exe().to_string_lossy().into_owned(),
+            "log".to_string(),
+            "--cmd".to_string(),
+            known_cmd.to_string(),
+            "--fail-on-no-server".to_string(),
+        ]),
+        cwd: None,
+        env: Some(env),
+        capture: true,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Null,
+        nice: None,
+    };
+    let process = NativeProcess::new(config);
+    process.start().expect("spawn clud log");
+
+    let mut stdout = String::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let exit_code = loop {
+        match process.read_combined(Some(Duration::from_millis(50))) {
+            ReadStatus::Line(event) => {
+                stdout.push_str(&String::from_utf8_lossy(&event.line));
+                stdout.push('\n');
+            }
+            ReadStatus::Timeout | ReadStatus::Eof => {}
+        }
+        match process.poll().expect("poll") {
+            Some(code) => break code,
+            None => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = process.kill();
+                    panic!("clud log did not exit within 10s; stdout so far:\n{stdout}");
+                }
+            }
+        }
+    };
+    assert_eq!(
+        exit_code, 0,
+        "clud log --fail-on-no-server should round-trip the POST; got exit={exit_code}\nstdout:\n{stdout}",
+    );
+
+    // Assert /state.json shows the entry under the child's parent PID.
+    // The child's parent is THIS test process — process.pid() returns
+    // the child PID. We don't know the exact PPID the child sees on
+    // Windows (which uses sysinfo) vs. POSIX (getppid), so just assert
+    // there is exactly one PID with one entry, and it's our PID.
+    let state_body = fetch_path(port, "GET", "/state.json", None).expect("GET /state.json");
+    let state: DashboardState = serde_json::from_str(&state_body).expect("parse state");
+    assert_eq!(
+        state.telemetry.len(),
+        1,
+        "expected exactly one PID summary, got {}: {:?}",
+        state.telemetry.len(),
+        state.telemetry
+    );
+    let summary = &state.telemetry[0];
+    assert_eq!(
+        summary.entry_count, 1,
+        "expected 1 entry, got {}",
+        summary.entry_count
+    );
+    let test_pid = std::process::id();
+    assert_eq!(
+        summary.parent_pid, test_pid,
+        "parent_pid should be the test process's PID ({test_pid}), got {}",
+        summary.parent_pid
+    );
+
+    // Assert /telemetry/by-pid/<pid> returns the full entry with our env marker.
+    let detail_path = format!("/telemetry/by-pid/{}", summary.parent_pid);
+    let detail_body = fetch_path(port, "GET", &detail_path, None).expect("GET detail");
+    let detail: TelemetryPidDetail = serde_json::from_str(&detail_body).expect("parse detail");
+    assert_eq!(detail.entries.len(), 1);
+    let entry = &detail.entries[0];
+    assert_eq!(entry.cmd, known_cmd);
+    assert_eq!(
+        entry.env.get("CLUD_TEST_MARKER").map(String::as_str),
+        Some("42"),
+        "CLUD_TEST_MARKER missing from captured env: {:?}",
+        entry.env
+    );
+    // All captured env keys must start with CLUD_ (the logger filters).
+    assert!(
+        entry.env.keys().all(|k| k.starts_with("CLUD_")),
+        "non-CLUD_ env keys leaked through: {:?}",
+        entry.env.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn clud_log_no_env_with_fail_flag_exits_nonzero() {
+    // Without CLUD_DAEMON_HTTP_SERVER, --fail-on-no-server must exit nonzero.
+    let mut env: Vec<(String, String)> = std::env::vars().collect();
+    env.retain(|(k, _)| k != "CLUD_DAEMON_HTTP_SERVER");
+
+    let config = ProcessConfig {
+        command: CommandSpec::Argv(vec![
+            clud_exe().to_string_lossy().into_owned(),
+            "log".to_string(),
+            "--cmd".to_string(),
+            "noserver".to_string(),
+            "--fail-on-no-server".to_string(),
+        ]),
+        cwd: None,
+        env: Some(env),
+        capture: true,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Null,
+        nice: None,
+    };
+    let process = NativeProcess::new(config);
+    process.start().expect("spawn clud log");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let exit_code = loop {
+        match process.read_combined(Some(Duration::from_millis(50))) {
+            ReadStatus::Line(_) | ReadStatus::Timeout | ReadStatus::Eof => {}
+        }
+        match process.poll().expect("poll") {
+            Some(code) => break code,
+            None => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = process.kill();
+                    panic!("clud log did not exit within 5s");
+                }
+            }
+        }
+    };
+    assert_ne!(exit_code, 0, "expected non-zero exit without env var");
+}
+
+#[test]
+fn clud_log_unreachable_server_with_fail_flag_exits_nonzero() {
+    // Point at a port nothing is listening on. --fail-on-no-server must
+    // surface the connection failure.
+    let mut env: Vec<(String, String)> = std::env::vars().collect();
+    env.retain(|(k, _)| k != "CLUD_DAEMON_HTTP_SERVER");
+    // Port 1 is reserved (tcpmux) and reliably refuses connections on
+    // every CI runner the matrix targets.
+    env.push((
+        "CLUD_DAEMON_HTTP_SERVER".to_string(),
+        "http://127.0.0.1:1".to_string(),
+    ));
+
+    let config = ProcessConfig {
+        command: CommandSpec::Argv(vec![
+            clud_exe().to_string_lossy().into_owned(),
+            "log".to_string(),
+            "--cmd".to_string(),
+            "unreachable".to_string(),
+            "--fail-on-no-server".to_string(),
+        ]),
+        cwd: None,
+        env: Some(env),
+        capture: true,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Null,
+        nice: None,
+    };
+    let process = NativeProcess::new(config);
+    process.start().expect("spawn clud log");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(6);
+    let exit_code = loop {
+        match process.read_combined(Some(Duration::from_millis(50))) {
+            ReadStatus::Line(_) | ReadStatus::Timeout | ReadStatus::Eof => {}
+        }
+        match process.poll().expect("poll") {
+            Some(code) => break code,
+            None => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = process.kill();
+                    panic!("clud log did not exit within 6s");
+                }
+            }
+        }
+    };
+    assert_ne!(exit_code, 0, "expected non-zero exit on unreachable server");
+}
+
+/// Tiny HTTP/1.0 client for the test. Mirrors the helper in
+/// `daemon::http::tests` so we don't need a real HTTP client dep.
+fn fetch_path(port: u16, method: &str, path: &str, body: Option<String>) -> io::Result<String> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+    let mut req = format!("{method} {path} HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n",);
+    if let Some(b) = &body {
+        req.push_str(&format!(
+            "Content-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            b.len(),
+            b
+        ));
+    } else {
+        req.push_str("\r\n");
+    }
+    stream.write_all(req.as_bytes())?;
+    stream.flush()?;
+    let mut buf = Vec::with_capacity(4096);
+    stream.read_to_end(&mut buf)?;
+    // Find the body start.
+    let body_start = (0..buf.len().saturating_sub(3))
+        .find(|&i| &buf[i..i + 4] == b"\r\n\r\n")
+        .map(|i| i + 4)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "no header terminator"))?;
+    String::from_utf8(buf[body_start..].to_vec())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}


### PR DESCRIPTION
Beta prototype for telemetry ingestion (issue #469). Adds a `clud log` subcommand that ships one event per invocation (parent PID, time, cmd, cwd, all `CLUD_*` env vars) to the daemon over HTTP, plus an in-memory sink keyed by parent PID and a new dashboard tab to inspect it.

## Summary

- **`clud log --cmd "..." [--fail-on-no-server]`** — `src/log_event.rs`. Default behaviour swallows failures (exit 0) so a hook caller is never broken. `--fail-on-no-server` exits non-zero when `CLUD_DAEMON_HTTP_SERVER` is unset or the POST fails — tests use this flag to prove a real round-trip.
- **`POST /telemetry/log` + `GET /telemetry/by-pid/<pid>`** — `daemon/http.rs`. In-memory `TelemetryStore` capped at 500 entries per PID (drop-oldest). Summary is rolled into `/state.json` so the existing 5s poll covers the list view; full per-entry payload (with envs) lives behind `/by-pid/<pid>` to keep the polled summary bounded.
- **New "Telemetry" tab in the dashboard SPA**, with History-API routing matching the user's spec: `/telemetry` lists PIDs, `/telemetry/<pid>` shows the per-entry table with `received | cwd | cmd | [env]` where `[env]` toggles a per-row table of the captured `CLUD_*` vars.
- **`spawn_dashboard_telemetry_only`** — a narrow `pub` entry point so the integration test can spawn the dashboard without taking on the `gc_service::RegistryMsg` type that the full `spawn_dashboard` signature would otherwise leak.

## End-to-end test (`tests/telemetry_endpoint.rs`)

Spawns the daemon HTTP listener, invokes `clud log --cmd "<known>" --fail-on-no-server` with `CLUD_DAEMON_HTTP_SERVER` pointing at the spawned port and a `CLUD_TEST_MARKER=42` env var, asserts:

1. `clud log` exited 0 (proves the POST round-tripped).
2. `/state.json` shows one PID summary with the test PID and `entry_count=1`.
3. `/telemetry/by-pid/<pid>` returns the captured `CLUD_TEST_MARKER=42` and no non-`CLUD_*` keys.

Plus two negative-path tests:
- `--fail-on-no-server` with no env var → exit non-zero, ≤5s.
- `--fail-on-no-server` against an unreachable port → exit non-zero, ≤2s timeout.

## Non-goals (deferred)

- Persistence across daemon restarts (in-memory only for the prototype; redb persistence is a follow-up).
- Wiring `clud log` into Claude Code's hook config — settings.json change, separate PR once the endpoint shape is stable.
- Real PID/cwd discovery via the caller's hook payload (Claude's payload shape unknown; prototype uses `getppid()` + `current_dir()`).

## Test plan

- [x] `soldr cargo test -p clud --test telemetry_endpoint` — 3 new tests pass.
- [x] `soldr cargo test -p clud --lib daemon::http` — 14 existing tests pass (updated `spawn_dashboard` + `build_dashboard_state` call sites to take the new `TelemetryStore` / summary args).
- [x] `bash lint` — clean (rustfmt + clippy + ruff).
- [x] Manual smoke: `CLUD_DAEMON_HTTP_SERVER=http://127.0.0.1:<port> clud log --cmd hi --fail-on-no-server` against a running daemon → record appears under `/telemetry` in the dashboard.

Pre-existing `shim_session::tests::prepend_to_path_is_idempotent` failure on Windows is unrelated to this PR (reproduces on `origin/main`).

Closes #469.
