### PR TITLE
feat(tools): bundle hooks/telemetry.py — PostToolUse → daemon /telemetry/log

### DIFF
--- a/crates/clud-bin/assets/tools/hooks/telemetry.py
+++ b/crates/clud-bin/assets/tools/hooks/telemetry.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+# managed-by: clud
+"""telemetry.py — PostToolUse hook that ships one record to the clud daemon.
+
+Hook contract (mirrors Claude Code PostToolUse payloads):
+- Input: JSON object on stdin with `tool_name`, `tool_input`,
+  `tool_response`, and (optionally) `cwd`, `session_id`.
+- Output: nothing actionable. This hook NEVER blocks a tool call —
+  it ALWAYS exits 0 regardless of what happens internally.
+
+Invoked via `clud tool run hooks/telemetry.py` so UV_CACHE_DIR is pinned
+to ~/.clud/cache/uv per the three-layer enforcement (issue #408). clud
+auto-installs this file to ~/.clud/tools/hooks/telemetry.py on every
+startup; the `# managed-by: clud` marker above is what gates the
+installer's overwrite behavior. Hand-edit at your own risk — drop the
+marker if you want the installer to leave your copy alone.
+
+Behavior:
+- If `$CLUD_DAEMON_HTTP_SERVER` is unset/empty, exits 0 silently.
+- Otherwise POSTs a JSON envelope to `<server>/telemetry/log` matching
+  the daemon's `TelemetryIngest` schema (parent_pid, time_ms, cmd, cwd,
+  env where every key starts with `CLUD_`).
+- 2s HTTP timeout — hook callers must not hang on a dead daemon.
+- Stdlib only (urllib.request); no third-party deps in the venv.
+
+Recommended `~/.claude/settings.json` wiring (matcher "*", async):
+
+    "PostToolUse": [{
+      "matcher": "*",
+      "hooks": [{
+        "type": "command",
+        "command": "clud tool run hooks/telemetry.py",
+        "async": true,
+        "timeout": 30
+      }]
+    }]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from typing import Any
+
+# Tight cap — hook callers must never wait on a stuck daemon.
+HTTP_TIMEOUT_SEC = 2.0
+# Truncate the cmd summary so the dashboard table stays readable and
+# the in-memory ring buffer doesn't bloat on huge tool_input blobs.
+CMD_MAX_LEN = 200
+
+
+def _cmd_summary(payload: dict[str, Any]) -> str:
+    """Pick the most useful one-line summary for the `cmd` field.
+
+    The daemon's `TelemetryIngest` schema has a single `cmd: String`
+    field; we lossy-summarize tool-specific input down to something a
+    human reading the dashboard's per-PID table can scan at a glance.
+    """
+    tool_name = payload.get("tool_name", "?")
+    tool_input = payload.get("tool_input") or {}
+
+    if tool_name == "Bash":
+        return f"Bash: {tool_input.get('command', '')}"
+    if tool_name in ("Edit", "Write", "Read", "NotebookEdit"):
+        return f"{tool_name}: {tool_input.get('file_path', '')}"
+    if tool_name in ("Grep", "Glob"):
+        return f"{tool_name}: {tool_input.get('pattern', '')}"
+    # Fallback: tool_name plus a truncated JSON snapshot of input.
+    try:
+        snippet = json.dumps(tool_input, ensure_ascii=False, default=str)
+    except Exception:
+        snippet = repr(tool_input)
+    if len(snippet) > CMD_MAX_LEN - len(tool_name) - 2:
+        snippet = snippet[: CMD_MAX_LEN - len(tool_name) - 5] + "..."
+    return f"{tool_name}: {snippet}"
+
+
+def main() -> int:
+    try:
+        server = os.environ.get("CLUD_DAEMON_HTTP_SERVER", "").strip()
+        if not server:
+            return 0  # No daemon configured. Silent no-op.
+
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return 0
+
+        try:
+            payload = json.loads(raw)
+        except Exception:
+            return 0  # Malformed hook payload — nothing actionable.
+
+        body = {
+            "parent_pid": os.getppid(),
+            "time_ms": int(time.time() * 1000),
+            "cmd": _cmd_summary(payload),
+            # Hook payload's `cwd` reflects Claude Code's cwd at fire
+            # time; fall back to ours when absent.
+            "cwd": payload.get("cwd") or os.getcwd(),
+            # Every CLUD_* env var, verbatim. Callers can use this as a
+            # tagging mechanism (e.g. CLUD_SESSION_ID, CLUD_TASK, ...).
+            "env": {k: v for k, v in os.environ.items() if k.startswith("CLUD_")},
+        }
+
+        url = server.rstrip("/") + "/telemetry/log"
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SEC):
+            pass
+    except Exception:
+        # Swallow EVERYTHING. The only contract is "exit 0".
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/clud-bin/src/tools.rs
+++ b/crates/clud-bin/src/tools.rs
@@ -162,6 +162,21 @@ pub const BUNDLED_TOOLS: &[BundledTool] = &[
         progress_timeout: None,
         quiet_ok: true,
     },
+    BundledTool {
+        rel_path: "hooks/telemetry.py",
+        body: include_str!("../assets/tools/hooks/telemetry.py"),
+        // PostToolUse hook (#473): ships the hook payload to the clud
+        // daemon's /telemetry/log endpoint. ALWAYS exits 0 by contract —
+        // a stuck or broken telemetry path must never block a tool call.
+        // Killable because the work IS the POST; killing mid-flight loses
+        // that one record but the tool call is unaffected (recommended
+        // wiring uses `async: true`). 30s backstop matches the other
+        // hooks; the script itself enforces a 2s HTTP timeout internally.
+        kill_semantics: KillSemantics::Killable,
+        command_timeout: Duration::from_secs(30),
+        progress_timeout: None,
+        quiet_ok: true,
+    },
     // docker-build tool family — implementation of zackees/clud#421.
     // Trampoline filename uses a hyphen to match the public CLI shape
     // (`clud tool run docker/docker-build.py soldr <path>`); sibling
@@ -339,6 +354,33 @@ mod tests {
             names.contains(&"hooks/uv_run_hook_guard.py"),
             "BUNDLED_TOOLS must include hooks/uv_run_hook_guard.py; \
              got {names:?}",
+        );
+    }
+
+    /// Issue #473: the `hooks/telemetry.py` PostToolUse bridge ships in
+    /// the bundle and is the documented producer for the daemon's
+    /// `/telemetry/log` endpoint (#469). If the entry is renamed or
+    /// removed, the recommended `~/.claude/settings.json` wiring
+    /// (`clud tool run hooks/telemetry.py`) silently breaks.
+    #[test]
+    fn bundled_includes_telemetry_hook() {
+        let names: Vec<&str> = BUNDLED_TOOLS.iter().map(|t| t.rel_path).collect();
+        assert!(
+            names.contains(&"hooks/telemetry.py"),
+            "BUNDLED_TOOLS must include hooks/telemetry.py; got {names:?}",
+        );
+        let tool = BUNDLED_TOOLS
+            .iter()
+            .find(|t| t.rel_path == "hooks/telemetry.py")
+            .expect("just-asserted entry");
+        // Contract assertions: never blocks, env-var-driven discovery.
+        assert!(
+            tool.body.contains("ALWAYS exits 0"),
+            "telemetry.py must document the always-exit-0 contract",
+        );
+        assert!(
+            tool.body.contains("CLUD_DAEMON_HTTP_SERVER"),
+            "telemetry.py must reference the env-var discovery contract",
         );
     }
 


### PR DESCRIPTION
Adds the missing producer side of the telemetry pipeline from #469. The destination (daemon `/telemetry/log` + `clud log` CLI + dashboard view) shipped in #470; this PR adds the bundled hook script that ships Claude Code tool-call events into it.

## Summary

- New `crates/clud-bin/assets/tools/hooks/telemetry.py` — uv-script-frontmatter Python, stdlib only.
- ALWAYS exits 0 by contract. Silent no-op when `$CLUD_DAEMON_HTTP_SERVER` is unset; otherwise POSTs the 5-field `TelemetryIngest` schema (`parent_pid`, `time_ms`, `cmd`, `cwd`, `env`) to `<server>/telemetry/log`.
- Tool-aware `cmd` summary so the dashboard is readable: `Bash` → command; `Edit`/`Write`/`Read`/`NotebookEdit` → file_path; `Grep`/`Glob` → pattern; otherwise truncated JSON of `tool_input`.
- Every `CLUD_*` env var is shipped verbatim in the `env` bag — callers can use those as a tagging mechanism (e.g. `CLUD_SESSION_ID`, `CLUD_TASK`).
- Registered in `BUNDLED_TOOLS` mirroring `block-bad-cmd.py`: Killable, 30s command timeout backstop, `quiet_ok: true`. Script enforces a 2s HTTP timeout internally.
- New `bundled_includes_telemetry_hook` registry-guard test catches drift in the entry name, the always-exit-0 contract docstring, and the env-var discovery contract.

## Recommended wiring in `~/.claude/settings.json`

```json
{
  \"hooks\": {
    \"PostToolUse\": [{
      \"matcher\": \"*\",
      \"hooks\": [{
        \"type\": \"command\",
        \"command\": \"clud tool run hooks/telemetry.py\",
        \"async\": true,
        \"timeout\": 30
      }]
    }]
  }
}
```

\`PostToolUse\` (not Pre) because the payload includes both \`tool_input\` and \`tool_response\` — one event per tool call. \`async: true\` so the hook never blocks tool execution (lesson from the earlier audit_hook.py experiment, where a 5s sync timeout was tight on Windows Python cold start). \`timeout: 30\` as headroom for \`uv run\` cold start.

## Test plan

- [x] \`soldr cargo test -p clud --lib tools::tests\` — 14 pass (including the new registry-guard test).
- [x] \`bash lint\` clean.

## Non-goals (documented in #473)

- No settings.json change in-repo — the wiring is per-user.
- No \`TelemetryIngest\` schema extension — stick with the 5-field shape from #469. Promoting CLUD_* vars to first-class fields is a later PR if needed.

Closes #473.