### PR TITLE
[codex] flash title on high daemon CPU

### DIFF
--- a/crates/clud-bin/src/console_title.rs
+++ b/crates/clud-bin/src/console_title.rs
@@ -31,13 +31,45 @@
 //! the PTY pump runs on every platform.
 
 use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(any(windows, test))]
+use std::time::Duration;
+use std::time::Instant;
+
+#[cfg(any(windows, test))]
+const CPU_FLASH_THRESHOLD_PCT: f32 = 70.0;
+#[cfg(windows)]
+const CPU_METRICS_POLL_INTERVAL: Duration = Duration::from_secs(2);
+#[cfg(any(windows, test))]
+const CPU_ALERT_TTL: Duration = Duration::from_millis(2500);
+#[cfg(any(windows, test))]
+const CPU_FLASH_INTERVAL: Duration = Duration::from_millis(500);
+
+#[derive(Debug)]
+#[cfg_attr(not(any(windows, test)), allow(dead_code))]
+struct TitleState {
+    base_title: String,
+    cpu_alert: Option<CpuAlert>,
+}
+
+#[derive(Debug)]
+#[cfg_attr(not(any(windows, test)), allow(dead_code))]
+struct CpuAlert {
+    title: String,
+    observed_at: Instant,
+    expires_at: Instant,
+}
 
 /// The title we want the console to display, shared between the
 /// foreground thread and the keeper thread. Empty string means
 /// `set_for_current_cwd` was never called and the keeper should idle.
-fn desired_title_cell() -> &'static Arc<Mutex<String>> {
-    static CELL: OnceLock<Arc<Mutex<String>>> = OnceLock::new();
-    CELL.get_or_init(|| Arc::new(Mutex::new(String::new())))
+fn title_state_cell() -> &'static Arc<Mutex<TitleState>> {
+    static CELL: OnceLock<Arc<Mutex<TitleState>>> = OnceLock::new();
+    CELL.get_or_init(|| {
+        Arc::new(Mutex::new(TitleState {
+            base_title: String::new(),
+            cpu_alert: None,
+        }))
+    })
 }
 
 /// Set the console title to `clud <cwd-basename>` for the current
@@ -48,9 +80,12 @@ fn desired_title_cell() -> &'static Arc<Mutex<String>> {
 pub fn set_for_current_cwd() {
     let basename = current_cwd_basename().unwrap_or_else(|| "?".to_string());
     let title = title_for_cwd_name(&basename);
-    *desired_title_cell()
+    let mut state = title_state_cell()
         .lock()
-        .expect("desired title mutex poisoned") = title.clone();
+        .expect("title state mutex poisoned");
+    state.base_title = title.clone();
+    state.cpu_alert = None;
+    drop(state);
     set_title(&title);
 }
 
