### PR TITLE
Persist explicit global backend selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- `clud --codex` / `clud --claude` global launch setup now uses an inline
+  terminal selector with a visible selection cursor, hides the hardware cursor
+  while active, supports Esc/Ctrl-C cancellation paths, and persists the
+  selected backend as the bare `clud` default until the opposite backend is
+  selected globally.
 - New `shell.disable_powershell` toggle in `~/.clud/settings.json` (default
   `false`, per-backend overrides under `shell.claude` / `shell.codex`). When
   enabled for the active backend, clud now injects `CLUD_DISABLE_POWERSHELL=1`

--- a/crates/clud-bin/src/backend.rs
+++ b/crates/clud-bin/src/backend.rs
@@ -17,6 +17,16 @@ impl Backend {
             Backend::Codex => "codex",
         }
     }
+
+    pub fn from_settings_str(value: &str) -> Option<Self> {
+        if value.eq_ignore_ascii_case("claude") {
+            Some(Backend::Claude)
+        } else if value.eq_ignore_ascii_case("codex") {
+            Some(Backend::Codex)
+        } else {
+            None
+        }
+    }
 }
 
 impl std::fmt::Display for Backend {
@@ -55,11 +65,25 @@ pub fn find_backend(backend: Backend) -> Option<PathBuf> {
 
 /// Resolve which backend to use based on CLI flags.
 /// Default is Claude.
-pub fn resolve_backend(_claude: bool, codex: bool) -> Backend {
+pub fn resolve_backend(claude: bool, codex: bool) -> Backend {
+    resolve_backend_with_default(claude, codex, None)
+}
+
+/// Resolve which backend to use based on CLI flags and a persisted default.
+///
+/// Explicit CLI backend flags always win. The persisted default only applies
+/// to bare `clud` launches.
+pub fn resolve_backend_with_default(
+    claude: bool,
+    codex: bool,
+    default_backend: Option<Backend>,
+) -> Backend {
     if codex {
         Backend::Codex
-    } else {
+    } else if claude {
         Backend::Claude
+    } else {
+        default_backend.unwrap_or(Backend::Claude)
     }
 }
 
@@ -142,6 +166,26 @@ mod tests {
     #[test]
     fn test_default_is_claude() {
         assert_eq!(resolve_backend(false, false), Backend::Claude);
+    }
+
+    #[test]
+    fn test_persisted_default_backend_wins_for_bare_launch() {
+        assert_eq!(
+            resolve_backend_with_default(false, false, Some(Backend::Codex)),
+            Backend::Codex
+        );
+    }
+
+    #[test]
+    fn test_explicit_backend_flags_override_persisted_default() {
+        assert_eq!(
+            resolve_backend_with_default(true, false, Some(Backend::Codex)),
+            Backend::Claude
+        );
+        assert_eq!(
+            resolve_backend_with_default(false, true, Some(Backend::Claude)),
+            Backend::Codex
+        );
     }
 
     #[test]

--- a/crates/clud-bin/src/clud_settings.rs
+++ b/crates/clud-bin/src/clud_settings.rs
@@ -106,6 +106,55 @@ pub fn load_or_init_codex_config_overrides_at(
     }
 }
 
+pub fn load_default_backend() -> Result<Option<Backend>, SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    load_default_backend_at(&home)
+}
+
+pub fn load_default_backend_at(home: &Path) -> Result<Option<Backend>, SettingsError> {
+    let lock_path = home.join(CLUD_DIR_NAME).join(LOCK_FILE_NAME);
+    let _lock = acquire_lock(&lock_path)?;
+    let document = read_settings_or_legacy(home)?;
+    let Some(value) = document
+        .get("backend")
+        .and_then(|item| item.get("default"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(infer_default_backend_from_launch_setup(&document));
+    };
+    Ok(Backend::from_settings_str(value))
+}
+
+pub fn save_default_backend(backend: Backend) -> Result<(), SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    save_default_backend_at(&home, backend)
+}
+
+pub fn save_default_backend_at(home: &Path, backend: Backend) -> Result<(), SettingsError> {
+    with_settings_document(home, |document| {
+        set_default_backend(document, backend);
+    })
+}
+
+pub fn save_global_launch_setup_selection(
+    backend: Backend,
+    scope: LaunchSetupScope,
+) -> Result<(), SettingsError> {
+    let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
+    save_global_launch_setup_selection_at(&home, backend, scope)
+}
+
+pub fn save_global_launch_setup_selection_at(
+    home: &Path,
+    backend: Backend,
+    scope: LaunchSetupScope,
+) -> Result<(), SettingsError> {
+    with_settings_document(home, |document| {
+        set_default_backend(document, backend);
+        set_launch_setup_scope(document, backend, scope);
+    })
+}
+
 pub fn load_auto_fix_hooks_enabled() -> Result<bool, SettingsError> {
     let home = home_dir().ok_or(SettingsError::NoHomeDir)?;
     load_auto_fix_hooks_enabled_at(&home)
@@ -173,17 +222,7 @@ pub fn save_launch_setup_scope_at(
     scope: LaunchSetupScope,
 ) -> Result<(), SettingsError> {
     with_settings_document(home, |document| {
-        let launch_setup = object_entry(document, "launch_setup");
-        let entry = launch_setup
-            .entry(backend_settings_key(backend).to_string())
-            .or_insert_with(|| json!({}));
-        if !entry.is_object() {
-            *entry = json!({});
-        }
-        entry.as_object_mut().unwrap().insert(
-            "scope".to_string(),
-            Value::String(scope.as_str().to_string()),
-        );
+        set_launch_setup_scope(document, backend, scope);
     })
 }
 
@@ -410,6 +449,18 @@ fn parse_legacy_toml_settings(path: &Path, text: &str) -> Result<Value, Settings
             .insert("auto_fix_hooks".to_string(), Value::Bool(enabled));
     }
 
+    if let Some(default_backend) = document
+        .get("backend")
+        .and_then(|item| item.get("default"))
+        .and_then(Item::as_str)
+        .and_then(Backend::from_settings_str)
+    {
+        object_entry(&mut root, "backend").insert(
+            "default".to_string(),
+            Value::String(default_backend.executable_name().to_string()),
+        );
+    }
+
     if let Some(launch_setup) = document.get("launch_setup").and_then(Item::as_table) {
         for (backend, item) in launch_setup.iter() {
             if let Some(scope) = item
@@ -565,6 +616,47 @@ fn seed_codex_config_override_defaults(document: &mut Value) {
         });
 }
 
+fn set_default_backend(document: &mut Value, backend: Backend) {
+    object_entry(document, "backend").insert(
+        "default".to_string(),
+        Value::String(backend.executable_name().to_string()),
+    );
+}
+
+fn set_launch_setup_scope(document: &mut Value, backend: Backend, scope: LaunchSetupScope) {
+    let launch_setup = object_entry(document, "launch_setup");
+    let entry = launch_setup
+        .entry(backend_settings_key(backend).to_string())
+        .or_insert_with(|| json!({}));
+    if !entry.is_object() {
+        *entry = json!({});
+    }
+    entry.as_object_mut().unwrap().insert(
+        "scope".to_string(),
+        Value::String(scope.as_str().to_string()),
+    );
+}
+
+fn infer_default_backend_from_launch_setup(document: &Value) -> Option<Backend> {
+    let mut inferred = None;
+    for backend in [Backend::Claude, Backend::Codex] {
+        let is_global = document
+            .get("launch_setup")
+            .and_then(|item| item.get(backend_settings_key(backend)))
+            .and_then(|item| item.get("scope"))
+            .and_then(Value::as_str)
+            .and_then(LaunchSetupScope::from_settings_str)
+            == Some(LaunchSetupScope::Global);
+        if is_global {
+            if inferred.is_some() {
+                return None;
+            }
+            inferred = Some(backend);
+        }
+    }
+    inferred
+}
+
 fn object_entry<'a>(document: &'a mut Value, key: &str) -> &'a mut Map<String, Value> {
     if !document.is_object() {
         *document = json!({});
@@ -646,6 +738,94 @@ mod tests {
             default_codex_config_overrides()
         );
         assert!(!settings_path_at(home.path()).exists());
+    }
+
+    #[test]
+    fn missing_settings_file_has_no_default_backend() {
+        let home = tempdir().unwrap();
+        assert_eq!(load_default_backend_at(home.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn saves_default_backend() {
+        let home = tempdir().unwrap();
+
+        save_default_backend_at(home.path(), Backend::Codex).unwrap();
+
+        assert_eq!(
+            load_default_backend_at(home.path()).unwrap(),
+            Some(Backend::Codex)
+        );
+        let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["backend"]["default"], "codex");
+    }
+
+    #[test]
+    fn infers_default_backend_from_sole_global_launch_setup_scope() {
+        let home = tempdir().unwrap();
+
+        save_launch_setup_scope_at(home.path(), Backend::Codex, LaunchSetupScope::Global).unwrap();
+
+        assert_eq!(
+            load_default_backend_at(home.path()).unwrap(),
+            Some(Backend::Codex)
+        );
+    }
+
+    #[test]
+    fn does_not_infer_default_backend_when_multiple_scopes_are_global() {
+        let home = tempdir().unwrap();
+
+        save_launch_setup_scope_at(home.path(), Backend::Claude, LaunchSetupScope::Global).unwrap();
+        save_launch_setup_scope_at(home.path(), Backend::Codex, LaunchSetupScope::Global).unwrap();
+
+        assert_eq!(load_default_backend_at(home.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn default_backend_preserves_existing_settings() {
+        let home = tempdir().unwrap();
+        let path = settings_path_at(home.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"{"unrelated":{"value":"kept"},"launch_setup":{"codex":{"scope":"global"}}}"#,
+        )
+        .unwrap();
+
+        save_default_backend_at(home.path(), Backend::Claude).unwrap();
+
+        let text = fs::read_to_string(path).unwrap();
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["unrelated"]["value"], "kept");
+        assert_eq!(json["launch_setup"]["codex"]["scope"], "global");
+        assert_eq!(json["backend"]["default"], "claude");
+    }
+
+    #[test]
+    fn saves_global_launch_setup_selection_in_one_document() {
+        let home = tempdir().unwrap();
+
+        save_global_launch_setup_selection_at(
+            home.path(),
+            Backend::Codex,
+            LaunchSetupScope::Global,
+        )
+        .unwrap();
+
+        assert_eq!(
+            load_default_backend_at(home.path()).unwrap(),
+            Some(Backend::Codex)
+        );
+        assert_eq!(
+            load_launch_setup_scope_at(home.path(), Backend::Codex).unwrap(),
+            Some(LaunchSetupScope::Global)
+        );
+        let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
+        let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["backend"]["default"], "codex");
+        assert_eq!(json["launch_setup"]["codex"]["scope"], "global");
     }
 
     #[test]
@@ -805,11 +985,15 @@ mod tests {
         fs::create_dir_all(legacy.parent().unwrap()).unwrap();
         fs::write(
             &legacy,
-            "[hook_health]\nauto_fix_hooks = false\n\n[launch_setup.codex]\nscope = \"global\"\n\n[optimize.rust]\nuse_soldr_shims = true\ninstall_soldr = false\nsoldr_version = \"9.9.9\"\n",
+            "[backend]\ndefault = \"codex\"\n\n[hook_health]\nauto_fix_hooks = false\n\n[launch_setup.codex]\nscope = \"global\"\n\n[optimize.rust]\nuse_soldr_shims = true\ninstall_soldr = false\nsoldr_version = \"9.9.9\"\n",
         )
         .unwrap();
 
         assert!(!load_auto_fix_hooks_enabled_at(home.path()).unwrap());
+        assert_eq!(
+            load_default_backend_at(home.path()).unwrap(),
+            Some(Backend::Codex)
+        );
         assert_eq!(
             load_launch_setup_scope_at(home.path(), Backend::Codex).unwrap(),
             Some(LaunchSetupScope::Global)
@@ -826,6 +1010,7 @@ mod tests {
         save_auto_fix_hooks_enabled_at(home.path(), true).unwrap();
         let text = fs::read_to_string(settings_path_at(home.path())).unwrap();
         let json: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["backend"]["default"], "codex");
         assert_eq!(json["hook_health"]["auto_fix_hooks"], true);
         assert_eq!(json["launch_setup"]["codex"]["scope"], "global");
         assert_eq!(json["optimize"]["rust"]["soldr_version"], "9.9.9");

--- a/crates/clud-bin/src/launch_setup.rs
+++ b/crates/clud-bin/src/launch_setup.rs
@@ -8,7 +8,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use crossterm::event::{self, Event, KeyCode};
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use crossterm::terminal;
 
 use crate::args::Args;
@@ -43,6 +43,7 @@ pub enum SelectorEvent {
     Up,
     Down,
     Enter,
+    Cancel,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,6 +60,8 @@ impl Default for ScopeSelector {
 }
 
 impl ScopeSelector {
+    const RENDERED_LINES: usize = 4;
+
     pub fn selected(self) -> LaunchSetupScope {
         self.selected
     }
@@ -68,23 +71,35 @@ impl ScopeSelector {
             SelectorEvent::Up => self.selected = LaunchSetupScope::SessionOnly,
             SelectorEvent::Down => self.selected = LaunchSetupScope::Global,
             SelectorEvent::Enter => return Some(self.selected),
+            SelectorEvent::Cancel => return Some(LaunchSetupScope::SessionOnly),
         }
         None
     }
 
     pub fn render<W: Write>(&self, out: &mut W) -> io::Result<()> {
-        writeln!(out, "Launch setup scope (Up/Down, Enter):")?;
+        writeln!(out, "Launch setup scope")?;
+        writeln!(out, "  Up/Down move, Enter select, Esc session-only")?;
         writeln!(
             out,
-            "{} Session only",
+            "{} {} Session only   this launch",
+            cursor(self.selected == LaunchSetupScope::SessionOnly),
             marker(self.selected == LaunchSetupScope::SessionOnly)
         )?;
         writeln!(
             out,
-            "{} Globally",
+            "{} {} Globally       remember this backend",
+            cursor(self.selected == LaunchSetupScope::Global),
             marker(self.selected == LaunchSetupScope::Global)
         )?;
         out.flush()
+    }
+}
+
+fn cursor(selected: bool) -> &'static str {
+    if selected {
+        ">"
+    } else {
+        " "
     }
 }
 
@@ -127,8 +142,42 @@ pub fn scope_for_configured_launch(
     scope_for_non_prompting_launch(args, interactive_terminal)
 }
 
+pub fn scope_for_launch_selection(
+    args: &Args,
+    interactive_terminal: bool,
+    configured_scope: Option<LaunchSetupScope>,
+    configured_default_backend: Option<Backend>,
+    selected_backend: Backend,
+) -> Option<LaunchSetupScope> {
+    if should_prompt_for_scope(args, interactive_terminal)
+        && configured_default_backend.is_some_and(|backend| backend != selected_backend)
+    {
+        return None;
+    }
+    scope_for_configured_launch(args, interactive_terminal, configured_scope)
+}
+
+pub fn should_persist_prompted_default_backend(args: &Args, scope: LaunchSetupScope) -> bool {
+    !args.dry_run && (args.claude || args.codex) && matches!(scope, LaunchSetupScope::Global)
+}
+
 pub fn prompt_scope<W: Write>(out: &mut W) -> io::Result<LaunchSetupScope> {
     let _raw = RawModeGuard::enable()?;
+    write!(out, "\x1b[?25l")?;
+    out.flush()?;
+
+    let result = prompt_scope_inner(out);
+    let restore_result = write!(out, "\x1b[?25h").and_then(|_| out.flush());
+    match result {
+        Ok(scope) => restore_result.map(|_| scope),
+        Err(error) => {
+            let _ = restore_result;
+            Err(error)
+        }
+    }
+}
+
+fn prompt_scope_inner<W: Write>(out: &mut W) -> io::Result<LaunchSetupScope> {
     let mut selector = ScopeSelector::default();
     selector.render(out)?;
     let _ = drain_pending_terminal_events();
@@ -138,9 +187,18 @@ pub fn prompt_scope<W: Write>(out: &mut W) -> io::Result<LaunchSetupScope> {
             continue;
         };
         let event = match key.code {
+            KeyCode::Char('c' | 'd') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "launch setup cancelled",
+                ));
+            }
             KeyCode::Up => SelectorEvent::Up,
             KeyCode::Down => SelectorEvent::Down,
+            KeyCode::Char('k') => SelectorEvent::Up,
+            KeyCode::Char('j') => SelectorEvent::Down,
             KeyCode::Enter => SelectorEvent::Enter,
+            KeyCode::Esc => SelectorEvent::Cancel,
             _ => continue,
         };
         if let Some(scope) = selector.handle(event) {
@@ -148,7 +206,7 @@ pub fn prompt_scope<W: Write>(out: &mut W) -> io::Result<LaunchSetupScope> {
             out.flush()?;
             return Ok(scope);
         }
-        write!(out, "\x1b[3A")?;
+        write!(out, "\x1b[{}A\x1b[J", ScopeSelector::RENDERED_LINES)?;
         selector.render(out)?;
     }
 }
@@ -395,7 +453,7 @@ mod tests {
         selector.render(&mut out).unwrap();
         assert_eq!(
             String::from_utf8(out).unwrap(),
-            "Launch setup scope (Up/Down, Enter):\n[x] Session only\n[ ] Globally\n"
+            "Launch setup scope\n  Up/Down move, Enter select, Esc session-only\n> [x] Session only   this launch\n  [ ] Globally       remember this backend\n"
         );
     }
 
@@ -413,15 +471,26 @@ mod tests {
     }
 
     #[test]
-    fn pending_enter_is_drained_before_prompt_accepts_input() {
+    fn selector_escape_chooses_session_only() {
+        let mut selector = ScopeSelector::default();
+        assert_eq!(selector.handle(SelectorEvent::Down), None);
+        assert_eq!(selector.selected(), LaunchSetupScope::Global);
+        assert_eq!(
+            selector.handle(SelectorEvent::Cancel),
+            Some(LaunchSetupScope::SessionOnly)
+        );
+    }
+
+    #[test]
+    fn pending_input_is_drained_before_prompt_accepts_input() {
         use crossterm::event::{KeyEvent, KeyModifiers};
         use std::cell::RefCell;
         use std::collections::VecDeque;
 
-        let events = RefCell::new(VecDeque::from([Event::Key(KeyEvent::new(
-            KeyCode::Enter,
-            KeyModifiers::NONE,
-        ))]));
+        let events = RefCell::new(VecDeque::from([
+            Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+            Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        ]));
 
         let drained = drain_pending_events(
             || Ok(!events.borrow().is_empty()),
@@ -429,7 +498,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(drained, 1);
+        assert_eq!(drained, 2);
         assert!(events.borrow().is_empty());
     }
 
@@ -475,6 +544,51 @@ mod tests {
     }
 
     #[test]
+    fn explicit_backend_that_differs_from_stored_default_prompts_again() {
+        let args = parse(&["clud", "--codex"]);
+        assert_eq!(
+            scope_for_launch_selection(
+                &args,
+                true,
+                Some(LaunchSetupScope::Global),
+                Some(Backend::Claude),
+                Backend::Codex,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_backend_matching_stored_default_uses_configured_scope() {
+        let args = parse(&["clud", "--codex"]);
+        assert_eq!(
+            scope_for_launch_selection(
+                &args,
+                true,
+                Some(LaunchSetupScope::Global),
+                Some(Backend::Codex),
+                Backend::Codex,
+            ),
+            Some(LaunchSetupScope::Global)
+        );
+    }
+
+    #[test]
+    fn one_shot_launches_do_not_prompt_when_backend_differs_from_default() {
+        let args = parse(&["clud", "--codex", "-p", "hello"]);
+        assert_eq!(
+            scope_for_launch_selection(
+                &args,
+                true,
+                Some(LaunchSetupScope::Global),
+                Some(Backend::Claude),
+                Backend::Codex,
+            ),
+            Some(LaunchSetupScope::Global)
+        );
+    }
+
+    #[test]
     fn configured_global_scope_applies_to_one_shot_launches() {
         let args = parse(&["clud", "--codex", "-p", "hello"]);
         assert_eq!(
@@ -490,6 +604,27 @@ mod tests {
             scope_for_configured_launch(&args, true, Some(LaunchSetupScope::Global)),
             Some(LaunchSetupScope::SessionOnly)
         );
+    }
+
+    #[test]
+    fn global_explicit_backend_selection_persists_default_backend() {
+        let args = parse(&["clud", "--codex"]);
+        assert!(should_persist_prompted_default_backend(
+            &args,
+            LaunchSetupScope::Global
+        ));
+        assert!(!should_persist_prompted_default_backend(
+            &args,
+            LaunchSetupScope::SessionOnly
+        ));
+        assert!(!should_persist_prompted_default_backend(
+            &parse(&["clud"]),
+            LaunchSetupScope::Global
+        ));
+        assert!(!should_persist_prompted_default_backend(
+            &parse(&["clud", "--codex", "--dry-run"]),
+            LaunchSetupScope::Global
+        ));
     }
 
     #[test]

--- a/crates/clud-bin/src/main.rs
+++ b/crates/clud-bin/src/main.rs
@@ -379,7 +379,19 @@ fn main() {
         uv_run_hook_guard::run(&root);
     }
 
-    let backend = backend::resolve_backend(args.claude, args.codex);
+    let configured_default_backend = if args.dry_run {
+        None
+    } else {
+        match clud_settings::load_default_backend() {
+            Ok(backend) => backend,
+            Err(error) => {
+                eprintln!("[clud] warning: failed to load default backend: {error}; using claude");
+                None
+            }
+        }
+    };
+    let backend =
+        backend::resolve_backend_with_default(args.claude, args.codex, configured_default_backend);
     let backend_path = {
         let mut bootstrap_host = backend_bootstrap::ProductionBackendBootstrapHost;
         let interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
@@ -404,11 +416,12 @@ fn main() {
     };
 
     // Issue #242: mutable harness setup is scoped per launch until the user
-    // opts into a backend-level global preference. Dry-runs always remain
-    // session-only; otherwise a stored `~/.clud/settings.json` scope wins.
-    // Bare interactive TUI launches without a stored scope can opt into global
-    // setup through a reusable selector. Global setup runs only the selected
-    // backend's actions.
+    // opts into a global selection. Dry-runs ignore stored preferences;
+    // otherwise `backend.default` controls bare launches and the selected
+    // backend's stored setup scope controls whether global setup runs.
+    // Interactive launches with an explicit backend can opt into global setup
+    // through the inline selector, and are prompted again when the explicit
+    // backend differs from `backend.default`.
     let setup_interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
     let configured_scope = if args.dry_run {
         None
@@ -423,17 +436,26 @@ fn main() {
             }
         }
     };
-    let mut persist_global_scope = false;
-    let setup_scope = if let Some(scope) =
-        launch_setup::scope_for_configured_launch(&args, setup_interactive, configured_scope)
-    {
+    let mut persist_prompted_global_selection = false;
+    let setup_scope = if let Some(scope) = launch_setup::scope_for_launch_selection(
+        &args,
+        setup_interactive,
+        configured_scope,
+        configured_default_backend,
+        backend,
+    ) {
         scope
     } else {
         let mut err = io::stderr().lock();
         match launch_setup::prompt_scope(&mut err) {
             Ok(scope) => {
-                persist_global_scope = matches!(scope, launch_setup::LaunchSetupScope::Global);
+                persist_prompted_global_selection =
+                    launch_setup::should_persist_prompted_default_backend(&args, scope);
                 scope
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {
+                eprintln!("[clud] launch setup cancelled");
+                std::process::exit(130);
             }
             Err(error) => {
                 eprintln!(
@@ -443,8 +465,9 @@ fn main() {
             }
         }
     };
-    if persist_global_scope {
-        if let Err(error) = clud_settings::save_launch_setup_scope(backend, setup_scope) {
+    if persist_prompted_global_selection {
+        if let Err(error) = clud_settings::save_global_launch_setup_selection(backend, setup_scope)
+        {
             eprintln!("[clud] note: could not save global setup preference: {error}");
         }
     }

--- a/docs/architecture/launch-setup.md
+++ b/docs/architecture/launch-setup.md
@@ -9,16 +9,23 @@ Interactive TUI launches that explicitly choose a backend with `--claude` or
 `--codex` prompt on stderr before the backend starts:
 
 ```text
-Launch setup scope (Up/Down, Enter):
-[x] Session only
-[ ] Globally
+Launch setup scope
+  Up/Down move, Enter select, Esc session-only
+> [x] Session only   this launch
+  [ ] Globally       remember this backend
 ```
 
-The default is session-only unless `~/.clud/settings.json` already stores a
-backend-level global preference, for example:
+The selector stays in the normal terminal scrollback: no alternate screen, no
+graphics mode. It hides the hardware cursor while active and uses the visible
+`>` marker as the selection cursor. The default is session-only unless
+`~/.clud/settings.json` already stores a backend-level global preference, for
+example:
 
 ```json
 {
+  "backend": {
+    "default": "codex"
+  },
   "launch_setup": {
     "codex": {
       "scope": "global"
@@ -30,16 +37,29 @@ backend-level global preference, for example:
 The selector drains any key events that were already pending when it appeared,
 so the Enter key used to submit the `clud` command is not reused as the
 selector confirmation. Enter accepts the highlighted option, Up selects
-session-only, and Down selects global. Selecting global writes the backend's
-scope to `~/.clud/settings.json`, so later launches for that backend run global
-setup without prompting. Selecting session-only stays scoped to that one launch.
+session-only, Down selects global, and Esc chooses session-only. `j`/`k` mirror
+Down/Up for terminals where those keys are more convenient. Ctrl-C/Ctrl-D abort
+the launch with exit code 130.
+
+Selecting global on an explicit `--codex` or `--claude` launch writes two
+settings to `~/.clud/settings.json`: the selected backend becomes
+`backend.default`, and that backend's setup scope becomes `global`. After
+`clud --codex` is selected globally, later bare `clud` launches use Codex until
+the user runs `clud --claude` and selects global. Selecting session-only stays
+scoped to that one launch and does not rewrite either setting.
+
+When an explicit backend flag differs from the stored `backend.default`, clud
+shows the selector even if that backend already has a stored global setup
+scope. This keeps temporary `clud --codex` / `clud --claude` launches from
+silently changing the default; only a fresh `Globally` selection changes it.
 
 A bare `clud` invocation (no `--claude` or `--codex`), non-interactive backend
 launches, piped stdin, one-shot prompt launches (`-p` / `-m`), continuations,
-and resumes do not prompt. They use session-only unless a stored backend scope
-says `global`. `--dry-run` always uses session-only and does not read or write
-the persisted preference. Self-contained maintenance commands exit before
-launch setup.
+and resumes do not prompt. They use the stored default backend when present and
+use session-only unless that backend's stored setup scope says `global`.
+`--dry-run` ignores stored backend and setup preferences: explicit backend
+flags still win, otherwise it uses the built-in Claude/session-only defaults.
+Self-contained maintenance commands exit before launch setup.
 
 Session-only launches skip persistent setup. They must not create or modify
 agent home setup files under `~/.claude`, `~/.codex`, `~/.agents`, or
@@ -60,6 +80,7 @@ Global setup runs only the selected backend's registered actions:
 | Codex | bundled skills | `~/.codex/skills/` gated by `~/.codex`; stale clud-managed `~/.agents/skills/` copies are purged |
 | Codex | hook timeout normalization | `~/.codex/hooks.json` and `~/.clud/settings.lock` / `settings.json` |
 | All | persisted global setup preference | `~/.clud/settings.lock` / `settings.json` |
+| All | persisted default backend | `~/.clud/settings.lock` / `settings.json` |
 
 All setup failures are non-fatal. `main.rs` logs a `[clud] note: ...` line and
 continues to build and run the backend `LaunchPlan`.


### PR DESCRIPTION
## Summary
- persist the selected backend as backend.default when an explicit --claude/--codex launch chooses global setup
- use backend.default for later bare clud launches while preserving explicit flag precedence
- improve the launch setup selector with a visible cursor, hidden hardware cursor during selection, Esc session-only, j/k navigation, and Ctrl-C/Ctrl-D cancellation
- document the persisted default backend behavior and add a changelog entry

## Tests
- bash lint
- CI-env cargo exact tests for backend default resolution, combined settings save, and prompted global selection persistence
- CI-env cargo test -p clud default_backend
- CI-env cargo test -p clud launch_setup::tests