### PR TITLE
docs: add AGENTS.md pointing to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+Agent guidance for this repository lives in [`CLAUDE.md`](CLAUDE.md).
+
+This file exists for tools that look for `AGENTS.md` by default (Codex, some agent harnesses). The actual conventions — build / lint / test commands, repository map, architecture pointers, design decisions, and the cross-cutting registries you must update when extending the codebase — are all there.


### PR DESCRIPTION
Compatibility shim for agent harnesses (Codex, others) that look for `AGENTS.md` by default. Single-sentence pointer to `CLAUDE.md` so we don't fork the source of truth — one file owns the build/lint/test commands, repo map, and cross-cutting registries.