### PR TITLE
fix: bound hook stdin reads

### DIFF
--- a/crates/clud-bin/assets/tools/hooks/block-bad-cmd.py
+++ b/crates/clud-bin/assets/tools/hooks/block-bad-cmd.py
@@ -29,11 +29,17 @@ from __future__ import annotations
 import datetime as _dt
 import json
 import os
+import queue
 import re
 import sys
+import threading
+import time
+import traceback
 from pathlib import Path
 
 LOG_PATH = Path.home() / ".clud" / "tools" / "hooks" / "block-bad-cmd.log"
+STDIN_READ_CHUNK_BYTES = 64 * 1024
+STDIN_READ_MAX_BYTES = 1024 * 1024
 RUST_TOOLS = {
     "cargo",
     "rustc",
@@ -103,6 +109,164 @@ def _log(msg: str) -> None:
             fh.write(f"[{ts}] pid={os.getpid()} {msg}\n")
     except OSError:
         pass
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return max(0.01, value)
+
+
+STDIN_READ_IDLE_TIMEOUT_SEC = _float_env("CLUD_HOOK_STDIN_IDLE_TIMEOUT_SEC", 0.25)
+STDIN_READ_DEADLINE_SEC = _float_env("CLUD_HOOK_STDIN_DEADLINE_SEC", 2.0)
+
+
+def _decode_stdin(chunks: list[bytes]) -> str:
+    return b"".join(chunks).decode("utf-8", errors="replace").lstrip("\ufeff")
+
+
+def _stack_summary(thread_id: int | None = None) -> str:
+    frame = None if thread_id is None else sys._current_frames().get(thread_id)
+    if frame is None:
+        stack = traceback.format_stack(limit=8)
+    else:
+        stack = traceback.format_stack(frame, limit=8)
+    return " | ".join(line.strip().replace("\n", " ") for line in stack)
+
+
+def _log_stdin_incomplete(
+    mode: str,
+    reason: str,
+    byte_count: int,
+    thread_id: int | None = None,
+) -> None:
+    _log(
+        "stdin_read_incomplete "
+        f"mode={mode} reason={reason} bytes={byte_count} "
+        f"stack={_stack_summary(thread_id)}"
+    )
+
+
+def _read_stdin_nonblocking() -> str | None:
+    stream = getattr(sys.stdin, "buffer", sys.stdin)
+    try:
+        fd = stream.fileno()
+        was_blocking = os.get_blocking(fd)
+        os.set_blocking(fd, False)
+    except (AttributeError, OSError, ValueError):
+        return None
+
+    chunks: list[bytes] = []
+    byte_count = 0
+    deadline = time.monotonic() + STDIN_READ_DEADLINE_SEC
+    idle_until: float | None = None
+    incomplete_reason: str | None = None
+    try:
+        while True:
+            try:
+                chunk = os.read(fd, STDIN_READ_CHUNK_BYTES)
+            except BlockingIOError:
+                now = time.monotonic()
+                wait_until = deadline if idle_until is None else min(deadline, idle_until)
+                if now >= wait_until:
+                    incomplete_reason = (
+                        "idle"
+                        if idle_until is not None and idle_until <= deadline
+                        else "deadline"
+                    )
+                    break
+                time.sleep(min(0.01, max(0.001, wait_until - now)))
+                continue
+            except OSError as exc:
+                _log(f"stdin_read_error mode=nonblocking error={exc}")
+                return _decode_stdin(chunks)
+
+            if not chunk:
+                break
+            chunks.append(chunk)
+            byte_count += len(chunk)
+            idle_until = time.monotonic() + STDIN_READ_IDLE_TIMEOUT_SEC
+            if byte_count >= STDIN_READ_MAX_BYTES:
+                incomplete_reason = "max_bytes"
+                break
+    finally:
+        try:
+            os.set_blocking(fd, was_blocking)
+        except OSError:
+            pass
+
+    if incomplete_reason is not None:
+        _log_stdin_incomplete("nonblocking", incomplete_reason, byte_count)
+    return _decode_stdin(chunks)
+
+
+def _read_stdin_threaded() -> str:
+    out: queue.Queue[bytes | BaseException | None] = queue.Queue()
+
+    def worker() -> None:
+        try:
+            fd = sys.stdin.fileno()
+            while True:
+                chunk = os.read(fd, STDIN_READ_CHUNK_BYTES)
+                if not chunk:
+                    out.put(None)
+                    return
+                out.put(chunk)
+        except BaseException as exc:  # pragma: no cover - defensive fallback path
+            out.put(exc)
+
+    thread = threading.Thread(target=worker, name="clud-hook-stdin-reader", daemon=True)
+    thread.start()
+
+    chunks: list[bytes] = []
+    byte_count = 0
+    deadline = time.monotonic() + STDIN_READ_DEADLINE_SEC
+    idle_until: float | None = None
+    incomplete_reason: str | None = None
+    while True:
+        now = time.monotonic()
+        wait_until = deadline if idle_until is None else min(deadline, idle_until)
+        if now >= wait_until:
+            incomplete_reason = (
+                "idle" if idle_until is not None and idle_until <= deadline else "deadline"
+            )
+            break
+        try:
+            item = out.get(timeout=max(0.001, wait_until - now))
+        except queue.Empty:
+            incomplete_reason = (
+                "idle" if idle_until is not None and idle_until <= deadline else "deadline"
+            )
+            break
+        if item is None:
+            break
+        if isinstance(item, BaseException):
+            _log(f"stdin_read_error mode=threaded error={item}")
+            break
+        chunks.append(item)
+        byte_count += len(item)
+        idle_until = time.monotonic() + STDIN_READ_IDLE_TIMEOUT_SEC
+        if byte_count >= STDIN_READ_MAX_BYTES:
+            incomplete_reason = "max_bytes"
+            break
+
+    if incomplete_reason is not None:
+        _log_stdin_incomplete("threaded", incomplete_reason, byte_count, thread.ident)
+    return _decode_stdin(chunks)
+
+
+def _read_stdin_bounded() -> str:
+    if os.name == "nt":
+        return _read_stdin_threaded()
+    raw = _read_stdin_nonblocking()
+    if raw is not None:
+        return raw
+    return _read_stdin_threaded()
 
 
 def _extract_command(payload: dict) -> str:
@@ -370,7 +534,8 @@ def _forbidden_reason(command_text: str, cwd: Path | None = None) -> str | None:
                         _log(f"CLUD_UV_RUST_ALLOW_ALL=1 bypassed hybrid block at {hybrid_root}")
                         print(
                             "\x1b[33mWARNING: AUTO COMPILING RUST because of uv run\n"
-                            f"CLUD_UV_RUST_ALLOW_ALL=1 is set, so the auto-sync gate at {hybrid_root} was bypassed.\n"
+                            "CLUD_UV_RUST_ALLOW_ALL=1 is set, so the auto-sync gate at "
+                            f"{hybrid_root} was bypassed.\n"
                             "DIRECTIVE TO AGENT: the next `uv run` in this project root will "
                             "trigger a full native rebuild (can take minutes). If you don't need "
                             "a fresh build, pass `--no-sync` (use existing venv), `--no-project` "
@@ -400,14 +565,15 @@ def _forbidden_reason(command_text: str, cwd: Path | None = None) -> str | None:
         if first in RUST_TOOLS:
             return (
                 f"Use `soldr {first} ...` instead of bare `{first}`. "
-                "soldr resolves the pinned rustup-managed toolchain and avoids GNU/Chocolatey shims."
+                "soldr resolves the pinned rustup-managed toolchain and avoids "
+                "GNU/Chocolatey shims."
             )
 
     return None
 
 
 def main() -> int:
-    raw = sys.stdin.read()
+    raw = _read_stdin_bounded()
     _log(f"raw_stdin_bytes={len(raw)}")
     try:
         payload = json.loads(raw) if raw.strip() else {}

--- a/crates/clud-bin/src/tool_run.rs
+++ b/crates/clud-bin/src/tool_run.rs
@@ -40,8 +40,8 @@ use crate::session_index::{
 use crate::shim_uv;
 use crate::tool_install::{ensure_installed as ensure_tools_installed, tools_root};
 use crate::tool_tee::TeeWriter;
-use crate::tool_termination::{emit_termination, ExitKind};
-use crate::tool_watchdog::{Watchdog, WatchdogDecision};
+use crate::tool_termination::{emit_termination, format_elapsed, ExitKind};
+use crate::tool_watchdog::{AbortReason, Watchdog, WatchdogDecision};
 use crate::tools::clud_uv_cache_dir;
 
 /// Poll interval for draining captured stdout/stderr into the tee writer.
@@ -118,7 +118,7 @@ pub fn run(rel_path: &str, args: &[String]) -> io::Result<i32> {
         (Some(ctx), Some(tool_id)) => {
             run_with_session(ctx, tool_id, rel_path, args, argv, env, telemetry)
         }
-        _ => run_passthrough(argv, env, telemetry),
+        _ => run_passthrough(rel_path, args, argv, env, telemetry),
     }
 }
 
@@ -126,10 +126,13 @@ pub fn run(rel_path: &str, args: &[String]) -> io::Result<i32> {
 /// immediately re-emit them and retain a stderr tail for tool telemetry.
 /// There is still no session index or per-tool log in this fallback path.
 fn run_passthrough(
+    rel_path: &str,
+    args: &[String],
     argv: Vec<String>,
     env: Vec<(String, String)>,
     telemetry: ToolTelemetry,
 ) -> io::Result<i32> {
+    let argv_for_diagnostic = argv.clone();
     let process = NativeProcess::new(ProcessConfig {
         command: CommandSpec::Argv(argv),
         cwd: None,
@@ -142,14 +145,46 @@ fn run_passthrough(
         nice: None,
     });
     process.start().map_err(io::Error::other)?;
+    let mut watchdog = Watchdog::for_rel_path(rel_path);
     let mut emitted_stdout = 0usize;
     let mut emitted_stderr = 0usize;
+    let mut last_drain_count = 0usize;
     let exit_code = loop {
         match process.wait(Some(DRAIN_POLL_INTERVAL)) {
             Ok(code) => break code,
             Err(ProcessError::Timeout) => {
                 (emitted_stdout, emitted_stderr) =
                     drain_passthrough_output(&process, emitted_stdout, emitted_stderr);
+                let drain_count = emitted_stdout + emitted_stderr;
+                if drain_count > last_drain_count {
+                    watchdog.note_output();
+                    last_drain_count = drain_count;
+                }
+                match watchdog.check() {
+                    WatchdogDecision::Continue => continue,
+                    WatchdogDecision::KillAndAbort(reason) => {
+                        let _ = process.kill();
+                        let _ = drain_passthrough_output(&process, emitted_stdout, emitted_stderr);
+                        let stderr_tail = stderr_tail_200(&process.captured_stderr().concat());
+                        let _ = emit_passthrough_abort_diagnostic(
+                            rel_path,
+                            args,
+                            &argv_for_diagnostic,
+                            watchdog.started_at.elapsed(),
+                            reason,
+                            stderr_tail.as_deref(),
+                        );
+                        telemetry.finish(124, stderr_tail);
+                        return Ok(124);
+                    }
+                    WatchdogDecision::ResumeLater(reason) => {
+                        let _ = drain_passthrough_output(&process, emitted_stdout, emitted_stderr);
+                        let mut err = io::stderr().lock();
+                        let _ = writeln!(err, "{}", watchdog.render_in_progress(reason));
+                        let _ = err.flush();
+                        return Ok(0);
+                    }
+                }
             }
             Err(other) => return Err(io::Error::other(other)),
         }
@@ -160,6 +195,53 @@ fn run_passthrough(
         stderr_tail_200(&process.captured_stderr().concat()),
     );
     Ok(exit_code)
+}
+
+fn render_passthrough_abort_payload(
+    rel_path: &str,
+    args: &[String],
+    argv: &[String],
+    elapsed: Duration,
+    reason: AbortReason,
+    stderr_tail: Option<&str>,
+) -> String {
+    serde_json::json!({
+        "v": 1,
+        "tool": rel_path,
+        "args": args,
+        "argv": argv,
+        "status": "aborted",
+        "reason": reason.label(),
+        "elapsed_ms": elapsed.as_millis() as u64,
+        "stderr_tail": stderr_tail,
+    })
+    .to_string()
+}
+
+fn emit_passthrough_abort_diagnostic(
+    rel_path: &str,
+    args: &[String],
+    argv: &[String],
+    elapsed: Duration,
+    reason: AbortReason,
+    stderr_tail: Option<&str>,
+) -> io::Result<()> {
+    let payload =
+        render_passthrough_abort_payload(rel_path, args, argv, elapsed, reason, stderr_tail);
+    let argv_json = serde_json::to_string(argv).unwrap_or_else(|_| format!("{argv:?}"));
+    let mut err = io::stderr().lock();
+    writeln!(err, "{payload}")?;
+    writeln!(
+        err,
+        "TIMEOUT after {} on {} in session-less tool runner.",
+        format_elapsed(elapsed),
+        rel_path
+    )?;
+    writeln!(err, "  command argv: {argv_json}")?;
+    if let Some(tail) = stderr_tail {
+        writeln!(err, "  stderr tail: {tail}")?;
+    }
+    err.flush()
 }
 
 /// Session-attached run: capture stdout/stderr through `running_process`,
@@ -1205,5 +1287,31 @@ mod tests {
         assert_eq!(tail.len(), 200);
         assert_eq!(tail, "x".repeat(200));
         assert!(stderr_tail_200(b"").is_none());
+    }
+
+    #[test]
+    fn passthrough_abort_payload_names_exact_argv() {
+        let args = vec!["--flag".to_string()];
+        let argv = vec![
+            "uv".to_string(),
+            "run".to_string(),
+            "--script".to_string(),
+            "hooks/block-bad-cmd.py".to_string(),
+        ];
+        let payload = render_passthrough_abort_payload(
+            "hooks/block-bad-cmd.py",
+            &args,
+            &argv,
+            Duration::from_millis(1234),
+            AbortReason::CommandTimeout,
+            Some("blocked at sys.stdin.read()"),
+        );
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(value["status"], "aborted");
+        assert_eq!(value["reason"], "command_timeout");
+        assert_eq!(value["tool"], "hooks/block-bad-cmd.py");
+        assert_eq!(value["args"][0], "--flag");
+        assert_eq!(value["argv"][0], "uv");
+        assert_eq!(value["stderr_tail"], "blocked at sys.stdin.read()");
     }
 }

--- a/tests/test_hook_stdin.py
+++ b/tests/test_hook_stdin.py
@@ -1,0 +1,86 @@
+"""Regression tests for bundled hook stdin handling."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BLOCK_BAD_CMD = (
+    ROOT / "crates" / "clud-bin" / "assets" / "tools" / "hooks" / "block-bad-cmd.py"
+)
+
+
+def _hook_env(home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env["CLUD_HOOK_STDIN_IDLE_TIMEOUT_SEC"] = "0.05"
+    env["CLUD_HOOK_STDIN_DEADLINE_SEC"] = "0.25"
+    return env
+
+
+def _run_hook_with_open_stdin(
+    tmp_path: Path,
+    payload: str | None,
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.Popen(
+        [sys.executable, str(BLOCK_BAD_CMD)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=_hook_env(tmp_path / "home"),
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    if payload is not None:
+        proc.stdin.write(payload)
+        proc.stdin.flush()
+
+    try:
+        returncode = proc.wait(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate(timeout=1.0)
+        raise AssertionError(
+            f"hook did not exit while stdin pipe remained open; stdout={stdout!r} "
+            f"stderr={stderr!r}"
+        ) from None
+
+    proc.stdin.close()
+    stdout = proc.stdout.read()
+    stderr = proc.stderr.read()
+    return subprocess.CompletedProcess(proc.args, returncode, stdout, stderr)
+
+
+def test_block_bad_cmd_reads_payload_without_waiting_for_stdin_eof(tmp_path: Path) -> None:
+    payload = json.dumps(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "bad" + " cmd"},
+        }
+    )
+
+    result = _run_hook_with_open_stdin(tmp_path, payload)
+
+    assert result.returncode == 2
+    assert "permissionDecision" in result.stdout
+    assert "deny" in result.stdout
+    assert "refusing to run" in result.stderr
+
+
+def test_block_bad_cmd_allows_missing_payload_without_waiting_for_stdin_eof(
+    tmp_path: Path,
+) -> None:
+    result = _run_hook_with_open_stdin(tmp_path, None)
+
+    assert result.returncode == 0
+    log_path = tmp_path / "home" / ".clud" / "tools" / "hooks" / "block-bad-cmd.log"
+    log = log_path.read_text(encoding="utf-8")
+    assert "stdin_read_incomplete" in log
+    assert "raw_stdin_bytes=0" in log


### PR DESCRIPTION
## Summary
- Bound the bundled PreToolUse hook stdin read so an open pipe without EOF produces a deterministic allow/deny decision instead of blocking on `sys.stdin.read()`.
- Added incomplete-stdin diagnostics to the hook log, including the read mode, reason, byte count, and stack summary.
- Applied bundled-tool watchdog metadata in the session-less `clud tool run` path and emit timeout diagnostics with the exact argv used to launch the hook.
- Added regression coverage for hook processes whose stdin pipe remains open with and without a payload.

Closes #481

## Tests
- `python -m pytest tests/test_hook_stdin.py -q`
- `python -m ruff check tests/test_hook_stdin.py crates/clud-bin/assets/tools/hooks/block-bad-cmd.py`
- `soldr cargo fmt --check`
- `soldr cargo test -p clud --lib tool_run::tests::passthrough_abort_payload_names_exact_argv`
- `bash lint`
- `bash test` *(fails in unrelated `tests/test_console_title.py::test_clud_stamps_console_title_on_windows`: expected tempdir-specific title, got `ā ‹ clud`, consistent with another active clud title keeper/session overwriting the shared console title; Rust tests and the new hook pytest passed during the run.)*