@@ -76,18 +111,26 @@ pub fn keep_setting_in_background() {
 fn spawn_keeper_thread() {
     let _ = std::thread::Builder::new()
         .name("clud-title-keeper".into())
-        .spawn(|| loop {
-            let want = desired_title_cell()
-                .lock()
-                .expect("desired title mutex poisoned")
-                .clone();
-            if !want.is_empty() {
-                let now = read_console_title();
-                if now.as_deref() != Some(want.as_str()) {
-                    set_title(&want);
+        .spawn(|| {
+            let mut last_metrics_poll = None::<Instant>;
+            loop {
+                let now = Instant::now();
+                if last_metrics_poll
+                    .map(|last| last.elapsed() >= CPU_METRICS_POLL_INTERVAL)
+                    .unwrap_or(true)
+                {
+                    last_metrics_poll = Some(now);
+                    refresh_cpu_alert_from_daemon(now);
                 }
+                let want = current_desired_title(Instant::now());
+                if !want.is_empty() {
+                    let now = read_console_title();
+                    if now.as_deref() != Some(want.as_str()) {
+                        set_title(&want);
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(750));
             }
-            std::thread::sleep(std::time::Duration::from_millis(750));
         });
 }
 
@@ -118,6 +161,78 @@ fn read_console_title() -> Option<String> {
 /// unit-tested on every platform.
 pub fn title_for_cwd_name(cwd_name: &str) -> String {
     format!("clud {}", cwd_name)
+}
+
+#[cfg(any(windows, test))]
+fn title_for_cpu_alert(base_title: &str, cpu_pct: f32) -> String {
+    format!("{base_title} CPU {:.0}%", cpu_pct)
+}
+
+#[cfg(windows)]
+fn current_desired_title(now: Instant) -> String {
+    let mut state = title_state_cell()
+        .lock()
+        .expect("title state mutex poisoned");
+    current_desired_title_locked(&mut state, now)
+}
+
+#[cfg(any(windows, test))]
+fn current_desired_title_locked(state: &mut TitleState, now: Instant) -> String {
+    let Some(alert) = &state.cpu_alert else {
+        return state.base_title.clone();
+    };
+    if now >= alert.expires_at {
+        state.cpu_alert = None;
+        return state.base_title.clone();
+    }
+    let flash_tick = now.saturating_duration_since(alert.observed_at).as_millis()
+        / CPU_FLASH_INTERVAL.as_millis();
+    if flash_tick % 2 == 0 {
+        alert.title.clone()
+    } else {
+        state.base_title.clone()
+    }
+}
+
+#[cfg(windows)]
+fn refresh_cpu_alert_from_daemon(now: Instant) {
+    let Ok(state_dir) = crate::daemon::default_state_dir() else {
+        clear_cpu_alert();
+        return;
+    };
+    match crate::daemon::daemon_client_metrics(&state_dir) {
+        Ok((_pid, cpu_pct)) => update_cpu_alert(cpu_pct, now),
+        Err(_) => clear_cpu_alert(),
+    }
+}
+
+#[cfg(windows)]
+fn update_cpu_alert(cpu_pct: f32, now: Instant) {
+    let mut state = title_state_cell()
+        .lock()
+        .expect("title state mutex poisoned");
+    update_cpu_alert_locked(&mut state, cpu_pct, now);
+}
+
+#[cfg(any(windows, test))]
+fn update_cpu_alert_locked(state: &mut TitleState, cpu_pct: f32, now: Instant) {
+    if cpu_pct > CPU_FLASH_THRESHOLD_PCT && !state.base_title.is_empty() {
+        state.cpu_alert = Some(CpuAlert {
+            title: title_for_cpu_alert(&state.base_title, cpu_pct),
+            observed_at: now,
+            expires_at: now + CPU_ALERT_TTL,
+        });
+    } else {
+        state.cpu_alert = None;
+    }
+}
+
+#[cfg(windows)]
+fn clear_cpu_alert() {
+    title_state_cell()
+        .lock()
+        .expect("title state mutex poisoned")
+        .cpu_alert = None;
 }
 
 /// Best-effort lookup of the current working directory's leaf name.
@@ -367,9 +482,10 @@ mod tests {
         // re-stamp; if the cell stays empty after `set_for_current_cwd`,
         // the keeper would idle forever. Verify the value is captured.
         set_for_current_cwd();
-        let stored = desired_title_cell()
+        let stored = title_state_cell()
             .lock()
-            .expect("desired title mutex")
+            .expect("title state mutex")
+            .base_title
             .clone();
         assert!(
             stored.starts_with("clud "),
@@ -379,6 +495,61 @@ mod tests {
             !stored.trim_end().eq("clud"),
             "desired title should include a basename component, got {stored:?}"
         );
+    }
+
+    #[test]
+    fn cpu_alert_title_formats_percentage() {
+        assert_eq!(title_for_cpu_alert("clud repo", 72.4), "clud repo CPU 72%");
+        assert_eq!(title_for_cpu_alert("clud repo", 72.5), "clud repo CPU 72%");
+        assert_eq!(title_for_cpu_alert("clud repo", 72.6), "clud repo CPU 73%");
+    }
+
+    #[test]
+    fn cpu_alert_flashes_between_alert_and_base_title() {
+        let now = Instant::now();
+        let mut state = TitleState {
+            base_title: "clud repo".to_string(),
+            cpu_alert: None,
+        };
+        update_cpu_alert_locked(&mut state, 71.0, now);
+
+        assert_eq!(
+            current_desired_title_locked(&mut state, now),
+            "clud repo CPU 71%"
+        );
+        assert_eq!(
+            current_desired_title_locked(&mut state, now + CPU_FLASH_INTERVAL),
+            "clud repo"
+        );
+        assert_eq!(
+            current_desired_title_locked(&mut state, now + CPU_FLASH_INTERVAL * 2),
+            "clud repo CPU 71%"
+        );
+    }
+
+    #[test]
+    fn cpu_alert_clears_below_threshold_and_after_ttl() {
+        let now = Instant::now();
+        let mut state = TitleState {
+            base_title: "clud repo".to_string(),
+            cpu_alert: None,
+        };
+
+        update_cpu_alert_locked(&mut state, 70.0, now);
+        assert!(state.cpu_alert.is_none(), "70% is not above threshold");
+
+        update_cpu_alert_locked(&mut state, 70.1, now);
+        assert!(state.cpu_alert.is_some());
+
+        update_cpu_alert_locked(&mut state, 10.0, now + Duration::from_secs(1));
+        assert!(state.cpu_alert.is_none());
+
+        update_cpu_alert_locked(&mut state, 80.0, now);
+        assert_eq!(
+            current_desired_title_locked(&mut state, now + CPU_ALERT_TTL),
+            "clud repo"
+        );
+        assert!(state.cpu_alert.is_none());
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/attach.rs
+++ b/crates/clud-bin/src/daemon/attach.rs
@@ -95,7 +95,8 @@ pub(super) fn run_attach(session_id: &str, state_dir: &Path, interrupted: &Atomi
         | DaemonResponse::Gc { .. }
         | DaemonResponse::LiveCwds { .. }
         | DaemonResponse::ShutdownAck { .. }
-        | DaemonResponse::ReapOrphansAck { .. } => 1,
+        | DaemonResponse::ReapOrphansAck { .. }
+        | DaemonResponse::Metrics { .. } => 1,
     }
 }
 

--- a/crates/clud-bin/src/daemon/client.rs
+++ b/crates/clud-bin/src/daemon/client.rs
@@ -190,6 +190,17 @@ pub(super) fn send_daemon_request(
     decode_daemon_response_line(&line).map_err(wire_error_to_io)
 }
 
+pub fn daemon_client_metrics(state_dir: &Path) -> io::Result<(u32, f32)> {
+    match send_daemon_request(state_dir, &DaemonRequest::Metrics)? {
+        DaemonResponse::Metrics { pid, cpu_pct } => Ok((pid, cpu_pct)),
+        DaemonResponse::Error { message } => Err(io::Error::other(message)),
+        response => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unexpected daemon response: {response:?}"),
+        )),
+    }
+}
+
 pub(super) fn request_session_termination(
     state_dir: &Path,
     session_id: &str,

--- a/crates/clud-bin/src/daemon/entry.rs
+++ b/crates/clud-bin/src/daemon/entry.rs
@@ -503,7 +503,8 @@ pub fn run_centralized_session(args: &Args, plan: &LaunchPlan, interrupted: &Ato
         | DaemonResponse::Gc { .. }
         | DaemonResponse::LiveCwds { .. }
         | DaemonResponse::ShutdownAck { .. }
-        | DaemonResponse::ReapOrphansAck { .. } => 1,
+        | DaemonResponse::ReapOrphansAck { .. }
+        | DaemonResponse::Metrics { .. } => 1,
     }
 }
 

--- a/crates/clud-bin/src/daemon/mod.rs
+++ b/crates/clud-bin/src/daemon/mod.rs
@@ -19,9 +19,9 @@ mod worker;
 mod worker_shared;
 
 pub use client::{
-    ensure_daemon, gc_client_insert, gc_client_list, gc_client_list_repo_visits, gc_client_purge,
-    gc_client_reconcile, gc_client_record_repo_visit, try_handoff_kill_to_daemon,
-    try_request_orphan_reap, GcPurgeOutcome,
+    daemon_client_metrics, ensure_daemon, gc_client_insert, gc_client_list,
+    gc_client_list_repo_visits, gc_client_purge, gc_client_reconcile, gc_client_record_repo_visit,
+    try_handoff_kill_to_daemon, try_request_orphan_reap, GcPurgeOutcome,
 };
 pub use entry::{experimental_enabled, handle_special_command, run_centralized_session};
 pub use http::{

--- a/crates/clud-bin/src/daemon/server.rs
+++ b/crates/clud-bin/src/daemon/server.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use running_process::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
 use serde_json::json;
-use sysinfo::Signal;
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System};
 
 use crate::win_creation_flags::invisible_helper_creationflags;
 
@@ -337,6 +337,10 @@ fn dispatch_daemon_request_with_id(
                 reaped: 0,
             }
         }
+        DaemonRequest::Metrics => DaemonResponse::Metrics {
+            pid: std::process::id(),
+            cpu_pct: sample_daemon_cpu_pct(),
+        },
         DaemonRequest::Gc { payload } => {
             let reply = dispatch_gc_op(state_dir, gc_tx, request_id, payload);
             DaemonResponse::Gc { reply }
@@ -379,6 +383,7 @@ fn request_op(request: &DaemonRequest) -> &'static str {
         DaemonRequest::Gc { .. } => "gc",
         DaemonRequest::Shutdown => "shutdown",
         DaemonRequest::ReapOrphans => "reap_orphans",
+        DaemonRequest::Metrics => "metrics",
     }
 }
 
@@ -393,8 +398,24 @@ fn response_op(response: &DaemonResponse) -> &'static str {
         DaemonResponse::Gc { .. } => "gc",
         DaemonResponse::ShutdownAck { .. } => "shutdown_ack",
         DaemonResponse::ReapOrphansAck { .. } => "reap_orphans_ack",
+        DaemonResponse::Metrics { .. } => "metrics",
         DaemonResponse::Error { .. } => "error",
     }
+}
+
+fn sample_daemon_cpu_pct() -> f32 {
+    static SAMPLER: std::sync::OnceLock<Mutex<System>> = std::sync::OnceLock::new();
+    let mut sys = SAMPLER
+        .get_or_init(|| Mutex::new(System::new()))
+        .lock()
+        .expect("daemon metrics sampler poisoned");
+    let pid = Pid::from_u32(std::process::id());
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        true,
+        ProcessRefreshKind::nothing().with_cpu(),
+    );
+    sys.process(pid).map(|proc| proc.cpu_usage()).unwrap_or(0.0)
 }
 
 fn gc_reply_op(reply: &GcReply) -> &'static str {
@@ -1260,5 +1281,20 @@ mod tests {
         assert!(finished["candidate_pids"].is_array());
         assert!(finished["reaped_pids"].is_array());
         assert_eq!(finished["reason"], "dead_originator");
+    }
+
+    #[test]
+    fn metrics_request_returns_daemon_pid_and_cpu_sample() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workers = Arc::new(Mutex::new(HashMap::<String, Arc<NativeProcess>>::new()));
+
+        let response = dispatch_daemon_request(tmp.path(), &workers, None, DaemonRequest::Metrics);
+        match response {
+            DaemonResponse::Metrics { pid, cpu_pct } => {
+                assert_eq!(pid, std::process::id());
+                assert!(cpu_pct >= 0.0, "cpu_pct should be non-negative: {cpu_pct}");
+            }
+            other => panic!("expected Metrics, got {other:?}"),
+        }
     }
 }

