### PR TITLE
feat(daemon): GET /telemetry endpoint; move list view off /state.json

### DIFF
--- a/crates/clud-bin/assets/dashboard/index.html
+++ b/crates/clud-bin/assets/dashboard/index.html
@@ -480,8 +480,8 @@
         </table>`;
     }
 
-    function renderTelemetry(state) {
-      const rows = state.telemetry || [];
+    function renderTelemetry(rows) {
+      rows = rows || [];
       document.getElementById('telemetry-count').textContent = rows.length ? `(${rows.length})` : '';
       if (!rows.length) {
         document.getElementById('telemetry-body').innerHTML =
@@ -585,20 +585,28 @@
     }
 
     async function refresh() {
+      // Issue #471: /state.json and /telemetry are independent endpoints.
+      // Fire them in parallel; either response can render on its own and
+      // partial failure of one does not blank the other.
+      const stateP = fetch('/state.json').then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)));
+      const telemetryP = fetch('/telemetry').then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)));
       try {
-        const resp = await fetch('/state.json');
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        const state = await resp.json();
+        const state = await stateP;
         lastState = state;
         renderHeader(state);
         renderSessions(state);
         renderGc(state);
         renderRepos(state);
         renderCtrlCEvents(state);
-        renderTelemetry(state);
       } catch (err) {
         document.getElementById('daemon-meta').textContent =
           `connection lost: ${err}`;
+      }
+      try {
+        renderTelemetry(await telemetryP);
+      } catch (err) {
+        document.getElementById('telemetry-body').innerHTML =
+          `<p class="empty">failed to load telemetry: ${esc(err)}</p>`;
       }
     }
 

--- a/crates/clud-bin/src/daemon/http.rs
+++ b/crates/clud-bin/src/daemon/http.rs
@@ -203,11 +203,6 @@ pub struct DashboardState {
     #[serde(default)]
     pub ctrl_c_events: Vec<CtrlCEvent>,
     pub stats: Stats,
-    /// Issue #469: per-PID telemetry summary (entry counts + last-seen).
-    /// Full per-entry payload (with envs) lives at `/telemetry/by-pid/<pid>`
-    /// so this list stays bounded for the 5s poller.
-    #[serde(default)]
-    pub telemetry: Vec<TelemetryPidSummary>,
 }
 
 /// Meta about the daemon serving this dashboard.
@@ -377,8 +372,12 @@ fn run_dashboard_loop(
                     ipc_port,
                     started_at_unix,
                     live_sessions_provider.as_ref(),
-                    &telemetry,
                 );
+            }
+            // Issue #471: telemetry summary lives at its own URL now
+            // (was previously bundled into `/state.json#telemetry`).
+            (Method::Get, "/telemetry") => {
+                handle_telemetry_summary(request, &telemetry);
             }
             (Method::Post, "/gc/purge") => {
                 handle_purge(request, gc_tx.as_ref());
@@ -407,18 +406,9 @@ fn handle_state(
     ipc_port: u16,
     started_at_unix: i64,
     live_sessions_provider: &(dyn Fn() -> Vec<LiveSession> + Send + Sync),
-    telemetry: &TelemetryStore,
 ) {
     let live_sessions = live_sessions_provider();
-    let telemetry_summary = telemetry.summary();
-    match build_dashboard_state(
-        state_dir,
-        gc_tx,
-        ipc_port,
-        started_at_unix,
-        live_sessions,
-        telemetry_summary,
-    ) {
+    match build_dashboard_state(state_dir, gc_tx, ipc_port, started_at_unix, live_sessions) {
         Ok(state) => match serde_json::to_vec(&state) {
             Ok(bytes) => respond_json(request, 200, &bytes),
             Err(err) => respond_json(
@@ -486,6 +476,22 @@ fn handle_purge(mut request: Request, gc_tx: Option<&mpsc::Sender<RegistryMsg>>)
     match send_gc_op(tx, op) {
         Ok(reply) => respond_purge_reply(request, reply),
         Err(err) => respond_json(request, 500, json_error_bytes(&err).as_slice()),
+    }
+}
+
+/// Issue #471: per-PID summary list at its own URL. Returns the same
+/// `Vec<TelemetryPidSummary>` shape that the bundled
+/// `/state.json#telemetry` field used to carry — no behavior change
+/// for the SPA's existing render code beyond the fetch destination.
+fn handle_telemetry_summary(request: Request, telemetry: &TelemetryStore) {
+    let summary = telemetry.summary();
+    match serde_json::to_vec(&summary) {
+        Ok(bytes) => respond_json(request, 200, &bytes),
+        Err(err) => respond_json(
+            request,
+            500,
+            json_error_bytes(&format!("serialize failed: {err}")).as_slice(),
+        ),
     }
 }
 
@@ -597,7 +603,6 @@ fn build_dashboard_state(
     ipc_port: u16,
     started_at_unix: i64,
     live_sessions: Vec<LiveSession>,
-    telemetry: Vec<TelemetryPidSummary>,
 ) -> Result<DashboardState, String> {
     let now_unix = current_unix();
 
@@ -669,7 +674,6 @@ fn build_dashboard_state(
         repos,
         ctrl_c_events,
         stats,
-        telemetry,
     })
 }
 

--- a/crates/clud-bin/src/daemon/http/tests.rs
+++ b/crates/clud-bin/src/daemon/http/tests.rs
@@ -84,8 +84,7 @@ fn empty_live_provider() -> super::LiveSessionsProvider {
 #[test]
 fn build_state_with_empty_state_dir_returns_zeros() {
     let dir = tempfile::tempdir().unwrap();
-    let state =
-        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
+    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
     assert_eq!(state.stats.session_count, 0);
     assert_eq!(state.stats.live_session_count, 0);
     assert_eq!(state.stats.gc_count, 0);
@@ -114,8 +113,7 @@ fn build_state_surfaces_direct_runner_registry_rows() {
         cwd: Some("/dev/repo".to_string()),
     }];
 
-    let state =
-        build_dashboard_state(dir.path(), None, 9999, 100, live, Vec::new()).expect("build");
+    let state = build_dashboard_state(dir.path(), None, 9999, 100, live).expect("build");
     let direct: Vec<_> = state
         .sessions
         .iter()
@@ -162,8 +160,7 @@ fn build_state_surfaces_completed_foreground_launch_records() {
     )
     .unwrap();
 
-    let state =
-        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
+    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
     assert_eq!(state.sessions.len(), 1);
     let session = &state.sessions[0];
     assert_eq!(session.id, "launch-1700000000000-4242");
@@ -190,8 +187,7 @@ fn build_state_includes_session_snapshots() {
         fake_snapshot("sess-a", "test", "/dev/foo"),
     );
 
-    let state =
-        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
+    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
     assert_eq!(state.sessions.len(), 1);
     assert_eq!(state.sessions[0].id, "sess-a");
     assert_eq!(state.sessions[0].name.as_deref(), Some("test"));
@@ -236,8 +232,7 @@ fn build_state_includes_ctrl_c_events_when_present() {
         let path = edir.join(format!("{:013}-{}.json", event.exit_at_ms, event.pid));
         std::fs::write(&path, serde_json::to_vec(&event).unwrap()).unwrap();
     }
-    let state =
-        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
+    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
     assert_eq!(state.ctrl_c_events.len(), 3);
     // Newest first
     assert_eq!(state.ctrl_c_events[0].exit_at_ms, 1_700_000_000_500 + 2_000);
@@ -262,8 +257,7 @@ fn build_state_includes_ctrl_c_profile() {
     });
     write_fake_session(dir.path(), "sess-ctrl-c", snap);
 
-    let state =
-        build_dashboard_state(dir.path(), None, 9999, 100, Vec::new(), Vec::new()).expect("build");
+    let state = build_dashboard_state(dir.path(), None, 9999, 100, Vec::new()).expect("build");
     let profile = state.sessions[0].ctrl_c.as_ref().expect("profile");
     assert_eq!(profile.cli_handoff_ms, Some(25));
     assert_eq!(profile.daemon_kill_ms, Some(64));

--- a/crates/clud-bin/tests/telemetry_endpoint.rs
+++ b/crates/clud-bin/tests/telemetry_endpoint.rs
@@ -5,10 +5,10 @@
 //! `CLUD_TEST_MARKER` env var, and asserts:
 //!
 //! 1. `clud log` exited 0 (proves the POST round-tripped).
-//! 2. `/state.json` shows the new entry under `telemetry` keyed by the
-//!    test process's PID.
-//! 3. `/telemetry/by-pid/<pid>` returns the full entry including the
-//!    captured `CLUD_*` env vars.
+//! 2. `GET /telemetry` returns one summary entry keyed by the test
+//!    process's PID (issue #471 — moved off `/state.json#telemetry`).
+//! 3. `GET /telemetry/by-pid/<pid>` returns the full entry including
+//!    the captured `CLUD_*` env vars.
 //!
 //! Validates the entire chain: CLI → HTTP POST → in-memory sink →
 //! dashboard read.
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clud::daemon::{
-    spawn_dashboard_telemetry_only, DashboardState, TelemetryPidDetail, TelemetryStore,
+    spawn_dashboard_telemetry_only, TelemetryPidDetail, TelemetryPidSummary, TelemetryStore,
 };
 use running_process::{
     CommandSpec, NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode,
@@ -104,21 +104,19 @@ fn telemetry_round_trip_via_clud_log_subprocess() {
         "clud log --fail-on-no-server should round-trip the POST; got exit={exit_code}\nstdout:\n{stdout}",
     );
 
-    // Assert /state.json shows the entry under the child's parent PID.
-    // The child's parent is THIS test process — process.pid() returns
-    // the child PID. We don't know the exact PPID the child sees on
-    // Windows (which uses sysinfo) vs. POSIX (getppid), so just assert
-    // there is exactly one PID with one entry, and it's our PID.
-    let state_body = fetch_path(port, "GET", "/state.json", None).expect("GET /state.json");
-    let state: DashboardState = serde_json::from_str(&state_body).expect("parse state");
+    // Issue #471: telemetry summary now lives at its own URL — fetch
+    // from `/telemetry` directly instead of pulling it out of the
+    // consolidated state document.
+    let summary_body = fetch_path(port, "GET", "/telemetry", None).expect("GET /telemetry");
+    let summaries: Vec<TelemetryPidSummary> =
+        serde_json::from_str(&summary_body).expect("parse summary");
     assert_eq!(
-        state.telemetry.len(),
+        summaries.len(),
         1,
-        "expected exactly one PID summary, got {}: {:?}",
-        state.telemetry.len(),
-        state.telemetry
+        "expected exactly one PID summary, got {}: {summaries:?}",
+        summaries.len(),
     );
-    let summary = &state.telemetry[0];
+    let summary = &summaries[0];
     assert_eq!(
         summary.entry_count, 1,
         "expected 1 entry, got {}",
@@ -245,6 +243,52 @@ fn clud_log_unreachable_server_with_fail_flag_exits_nonzero() {
         }
     };
     assert_ne!(exit_code, 0, "expected non-zero exit on unreachable server");
+}
+
+/// Issue #471: `GET /telemetry` returns the per-PID summary list
+/// independently of `/state.json`. Asserts the empty case + that two
+/// distinct PIDs from two POSTs both appear, sorted last-seen-desc.
+#[test]
+fn telemetry_summary_endpoint_returns_independent_list() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let telemetry = TelemetryStore::new();
+    let port =
+        spawn_dashboard_telemetry_only(dir.path().to_path_buf(), 9999, 100, telemetry.clone())
+            .expect("dashboard spawned");
+
+    // Empty case: no POSTs yet → empty array.
+    let empty_body = fetch_path(port, "GET", "/telemetry", None).expect("GET /telemetry empty");
+    let empty: Vec<TelemetryPidSummary> = serde_json::from_str(&empty_body).expect("parse empty");
+    assert!(empty.is_empty(), "expected empty array, got {empty:?}");
+
+    // POST two entries from two distinct PIDs.
+    for (pid, ts) in [(111u32, 1_700_000_001_000u64), (222, 1_700_000_002_000)] {
+        let body =
+            format!(r#"{{"parent_pid":{pid},"time_ms":{ts},"cmd":"e","cwd":"/tmp","env":{{}}}}"#);
+        let resp =
+            fetch_path(port, "POST", "/telemetry/log", Some(body)).expect("POST /telemetry/log");
+        assert!(resp.contains("{}"), "expected ack {{}}, got: {resp}");
+    }
+
+    let body = fetch_path(port, "GET", "/telemetry", None).expect("GET /telemetry populated");
+    let summaries: Vec<TelemetryPidSummary> = serde_json::from_str(&body).expect("parse populated");
+    assert_eq!(summaries.len(), 2);
+    // Sort order is last_at_ms desc — newer (received later) comes first.
+    // Both POSTs happened in the same test second, so use parent_pid as a
+    // tie-breaker assertion: the SET equals {111, 222}.
+    let pids: std::collections::BTreeSet<u32> = summaries.iter().map(|s| s.parent_pid).collect();
+    assert_eq!(pids, [111, 222].into_iter().collect());
+    assert!(
+        summaries.iter().all(|s| s.entry_count == 1),
+        "each PID should have exactly one entry: {summaries:?}"
+    );
+    // Sanity: /state.json must NOT contain a `telemetry` field anymore.
+    let state_body = fetch_path(port, "GET", "/state.json", None).expect("GET /state.json");
+    let state: serde_json::Value = serde_json::from_str(&state_body).expect("parse state");
+    assert!(
+        state.get("telemetry").is_none(),
+        "/state.json should no longer carry telemetry; got {state}"
+    );
 }
 
 /// Tiny HTTP/1.0 client for the test. Mirrors the helper in


### PR DESCRIPTION
Cleanup follow-up to #470. Telemetry summary was bundled into `/state.json#telemetry` — convenient for the dashboard's existing 5s poll but inconsistent with the URL shape (SPA route was `/telemetry`, peer endpoint was `/telemetry/by-pid/<pid>`, list API was buried in the consolidated state document).

## Summary

- New `GET /telemetry` returns `Vec<TelemetryPidSummary>` directly.
- Drop `DashboardState::telemetry`; `build_dashboard_state` no longer takes the summary arg.
- SPA `refresh()` fires `/state.json` and `/telemetry` in parallel and renders independently — partial failure of one does not blank the other.
- New `telemetry_summary_endpoint_returns_independent_list` test asserts the empty case, the 2-PID populated case, AND that `/state.json` no longer carries a `telemetry` field.
- Existing `telemetry_round_trip_via_clud_log_subprocess` now fetches from `/telemetry` instead of pulling from state.

## Endpoints after this change

- `GET /telemetry` — summary list (new)
- `GET /telemetry/by-pid/<pid>` — per-PID detail with envs (unchanged)
- `POST /telemetry/log` — ingest (unchanged)
- `GET /state.json` — no longer carries `telemetry`

## Test plan

- [x] `soldr cargo test -p clud --test telemetry_endpoint` — 4 tests pass (3 prior + 1 new).
- [x] `soldr cargo test -p clud --lib daemon::http` — 14 existing tests pass after dropping the 6th `build_dashboard_state` arg.
- [x] `bash lint` clean.

Closes #471.