### PR TITLE
Refresh bundled tools during foreground startup

### DIFF
--- a/crates/clud-bin/src/launch_setup.rs
+++ b/crates/clud-bin/src/launch_setup.rs
@@ -308,12 +308,12 @@ impl HarnessSetupAction for CodexHookNormalizeAction {
 }
 
 pub fn setup_actions() -> Vec<Box<dyn HarnessSetupAction>> {
-    // Note: bundled Python tools (~/.clud/tools/*) are installed by the
-    // daemon at startup (see `daemon/server.rs::run_daemon`), not as part
-    // of this launch-setup pipeline. `clud tool run` bootstraps the
-    // daemon when needed so first-run hooks bypass NotFound. The launch
-    // setup actions here are limited to backend-specific skills, drift
-    // tracking, and codex hook normalization.
+    // Note: bundled Python tools (~/.clud/tools/*) are refreshed by
+    // foreground startup and daemon startup, not as part of this
+    // launch-setup pipeline. `clud tool run` also self-heals inline so
+    // first-run hooks bypass NotFound. The launch setup actions here are
+    // limited to backend-specific skills, drift tracking, and codex hook
+    // normalization.
     vec![
         Box::new(BundledSkillsAction {
             backend: Backend::Claude,
@@ -568,10 +568,11 @@ mod tests {
         assert_eq!(report.ran, vec!["bundled-skills", "claude-drift-skills"]);
         assert!(home.path().join(".claude/skills/clud-pr/SKILL.md").exists());
         assert!(!home.path().join(".agents").exists());
-        // Launch setup no longer installs bundled tools — the daemon owns
-        // that. `.clud/` is created by the bundled-skills action for
-        // settings.json under codex setup, but the claude path does not
-        // touch it, so it stays absent here.
+        // Launch setup does not install bundled tools. Foreground startup,
+        // daemon startup, and `clud tool run` own that path. `.clud/` is
+        // created by the bundled-skills action for settings.json under codex
+        // setup, but the claude path does not touch it, so it stays absent
+        // here.
         assert!(!home.path().join(".clud").exists());
         let hooks = fs::read_to_string(home.path().join(".codex/hooks.json")).unwrap();
         assert!(hooks.contains(r#""timeout":5"#), "{hooks}");

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -2,7 +2,7 @@ use clud::{
     args, backend, backend_bootstrap, clud_settings, command, console_setup, console_title,
     cpu_banner, crash_report, ctrl_c_track, daemon, gc, graphics, hook_health, large_file_guard,
     launch_log, launch_setup, log_event, loop_artifacts, loop_spec, optimize, orphan_reaper,
-    runner, runtime_cache, startup, symbols, tool_cli, tools, trampoline, trash, ui,
+    runner, runtime_cache, startup, symbols, tool_cli, tool_install, tools, trampoline, trash, ui,
     uv_run_hook_guard, verbose_log, wasm, worktrees,
 };
 
@@ -273,6 +273,15 @@ fn main() {
         std::process::exit(exit_code);
     }
 
+    // Bundled Python tools are embedded in this binary via BUNDLED_TOOLS.
+    // Refresh managed copies during normal foreground startup so an
+    // upgraded clud binary replaces stale `~/.clud/tools/...` commands even
+    // when an older daemon is already running. `clud tool run` keeps its own
+    // inline self-heal path for hook invocations; dry-run remains no-write.
+    if !args.dry_run {
+        tool_install::ensure_installed();
+    }
+
     if hook_health::should_check_launch(&args) {
         let auto_fix_hooks = if args.no_fix_hooks {
             false
@@ -352,9 +361,8 @@ fn main() {
         verbose_log::log("[clud] daemon: skipped");
     }
 
-    // After the daemon has had its chance to install bundled tools
-    // (`daemon::server::run_daemon` → `tool_install::ensure_installed`),
-    // fire the hook-config scanner against the cwd. Warns on bare
+    // After foreground startup has refreshed bundled tools, fire the
+    // hook-config scanner against the cwd. Warns on bare
     // `uv run` in Pre/PostToolUse hooks of Python+Rust polyglot
     // repos — the failure mode that turns every hook fire into a
     // multi-minute Rust rebuild on maturin-backed projects (see the

--- a/docs/architecture/launch-setup.md
+++ b/docs/architecture/launch-setup.md
@@ -43,7 +43,11 @@ launch setup.
 
 Session-only launches skip persistent setup. They must not create or modify
 agent home setup files under `~/.claude`, `~/.codex`, `~/.agents`, or
-`~/.clud` as part of harness setup.
+`~/.clud` as part of harness setup. Bundled Python tools under
+`~/.clud/tools/` are outside this launch-setup selector: normal foreground
+startup, daemon startup, and `clud tool run` refresh clud-managed copies by
+comparing the installed file with the embedded `BUNDLED_TOOLS` body and
+replacing divergent managed copies.
 
 ## Global Actions
 
@@ -59,6 +63,11 @@ Global setup runs only the selected backend's registered actions:
 
 All setup failures are non-fatal. `main.rs` logs a `[clud] note: ...` line and
 continues to build and run the backend `LaunchPlan`.
+
+Bundled Python tools are deliberately not registered as launch-setup actions.
+They are backend-agnostic clud commands, so their stale-copy replacement runs
+on non-dry-run foreground startup even when the selected launch setup scope is
+session-only.
 
 ## Adding an Action
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -109,11 +109,28 @@ def copied_clud_env(_source: Path) -> dict[str, str]:
     return env
 
 
+def _copy_clud_for_test(temp_dir: str) -> Path:
+    source = Path(CLUD)
+    launch = Path(temp_dir) / source.name
+    shutil.copy2(source, launch)
+    return launch
+
+
+def _fake_claude_on_path(bin_dir: Path) -> None:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    if sys.platform == "win32":
+        fake = bin_dir / "claude.cmd"
+        fake.write_text("@echo off\r\nexit /b 0\r\n", encoding="utf-8")
+    else:
+        fake = bin_dir / "claude"
+        fake.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+        fake.chmod(0o755)
+
+
 def _run(*args: str, input_data: str | None = None) -> subprocess.CompletedProcess[str]:
     with tempfile.TemporaryDirectory() as temp_dir:
         source = Path(CLUD)
-        launch = Path(temp_dir) / source.name
-        shutil.copy2(source, launch)
+        launch = _copy_clud_for_test(temp_dir)
         return subprocess.run(
             [str(launch), *args],
             capture_output=True,
@@ -374,6 +391,81 @@ def test_pipe_mode() -> None:
     data = json.loads(result.stdout)
     assert "-p" in data["command"]
     assert "piped prompt" in data["command"]
+
+
+def test_startup_refreshes_stale_managed_bundled_tool(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    repo.mkdir()
+    home.mkdir()
+    _fake_claude_on_path(fake_bin)
+
+    hook = home / ".clud" / "tools" / "hooks" / "block-bad-cmd.py"
+    hook.parent.mkdir(parents=True)
+    hook.write_text("# managed-by: clud\nprint('stale hook')\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source = Path(CLUD)
+        launch = _copy_clud_for_test(temp_dir)
+        env = copied_clud_env(source)
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        env["CLUD_HOOK_HOME"] = str(home)
+        env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+        result = subprocess.run(
+            [
+                str(launch),
+                "--no-daemon",
+                "--no-fix-hooks",
+                "--no-cpu-banner",
+                "--no-dnd",
+                "--subprocess",
+                "-p",
+                "hello",
+            ],
+            cwd=repo,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+    assert result.returncode == 0, (
+        f"startup launch failed (rc={result.returncode}): "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    updated = hook.read_text(encoding="utf-8")
+    assert "def _read_stdin_bounded() -> str" in updated
+    assert "stdin_read_incomplete " in updated
+    assert "stale hook" not in updated
+
+
+def test_dry_run_does_not_refresh_stale_managed_bundled_tool(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    hook = home / ".clud" / "tools" / "hooks" / "block-bad-cmd.py"
+    hook.parent.mkdir(parents=True)
+    stale = "# managed-by: clud\nprint('stale hook')\n"
+    hook.write_text(stale, encoding="utf-8")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source = Path(CLUD)
+        launch = _copy_clud_for_test(temp_dir)
+        env = copied_clud_env(source)
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        env["CLUD_HOOK_HOME"] = str(home)
+        result = subprocess.run(
+            [str(launch), "--dry-run", "-p", "hello"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert hook.read_text(encoding="utf-8") == stale
 
 
 def test_clean_worktrees_dry_run_smoke() -> None:


### PR DESCRIPTION
## Summary
- refresh clud-managed bundled tools during normal foreground startup so upgraded binaries replace stale ~/.clud/tools copies even when an older daemon is already running
- keep dry-run no-write behavior intact
- document that bundled tools are outside launch setup and are owned by foreground startup, daemon startup, and clud tool run

## Tests
- python -m pytest tests/test_hello.py::test_startup_refreshes_stale_managed_bundled_tool tests/test_hello.py::test_dry_run_does_not_refresh_stale_managed_bundled_tool -q
- soldr cargo test -p clud tool_install::tests::semantic_diff_overwrites_managed_copy -- --exact
- bash lint
- python -m pytest tests/test_hello.py -q