--- a/crates/clud-bin/src/daemon/types.rs
+++ b/crates/clud-bin/src/daemon/types.rs
@@ -216,6 +216,9 @@ pub(super) enum DaemonRequest {
     /// replies `ReapOrphansAck` immediately and does the sweep on a
     /// background thread.
     ReapOrphans,
+    /// Return lightweight daemon process metrics for foreground clients
+    /// that want ambient status without scraping dashboard JSON.
+    Metrics,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -255,6 +258,10 @@ pub(super) enum DaemonResponse {
     ReapOrphansAck {
         found: u32,
         reaped: u32,
+    },
+    Metrics {
+        pid: u32,
+        cpu_pct: f32,
     },
     Error {
         message: String,
@@ -559,6 +566,32 @@ mod tests {
     fn list_live_cwds_request_serializes_as_tagged_op() {
         let wire = serde_json::to_string(&DaemonRequest::ListLiveCwds).unwrap();
         assert_eq!(wire, r#"{"op":"list_live_cwds"}"#);
+    }
+
+    #[test]
+    fn metrics_request_serializes_as_tagged_op() {
+        let wire = serde_json::to_string(&DaemonRequest::Metrics).unwrap();
+        assert_eq!(wire, r#"{"op":"metrics"}"#);
+    }
+
+    #[test]
+    fn metrics_response_roundtrips() {
+        let response = DaemonResponse::Metrics {
+            pid: 142500,
+            cpu_pct: 72.5,
+        };
+        let wire = serde_json::to_string(&response).unwrap();
+        assert!(wire.contains(r#""op":"metrics""#));
+        assert!(wire.contains(r#""pid":142500"#));
+
+        let parsed: DaemonResponse = serde_json::from_str(&wire).unwrap();
+        match parsed {
+            DaemonResponse::Metrics { pid, cpu_pct } => {
+                assert_eq!(pid, 142500);
+                assert!((cpu_pct - 72.5).abs() < f32::EPSILON);
+            }
+            other => panic!("expected Metrics, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/clud-bin/src/daemon/wire_prost/daemon_msgs.rs
+++ b/crates/clud-bin/src/daemon/wire_prost/daemon_msgs.rs
@@ -85,6 +85,7 @@ fn daemon_request_to_proto(
         }),
         DaemonRequest::Shutdown => Request::Shutdown(proto::ShutdownRequest {}),
         DaemonRequest::ReapOrphans => Request::ReapOrphans(proto::ReapOrphansRequest {}),
+        DaemonRequest::Metrics => Request::Metrics(proto::MetricsRequest {}),
     };
     Ok(proto::ClientToDaemon {
         request: Some(request),
@@ -125,6 +126,7 @@ fn daemon_request_from_proto(proto: proto::ClientToDaemon) -> Result<DaemonReque
         }),
         Request::Shutdown(_) => Ok(DaemonRequest::Shutdown),
         Request::ReapOrphans(_) => Ok(DaemonRequest::ReapOrphans),
+        Request::Metrics(_) => Ok(DaemonRequest::Metrics),
     }
 }
 
@@ -182,6 +184,10 @@ fn daemon_response_to_proto(
                 reaped: *reaped,
             })
         }
+        DaemonResponse::Metrics { pid, cpu_pct } => Response::Metrics(proto::MetricsResponse {
+            pid: *pid,
+            cpu_pct: *cpu_pct,
+        }),
         DaemonResponse::Error { message } => Response::Error(proto::ErrorResponse {
             message: message.clone(),
         }),
@@ -223,6 +229,10 @@ fn daemon_response_from_proto(proto: proto::DaemonToClient) -> Result<DaemonResp
         Response::ReapOrphansAck(ack) => Ok(DaemonResponse::ReapOrphansAck {
             found: ack.found,
             reaped: ack.reaped,
+        }),
+        Response::Metrics(metrics) => Ok(DaemonResponse::Metrics {
+            pid: metrics.pid,
+            cpu_pct: metrics.cpu_pct,
         }),
         Response::Error(error) => Ok(DaemonResponse::Error {
             message: error.message,

--- a/crates/clud-bin/src/daemon/wire_prost/tests.rs
+++ b/crates/clud-bin/src/daemon/wire_prost/tests.rs
@@ -176,6 +176,7 @@ fn daemon_request_prost_roundtrips_json_shapes() {
         },
         DaemonRequest::Shutdown,
         DaemonRequest::ReapOrphans,
+        DaemonRequest::Metrics,
     ];
 
     for request in cases {
@@ -211,6 +212,10 @@ fn daemon_response_prost_roundtrips_json_shapes() {
         DaemonResponse::ReapOrphansAck {
             found: 3,
             reaped: 3,
+        },
+        DaemonResponse::Metrics {
+            pid: 1234,
+            cpu_pct: 72.5,
         },
         DaemonResponse::Error {
             message: "failed".to_string(),

--- a/proto/clud_v1.proto
+++ b/proto/clud_v1.proto
@@ -18,6 +18,7 @@ message ClientToDaemon {
     GcRequest gc = 7;
     ShutdownRequest shutdown = 8;
     ReapOrphansRequest reap_orphans = 9;
+    MetricsRequest metrics = 10;
   }
   string request_id = 100;
 }
@@ -34,6 +35,7 @@ message DaemonToClient {
     ShutdownAckResponse shutdown_ack = 8;
     ErrorResponse error = 9;
     ReapOrphansAckResponse reap_orphans_ack = 10;
+    MetricsResponse metrics = 11;
   }
   string request_id = 100;
 }
@@ -96,6 +98,13 @@ message ShutdownRequest {}
 // whose originator is no longer alive and reaps its tree. The ack is sent
 // before the kill begins so the CLI does not block on shutdown.
 message ReapOrphansRequest {}
+
+message MetricsRequest {}
+
+message MetricsResponse {
+  uint32 pid = 1;
+  float cpu_pct = 2;
+}
 
 message ReapOrphansAckResponse {
   // Number of CLUD-tagged processes whose originator was already dead at


### PR DESCRIPTION
## Summary

Adds a lightweight daemon `metrics` IPC request that returns the daemon PID and CPU percentage, wired through both JSON and prost daemon transports. The Windows console title keeper now polls those daemon metrics every 2 seconds and flashes the title between `clud <cwd>` and `clud <cwd> CPU N%` when daemon CPU is above 70%.

## Impact

High daemon CPU becomes visible in the existing title-bar signal without adding another foreground sampler or changing dashboard JSON. If the daemon is unavailable or metrics cannot be read, the title falls back to the normal `clud <cwd>` behavior.

## Validation

- `soldr cargo test -p clud --lib console_title::`
- `soldr cargo test -p clud --lib daemon::types::`
- `soldr cargo test -p clud --lib daemon::wire_prost::`
- `soldr cargo test -p clud --lib daemon::server::tests::metrics_request_returns_daemon_pid_and_cpu_sample`
- `bash lint`

Note: full `soldr cargo test -p clud --lib` compiled and ran but failed on pre-existing unrelated `shim_session::tests::prepend_to_path_is_idempotent`.